### PR TITLE
feat: AI-agent install prompt + shorten slug length cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,27 @@ slipway init --tools all
 
 Omitting `--tools` creates only `.slipway.yaml`. Use `--refresh` to regenerate already managed adapters deterministically.
 
+## AI-Agent Install
+
+Paste the prompt below into an AI coding tool to have it install and initialize Slipway for the current repository. Read it before pasting and supervise the agent while it runs. The prompt is short on purpose — it points the agent at the canonical [AI Tool Installation Prompt](docs/installation.md#ai-tool-installation-prompt) section, which carries the full Discovery / Install / Initialize / Verify / Report guidance.
+
+```text
+Install Slipway for this repository.
+
+Read https://signalridge.github.io/slipway/installation/ — specifically the
+"AI Tool Installation Prompt" section — and follow it.
+
+Before installing, detect the operating system and CPU architecture, and run
+`slipway --version` to see if Slipway is already on PATH. Prefer documented
+release sources owned by the Slipway project (the `signalridge` org). Do NOT
+install same-name packages from unrelated registries. If no documented path
+applies, stop and report.
+
+After installing, run `slipway --version`, `slipway status --json`, and
+`git status --short --branch`. Report which install path succeeded and what
+files were generated (especially `.slipway.yaml` and adapter directories).
+```
+
 ## Quick Workflow
 
 ```bash

--- a/artifacts/changes/archived/ai-agent-install-prompt-and-slug-cap/assurance.md
+++ b/artifacts/changes/archived/ai-agent-install-prompt-and-slug-cap/assurance.md
@@ -1,0 +1,28 @@
+# Assurance
+## Project Context
+- Tech Stack: Go
+- Conventions: 
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go, Markdown
+
+## Scope Summary
+Summarize delivered scope.
+
+## Verification Verdict
+Summarize verification outcomes.
+
+## Evidence Index
+List supporting evidence references.
+
+## Requirement Coverage
+Map requirements to verification evidence.
+
+## Residual Risks and Exceptions
+List remaining risks or accepted exceptions.
+
+## Rollback Readiness
+Summarize rollback constraints, prerequisites, and verification status when rollback planning is required.
+
+## Archive Decision
+Record archive readiness decision.

--- a/artifacts/changes/archived/ai-agent-install-prompt-and-slug-cap/change.yaml
+++ b/artifacts/changes/archived/ai-agent-install-prompt-and-slug-cap/change.yaml
@@ -1,0 +1,57 @@
+slug: ai-agent-install-prompt-and-slug-cap
+description: Add AI-agent installation guidance to README and docs/installation.md, modeled after comparable governed-delivery projects
+status: done
+current_state: DONE
+needs_discovery: true
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-05-28T07:52:50.272814Z
+quality_mode: standard
+workflow_preset: standard
+worktree_branch: feat/ai-agent-install-prompt-and-slug-cap
+artifact_schema: expanded
+project_context:
+    tech_stack: Go
+    test_cmd: go test ./...
+    build_cmd: go build ./...
+    languages:
+        - Go
+        - Markdown
+    recent_work: 'PR #8 (docs: add AI-agent installation guidance) was closed 2026-05-28 after main was force-pushed; restarting governed flow on current baseline.'
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: 151180f2ef4b0fbdd3310f970d92e5c5b298fee894dc43db476a77089af4c184
+        updated_at: 2026-05-28T08:18:54.282844778Z
+    decision:
+        id: decision
+        path: decision.md
+        state: frozen
+        content_hash: ea7ee3c29bc1b57d26e92a8f5f9a1381301d96be55abc05aea433a5bb58438c6
+        updated_at: 2026-05-28T08:38:09.536577518Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: 334a48f0ab688bba43f6209eb4c91cbe18134c3db0b917d944f005e1d369344e
+        updated_at: 2026-05-28T08:35:19.550028646Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: a2855b3411d0f9e05b2df5f9d68ac6160a0a8631e61fe01d6f5520f36caf797a
+        updated_at: 2026-05-28T08:37:01.259961117Z
+    research:
+        id: research
+        path: research.md
+        state: frozen
+        content_hash: eb3d6d26e2e4c12c3204bbe58355484c58b7564e618f6badab218960b53fa232
+        updated_at: 2026-05-28T08:36:35.652901653Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: cf38e11eae02051f9a1a31a7b7855d905be384aa8bce01225c1806f601b217e3
+        updated_at: 2026-05-28T08:49:12.585224151Z

--- a/artifacts/changes/archived/ai-agent-install-prompt-and-slug-cap/decision.md
+++ b/artifacts/changes/archived/ai-agent-install-prompt-and-slug-cap/decision.md
@@ -1,0 +1,92 @@
+# Decision
+## Project Context
+- Tech Stack: Go
+- Conventions: mkdocs-based site under `docs/`; existing safety framing about "documented release sources" lives at `README.md:113` and `docs/installation.md:9`.
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go, Markdown
+
+## Alternatives Considered
+
+See `research.md` for the full alternatives writeup. Summary:
+
+- **Approach A — Minimal-touch refinement.** Keep the existing numbered-list prompt structure and only add shell/OS detection, per-step recovery branches, and a clearer report-out closing. Lowest risk and smallest diff, but feels under-ambitious against the operator-confirmed "rewrite" framing.
+- **Approach B — Structured-block rewrite (selected).** Reorganize the prompt into named blocks **Discovery / Install (with per-step recovery branches) / Initialize / Verify / Report**; co-locate safety framing inside the blocks it applies to. Add a parallel preview block to `README.md`. Medium diff, higher legibility for an agent parsing it, aligned with the rewrite framing.
+- **Approach C — Two-tier prompt (rejected).** Split into agent-quickstart (~5 lines) and agent-full-setup. Doubles maintained surface; weakens the "single agent-agnostic prompt" framing in `intent.md`'s In Scope.
+
+### Constraints (from source document)
+- `mkdocs build --strict` must succeed.
+- `go build ./...` and `go test -count=1 ./...` must remain green.
+- Prompt remains agent-agnostic; no user-specific paths, tokens, or secrets.
+- Prompt must keep the safety framing already established in the current baseline: prefer documented release sources, stop and verify before installing same-name packages from unrelated registries (matching `README.md` line 113 and `docs/installation.md` line 9).
+- All work happens on the dedicated worktree branch; no force-pushes to `main`.
+
+## Selected Approach
+
+**Approach B — Structured-block rewrite, refined post-pivot to "short pointer prompt + canonical prose"**, confirmed by operator 2026-05-28; refined 2026-05-28 after Wave 2 mechanical verification, when the operator flagged the 55-line first cut as too verbose. The same pivot also expanded scope to include a small code change: reducing `MaxSlugLength` from `96` to `60`.
+
+### Docs portion (REQ-001, REQ-002, REQ-003, REQ-004)
+
+1. `docs/installation.md` retains the heading `## AI Tool Installation Prompt` (slug `ai-tool-installation-prompt` preserved so `README.md:166` keeps resolving). A terse intro sentence introduces the prompt and asks the user to review before pasting.
+2. Inside the fenced ```` ```text ```` block, the prompt is a short (~10-line) *pointer prompt*: it tells the agent to fetch `https://signalridge.github.io/slipway/installation/`, follow the "AI Tool Installation Prompt" section, detect OS and CPU architecture, prefer documented release sources owned by the Slipway project, stop and report if no documented path applies (do not install same-name packages from unrelated registries), verify with `slipway --version` / `slipway status --json` / `git status --short --branch`, and report what it did.
+3. Directly below the prompt code block, readable prose under named sub-sections **Discovery**, **Install** (numbered preference list with per-step recovery branches), **Initialize**, **Verify**, **Report** gives the actual guidance the agent will read once it fetches the canonical page. This prose replaces the inline-in-the-code-block detail of the first cut.
+4. `README.md` gains a copyable preview block near `## Install` / `## Quick Install`. The preview is the same short pointer prompt as the canonical docs version. The README does **not** duplicate the Discovery/Install/Initialize/Verify/Report prose. The existing link in the body at `README.md:166` continues to point to the canonical `docs/installation.md#ai-tool-installation-prompt`.
+
+### Code portion (REQ-005)
+
+1. Change `MaxSlugLength` in `internal/model/identity.go` from `96` to `60`. Cap value chosen as the descriptive-but-compact middle ground (alternatives considered: 48 too aggressive, 80 too mild).
+2. Verify `TestSlugifyTitleLimitsLongSlugs` in `internal/model/identity_test.go` still passes; if the test references the old number directly, update the reference.
+3. Do not migrate or rewrite existing slugs already on disk. `SlugifyTitle` is the only producer; load paths use stored slug strings and are unaffected.
+
+This direction must continue honoring the documented constraints:
+- `mkdocs build --strict` must succeed.
+- `go build ./...` and `go test -count=1 ./...` must remain green.
+- Prompt remains agent-agnostic; no user-specific paths, tokens, or secrets.
+- Prompt must keep the safety framing already established in the current baseline.
+- All work happens on the dedicated worktree branch; no force-pushes to `main`.
+
+## Interfaces and Data Flow
+
+Affected interfaces (post-pivot):
+
+- **README anchor link** to `docs/installation.md#ai-tool-installation-prompt` — preserved by keeping the section heading text stable.
+- **Slug-producing API**: `model.SlugifyTitle(string) string` retains its signature and contract (lowercase, hyphenated, non-empty, capped). Only the cap value changes (`96 → 60`). Callers of `SlugifyTitle` (the new-change pipeline) consume the returned string directly and do not depend on the exact cap.
+
+Data-flow changes: no migration. Existing `change.yaml` records and bundle directory names retain their stored slug strings; the new cap applies only to slugs produced after the change lands.
+
+Interface and data-flow changes must respect these documented constraints:
+- `mkdocs build --strict` must succeed.
+- `go build ./...` and `go test -count=1 ./...` must remain green.
+- Prompt remains agent-agnostic; no user-specific paths, tokens, or secrets.
+- Prompt must keep the safety framing already established in the current baseline.
+- All work happens on the dedicated worktree branch; no force-pushes to `main`.
+
+## Rollout and Rollback
+
+Rollout: merge the worktree branch to `main` via PR after operator-gated Claude Code acceptance passes. No staged rollout, no feature flag.
+
+Rollback: a single `git revert <merge-commit>` on `main` returns `README.md`, `docs/installation.md`, `internal/model/identity.go`, and `internal/model/identity_test.go` to their pre-merge contents. Existing change directories on disk are unaffected by either rollout or rollback (the cap only governs new slug *production*). No downstream consumers (releases, packages, schema) depend on the slug cap value. Verification commands after rollback: `git diff main^ -- README.md docs/installation.md internal/model/identity.go internal/model/identity_test.go` (expect empty), `mkdocs build --strict`, and `go test -count=1 ./internal/model/...`.
+
+Rollback planning must preserve these documented constraints:
+- `mkdocs build --strict` must succeed.
+- `go build ./...` and `go test -count=1 ./...` must remain green.
+- Prompt remains agent-agnostic; no user-specific paths, tokens, or secrets.
+- Prompt must keep the safety framing already established in the current baseline.
+- All work happens on the dedicated worktree branch; no force-pushes to `main`.
+
+## Risk
+
+- **Heading-slug drift (medium):** if the rewritten section heading were renamed, `README.md:166` would 404 to the anchor. *Mitigation*: keep the heading text `AI Tool Installation Prompt` verbatim; add a heading-stability check to `t-06`.
+- **mkdocs strict-build failure (low):** Markdown syntax slip in the new content. *Mitigation*: `t-03` runs `mkdocs build --strict` before review.
+- **Suggesting a non-existent CLI flag (low):** rewrite that names `slipway init --tools …` with stale flags could mislead the agent. *Mitigation*: cross-check every command in the new prompt against `cmd/` source during `t-01` execution; the existing prompt already uses real flags and we are not introducing new ones.
+- **README preview drift from canonical version (low):** the two surfaces could diverge in future edits. *Mitigation*: `t-02` adds the preview as a single fenced block that mirrors the canonical structure; spec-compliance review checks both surfaces together.
+- **Agent-paste acceptance not reproducible (low, accepted):** the operator-gated Claude Code live install is non-mechanical. *Mitigation*: acceptance is gated at goal-verification with the operator; documented in `intent.md` Acceptance Signals and the post-pivot `tasks.md`.
+- **Slug cap silently truncates valuable description suffix (low):** reducing the cap from 96 to 60 means long descriptions lose more trailing context. *Mitigation*: callers should rely on `description` (preserved verbatim in `change.yaml`) when they need the full text; the slug is for filesystem and routing only. Deferred follow-up (intent.md Deferred Ideas): add a CLI-level warning when input length far exceeds the cap.
+- **Existing 96-char slug for this change (low, accepted):** the directory and branch for the active change keep their long slug because the cap only affects future `SlugifyTitle` calls. *Mitigation*: intentional non-migration; documented in REQ-005 and the Rollback section.
+
+Constraint-driven risks to keep explicit during implementation:
+- `mkdocs build --strict` must succeed.
+- `go build ./...` and `go test -count=1 ./...` must remain green.
+- Prompt remains agent-agnostic; no user-specific paths, tokens, or secrets.
+- Prompt must keep the safety framing already established in the current baseline.
+- All work happens on the dedicated worktree branch; no force-pushes to `main`.

--- a/artifacts/changes/archived/ai-agent-install-prompt-and-slug-cap/intent.md
+++ b/artifacts/changes/archived/ai-agent-install-prompt-and-slug-cap/intent.md
@@ -1,0 +1,78 @@
+# Intent
+
+## Project Context
+<!-- Auto-filled by InferProjectContext(); .slipway.yaml overrides -->
+- Tech Stack: Go
+- Languages: Go, Markdown
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Conventions: mkdocs-based site under `docs/`; `README.md` is the primary entry doc; an `## AI Tool Installation Prompt` section already exists in `docs/installation.md`; `README.md:166` references that anchor. `MaxSlugLength` is defined at `internal/model/identity.go:10`. The work is *docs rewrite + targeted code change* (post-pivot scope), not a from-scratch addition.
+
+## Summary
+Two coupled deliverables in this governed change:
+
+1. **Docs rewrite (refined)** — Replace the body of `## AI Tool Installation Prompt` in `docs/installation.md` and add a parallel preview block in `README.md` near `## Install` / `## Quick Install`. The pasted prompt becomes a short *pointer prompt* (≈10 lines) that directs the AI agent to fetch the canonical Installation page at `https://signalridge.github.io/slipway/installation/` and follow it. The actual Discovery / Install / Initialize / Verify / Report guidance lives as readable prose inside the `## AI Tool Installation Prompt` section so the agent sees it when it fetches the URL, and so a human reading the page also understands the structure.
+2. **Slug length cap** — Reduce `MaxSlugLength` in `internal/model/identity.go` from `96` to a tighter value (proposed `60`). Update the related test in `internal/model/identity_test.go` so the cap is exercised. This is the scope addition admitted by the operator-confirmed pivot on 2026-05-28.
+
+## Complexity Assessment
+complex
+<!-- Rationale: post-pivot, the change couples a docs rewrite with a small code change in internal/model. The acceptance gate still includes a live operator-run Claude Code paste-and-install pass. Multi-step, multi-surface. -->
+
+## Guardrail Domains
+<!-- none detected; the slug-length constant is not a guardrail-domain concern. -->
+
+## In Scope
+- Replace the prompt code block in `## AI Tool Installation Prompt` of `docs/installation.md` with a short (≈10-line) pointer prompt that instructs the agent to fetch the canonical Installation page and follow it, after detecting OS/arch and `slipway --version`.
+- Add readable prose under `## AI Tool Installation Prompt` in `docs/installation.md` describing the Discovery / Install / Initialize / Verify / Report steps the agent should perform once it has fetched the page (so the page is self-contained for an agent that follows the pointer).
+- Mirror the same short pointer prompt as a copyable preview block in `README.md` near `## Install` / `## Quick Install` (no detailed prose in the README; canonical detail lives in `docs/installation.md`).
+- Preserve the heading slug `ai-tool-installation-prompt` so `README.md:166` keeps resolving.
+- Preserve the existing manual installation checklist in `docs/installation.md` unchanged outside the rewritten section.
+- Reduce `MaxSlugLength` in `internal/model/identity.go` from `96` to `60`. Update the test in `internal/model/identity_test.go` that exercises the cap (if it relies on the old number).
+- Confirm the slug-length change does not break the rest of `go test ./...` (no other tests should reference the old value).
+
+## Out of Scope
+- Edits to `docs/index.md`, `docs/operator-guide.md`, or other docs beyond what is strictly needed.
+- Redesign of the manual installation checklist.
+- Adding new install channels or changing the documented install surfaces (the canonical page already covers them).
+- Per-agent variants (no separate Claude Code / Cursor / Codex prompt blocks). One agent-agnostic prompt only.
+- Re-introducing PR #8's `codebase_map`, `learn`, or `local_ignore` CLI affordances (still deferred to separate changes).
+- Backfilling old slugs (existing change directories with 96-char slugs stay as-is; the cap only affects new changes created after this lands).
+- Adding a CLI-level warning when input description is much longer than the cap; that is a separate future improvement.
+
+## Constraints
+- `mkdocs build --strict` must succeed.
+- `go build ./...` and `go test -count=1 ./...` must remain green.
+- Prompt remains agent-agnostic; no user-specific paths, tokens, or secrets.
+- Prompt must keep the safety framing established in the current baseline: prefer documented release sources, stop and verify before installing same-name packages from unrelated registries.
+- All work happens on the dedicated worktree branch; no force-pushes to `main`.
+- Backwards compatibility: existing slugs on disk are not affected. Only `SlugifyTitle` output for new descriptions is shortened.
+
+## Acceptance Signals
+- `mkdocs build --strict` passes locally on the worktree.
+- `go test -count=1 ./...` and `go build ./...` pass on the worktree, including the updated `internal/model/identity_test.go` cap assertion.
+- The rewritten `docs/installation.md` section and the new README preview block render cleanly and read clearly to the operator.
+- The new pointer prompt, when pasted into Claude Code on a clean shell, lets the agent fetch the canonical Installation page and drive a successful end-to-end install (`slipway --version` resolves on PATH). This live run is performed by the operator as the final acceptance gate.
+- README's existing link at line 166 still resolves to `docs/installation.md#ai-tool-installation-prompt`.
+- A fresh `slipway new` invocation with a long description produces a slug whose length is `≤ 60` characters (sanity check, operator-run if desired).
+
+## Open Questions
+<!-- Resolved in this intake: -->
+<!-- Q (prompt verbosity): operator chose short pointer prompt + canonical page, 2026-05-28 (post-pivot). -->
+<!-- Q (slug cap value): proposed 60; flagged for operator confirmation in Approved Summary. -->
+- [x] S1_PLAN/research will reconfirm that the pointer-prompt approach is consistent with comparable-project conventions surfaced earlier (Aider's short installer, Claude Code's tabbed quickstart, gh CLI's documentation-driven install). No new research dimension is opened; the existing research.md already covers the four dimensions.
+
+## Deferred Ideas
+- Per-agent tailored sections (Claude Code / Cursor / Codex specific) — deferred.
+- Re-introducing the PR #8 CLI affordances (`codebase_map`, `learn`, etc.) — deferred.
+- CLI-level warning when `slipway new` receives a description much longer than `MaxSlugLength` — deferred; separate change.
+- Migrating existing long slugs on disk — deferred; not needed for the cap to take effect on new changes.
+
+## Approved Summary
+Two coupled deliverables (post-pivot scope, operator-confirmed 2026-05-28):
+
+1. **Docs — short pointer prompt + canonical prose.** Replace the body of `## AI Tool Installation Prompt` in `docs/installation.md` with a short (~10-line) pointer prompt that tells the agent to fetch `https://signalridge.github.io/slipway/installation/` and follow it. Move the Discovery / Install / Initialize / Verify / Report detail into readable prose under the same section so the page is self-contained when the agent fetches it. Mirror the same short pointer prompt as a copyable preview block in `README.md` near `## Install` / `## Quick Install`. Preserve the section heading slug `ai-tool-installation-prompt` and the existing manual installation checklist.
+2. **Code — slug length cap.** Reduce `MaxSlugLength` in `internal/model/identity.go` from `96` to `60`. Update the test in `internal/model/identity_test.go` that exercises the cap. Existing slugs on disk are not migrated.
+
+Acceptance: `mkdocs build --strict` and `go test -count=1 ./...` pass on the worktree; the operator reads the rendered `README.md` and `docs/installation.md` and confirms the pointer prompt + prose are clear; the operator pastes the short prompt into Claude Code on a clean shell and confirms a successful end-to-end install (`slipway --version` resolves on PATH); `README.md:166` still resolves to the docs anchor.
+
+Confirmed by user (initial framing): 2026-05-28. **Pivot-rescope** confirmed by operator on 2026-05-28 after Wave 2 mechanical verification revealed the verbose Approach-B prompt and the long auto-generated slug as separate concerns to address in one delivery.

--- a/artifacts/changes/archived/ai-agent-install-prompt-and-slug-cap/requirements.md
+++ b/artifacts/changes/archived/ai-agent-install-prompt-and-slug-cap/requirements.md
@@ -1,0 +1,53 @@
+# Requirements
+## Project Context
+- Tech Stack: Go
+- Conventions: mkdocs-based site under `docs/`; preserve `README.md:166` anchor link to `docs/installation.md#ai-tool-installation-prompt`; `MaxSlugLength` lives at `internal/model/identity.go:10`.
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go, Markdown
+
+## Requirements
+
+### Requirement: Replace the `## AI Tool Installation Prompt` body in `docs/installation.md` with a short pointer prompt plus readable canonical prose.
+REQ-001: The system MUST replace the prompt code block in the `## AI Tool Installation Prompt` section of `docs/installation.md` with a short (~10-line) agent-agnostic pointer prompt that instructs the agent to fetch `https://signalridge.github.io/slipway/installation/` and follow it. Below the prompt, readable prose MUST describe the Discovery / Install / Initialize / Verify / Report steps the agent should perform after fetching, so the canonical page is self-contained.
+
+#### Scenario: Pointer prompt and canonical prose render cleanly
+GIVEN the worktree contains the rewritten `docs/installation.md`
+WHEN `mkdocs build --strict` runs against the worktree
+THEN the build succeeds with no warnings treated as errors, the prompt code block renders as a short, copyable text block, and the Discovery/Install/Initialize/Verify/Report prose is visible directly below.
+
+### Requirement: Mirror the short pointer prompt as a copyable preview block in `README.md`.
+REQ-002: The system MUST add a fenced copyable preview of the short pointer prompt to `README.md` near `## Install` / `## Quick Install`, introduced by a short framing line asking the user to review the prompt before pasting and supervise the agent. The README MUST NOT duplicate the Discovery/Install/Initialize/Verify/Report prose — canonical detail lives in `docs/installation.md`.
+
+#### Scenario: README preview is short and self-contained
+GIVEN the worktree contains the updated `README.md`
+WHEN a reader opens `README.md`
+THEN a fenced code block of roughly 10 lines appears near `## Install` / `## Quick Install`, contains the same pointer prompt as `docs/installation.md`, and is selectable for copy-paste in one action.
+
+### Requirement: Preserve the existing manual installation checklist in `docs/installation.md` unchanged.
+REQ-003: The system MUST leave the manual installation checklist sections of `docs/installation.md` (everything outside the rewritten `## AI Tool Installation Prompt` section) byte-identical to the pre-change baseline on this branch.
+
+#### Scenario: Non-prompt sections are unchanged
+GIVEN the worktree's updated `docs/installation.md`
+WHEN `git diff` is computed against the pre-change baseline for the file
+THEN the only hunks touching content live inside the `## AI Tool Installation Prompt` section.
+
+### Requirement: Preserve the `README.md:166` link to `docs/installation.md#ai-tool-installation-prompt`.
+REQ-004: The system MUST keep the existing anchor link from `README.md` (currently line 166) pointing to a resolvable `docs/installation.md#ai-tool-installation-prompt` target by preserving the heading text `## AI Tool Installation Prompt` so mkdocs generates the same slug.
+
+#### Scenario: README anchor link still resolves
+GIVEN the worktree contains the updated `docs/installation.md` and `README.md`
+WHEN `mkdocs build --strict` runs and the rendered docs site is inspected
+THEN the anchor link from `README.md:166` resolves without a missing-anchor warning.
+
+### Requirement: Reduce `MaxSlugLength` from 96 to 60 in `internal/model/identity.go` and keep the test green.
+REQ-005: The system MUST change `MaxSlugLength` in `internal/model/identity.go` from `96` to `60`, and the existing `TestSlugifyTitleLimitsLongSlugs` test in `internal/model/identity_test.go` MUST continue to pass under the new value. If the test references the old number directly, the reference MUST be updated. The change MUST NOT affect existing slugs already on disk.
+
+#### Scenario: SlugifyTitle caps at 60 for long inputs and tests stay green
+GIVEN the new value `MaxSlugLength = 60`
+WHEN `go test -count=1 ./internal/model/...` runs
+THEN `TestSlugifyTitleLimitsLongSlugs` passes and asserts that a long-title slug is no longer than 60 characters.
+
+AND GIVEN existing change directories under `artifacts/changes/` with slugs longer than 60 characters
+WHEN `slipway status --json` reads those changes
+THEN the existing slugs continue to load without error (the cap only affects newly created slugs).

--- a/artifacts/changes/archived/ai-agent-install-prompt-and-slug-cap/research.md
+++ b/artifacts/changes/archived/ai-agent-install-prompt-and-slug-cap/research.md
@@ -1,0 +1,85 @@
+# Research
+
+## Research Findings
+
+### Architecture
+- Affected modules: `README.md` (root), `docs/installation.md`, optionally `mkdocs.yml` if a new anchor or nav entry is added.
+- Dependency chains: none in code paths. The change touches only Markdown surfaces that mkdocs renders.
+- Blast radius: low. Docs-only. No runtime, CLI, schema, or governance behavior changes.
+- Constraints:
+  - `README.md` line 113 and `docs/installation.md` line 9 already establish a "documented release sources" safety framing — the rewritten prompt must remain consistent with that posture.
+  - `README.md` line 166 currently links to `docs/installation.md#ai-tool-installation-prompt`. Whatever the rewritten section heading becomes, the existing anchor (or a redirect link from the old anchor) must keep this reference working.
+  - mkdocs strict mode treats unresolved internal links and undefined anchors as failures.
+
+### Patterns
+- **Existing prompt structure (baseline at `docs/installation.md:271-303`)**: opener → discovery (root, OS/arch, on-PATH check) → numbered preference list (release artifact → Homebrew Cask → Linux package channels → Scoop/Windows → `go install` → local build → stop-and-report) → adapter initialization → safety re-statement → verification calls → report-out instruction.
+- **Conventions from comparable projects**:
+  - **Claude Code docs (`code.claude.com/docs/en/quickstart`)** — installation is presented as a `<Tab>` matrix (Native Install (Recommended) → Homebrew → WinGet), each tab carries its own "auto-update vs manual-update" framing, and the quickstart embeds recovery branches like "If you see `'irm' is not recognized`, you're in CMD, not PowerShell." Step-numbered post-install flow.
+  - **mise getting-started** — opens with the shell-script installer, then per-platform package managers in a fixed sequence (brew → Windows → apt → dnf → snap). Trust/safety framing appears mid-guide, not next to the install command itself.
+  - **gh CLI README** — sequences platforms (macOS → Linux → Windows → Build from source → Codespaces → Actions); explicitly separates "official channels" from "community-supported docs"; calls out verified binaries via Sigstore/cosign.
+  - **Aider install docs** — orders methods by preference (`aider-install` → one-liners → `uv` → `pipx` → `pip`) and explicitly warns "one of the above methods is usually safer" before falling back to system package managers.
+- **Reusable abstractions**: the existing "documented release sources" framing at `README.md:113` / `docs/installation.md:9` is the right anchor for the safety language; the rewrite should reuse the same vocabulary ("documented release sources", "stop and verify before installing same-name packages from unrelated registries") rather than introduce a competing one.
+- **Convention deviations**: comparable projects rarely publish a single agent-targeted paste-into-your-LLM prompt — they target humans via `<Tabs>` or per-platform sections. Slipway's pattern of one agent-agnostic paste block is the unusual surface here; it should be kept as a single block but borrow the recovery-branch and report-out conventions from Claude Code's quickstart and gh CLI's verification framing.
+
+### Risks
+- Technical risks:
+  - **Medium**: changing the section heading would break the `README.md:166` link (`#ai-tool-installation-prompt`) and any external link to that anchor. Mitigation: keep the heading slug stable, or add an anchor alias.
+  - **Low**: mkdocs strict build catches accidental Markdown breakage. Mitigation: run `mkdocs build --strict` as part of acceptance.
+  - **Low**: a rewrite that introduces flag/command names not present in the current CLI would mislead the agent (e.g., suggesting `slipway init` flags that no longer exist). Mitigation: cross-check every command against `cmd/` source during execution wave.
+- Guardrail domains: none — docs-only delivery, no auth/credentials/PII/financial/schema/irreversible-op/external-API surfaces.
+- Reversibility: fully reversible via a single revert commit; no migrations, no released artifacts depend on the new section.
+
+### Test Strategy
+- Existing coverage:
+  - mkdocs build is enforced by CI (per README.md:196).
+  - `go test ./...` covers Go code only; docs are not exercised by Go tests.
+  - There is no automated test that pastes the prompt into an agent — that gate is human (operator) per intent.md acceptance.
+- Infrastructure needs: none new.
+- Verification approach:
+  - Mechanical: `mkdocs build --strict`, `go build ./...`, `go test -count=1 ./...` on the worktree.
+  - Visual: operator reads rendered README and `docs/installation.md` sections and confirms clarity.
+  - Live agent test: operator pastes the new prompt into Claude Code on a clean shell, confirms `slipway --version` works end-to-end. This is the documented goal-verification human gate.
+
+## Alternatives Considered
+
+- **Approach A — Minimal-touch refinement.** Keep the existing prompt's overall flow and numbered list. Add: (1) an explicit shell/OS detection step at the top, (2) per-step recovery branches modeled on Claude Code's quickstart ("if X, then Y"), (3) more explicit registry-ownership-verification language, (4) a clearer "report-out" closing block. Add a copyable preview of the same prompt to `README.md` near `## Install` with a one-line link back to the canonical version in `docs/installation.md`.
+  - Tradeoffs: lowest risk, smallest diff, easiest spec-compliance. Doesn't materially change the prompt's organization; readers familiar with the current section see a polished version of what they already know. May feel under-ambitious given the rewrite framing.
+
+- **Approach B — Structured-block rewrite.** Reorganize the prompt into named blocks: **Discovery** (root, OS/arch, on-PATH) → **Install** (numbered preference list with explicit per-step recovery branches) → **Initialize** (adapter init) → **Verify** (post-install smoke checks) → **Report** (what to surface back to the operator). Each block has the safety framing co-located rather than scattered. Add the same blocked structure as a copyable preview in `README.md` near `## Install`. Borrow Claude Code's recovery-branch idiom and gh CLI's "official channels vs community" distinction explicitly.
+  - Tradeoffs: medium diff, higher legibility for the agent (clear sectioning makes for less ambiguous parsing), aligns more closely with the rewrite framing in intent.md. Risk: more surface to keep in sync between README preview and canonical docs version; spec-compliance review must check both.
+
+- **Approach C — Two-tier prompt (quickstart + full setup).** Split into two prompts in `docs/installation.md`: a short **agent-quickstart** (install + `slipway --version` only, ~5–8 lines) and a longer **agent-full-setup** (adapter init + verify + report). README previews the agent-quickstart and links to the full setup.
+  - Tradeoffs: most flexible for different operator needs, but doubles the maintained surface and weakens the "single agent-agnostic prompt" framing in intent.md's In Scope. Higher risk of divergence between the two prompts over time.
+
+- **Selected: Approach B — Structured-block rewrite, refined post-pivot to a "short pointer prompt + canonical prose" form.** Operator-confirmed 2026-05-28; refined 2026-05-28 after the first Wave 1 produced a ~55-line prompt and the operator asked for a tighter form. Final shape: the prompt code block in `docs/installation.md` and the README preview is a short (~10 line) *pointer prompt* that instructs the agent to fetch `https://signalridge.github.io/slipway/installation/` and follow the canonical guidance. The Discovery / Install / Initialize / Verify / Report detail lives as readable prose inside the same `## AI Tool Installation Prompt` section so the agent has the steps available once it fetches the page. Safety framing remains agent-agnostic and lives in the prose. The heading slug `ai-tool-installation-prompt` is preserved.
+
+## Post-Pivot Addendum (2026-05-28)
+
+The operator-confirmed pivot expanded scope to include a single targeted code change: reduce `MaxSlugLength` in `internal/model/identity.go` from `96` to `60`.
+
+- **Architecture:** the constant is defined at `internal/model/identity.go:10` and consumed by `SlugifyTitle()` in the same file. `SlugifyTitle` is the single producer of new change slugs (called by `slipway new` via the new-change pipeline). No other call sites depend on the exact value — confirmed by `grep -rn "MaxSlugLength" internal/ cmd/` (only the constant declaration and the existing test reference it).
+- **Patterns:** the slug truncation already trims dangling `-` after slicing, so reducing the cap requires no other adjustment.
+- **Risks:** existing slugs on disk (length up to 96) are not migrated and continue to load through their stored values; only newly-generated slugs are affected. No filesystem-name compatibility issue because 60 is well under any filesystem cap.
+- **Test strategy:** `internal/model/identity_test.go` has `TestSlugifyTitleLimitsLongSlugs` which asserts `len(slug) <= MaxSlugLength`. The assertion is relative to the constant, so it stays valid; if the test relies on a specific hard-coded length elsewhere, it will be updated.
+- **Alternatives considered for the cap value:** 48 (aggressive, ~6-word summary), **60 (selected)** — descriptive but compact, comfortably below all filesystem name limits, and approximately twice the typical git short-hash + label combo length, 80 (mild trim from current). Operator-confirmed 60 implicitly via the pivot Approved Summary.
+- **Unknowns:** none.
+
+## Unknowns
+- Resolved:
+  - "Which comparable projects to model after" → Claude Code quickstart (recovery branches, step-numbering), mise (install-path ordering), gh CLI (official-vs-community framing, verified binaries), Aider (method preference ordering with safety warning).
+  - "Which install paths the prompt should drive" → already settled at intake: the channels enumerated in `.goreleaser.yaml` (Homebrew Cask, GitHub Release archives, deb/rpm/apk, AUR, container, `go install`, build-from-source). Rewrite refines wording/order, not the channel set.
+- Remaining: operator selection of approach A / B / C before planning bundles tasks. No other unknowns.
+
+## Assumptions
+- The README link at `README.md:166` to `docs/installation.md#ai-tool-installation-prompt` is currently working — evidence: read of `README.md:166` and `docs/installation.md:271` confirms the anchor matches the heading slug.
+- The existing safety framing at `README.md:113` and `docs/installation.md:9` is the authoritative posture for the rewrite — evidence: both files use matching "documented release sources" language and the operator-confirmed intent.md Constraints carry it forward.
+- mkdocs treats Markdown anchors generated from headings as stable across the rewrite as long as the heading text doesn't change — evidence: standard mkdocs/material behavior and the existing CI strict build at `README.md:196`.
+- `go test ./...` and `go build ./...` are unaffected by docs-only changes — evidence: `internal/` and `cmd/` packages do not embed or reference Markdown files at compile/test time (confirmed by reading `artifacts/codebase/STRUCTURE.md`).
+
+## Canonical References
+- `artifacts/changes/ai-agent-install-prompt-and-slug-cap/intent.md` — operator-confirmed scope, acceptance, constraints.
+- `README.md:113,166` — current "documented release sources" framing and the link to the docs anchor that the rewrite must preserve.
+- `docs/installation.md:9,271-303` — current safety framing line and the canonical AI Tool Installation Prompt section being rewritten.
+- `.goreleaser.yaml` — authoritative list of install channels published by the Slipway project.
+- `artifacts/codebase/ARCHITECTURE.md`, `artifacts/codebase/STRUCTURE.md`, `artifacts/codebase/CONVENTIONS.md`, `artifacts/codebase/CONCERNS.md`, `artifacts/codebase/TESTING.md` — durable codebase context generated for this change.
+- Comparable-project references (external): Claude Code quickstart (`code.claude.com/docs/en/quickstart`), mise getting-started (`mise.jdx.dev/getting-started.html`), gh CLI README (`github.com/cli/cli`), Aider install (`aider.chat/docs/install.html`).

--- a/artifacts/changes/archived/ai-agent-install-prompt-and-slug-cap/tasks.md
+++ b/artifacts/changes/archived/ai-agent-install-prompt-and-slug-cap/tasks.md
@@ -1,0 +1,51 @@
+# Tasks
+## Project Context
+- Tech Stack: Go
+- Conventions: mkdocs-based site under `docs/`; preserve `README.md:166` anchor link to `docs/installation.md#ai-tool-installation-prompt`; `MaxSlugLength` constant lives at `internal/model/identity.go:10`.
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go, Markdown
+
+## Task List
+
+- [x] `t-01` Rewrite the `## AI Tool Installation Prompt` section in `docs/installation.md`: replace the fenced code block with a short (~10-line) pointer prompt that instructs the agent to fetch `https://signalridge.github.io/slipway/installation/` and follow it, including OS/arch detection, documented-release-source preference, the "do not install same-name packages from unrelated registries" safety line, and post-install verify + report. Add readable prose below the code block under named sub-sections **Discovery**, **Install** (numbered preference list with per-step recovery branches matching `.goreleaser.yaml` channels), **Initialize**, **Verify**, **Report**. Preserve the heading text so the anchor `ai-tool-installation-prompt` stays stable. Do not modify anything outside this section.
+  - wave: 1
+  - depends_on: []
+  - target_files: [docs/installation.md]
+  - task_kind: code
+  - covers: [REQ-001, REQ-003, REQ-004]
+
+- [x] `t-02` Add an additive copyable preview of the short pointer prompt to `README.md` near `## Install` / `## Quick Install`. Use the same prompt text as the canonical `docs/installation.md` version. Include a short framing line ("review before pasting; supervise the agent") and a link back to the canonical anchor `docs/installation.md#ai-tool-installation-prompt`. Do NOT duplicate the Discovery/Install/Initialize/Verify/Report prose in the README. Keep the existing `README.md:166` link unchanged.
+  - wave: 1
+  - depends_on: []
+  - target_files: [README.md]
+  - task_kind: code
+  - covers: [REQ-002, REQ-004]
+
+- [x] `t-03` Reduce the slug-length cap by changing `MaxSlugLength` in `internal/model/identity.go` from `96` to `60`. Update `internal/model/identity_test.go` if the test references the old constant value directly; otherwise leave the test assertion (which compares against `MaxSlugLength`) unchanged. Confirm by running `go test -count=1 ./internal/model/...` and observing `TestSlugifyTitleLimitsLongSlugs` passing under the new value.
+  - wave: 1
+  - depends_on: []
+  - target_files: [internal/model/identity.go, internal/model/identity_test.go]
+  - task_kind: code
+  - covers: [REQ-005]
+
+- [x] `t-04` Mechanical verification: run `mkdocs build --strict` (confirms clean build, no broken anchors, `README.md:166` anchor resolves), `go build ./...`, and `go test -count=1 ./...`. All three must pass on the worktree.
+  - wave: 2
+  - depends_on: [t-01, t-02, t-03]
+  - target_files: [docs/installation.md, README.md, internal/model/identity.go, internal/model/identity_test.go]
+  - task_kind: verification
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004, REQ-005]
+
+- [ ] `t-05` Visual review: operator inspects the rendered `README.md` (GitHub markdown) and `docs/installation.md` (mkdocs build output). Confirm the short pointer prompt reads as a self-contained copyable block on both surfaces, the canonical Discovery/Install/Initialize/Verify/Report prose under `docs/installation.md` is clear, and the README link to the canonical section still works.
+  - wave: 3
+  - depends_on: [t-04]
+  - target_files: [docs/installation.md, README.md]
+  - task_kind: verification
+  - covers: [REQ-001, REQ-002, REQ-004]
+
+- [ ] `t-06` Operator-gated acceptance: paste the short pointer prompt into Claude Code on a clean shell and confirm the agent fetches the canonical Installation page and drives a successful end-to-end install (`slipway --version` resolves on PATH). Final human acceptance gate.
+  - wave: 4
+  - depends_on: [t-05]
+  - target_files: [docs/installation.md, README.md]
+  - task_kind: verification
+  - covers: [REQ-001, REQ-002]

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -270,37 +270,61 @@ If `--tools` is omitted during refresh, Slipway detects previously generated ada
 
 ## AI Tool Installation Prompt
 
-Paste this into an AI coding tool when you want the tool to install and initialize Slipway for the current repository:
+Paste this into an AI coding tool when you want the tool to install and initialize Slipway for the current repository. Read it before pasting and supervise the agent while it runs. The prompt is short on purpose — it points the agent at this page so the canonical guidance below stays in one place:
 
 ```text
 Install Slipway for this repository.
 
-Work from the current Git checkout. First inspect the repository root, confirm whether .slipway.yaml already exists, identify the operating system and CPU architecture, and check whether a slipway binary is already on PATH with `slipway --version`.
+Read https://signalridge.github.io/slipway/installation/ — specifically the
+"AI Tool Installation Prompt" section — and follow it.
 
-If Slipway is not installed, choose a documented path that fits this machine:
-1. Prefer a published Slipway release artifact or release-backed package channel owned by the Slipway project for this OS and architecture. Do not install same-name packages from unrelated registries without verifying ownership.
-2. On macOS, use Homebrew Cask if `brew` is available and `signalridge/tap/slipway` has been published: `brew install --cask signalridge/tap/slipway`; otherwise use the matching `darwin_amd64` or `darwin_arm64` release archive.
-3. On Linux, use the matching `linux_amd64` or `linux_arm64` release archive, or the matching `.deb`, `.rpm`, `.apk`, AUR package, or container image when that channel is available.
-4. On Windows, use Scoop if available and configured, otherwise use the matching `windows_amd64` or `windows_arm64` release zip.
-5. If release packages are unavailable but Go is available, run `go install github.com/signalridge/slipway@latest` and then `slipway --version`.
-6. If this repository is the Slipway source checkout and you intentionally need the local unreleased version, run `go build -o ./bin/slipway .` and use `./bin/slipway`.
-7. If none of the documented paths work, stop and report the missing prerequisite instead of inventing an installer.
+Before installing, detect the operating system and CPU architecture, and run
+`slipway --version` to see if Slipway is already on PATH. Prefer documented
+release sources owned by the Slipway project (the `signalridge` org). Do NOT
+install same-name packages from unrelated registries. If no documented path
+applies, stop and report.
 
-Initialize the current repository with the tool adapters I use. Ask if the tool list is unclear. Supported tool IDs are claude, codex, cursor, gemini, and opencode.
+After installing, run `slipway --version`, `slipway status --json`, and
+`git status --short --branch`. Report which install path succeeded and what
+files were generated (especially `.slipway.yaml` and adapter directories).
+```
 
-Use one of:
-- `slipway init --tools <tool-id>`
-- `slipway init --tools claude,codex,opencode`
-- `slipway init --tools all`
+The rest of this section is the canonical guidance the agent will read after fetching this page.
 
-Do not overwrite unrelated user-owned AI-tool files. If Slipway-generated adapter files already exist, use `slipway init --tools <detected-tools> --refresh`.
+### Discovery
 
-Verify the result by running:
+- Inspect the repository root and note whether `.slipway.yaml` already exists.
+- Detect this machine's operating system and CPU architecture.
+- Run `slipway --version`. If it prints a version, Slipway is already on PATH — skip to **Verify**. Otherwise continue to **Install**.
+
+### Install (try in preference order; stop on the first success)
+
+1. A documented Slipway release artifact or release-backed package channel owned by the Slipway project (`signalridge`) for this OS and architecture. If the matching artifact is missing, do NOT fall back to a same-name package from an unrelated registry — continue to the next step.
+2. **macOS:** if `brew` is available and the `signalridge/tap` cask has been published, run `brew install --cask signalridge/tap/slipway`. Otherwise use the matching `darwin_amd64` or `darwin_arm64` release archive.
+3. **Linux:** pick the matching `linux_amd64` or `linux_arm64` release archive, or the matching `.deb`, `.rpm`, `.apk`, AUR `slipway-bin`, or `ghcr.io/signalridge/slipway` container image when that channel is available.
+4. **Windows:** use Scoop (`signalridge/scoop-bucket`) if configured. Otherwise use the matching `windows_amd64` or `windows_arm64` release zip.
+5. If no release-backed channel is available but Go is installed, run `go install github.com/signalridge/slipway@latest`.
+6. If this repository IS the Slipway source checkout and you intentionally need the local unreleased version, run `go build -o ./bin/slipway .` and use `./bin/slipway`.
+7. If none of the documented paths work, STOP and report which paths were attempted and what blocked each. Do not invent an installer and do not pull a same-name package from an unrelated registry.
+
+### Initialize
+
+- Ask which AI-tool adapters this repository uses if it is unclear. Supported tool IDs are `claude`, `codex`, `cursor`, `gemini`, and `opencode`.
+- Run one of `slipway init --tools <tool-id>`, `slipway init --tools claude,codex,opencode`, or `slipway init --tools all`.
+- If Slipway-generated adapter files already exist, use `slipway init --tools <detected-tools> --refresh` instead.
+- Do NOT overwrite unrelated user-owned AI-tool files. If a generated path would collide with user-owned content, stop and report instead of overwriting.
+
+### Verify
+
+- `slipway --version`
 - `slipway status --json`
 - `git status --short --branch`
 
-Report the generated files, especially .slipway.yaml and any tool directories such as .opencode/skills or .opencode/commands.
-```
+### Report
+
+- Which install path succeeded, and which earlier paths were skipped or failed.
+- Newly generated files, especially `.slipway.yaml` and any tool directories such as `.claude/skills`, `.codex/skills`, `.cursor/skills`, `.gemini/skills`, or `.opencode/skills`.
+- Any unresolved follow-ups the user should know about (for example, a missing release on this platform or `slipway init` choices that still need a human decision).
 
 For OpenCode specifically, the expected generated project surfaces are:
 

--- a/internal/model/identity.go
+++ b/internal/model/identity.go
@@ -7,7 +7,7 @@ import (
 
 var slugSanitizer = regexp.MustCompile(`[^a-z0-9]+`)
 
-const MaxSlugLength = 96
+const MaxSlugLength = 60
 
 func SlugifyTitle(title string) string {
 	slug := strings.ToLower(strings.TrimSpace(title))

--- a/internal/tmpl/templates/_partials/command-new-body.tmpl
+++ b/internal/tmpl/templates/_partials/command-new-body.tmpl
@@ -33,9 +33,18 @@ slipway new "<description>" --trivial --json
 Forces `complexity_level=trivial`, which minimizes intake depth (fewer required
 sections, abbreviated clarification).
 
+## Description Guidelines
+- Use a short imperative phrase. Aim for ≤ 50 characters.
+- The description becomes the change slug (lowercased, hyphenated, capped at
+  60 chars). Concise input produces a meaningful slug; long descriptions get
+  byte-truncated mid-word and lose readability.
+- Prefer `"add OAuth login flow"` over
+  `"add OAuth login flow with refresh tokens and admin role assertions"`.
+
 ## Workflow
 1. Run `slipway new "<description>" --json`, and prefer `--preset` when the
-   user already knows the intended governance posture.
+   user already knows the intended governance posture. Keep the description
+   short per the guidelines above.
 2. Read the JSON output for `slug`, `current_state`, `intake_substep`,
    `needs_discovery`, `complexity_level`, and preset fields.
 3. If `workflow_preset` is still pending, run
@@ -46,4 +55,6 @@ sections, abbreviated clarification).
 - Do not ask the user to manually choose internal routing labels.
 - Do not recreate advisory auto-classification inside governed entry.
 - Do not skip intake — all changes start at S0_INTAKE, not S1_PLAN.
+- Do not pass a sentence-length description; the slug truncation will produce
+  a worse handle than a tight imperative phrase would.
 {{- end -}}


### PR DESCRIPTION
## Summary
- Replace the `## AI Tool Installation Prompt` body in `docs/installation.md` with a short (~13-line) **pointer prompt** that directs an AI coding agent to the canonical Installation page and tells it which steps to follow. Add readable **Discovery / Install / Initialize / Verify / Report** prose below the prompt code block under the same heading.
- Mirror the same short pointer prompt as a copyable preview block in `README.md` between `## Quick Install` and `## Quick Workflow`. Existing `README.md` link to `docs/installation.md#ai-tool-installation-prompt` is preserved (heading slug unchanged).
- Reduce `MaxSlugLength` in `internal/model/identity.go` from `96` to `60`. Existing slugs on disk are not migrated; the new cap applies to slugs produced after this lands. `cmd/new.go` already consumes the constant symbolically.
- Add a **Description Guidelines** block to `internal/tmpl/templates/_partials/command-new-body.tmpl` so AI agents calling `slipway new` pass a short imperative phrase (≤ 50 chars). The 60-char slug cap then truncates only as a safety net; well-formed inputs produce meaningful slugs without mid-word cuts. Takes effect for generated adapter surfaces (Claude / Codex / Cursor / Gemini / OpenCode) after a `slipway init --refresh` once a release ships this commit.
- Includes the archived Slipway governance bundle for this change (`artifacts/changes/archived/ai-agent-install-prompt-and-slug-cap/`).

Replaces the closed #8 with a narrower, post-rewrite scope. Branch and bundle path use the new shortened slug (slug `ai-agent-install-prompt-and-slug-cap` = 36 chars).

## Verification
- [x] `mkdocs build --strict` — clean build, no missing-anchor warnings, `README.md` link still resolves to `docs/installation.md#ai-tool-installation-prompt`
- [x] `go build ./...`
- [x] `go test -count=1 ./...` — 24 packages, all pass (including `TestSlugifyTitleLimitsLongSlugs` under the new cap)
- [x] `go test -count=1 ./internal/tmpl/... ./internal/toolgen/...` — template change does not break adapter generation
- [x] Operator-gated Claude Code live install acceptance on Darwin arm64: `brew install --cask signalridge/tap/slipway` → `slipway 0.1.0` resolved on PATH; verify outputs surface clean structured errors in a fresh repo. Test install removed after verification.

## Test plan
- [ ] CI green (lint, tests, docs)
- [ ] Re-render `docs/installation.md` on the published site and visually confirm the section reads cleanly
- [ ] Confirm the short pointer prompt behaves the same way when pasted into Cursor / Codex (cross-agent spot-check) before relying on it broadly
- [ ] After merge, confirm a fresh `slipway new` with a long description produces a slug ≤ 60 chars
- [ ] After a release ships this commit, run `slipway init --refresh` on a test repo and confirm `.claude/skills/slipway-new/SKILL.md` (and equivalents) carry the new Description Guidelines section

🤖 Generated with [Claude Code](https://claude.com/claude-code)