### PR TITLE
fix(codebase-map): stop fabricating repo context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,7 @@ All routed commands support `--json` for structured output:
 - `slipway review --json` — review current change
 - `slipway validate --json` — validate governance state
 - `slipway repair --json` — repair local integrity issues
+- `slipway codebase-map --json` — create or refresh advisory repo-scoped context under `artifacts/codebase`
 - `slipway next --json` — query next step as a handoff-only JSON surface (read-only, does not advance state)
 - `slipway next --json --no-auto-pass` — query next step, reporting `auto_pass_eligible` instead of auto-passing
 - `slipway next --json --diagnostics` — include governance/readiness diagnostics in the next-step view
@@ -105,3 +106,8 @@ conventions such as `.claude/skills/slipway-{name}/SKILL.md`. Default `next`
 JSON is intentionally compact; use `--diagnostics` for gate status, artifact
 status, skill evidence, context-budget details, wave plans, and transition
 traces.
+
+`codebase-map --json` can report `status: "baseline"` with `baseline_docs`
+when documents contain only CLI-detected repository facts. Treat baseline docs
+as a starting point awaiting source-backed verification, not as completed
+brownfield analysis.

--- a/artifacts/changes/archived/fix-codebase-map-fabricating-go-slipway-repository-context-f/assurance.md
+++ b/artifacts/changes/archived/fix-codebase-map-fabricating-go-slipway-repository-context-f/assurance.md
@@ -1,0 +1,56 @@
+# Assurance
+## Project Context
+- Tech Stack: Go
+- Conventions: Cobra CLI; cmd/ surfaces, internal/state durable state, internal/engine workflow logic
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Scope Summary
+Resolve issue #17: (1) make `slipway codebase-map` language-agnostic and stop
+fabricating Go/Slipway context; (2) refresh old deterministic Go/Slipway generated
+map docs already written into non-Go repos without overwriting authored maps; (3)
+add a `baseline` status so generated facts are not mistaken for authored analysis;
+(4) make next/run active-change discovery from the repo root self-explanatory and
+lock `--change <slug>` worktree resolution from any directory; (5) make status and
+repair handle empty stale root active-bundle residue after a worktree-bound `done`
+without blocking closeout; (6) make `validate --change <archived-slug>` fail with
+a concrete archived-change diagnostic instead of an empty no-active view. No new
+config field; git + change.yaml are the source of truth.
+
+## Verification Verdict
+Pass. S2 execution, S3 spec/code-quality review, and S4 goal-verification completed
+with fresh evidence. Final signals: separate RED contract evidence before production
+changes, a late S4 RED/green micro-loop for Go single-line `require` parsing,
+`go build ./...` green, `go test -count=1 ./...` green, focused cross-package coverage
+green, and issue #17 regression tests pass.
+
+## Evidence Index
+- intent.md (approved scope), research.md (evidence-backed findings), decision.md (selected approach)
+- verification/intake-clarification.yaml, verification/research-orchestration.yaml, verification/plan-audit.yaml
+- verification/tdd-governance.yaml, verification/wave-orchestration.yaml,
+  verification/spec-compliance-review.yaml, verification/code-quality-review.yaml,
+  verification/goal-verification.yaml
+
+## Requirement Coverage
+- REQ-001, REQ-002, REQ-003, REQ-004 -> t-00a, t-01, t-03, t-05
+- REQ-005, REQ-006 -> t-00b, t-02, t-04, t-06
+- REQ-007 -> t-00a, t-00b, t-08
+- REQ-008 -> t-05, t-06, t-10, t-08
+- REQ-009 -> t-07
+- REQ-010 -> t-08
+- REQ-011, REQ-012 -> t-00c, t-09, t-10
+- REQ-013 -> t-00d, t-06, t-07, t-11, t-08
+
+## Residual Risks and Exceptions
+- `internal/state/stats.go` freshness stays coarse/modtime-based (import-cycle boundary) - accepted exception.
+- Existing generated baseline docs are refreshed only when they match the old deterministic
+  Go/Slipway generated shape. Generic authored map refresh remains out of scope.
+
+## Rollback Readiness
+Pure code change; no data migration. Rollback = revert the PR/commit. Verification after rollback:
+`go build ./... && go test ./...`. Generated `artifacts/codebase/*` are advisory and regenerated on demand.
+
+## Archive Decision
+Pending explicit `slipway done`. Goal-verification passes and the change is ready for
+the final lifecycle transition.

--- a/artifacts/changes/archived/fix-codebase-map-fabricating-go-slipway-repository-context-f/change.yaml
+++ b/artifacts/changes/archived/fix-codebase-map-fabricating-go-slipway-repository-context-f/change.yaml
@@ -1,0 +1,58 @@
+version: 1
+slug: fix-codebase-map-fabricating-go-slipway-repository-context-f
+description: Fix codebase-map fabricating Go/Slipway repository context for non-Go/non-Slipway repos (language-agnostic fact detection + distinguish CLI-generated baseline docs from authored content in status/JSON), and make next/run active-change discovery self-explanatory when invoked from the root checkout while a change is bound to another worktree
+status: done
+current_state: DONE
+needs_discovery: true
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-05-30T10:10:19.227948Z
+guardrail_domain: external_api_contracts
+quality_mode: standard
+workflow_preset: standard
+worktree_branch: feat/fix-codebase-map-fabricating-go-slipway-repository-context-f
+artifact_schema: expanded
+project_context:
+    tech_stack: Go
+    test_cmd: go test ./...
+    build_cmd: go build ./...
+    languages:
+        - Go
+    recent_work: 0.3.0 release (#16); improved governed workflow diagnostics (#15)
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: 7b554f4b3e09bc74d43918483014f615e0bd8d881d14b3e99e60f13cf6db7be5
+        updated_at: 2026-05-30T12:52:51.616175001Z
+    decision:
+        id: decision
+        path: decision.md
+        state: frozen
+        content_hash: b9bde2dbd93602a3d86791624c36ff3b204e5454c5ec2d262233295a042f0e88
+        updated_at: 2026-05-30T12:31:28.76436513Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: e327f6c14721bc5764ebd052875c40bd4db93f3054554c4b92789e517e6be65d
+        updated_at: 2026-05-30T12:33:46.326276373Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: 74256d91d6756c64affe51d498ea44a8816dfcafe40acca3a263f4b7428580a7
+        updated_at: 2026-05-30T12:29:42.399850544Z
+    research:
+        id: research
+        path: research.md
+        state: frozen
+        content_hash: 9bde812d57df5f436aea0f68e67b49e1f1f39f1cf24b4b66d3cf8fc3a9502ecf
+        updated_at: 2026-05-30T12:31:49.869254644Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: 7c35d63d573b44a1785c5f30ffe25536813f597ee04259c2e738cc207af5a6da
+        updated_at: 2026-05-30T12:30:48.943371934Z

--- a/artifacts/changes/archived/fix-codebase-map-fabricating-go-slipway-repository-context-f/decision.md
+++ b/artifacts/changes/archived/fix-codebase-map-fabricating-go-slipway-repository-context-f/decision.md
@@ -1,0 +1,153 @@
+# Decision
+## Project Context
+- Tech Stack: Go
+- Conventions: Cobra CLI; cmd/ surfaces, internal/state durable state, internal/engine workflow logic
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Alternatives Considered
+
+### Obs-1 - codebase-map content generation
+- **(A) Language-agnostic fact detection + blank scaffold for semantic docs + new `baseline` status.**
+  Tradeoffs: more detection code, but bootstraps real facts for any stack, never fabricates semantic
+  prose, and `baseline` tells hosts the docs still await authored verification.
+- (B) Pure scaffold generator (no fact detection at all). Tradeoffs: simplest, but discards useful
+  deterministic facts (languages, build/test commands) the host would otherwise re-derive.
+- (C) Keep generation but emit scaffold only for "unknown" stacks. Tradeoffs: still Go-biased and
+  fails the language-agnostic contract for known-but-non-Go stacks unless fully generalized anyway.
+
+### Obs-1b - existing docs polluted by old generated Go/Slipway baseline
+- **(A) Targeted legacy generated-doc refresh.** Detect the old deterministic Slipway-generated
+  Go/Slipway baseline shape and refresh it to the current baseline/scaffold. Tradeoffs: extra
+  migration logic, but fixes the issue #17 rerun scenario for already-polluted worktrees.
+- (B) Require operators to delete `artifacts/codebase/` manually before rerun. Tradeoffs: minimal code,
+  but leaves the reported Lattice worktree broken unless the operator already knows the workaround.
+- (C) Overwrite any content whose detected facts differ from the current repo. Tradeoffs: broader
+  cleanup, but risks deleting hand-authored architecture analysis.
+
+### Obs-2 - active-change discovery from the repo root
+- **(A) Improve the diagnostic only; rely on existing `--change <slug>` routing.** Research confirms
+  `next/run --change <slug>` already resolve context to the bound worktree (`ResolveChangePaths`
+  uses `change.WorktreePath`) and from-root discovery already walks git worktrees. Tradeoffs:
+  smallest change; keeps default cwd scoping; no new surfaces.
+- (B) Auto-resolve a single bound change from root. Tradeoffs: changes default scoping behavior -
+  rejected by the user (keep worktree scoping).
+- (C) New configurable `worktree_root` + slug-derivation, or a separate registry file. Tradeoffs:
+  new surfaces to maintain; redundant with git's worktree registry + `change.yaml` - rejected in
+  favor of git+change.yaml discovery.
+
+### Obs-3 - stale empty active bundle residue after done
+- **(A) Treat empty orphan active bundle directories as safe residue: ignore them for active-change
+  discovery and let `repair` remove them.** Tradeoffs: preserves corruption signaling for non-empty
+  orphan bundles while preventing a post-archive empty `verification/` directory from blocking status.
+- (B) Ignore every orphan bundle directory without `change.yaml`. Tradeoffs: hides real partial state
+  corruption and could lose operator-visible recovery evidence.
+- (C) Make `done` fail when any root duplicate exists. Tradeoffs: blocks successful archive because of
+  stale non-authoritative residue and still does not help older workspaces already in this state.
+
+### Obs-4 - validate --change archived slug
+- **(A) Fail explicitly for archived terminal changes.** `validate` remains an active-governance
+  readiness command, but exact archived slugs return `archived_change_not_validatable` with status and
+  archive path. Tradeoffs: smallest contract fix and directly resolves the misleading empty no-active
+  diagnostic.
+- (B) Fully validate archived bundles. Tradeoffs: broader path-authority work because archived
+  `change.yaml` snapshots intentionally scrub `WorktreePath` and active-bundle paths are no longer the
+  authority.
+- (C) Keep generic `no_active_change`. Tradeoffs: preserves current behavior but leaves the printed
+  `--change <slug>` remediation misleading after archive.
+
+### Guardrail execution shape
+- **(A) Separate RED contract test tasks in wave 1, with production tasks depending on them.**
+  Tradeoffs: one additional wave, but aligns with `slipway-tdd-governance` and gives auditable
+  test-first evidence before guarded production changes.
+- (B) Keep implementation waves first and write tests later. Tradeoffs: simpler task list, but violates
+  the guardrail-domain TDD hard gate.
+- (C) Put tests and implementation in the same task/commit. Tradeoffs: convenient, but same-commit
+  evidence is not test-first proof.
+
+## Selected Approach
+- **Obs-1: (A)** Replace `inspectCodebaseMapFacts` with a manifest+extension-driven,
+  language-agnostic detector and rewrite `codebaseMapBaselineDoc` to fill only detected fields.
+  Add `CodebaseMapStatusBaseline`; `AssessCodebaseMapDocs` compares each doc to the freshly
+  regenerated baseline to classify `baseline` vs `populated`; add `baseline_docs` to the `--json`
+  view + text writer.
+- **Obs-1b: (A)** Add targeted legacy generated-doc recognition for the old deterministic Go/Slipway
+  baseline output and allow `EnsureCodebaseMapDocs` to refresh that generated content on rerun.
+  Preserve hand-authored substantive docs.
+- **Obs-2: (A)** Make `FindActiveChangeForWorktree` distinguish "no active change" from "bound
+  elsewhere" and return a typed signal carrying the bound changes; translate it in
+  `wrapResolutionError`/`resolveActiveChangeRef` into a `change_bound_to_other_worktree`
+  precondition error. Lock the already-correct `--change <slug>`-from-root routing with tests.
+- **Obs-3: (A)** Add a narrow empty-orphan test for active bundle directories without `change.yaml`.
+  Active-change discovery skips only fileless orphan bundle directories; `repair` removes those empty
+  directories and records an applied repair. Non-empty orphan bundle directories remain integrity
+  findings requiring operator review.
+- **Obs-4: (A)** Extend explicit slug resolution to detect archived changes when the active lookup
+  misses. Return a concrete precondition error with terminal status and archived `change.yaml` path,
+  and document `validate --change` as an active-change selector.
+- **Guardrail execution: (A)** Wave 1 owns RED contract tests only. Production code tasks depend on
+  the relevant RED tasks and must cite separate RED evidence before implementation.
+
+Honors documented constraints: deterministic sorted output; fail-closed domain_review + rollback_required;
+all work inside the governed worktree; green build/test.
+
+## Interfaces and Data Flow
+- `internal/engine/artifact/codebase_map.go`:
+  - `inspectCodebaseMapFacts(root)` -> language-agnostic `codebaseMapFacts` (languages,
+    build/test cmds, deps, top dirs, entry points, test layout). New table-driven ecosystem
+    detection + bounded extension scan.
+  - New baseline builder computes facts once and renders only detected values into the fixed doc set.
+  - New legacy generated-doc predicate recognizes the old deterministic Go/Slipway baseline shape.
+    `EnsureCodebaseMapDocs` refreshes files that are blank scaffold or recognized old generated
+    baseline docs; it does not overwrite authored content.
+  - `AssessCodebaseMapDocs(root)`: regenerate baselines once; per doc -> missing | scaffold_only |
+    baseline | populated. Aggregate status becomes `baseline` when generated baseline docs are present
+    and no authored populated docs are required to consider the map complete.
+  - New exported `CodebaseMapStatusBaseline`; assessment gains `BaselineDocs []string`.
+- `cmd/codebase_map.go`: `codebaseMapView` gains `BaselineDocs []string`
+  (`baseline_docs,omitempty`); text writer prints a Baseline section.
+- `internal/state/store.go`: `FindActiveChangeForWorktree` returns a new typed
+  `*ChangeBoundElsewhereError` (carrying []{slug, worktreePath}) instead of `ErrNoActiveChange`
+  when active changes exist but are all bound to non-matching worktrees. `FindActiveChange`
+  semantics unchanged.
+- `cmd/common.go`: `wrapResolutionError` maps `*ChangeBoundElsewhereError` ->
+  `newPreconditionError` (`change_bound_to_other_worktree`, details: bound_changes[]).
+- `internal/state/store.go` / `internal/state/health.go`: empty orphan bundle directories are recognized
+  by checking that the directory tree contains no files; discovery and health ignore those safe residues.
+- `cmd/repair.go`: calls the state cleanup helper before orphan reporting, exposes
+  `removed_empty_orphan_bundles`, and includes an `empty_orphan_bundle` applied repair entry.
+- `internal/state/lifecycle.go`: exposes the archived `change.yaml` read path selected for an exact
+  archived slug so command errors can name the actual terminal authority.
+- `cmd/common.go` / `cmd/validate.go`: explicit slug resolution returns
+  `archived_change_not_validatable` for archived changes; validate help says the flag selects an
+  explicit active change.
+- Data flow unchanged: `change.yaml` remains current-state authority; worktree paths read from
+  `change.WorktreePath`; discovery via `git worktree list`.
+
+## Rollout and Rollback
+- Rollout: single PR on `feat/fix-codebase-map-fabricating-go-slipway-repository-context-f`;
+  reviewable in six waves:
+  1. RED contract tests for codebase-map, active-change, and archived validate behavior.
+  2. RED contract tests for stale empty bundle residue plus core production fixes for fact
+     detection/legacy refresh and bound-elsewhere diagnostics.
+  3. Baseline status/view plumbing, `--change` routing hardening, and empty orphan bundle handling.
+  4. Codebase-map / active-change regression tests, archived validate diagnostic, and documentation.
+  5. Stale empty bundle regression tests.
+  6. Full verification + guardrail review evidence.
+- Verification command: `go build ./... && go test ./...`.
+- Rollback: pure code change, no data migration. Revert the commit/PR. Generated
+  `artifacts/codebase/*` docs are advisory and regenerated on demand.
+
+## Risk
+- [medium] Existing polluted codebase-map docs need targeted migration. Mitigation: restrict
+  auto-refresh to the known old deterministic generated Go/Slipway baseline shape and test authored
+  content preservation.
+- [medium] Contract behavior changes: freshly mapped repos move from `populated` to `baseline`.
+  Mitigation: explicit command tests and docs explaining the new trust level.
+- [low] Multi-language detection false positives/negatives. Mitigation: deterministic manifest+
+  extension detection with clean "not detected" -> blank scaffold fallback; per-ecosystem tests.
+- [low] `stats` freshness stays modtime/coarse (cannot import `artifact`; import cycle). `baseline`
+  is scoped to the codebase-map/next planning surface. Documented boundary.
+- Guardrail (external_api_contracts): RED-test-first with separate pre-implementation RED evidence.
+  domain_review + rollback_required run at S3/S4 review.

--- a/artifacts/changes/archived/fix-codebase-map-fabricating-go-slipway-repository-context-f/intent.md
+++ b/artifacts/changes/archived/fix-codebase-map-fabricating-go-slipway-repository-context-f/intent.md
@@ -1,0 +1,192 @@
+# Intent
+
+## Project Context
+<!-- Auto-filled by InferProjectContext(); .slipway.yaml overrides -->
+- Tech Stack: Go
+- Languages: Go
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Conventions: Cobra CLI; cmd/ owns surfaces, internal/state owns durable state, internal/engine owns workflow logic; JSON surfaces are consumed contracts.
+
+## Summary
+Resolve GitHub issue #17 (Lattice feedback). Five execution-relevant problems
+are in scope:
+(1) CONFIRMED DEFECT - `slipway codebase-map` fabricates Go/Slipway repository
+context (`Languages: Go`, `go build ./...`, `cmd/`, `internal/state`) for any
+repo regardless of the detected stack, and marks the generated docs as
+`populated`, misleading AI hosts that consume them as authored brownfield
+context.
+(2) CONFIRMED RERUN GAP - repositories already polluted by the old Go/Slipway
+generated docs are not repaired by rerunning `slipway codebase-map`, because
+existing non-scaffold docs are preserved and assessed as `populated`.
+(3) CONCERN - `slipway next`/`run` return a misleading `no_active_change` when
+invoked from the repo root while the active change is bound to a worktree,
+whereas `slipway status` discovers it. The diagnostic is not self-explanatory.
+(4) CONFIRMED CLOSEOUT DEFECT - after `slipway done`, an empty stale root
+active-bundle directory can make status fail and repair report non-repairable
+state even though the worktree archive is intact.
+(5) CONCERN - `slipway validate --change <archived-slug>` returns the same
+empty no-active diagnostic after archive, even though the remediation suggests
+using an explicit slug.
+
+## Complexity Assessment
+complex
+<!-- Rationale: multi-file change across cmd/, internal/engine/artifact, and
+internal/state; changes externally-consumed JSON/text surfaces (`baseline` status
++ field; active-change resolution diagnostic; validate explicit selector error);
+requires multi-language fixtures, legacy-generated-doc fixtures, closeout
+residue fixtures, and guardrail-domain RED evidence before production changes. -->
+
+## Guardrail Domains
+external_api_contracts
+<!-- The codebase-map `--json` view and next/run/validate resolution errors are
+contracts consumed by AI host callers. domain_review + rollback_required apply. -->
+
+## In Scope
+Obs-1 - codebase-map content generation (`internal/engine/artifact/codebase_map.go`, `cmd/codebase_map.go`):
+- Replace the Go-only `inspectCodebaseMapFacts` with language-agnostic detection:
+  manifest-driven ecosystem detection (`go.mod`, `Cargo.toml`, `package.json`/`tsconfig.json`,
+  `pyproject.toml`/`setup.py`/`requirements.txt`, `pom.xml`, `build.gradle[.kts]`, `Gemfile`,
+  `composer.json`, `*.csproj`/`*.sln`, ...) -> detected languages, build/test commands, key
+  dependencies; plus language-agnostic directory layout, entry points, and test layout.
+- Rewrite `codebaseMapBaselineDoc` so STACK/STRUCTURE/TESTING contain only detected facts
+  (undetected fields stay as blank scaffold lines; with zero detections the doc equals the
+  blank template) and INTEGRATIONS/ARCHITECTURE/CONVENTIONS/CONCERNS are emitted as blank
+  scaffold (no hardcoded Slipway/Go prose).
+- Add targeted recognition of old deterministic Go/Slipway generated map content and refresh it
+  to the current baseline/scaffold on rerun, without overwriting hand-authored substantive maps.
+- Add `CodebaseMapStatusBaseline`; `AssessCodebaseMapDocs` classifies CLI-generated baseline
+  docs (non-blank content equal to the regenerated baseline) as `baseline` (not `populated`),
+  with a `baseline` aggregate status. Add `baseline_docs` to the `--json` view + text writer.
+
+Obs-2 - active-change discovery from the root checkout (`cmd/common.go`, `internal/state/store.go`):
+- Resolve a change's worktree from its recorded `change.yaml` `WorktreePath` (written at creation
+  and already discoverable from the repo root via `ListChanges`), cross-checked against git's own
+  worktree registry (`git worktree list`). No new hand-maintained registry and no new config field
+  - git + `change.yaml` are the source of truth.
+- `next`/`run` (and peers) with `--change <slug>` resolve and operate against that change's bound
+  worktree from any directory, including the repo root.
+- Self-explanatory diagnostic: when invoked from a directory that matches no bound worktree and
+  >=1 active change is bound elsewhere, return an error naming the slug(s) + bound worktree path
+  + remediation (`--change <slug>` or cd into the worktree) instead of `no_active_change`.
+
+Obs-3 - post-archive empty bundle residue (`internal/state/store.go`, `internal/state/health.go`, `cmd/repair.go`):
+- Active-change discovery and status ignore active bundle directories that lack `change.yaml` only
+  when the directory tree contains no files.
+- `repair --json` removes those empty orphan active-bundle directories and reports an applied
+  `empty_orphan_bundle` repair. Non-empty orphan bundles remain integrity findings.
+
+Obs-4 - archived explicit validate selector (`cmd/common.go`, `cmd/validate.go`, `internal/state/lifecycle.go`):
+- `validate --change <archived-slug>` fails explicitly with `archived_change_not_validatable`,
+  terminal status, and archived authority path, instead of returning an empty-slug no-active
+  diagnostic. Full archived-bundle validation is out of scope for this change.
+
+TDD + tests + docs:
+- Author separate RED contract tests before production changes:
+  codebase-map behavior tests first, active-change behavior tests first, archived validate behavior
+  tests first, and empty-bundle residue behavior tests first.
+- Multi-language codebase-map regression tests (Rust/Cargo, Node, Python, no-manifest, Slipway/Go)
+  plus legacy generated Go/Slipway map refresh and authored-content preservation.
+- Tests for the obs-2 diagnostic + slug-derived worktree resolution from git + `change.yaml`.
+- Tests for the obs-3 empty residue behavior and obs-4 archived explicit validate diagnostic.
+- Update `CLAUDE.md`, docs, context-assembly guidance, and `slipway-codebase-mapping` guidance for
+  the new `baseline` status and its trust level; update command docs for active-only validate
+  selector behavior.
+
+## Out of Scope
+- Deep semantic auto-authoring of ARCHITECTURE/CONVENTIONS/CONCERNS/INTEGRATIONS - those remain
+  AI/human-authored scaffolds; the CLI only bootstraps deterministically detectable facts.
+- Changing the default cwd-based worktree scoping of `next`/`run`.
+- A separate stateful registry file, a `worktree_root` config field, or slug-derived path guessing.
+- Exhaustive coverage of every programming language/build tool; cover the common ecosystems with
+  a clean "not detected" fallback.
+- Generic overwrite of user-authored codebase-map analysis when repository facts later change.
+- Full validation of archived terminal bundles through `validate --change`; the command now fails
+  explicitly for archived slugs and names the archived authority path.
+
+## Constraints
+- Deterministic, sorted output for testability.
+- Guardrail domain `external_api_contracts`: RED-test-first, domain_review, and rollback_required
+  are enforced.
+- Work stays within the governed worktree; `go build ./...` and `go test ./...` must pass.
+
+## Acceptance Signals
+- `slipway codebase-map --json` in a Rust/Cargo-only repo: STACK lists `Rust` + cargo build/test
+  commands (not Go / `go build ./...`); ARCHITECTURE/STRUCTURE contain no Slipway `cmd/`/
+  `internal/` prose; aggregate status is `baseline` (not `populated`).
+- `slipway codebase-map --json` in a Rust/Cargo repo already containing old Go/Slipway generated
+  codebase-map docs removes or replaces the old generated phrases and does not report the old
+  generated content as authored `populated` analysis.
+- `slipway codebase-map --json` in a repo with no recognizable manifest: no fabricated `Go`;
+  docs are blank scaffold; status `scaffold_only`.
+- `slipway codebase-map --json` in the Slipway repo itself: detects Go + go commands as baseline
+  facts and reports them as `baseline`.
+- From the repo root with a change bound to a worktree: bare `slipway next`/`run` return a
+  self-explanatory error naming the bound worktree + slug; `slipway next --change <slug>` from
+  the root resolves and operates against that worktree.
+- After a worktree-bound `done`, empty stale root active-bundle residue does not break status and
+  `repair --json` removes it; non-empty orphan bundle dirs remain protected.
+- `slipway validate --json --change <archived-slug>` returns
+  `archived_change_not_validatable` with terminal status and archived `change.yaml` path, not an
+  empty-slug no-active diagnostic.
+- Separate RED evidence exists before production changes for the codebase-map and active-change
+  contract changes.
+- `go build ./...` and `go test ./...` pass.
+
+## Open Questions
+<!-- Unresolved questions -> consumed by S1_PLAN/research; all resolved during S0/S1 research -->
+- [x] Does `next --change <slug>` resolve context to the bound worktree from root? Resolved: yes - ResolveChangePaths uses change.WorktreePath (research.md).
+- [x] Is `change.yaml` WorktreePath readable from the repo root after binding/relocation? Resolved: yes - discovery walks git worktrees (research.md).
+- [x] Which ecosystems to detect deterministically without overreach? Resolved: manifest+extension set, deps for go/cargo/npm/pip (research.md).
+- [x] Should old buggy Go/Slipway generated codebase-map content be refreshed automatically? Resolved: yes - targeted refresh is in scope; manual deletion is not an adequate issue #17 fix.
+- [x] How should post-archive empty active-bundle residue be handled? Resolved: ignore/remove only fileless orphan dirs; preserve non-empty orphan bundles.
+- [x] How should `validate --change <archived-slug>` behave? Resolved: fail explicitly with `archived_change_not_validatable`; full archived validation is deferred.
+- [x] How is RED-first enforced? Resolved: separate wave-1 RED contract test tasks must precede production code tasks.
+
+## Deferred Ideas
+- A first-class `slipway worktree` discovery/listing surface.
+- Auto-suggesting `--change <slug>` in shell completion.
+
+## Approved Summary
+<!-- User-confirmed final summary + confirmation timestamp -->
+Confirmed by user: 2026-05-30T10:26:41Z
+Artifact review corrections accepted: 2026-05-30T11:47:40Z
+
+Resolve GitHub issue #17 with the following fixes:
+
+1. **codebase-map generation.** Replace the hardcoded Go/Slipway baseline
+   generator with language-agnostic, manifest-driven fact detection (Go, Rust,
+   Node/TS, Python, Java/Kotlin, Ruby, PHP, .NET, ...). STACK/STRUCTURE/TESTING
+   are populated only with detected facts. ARCHITECTURE/CONVENTIONS/CONCERNS/
+   INTEGRATIONS are emitted as blank scaffold; the CLI never fabricates semantic
+   prose.
+
+2. **legacy polluted map refresh.** Detect the old deterministic Go/Slipway
+   generated docs that prior Slipway versions wrote into non-Go repos and refresh
+   those generated docs on rerun. Preserve hand-authored substantive maps.
+
+3. **baseline status.** Add a `baseline` doc/aggregate status (+ `baseline_docs`
+   field) so AI hosts treat CLI-detected facts as awaiting authored verification,
+   not as completed brownfield analysis.
+
+4. **next/run active-change discovery.** Keep default cwd-based worktree scoping.
+   Locate a change's worktree from git's worktree registry plus `change.yaml`
+   `WorktreePath`. `next/run --change <slug>` resolves against the bound
+   worktree from any directory; a bare root invocation returns a
+   self-explanatory `change_bound_to_other_worktree` diagnostic.
+
+5. **TDD execution shape.** Separate RED contract test tasks run before any
+   production code changes. Implementation tasks depend on those RED tasks.
+
+6. **post-archive empty residue.** Empty root active-bundle residue left after a
+   worktree-bound `done` no longer breaks status; repair removes it and keeps
+   non-empty orphans protected.
+
+7. **archived validate selector.** `validate --change <archived-slug>` now fails
+   with a concrete archived-change diagnostic instead of an empty no-active view.
+
+**Out of scope:** semantic auto-authoring of architecture/conventions docs;
+changing default cwd scoping; a `worktree_root` config field or separate
+registry file; exhaustive language coverage; generic overwrite of authored
+codebase maps after repository facts change; full archived-bundle validation
+through `validate --change`.

--- a/artifacts/changes/archived/fix-codebase-map-fabricating-go-slipway-repository-context-f/requirements.md
+++ b/artifacts/changes/archived/fix-codebase-map-fabricating-go-slipway-repository-context-f/requirements.md
@@ -1,0 +1,208 @@
+# Requirements
+## Project Context
+- Tech Stack: Go
+- Conventions: Cobra CLI; cmd/ surfaces, internal/state durable state, internal/engine workflow logic; --json surfaces are consumed contracts
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Requirements
+
+### Requirement: Language-agnostic codebase-map fact detection
+REQ-001: `slipway codebase-map` MUST detect repository facts (languages, build/test
+commands, key dependencies) from the actual repository via manifest files
+(`go.mod`, `Cargo.toml`, `package.json`/`tsconfig.json`,
+`pyproject.toml`/`setup.py`/`requirements.txt`, `pom.xml`, `build.gradle[.kts]`,
+`Gemfile`, `composer.json`, `*.csproj`/`*.sln`) and a bounded source-file
+extension scan, and MUST NOT assume Go or any single stack.
+
+#### Scenario: Rust/Cargo repository
+GIVEN a repository whose only manifest is a `Cargo.toml`
+WHEN `slipway codebase-map --json` runs
+THEN STACK lists `Rust` and cargo build/test commands
+AND it never reports `Languages: Go` or `go build ./...`.
+
+#### Scenario: No recognizable manifest
+GIVEN a repository with no recognizable language manifest or source files
+WHEN `slipway codebase-map --json` runs
+THEN no language is fabricated (no `Languages: Go`)
+AND the docs equal the blank scaffold templates.
+
+### Requirement: No fabricated semantic prose in baseline docs
+REQ-002: Baseline generation MUST populate STACK/STRUCTURE/TESTING only with
+detected facts (undetected fields remain blank scaffold lines; zero detections
+yield the blank template), and MUST emit INTEGRATIONS/ARCHITECTURE/CONVENTIONS/
+CONCERNS as blank scaffold. The CLI MUST NOT emit hardcoded Slipway/Go prose
+(for example `cmd/ owns CLI surfaces`, `internal/state`) for arbitrary
+repositories.
+
+#### Scenario: Non-Slipway repository
+GIVEN any repository that is not Slipway
+WHEN `slipway codebase-map` generates ARCHITECTURE.md / STRUCTURE.md
+THEN they contain no Slipway-specific `cmd/`/`internal/` prose.
+
+### Requirement: Refresh legacy buggy generated codebase maps
+REQ-003: `slipway codebase-map` MUST recognize and refresh the old deterministic
+Go/Slipway baseline documents that prior Slipway versions generated for
+non-Go/non-Slipway repositories. This is a targeted migration of Slipway-authored
+buggy baseline content only; hand-authored substantive analysis MUST NOT be
+overwritten merely because repository facts later changed.
+
+#### Scenario: Rust repository already polluted by old Go/Slipway docs
+GIVEN a Rust/Cargo repository whose `artifacts/codebase` files already contain
+old Slipway-generated phrases such as `Languages: Go`, `go build ./...`, and
+`cmd/ owns CLI surfaces`
+WHEN `slipway codebase-map --json` runs again
+THEN those old generated phrases are removed or replaced by the current
+Rust/scaffold baseline
+AND the command does not report the old generated content as authored
+`populated` analysis.
+
+#### Scenario: User-authored map is preserved
+GIVEN a repository whose codebase-map docs contain project-specific authored
+analysis that does not match the old deterministic Go/Slipway baseline shape
+WHEN `slipway codebase-map --json` runs
+THEN that authored content is preserved.
+
+### Requirement: Distinguish CLI baseline from authored content
+REQ-004: The `codebase-map` assessment MUST classify a doc whose content equals
+the freshly regenerated CLI baseline (and is non-blank) as a new `baseline`
+status rather than `populated`, expose an aggregate `baseline` status and a
+`baseline_docs` list on the `--json` and text surfaces.
+
+#### Scenario: Freshly mapped repository
+GIVEN a repository freshly processed by `slipway codebase-map`
+WHEN `slipway codebase-map --json` reports status
+THEN the aggregate status is `baseline` (not `populated`)
+AND CLI-detected docs appear under `baseline_docs`.
+
+### Requirement: Self-explanatory from-root active-change diagnostic
+REQ-005: When `slipway next`/`run` are invoked from a directory matching no bound
+worktree while >=1 active change is bound to another worktree, the CLI MUST
+return a self-explanatory error that names the change slug(s) and bound worktree
+path(s) with remediation (use `--change <slug>` or cd into the worktree),
+instead of the misleading `no_active_change`.
+
+#### Scenario: Bare invocation from the repo root
+GIVEN an active change bound to `.worktrees/<slug>`
+WHEN `slipway next --json` runs from the repo root
+THEN the error code is `change_bound_to_other_worktree`
+AND it names the slug and the bound worktree path with remediation.
+
+### Requirement: --change resolves the bound worktree from any directory
+REQ-006: `slipway next`/`run --change <slug>` MUST resolve and operate against the
+change's bound worktree (located via git's worktree registry + `change.yaml`
+`WorktreePath`) from any directory, including the repo root. No new config field
+or hand-maintained registry is introduced.
+
+#### Scenario: --change from the repo root
+GIVEN an active change bound to `.worktrees/<slug>`
+WHEN `slipway next --json --change <slug>` runs from the repo root
+THEN it succeeds and the `input_context.workspace_root` points to the worktree.
+
+### Requirement: RED tests precede guarded production changes
+REQ-007: Because this change is in the `external_api_contracts` guardrail domain,
+contract tests for changed behavior MUST be authored and captured as RED evidence
+before production code changes. Same-commit test+implementation evidence is not
+sufficient.
+
+#### Scenario: codebase-map implementation starts
+GIVEN codebase-map production files are about to be changed
+WHEN wave execution begins
+THEN failing tests for Rust baseline generation, legacy Go/Slipway map refresh,
+no-manifest scaffold behavior, and `baseline` status already exist and fail
+against the old implementation.
+
+#### Scenario: active-change diagnostic implementation starts
+GIVEN active-change resolution production files are about to be changed
+WHEN wave execution begins
+THEN failing tests for `change_bound_to_other_worktree` and root `--change`
+resolution already exist and fail against the old implementation.
+
+#### Scenario: archived explicit validate diagnostic implementation starts
+GIVEN explicit change selector diagnostics are about to be changed
+WHEN implementation begins
+THEN a failing test already proves `validate --change <archived-slug>` returns
+a concrete archived-change diagnostic instead of an empty-slug no-active view.
+
+### Requirement: Automated coverage and green build
+REQ-008: Automated tests MUST cover multi-language detection (Rust/Node/Python/
+no-manifest), legacy generated Go/Slipway map refresh, the `baseline` status, the
+from-root diagnostic, `--change` resolution from root, and stale empty active
+bundle handling after archive, and explicit archived-slug validation diagnostics;
+existing codebase-map command tests MUST be updated to the new contract; `go build ./...` and
+`go test ./...` pass.
+
+#### Scenario: Verification suite
+GIVEN the implementation is complete
+WHEN `go build ./...` and `go test ./...` run
+THEN both succeed and the new/updated tests pass.
+
+### Requirement: Documentation updated for the baseline contract
+REQ-009: Project documentation and agent-facing skill guidance MUST describe the
+new `baseline` status so AI host callers interpret CLI-detected facts as a
+starting point awaiting authored verification, not as completed brownfield
+analysis.
+
+#### Scenario: Agent guidance describes baseline
+GIVEN the new `baseline` status exists
+WHEN a reader consults CLAUDE.md, command docs, codebase-map reference guidance,
+or the codebase-mapping skill template
+THEN `baseline` and its intended trust level are documented.
+
+### Requirement: external_api_contracts guardrail compliance
+REQ-010: The change MUST preserve the governed external-contract discipline:
+explicit contract tests, TDD evidence for guarded production changes, domain
+review after implementation, independent review before closeout, and rollback by
+reverting the code change.
+
+#### Scenario: Guardrail closeout
+GIVEN implementation and tests are complete
+WHEN review/verification runs
+THEN TDD evidence, domain review evidence, independent review evidence, and full
+verification evidence are present before closeout.
+
+### Requirement: Ignore safe stale empty active bundles after archive
+REQ-011: After a successful `slipway done` archives a worktree-bound change, any
+stale root-checkout active bundle directory that lacks `change.yaml` and contains
+only empty subdirectories MUST NOT make `slipway status`, `next`, or active-change
+discovery fail with `change bundle missing authority file`.
+
+#### Scenario: Empty root residue after worktree archive
+GIVEN a worktree-bound change has been archived
+AND the root checkout still has `artifacts/changes/<slug>/verification/` with no files
+WHEN active-change discovery or status runs
+THEN the empty stale directory is ignored rather than reported as authoritative
+state corruption.
+
+### Requirement: Repair safely removes empty orphan bundle directories
+REQ-012: `slipway repair` MUST safely remove orphan active bundle directories
+that contain no files, while preserving and reporting non-empty orphan bundle
+directories as operator-reviewed integrity findings.
+
+#### Scenario: Repair removes empty stale root bundle
+GIVEN `artifacts/changes/<slug>/verification/` exists without files or `change.yaml`
+WHEN `slipway repair --json` runs
+THEN the empty stale bundle directory is removed and reported as an applied repair.
+
+#### Scenario: Repair preserves non-empty orphan bundle
+GIVEN an orphan active bundle directory contains any file
+WHEN `slipway repair --json` runs
+THEN the directory is preserved and reported as requiring operator intervention.
+
+### Requirement: Archived explicit validate selector is self-explanatory
+REQ-013: `slipway validate --change <slug>` MUST NOT return the generic empty
+no-active diagnostic when `<slug>` names an archived/done change. It MUST either
+validate the archived change or fail with a concrete diagnostic that names the
+slug, terminal status, archived authority path, and supported next action. This
+change selects the fail-explicitly behavior because validate currently operates
+on active governance state.
+
+#### Scenario: Explicit archived slug
+GIVEN an archived change exists at `artifacts/changes/archived/<slug>/change.yaml`
+WHEN `slipway validate --json --change <slug>` runs
+THEN the error code is `archived_change_not_validatable`
+AND the error details include `slug`, `status`, `archived: true`, and
+`archive_path`
+AND the command does not emit the empty-slug `no active change or ambiguous`
+diagnostic.

--- a/artifacts/changes/archived/fix-codebase-map-fabricating-go-slipway-repository-context-f/research.md
+++ b/artifacts/changes/archived/fix-codebase-map-fabricating-go-slipway-repository-context-f/research.md
@@ -1,0 +1,202 @@
+# Research
+
+## Research Findings
+
+### Architecture
+- Affected modules:
+  - `internal/engine/artifact/codebase_map.go` - `inspectCodebaseMapFacts` (Go-only),
+    `codebaseMapBaselineDoc` (hardcoded Go/Slipway prose), `EnsureCodebaseMapDocs`
+    (only refreshes scaffold-only files), `AssessCodebaseMapDocs` (classifies any
+    non-scaffold content as `populated`), `CodebaseMapDocIsScaffoldOnly`.
+  - `cmd/codebase_map.go` - `codebaseMapView` JSON contract (`status`, `doc_states`,
+    `populated_docs`, `scaffold_only_docs`) + text writer.
+  - `cmd/common.go` - `resolveActiveChangeRef`, `wrapResolutionError`, `currentWorktreeRoot`.
+  - `internal/state/store.go` - `FindActiveChangeForWorktree`, `FindActiveChange`,
+    `ListChanges`, `discoverActiveChangeSlugsAcrossRoots` (walks git worktrees).
+  - `internal/engine/progression/skill_resolution.go` - `HasEmptyCodebaseMap` consumes
+    `CodebaseMapDocIsScaffoldOnly`; drives the "run codebase-map" technique hint in
+    `cmd/next_skill_view.go`.
+  - `internal/state/stats.go` - separate coarse freshness surface; cannot import `artifact`
+    due to import cycle.
+- Key root causes:
+  - New repo generation root cause: `codebaseMapBaselineDoc` emits Go/Slipway-specific content
+    regardless of detected repo facts.
+  - Rerun/rooted-pollution root cause: `EnsureCodebaseMapDocs` preserves any non-scaffold existing
+    doc, so old buggy generated Go/Slipway docs are not refreshed; `AssessCodebaseMapDocs` then marks
+    them as `populated`.
+  - Root active-change concern: `FindActiveChangeForWorktree` collapses "no active change" and
+    "active change exists but is bound elsewhere" into the same no-active diagnostic.
+  - Closeout residue root cause: active-bundle discovery treats any directory under
+    `artifacts/changes/<slug>` without `change.yaml` as missing authority, even when the directory
+    contains only empty stale subdirectories outside the worktree-bound archive authority. `repair`
+    reports the same empty residue as non-repairable because orphan detection has no safe-empty
+    cleanup path.
+  - Archived validate root cause: `validate --change` uses active-only explicit slug resolution.
+    When the active lookup misses an archived slug, the command falls back to a generic empty
+    no-active diagnostic instead of checking the archived terminal authority.
+- Dependency chains:
+  - `cmd/codebase_map.go` -> `artifact.EnsureCodebaseMapDocs` / `artifact.AssessCodebaseMapDocs`.
+  - `cmd/next*.go` -> `state.ResolveChangePaths(root, change)` -> workspace_root from
+    `change.WorktreePath` -> `artifact.CodebaseMapDisplayDocs`; and `progression.HasEmptyCodebaseMap`.
+  - `artifact` imports `internal/state`; therefore `state` (stats) cannot import `artifact`.
+- Blast radius: HIGH. This changes AI-host-facing CLI surfaces (`codebase-map`, next/run errors,
+  validate explicit selector errors), generated advisory context, and guardrail-domain test/evidence
+  requirements.
+- Invariants to preserve:
+  - `change.yaml` remains single current-state authority; bundles relocate into the worktree.
+  - Deterministic, sorted output for docs/status/test assertions.
+  - User-authored codebase-map analysis is not overwritten by generic fact drift.
+
+### Patterns
+- Existing conventions:
+  - Codebase-map docs are an ordered fixed set (`codebaseMapDocNames`); doc->key map
+    (`codebaseMapDocKeys`); blank templates (`codebaseMapDocTemplates`).
+  - Facts are inspected from the filesystem then rendered into doc strings; status is derived by
+    comparing rendered content against templates / substantive-content heuristics.
+  - Worktree path is stored on the change and git maintains worktree roots; `.worktrees` is
+    hardcoded in `DefaultWorktreePath`.
+  - From-root discovery already walks all git worktrees:
+    `discoverActiveChangeSlugsAcrossRoots` + `allWorkspaceRoots`/`candidateWorkspaceRoots`.
+- Reusable abstractions to leverage:
+  - `state.ResolveChangePaths(root, change)` already resolves workspace_root from `change.WorktreePath`;
+    `next/run --change <slug>` should remain locked by tests.
+  - `state.NormalizePath` for path comparison; typed CLI errors via `newPreconditionError`.
+  - For status comparison: regenerate the current baseline once per assessment and compare normalized
+    doc content.
+- New local patterns required:
+  - Add a targeted predicate for the old deterministic Go/Slipway generated baseline shape. It should
+    match combinations of known generated phrases/full normalized old output, not arbitrary "looks Go"
+    prose, so authored docs are preserved.
+  - Add `baseline` as a distinct assessment state for current generated facts.
+  - Put RED contract test tasks before production code tasks in the wave plan.
+  - Treat empty orphan bundle directories as safe residue only when a tree walk finds no files; keep
+    non-empty orphan bundle directories as integrity findings.
+
+### Risks
+- Technical risks:
+  - [medium] Legacy generated-doc detection could be too broad and overwrite authored content.
+    Mitigation: match only the old deterministic generated output shape/phrase combinations and test
+    authored-content preservation.
+  - [medium] Existing command behavior changes from reporting fresh generated docs as `populated` to
+    `baseline`. Mitigation: explicit contract tests and agent-facing docs about trust level.
+  - [low] Multi-language detection false negatives/positives. Mitigation: deterministic manifest+
+    extension detection with clean "not detected" -> blank scaffold fallback; unit tests per ecosystem.
+  - [low] `stats` freshness stays modtime/coarse and may count baseline docs as present. Out of scope
+    because it is not the planning-authority surface and avoiding it prevents an import-cycle refactor.
+- Guardrail domains: `external_api_contracts`. TDD evidence, domain_review, independent_review, and
+  rollback-required handling are required before closeout.
+- Reversibility: HIGH. Pure code change; no data migration. Rollback = revert the commit. Generated
+  `artifacts/codebase/*` docs are advisory and regenerated on demand.
+
+### Test Strategy
+- Existing coverage:
+  - `cmd/codebase_map_command_test.go` (`TestCodebaseMapCommandCreatesDurableDocSet`,
+    `TestCodebaseMapCommandWritesToInvocationWorktree`).
+  - `cmd/codebase_map_context_test.go` (next includes durable map paths).
+  - `internal/engine/progression/skill_resolution_test.go` (HasEmptyCodebaseMap).
+  - `internal/state/stats_test.go` (codebase-map stats; unchanged boundary).
+  - Worktree/active-change resolution tests in `cmd/*_test.go`.
+- Required RED tests before production code:
+  - Codebase-map RED tests: Rust/Cargo repo does not emit Go facts; no-manifest repo yields blank
+    scaffold; legacy Go/Slipway generated docs in a Rust repo are refreshed on rerun; generated
+    baseline status is `baseline`, not `populated`.
+  - Active-change RED tests: bare root invocation returns `change_bound_to_other_worktree` with
+    slug/path/remediation; `next --change <slug>` from root resolves to the bound worktree.
+  - Closeout/repair RED tests: empty root active-bundle residue does not break active-change discovery;
+    repair removes it and reports an applied repair; non-empty orphan bundles remain protected.
+  - Archived validate RED tests: `validate --change <archived-slug>` returns
+    `archived_change_not_validatable` with slug/status/archive path and does not emit the empty
+    no-active diagnostic.
+- Regression tests after implementation:
+  - Node/TS, Python, Slipway/Go, and no-manifest cases.
+  - authored-content preservation for codebase-map docs.
+  - JSON/text view lists `baseline_docs`.
+  - multiple active bound changes, zero active changes, and JSON error detail shape.
+  - empty nested orphan bundle residue and non-empty orphan bundle preservation.
+  - exact archived slug behavior for the shared explicit change resolver and validate command.
+- Verification approach:
+  - AC1 Rust repo -> Rust/cargo + baseline, no Go/Slipway prose.
+  - AC2 legacy polluted Rust repo -> old generated phrases removed/refreshed, not `populated`.
+  - AC3 no manifest -> blank scaffold and `scaffold_only`.
+  - AC4 Slipway repo -> Go facts detected as baseline.
+  - AC5 from-root diagnostic + `--change <slug>` works.
+  - AC6 archived validate selector returns concrete archived-change diagnostic.
+  - `go build ./...` && `go test ./...`.
+
+## Alternatives Considered
+- codebase-map content generation:
+  - **(A) Language-agnostic fact detection + blank scaffold for semantic docs + new `baseline`
+    status.** Tradeoff: more detection code, but bootstraps real facts for any stack and never
+    fabricates semantic prose.
+  - (B) Make codebase-map a pure scaffold generator. Tradeoff: simplest, but discards deterministic
+    facts that are useful as a starting point.
+  - (C) Keep generation but emit scaffold for "unknown" stacks only. Tradeoff: still Go-biased unless
+    fully generalized.
+  - **Selected: (A)**.
+- legacy polluted docs:
+  - **(A) Targeted refresh of old deterministic Go/Slipway generated docs.** Tradeoff: extra matching
+    logic, but directly fixes the issue #17 rerun scenario.
+  - (B) Require manual deletion before rerun. Tradeoff: leaves existing Lattice worktrees broken unless
+    the operator already knows the workaround.
+  - (C) Generic overwrite when repo facts differ. Tradeoff: can destroy authored map analysis.
+  - **Selected: (A)**.
+- obs-2 active-change discovery from root:
+  - **(A) Improve the diagnostic only.** `FindActiveChangeForWorktree` distinguishes "bound
+    elsewhere"; bare `next/run` from root returns `change_bound_to_other_worktree` naming slug +
+    worktree path + remediation. Rely on existing `--change <slug>` routing.
+  - (B) Auto-resolve a single bound change from root. Tradeoff: changes default scoping behavior.
+  - (C) New configurable `worktree_root` or a separate registry file. Tradeoff: new surfaces to maintain;
+    redundant with git's worktree registry + `change.yaml`.
+  - **Selected: (A)**.
+- obs-4 archived explicit validate selector:
+  - **(A) Fail explicitly for archived terminal changes.** Tradeoff: does not validate archived
+    bundles, but fixes the misleading remediation with a narrow active-command diagnostic.
+  - (B) Fully validate archived bundles. Tradeoff: broader path-authority work because archived
+    snapshots intentionally scrub worktree runtime fields.
+  - (C) Keep generic no-active. Tradeoff: leaves `--change <slug>` remediation misleading.
+  - **Selected: (A)**.
+- guardrail wave shape:
+  - **(A) Separate RED contract tests into wave 1 and make production tasks depend on them.**
+    Tradeoff: more tasks, but satisfies TDD governance.
+  - (B) Keep test tasks after implementation. Tradeoff: violates the guardrail-domain hard gate.
+  - (C) Same task/commit test+implementation evidence. Tradeoff: not auditable test-first proof.
+  - **Selected: (A)**.
+
+## Unknowns
+- Resolved: Does `next --change <slug>` resolve context to the bound worktree from root? ->
+  YES. `buildNextContextByMode` -> `state.ResolveChangePaths(root, change)` uses `change.WorktreePath`.
+- Resolved: Is `change.yaml` readable from root after binding? -> YES. Bundles relocate into the
+  worktree, but from-root discovery walks git worktrees.
+- Resolved: Is `.worktrees` configurable today? -> NO; hardcoded in `DefaultWorktreePath`. We keep it
+  hardcoded.
+- Resolved: Ecosystem detection set -> manifest-driven (go.mod, Cargo.toml, package.json+tsconfig,
+  pyproject/setup.py/requirements.txt, pom.xml, build.gradle[.kts], Gemfile, composer.json,
+  *.csproj/*.sln) + extension scan; deps parsed for go/cargo/npm/pip, language+commands for the rest.
+- Resolved: How to handle old generated Go/Slipway docs? -> targeted refresh of the old deterministic
+  generated baseline shape; preserve authored content.
+- Resolved: How to handle `validate --change <archived-slug>`? -> fail explicitly with
+  `archived_change_not_validatable`, status, and archived authority path. Full archived validation is
+  a separate path-authority change because validate remains active-readiness oriented.
+- Resolved: How to satisfy TDD governance? -> wave 1 contains RED-only contract tests; production tasks
+  depend on them and must cite separate RED evidence.
+- Remaining: None blocking.
+
+## Assumptions
+- The `codebase-map --json` `status` and the docs read during plan-audit/wave-orchestration are the
+  surfaces the issue targets - Evidence: issue #17 body/comments + command/skill references.
+- Old generated Go/Slipway docs can be detected narrowly enough to avoid overwriting authored maps -
+  Evidence: the old generator emitted deterministic phrases and fixed document shapes.
+- git is available at runtime (already assumed: `currentWorktreeRoot`, `listGitWorktrees` shell out).
+
+## Canonical References
+- `internal/engine/artifact/codebase_map.go` (facts + baseline + refresh + assessment)
+- `cmd/codebase_map.go` (JSON contract + text writer)
+- `cmd/common.go` `resolveActiveChangeRef`, `wrapResolutionError`, `currentWorktreeRoot`
+- `cmd/validate.go` `--change` active selector help and validate fallback behavior
+- `internal/state/store.go` `FindActiveChangeForWorktree`, `discoverActiveChangeSlugsAcrossRoots`
+- `internal/state/lifecycle.go` `LoadArchivedChange` / archived authority path lookup
+- `internal/state/paths.go` `ResolveChangePaths`, `changeWorkspaceRoot`
+- `internal/state/worktree.go` `DefaultWorktreePath`, `listGitWorktrees`
+- `cmd/next_context_build.go` workspace_root resolution
+- `internal/engine/progression/skill_resolution.go` `HasEmptyCodebaseMap`
+- `internal/state/stats.go` `collectCodebaseMapStats` (separate freshness surface)

--- a/artifacts/changes/archived/fix-codebase-map-fabricating-go-slipway-repository-context-f/tasks.md
+++ b/artifacts/changes/archived/fix-codebase-map-fabricating-go-slipway-repository-context-f/tasks.md
@@ -1,0 +1,182 @@
+# Tasks
+## Project Context
+- Tech Stack: Go
+- Conventions: Cobra CLI; cmd/ surfaces, internal/state durable state, internal/engine workflow logic
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Task List
+
+- [x] `t-00a` RED contract tests for codebase-map behavior
+  - wave: 1
+  - depends_on: []
+  - target_files: [internal/engine/artifact/codebase_map_test.go, cmd/codebase_map_command_test.go]
+  - task_kind: test
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004, REQ-007]
+  - evidence: verdict (tests fail against the current Go-only / populated implementation before production changes)
+  - acceptance: add failing behavioral tests for Rust/Cargo baseline facts, no-manifest blank scaffold,
+    legacy Go/Slipway generated map refresh, no fabricated semantic prose, and `baseline` /
+    `baseline_docs` status. Capture RED command output before any production file changes.
+
+- [x] `t-00b` RED contract tests for from-root active-change behavior
+  - wave: 1
+  - depends_on: []
+  - target_files: [internal/state/store_test.go, cmd/active_change_resolution_test.go]
+  - task_kind: test
+  - covers: [REQ-005, REQ-006, REQ-007]
+  - evidence: verdict (tests fail against the current `no_active_change` diagnostic / root routing contract)
+  - acceptance: add failing behavioral tests for bare root invocation returning
+    `change_bound_to_other_worktree` with slug/path/remediation and for
+    `next --change <slug>` from root targeting the bound worktree. Capture RED command output before
+    production file changes.
+
+- [x] `t-00d` RED contract tests for archived explicit validate behavior
+  - wave: 1
+  - depends_on: []
+  - target_files: [cmd/common_test.go]
+  - task_kind: test
+  - covers: [REQ-007, REQ-013]
+  - evidence: verdict (tests fail against the current empty no-active diagnostic for archived explicit validate)
+  - acceptance: add failing command/helper tests proving `validate --change <archived-slug>`
+    returns `archived_change_not_validatable` with slug/status/archive path and does not emit
+    the empty-slug `no active change or ambiguous` diagnostic.
+
+- [x] `t-00c` RED contract tests for stale empty bundle closeout behavior
+  - wave: 2
+  - depends_on: []
+  - target_files: [internal/state/store_test.go, cmd/repair_test.go]
+  - task_kind: test
+  - covers: [REQ-011, REQ-012]
+  - evidence: verdict (tests fail against the current missing-authority status / non-repairable repair behavior)
+  - acceptance: add failing behavioral tests proving empty root active-bundle residue is ignored by
+    active-change discovery and removed by repair, while non-empty orphan bundles remain protected.
+
+- [x] `t-01` Language-agnostic fact detection + legacy generated map refresh
+  - wave: 2
+  - depends_on: [t-00a]
+  - target_files: [internal/engine/artifact/codebase_map.go]
+  - task_kind: code
+  - covers: [REQ-001, REQ-002, REQ-003]
+  - evidence: artifact (regenerated STACK/STRUCTURE/TESTING reflect detected stack; legacy Go/Slipway baseline is replaced; semantic docs blank)
+  - acceptance: inspectCodebaseMapFacts detects languages/build-test/deps via manifests + bounded
+    extension scan; codebaseMapBaselineDoc fills only detected fields; zero detections == blank
+    template; hardcoded Slipway/Go prose is removed; known old deterministic Go/Slipway baseline docs
+    are recognized and refreshed without overwriting authored content.
+
+- [x] `t-02` Bound-elsewhere active-change diagnostic
+  - wave: 2
+  - depends_on: [t-00b]
+  - target_files: [internal/state/store.go, cmd/common.go]
+  - task_kind: code
+  - covers: [REQ-005]
+  - evidence: verdict (CLI returns change_bound_to_other_worktree from root)
+  - acceptance: FindActiveChangeForWorktree returns a typed ChangeBoundElsewhereError listing bound
+    {slug, worktreePath} when active changes exist but none match the current dir / are unbound;
+    wrapResolutionError maps it to a self-explanatory precondition error with remediation.
+
+- [x] `t-09` Safe empty orphan bundle handling
+  - wave: 3
+  - depends_on: [t-00c]
+  - target_files: [internal/state/store.go, internal/state/health.go, cmd/repair.go]
+  - task_kind: code
+  - covers: [REQ-011, REQ-012]
+  - evidence: verdict (status/active-change discovery ignore empty residue; repair removes it)
+  - acceptance: active bundle discovery skips directories without change.yaml only when they contain
+    no files; repair removes those empty orphan bundle directories and records an applied repair;
+    non-empty orphan bundle directories continue to be surfaced as non-repairable integrity findings.
+
+- [x] `t-03` Add `baseline` status + `baseline_docs` (assessment + cmd view + text)
+  - wave: 3
+  - depends_on: [t-01]
+  - target_files: [internal/engine/artifact/codebase_map.go, cmd/codebase_map.go]
+  - task_kind: code
+  - covers: [REQ-004]
+  - evidence: verdict (codebase-map --json reports status baseline + baseline_docs)
+  - acceptance: CodebaseMapStatusBaseline added; AssessCodebaseMapDocs classifies baseline vs populated
+    by comparing to regenerated baseline; aggregate baseline status; codebaseMapView.BaselineDocs +
+    text writer.
+
+- [x] `t-04` Lock `--change <slug>` worktree resolution from any directory
+  - wave: 3
+  - depends_on: [t-02]
+  - target_files: [cmd/common.go, cmd/next.go, cmd/run.go]
+  - task_kind: code
+  - covers: [REQ-006]
+  - evidence: verdict (next --change <slug> from root targets worktree)
+  - acceptance: confirm/harden resolveExplicitChange -> ResolveChangePaths path so --change resolves the
+    bound worktree from root; minimal code change only if a gap is found (behavior is expected to be
+    already correct, but must remain covered by the RED test from t-00b).
+
+- [x] `t-05` Complete codebase-map regression suite
+  - wave: 4
+  - depends_on: [t-01, t-03]
+  - target_files: [internal/engine/artifact/codebase_map_test.go, cmd/codebase_map_command_test.go, cmd/cli_e2e_test.go]
+  - task_kind: test
+  - covers: [REQ-008]
+  - evidence: checklist (Rust/Node/Python/no-manifest/Slipway cases; legacy generated map refresh; baseline status; updated TestCodebaseMapCommandCreatesDurableDocSet)
+  - acceptance: extend the initial RED tests into full regression coverage for Node, Python, Slipway/Go,
+    existing command tests, authored-content preservation, and aggregate/doc state classification.
+
+- [x] `t-06` Complete active-change resolution regression suite
+  - wave: 4
+  - depends_on: [t-02, t-04]
+  - target_files: [internal/state/store_test.go, cmd/active_change_resolution_test.go, cmd/common_test.go]
+  - task_kind: test
+  - covers: [REQ-008, REQ-013]
+  - evidence: checklist (bound-elsewhere error from root; --change <slug> from root succeeds and targets worktree; archived explicit validate diagnostic)
+  - acceptance: extend the initial RED tests with edge cases for zero active changes, multiple active
+    bound changes, unbound active changes if applicable, JSON error details, root/worktree path
+    display, and archived explicit validate behavior.
+
+- [x] `t-10` Complete stale empty bundle regression suite
+  - wave: 5
+  - depends_on: [t-09]
+  - target_files: [internal/state/store_test.go, cmd/repair_test.go, internal/state/health_test.go]
+  - task_kind: test
+  - covers: [REQ-008, REQ-011, REQ-012]
+  - evidence: checklist (empty residue ignored; repair removes empty residue; non-empty orphan preserved)
+  - acceptance: cover empty nested directory residue, non-empty orphan protection, and repair JSON
+    `applied_repairs` shape for removed empty orphan bundles.
+
+- [x] `t-07` Documentation for the `baseline` status
+  - wave: 4
+  - depends_on: [t-03]
+  - target_files: [CLAUDE.md, docs/commands.md, internal/tmpl/templates/skills/context-assembly/references/codebase-map.md, internal/tmpl/templates/skills/codebase-mapping/SKILL.md]
+  - task_kind: doc
+  - covers: [REQ-009, REQ-013]
+  - evidence: artifact (docs and agent-facing skill guidance describe the baseline status; command docs note active-only validate selector behavior)
+  - acceptance: describe `baseline` as CLI-detected facts awaiting authored verification/citations;
+    ensure codebase-mapping and context-assembly guidance do not treat baseline docs as completed
+    brownfield analysis; document that `validate --change` selects active changes and explicit
+    archived slugs fail with a concrete archived-change diagnostic.
+
+- [x] `t-11` Archived explicit selector diagnostic
+  - wave: 4
+  - depends_on: [t-00d]
+  - target_files: [cmd/common.go, cmd/validate.go, internal/state/lifecycle.go]
+  - task_kind: code
+  - covers: [REQ-013]
+  - evidence: verdict (`validate --change <archived-slug>` returns archived_change_not_validatable)
+  - acceptance: explicit slug resolution detects archived changes after active lookup misses,
+    returns a precondition error with terminal status and archived authority path, and the
+    validate flag help names an explicit active change slug.
+
+- [x] `t-08` Full verification + guardrail compliance
+  - wave: 6
+  - depends_on: [t-05, t-06, t-07, t-10, t-11]
+  - target_files: [internal/engine/artifact/codebase_map.go, cmd/codebase_map.go, internal/state/store.go, cmd/common.go, cmd/cli_e2e_test.go, artifacts/changes/fix-codebase-map-fabricating-go-slipway-repository-context-f/verification/tdd-governance.yaml, artifacts/changes/fix-codebase-map-fabricating-go-slipway-repository-context-f/verification/wave-orchestration.yaml]
+  - task_kind: verification
+  - covers: [REQ-007, REQ-008, REQ-010, REQ-013]
+  - evidence: verdict (`go build ./...` && `go test ./...` green; TDD/domain/independent review evidence present)
+  - acceptance: build + full test suite pass; tdd-governance verifies separate RED evidence before
+    production changes for t-01/t-02/t-03/t-04; domain_review and independent_review evidence are ready
+    before closeout.
+
+## Non-Goals
+- No semantic auto-authoring of ARCHITECTURE/CONVENTIONS/CONCERNS/INTEGRATIONS.
+- No change to default cwd-based worktree scoping of next/run.
+- No new `worktree_root` config field or separate registry file.
+- No exhaustive language coverage; common ecosystems with a clean "not detected" fallback.
+- No generic overwrite of user-authored codebase-map analysis when repository facts later change.
+- `internal/state/stats.go` freshness model is unchanged (out of scope; import-cycle boundary).

--- a/cmd/active_change_resolution_test.go
+++ b/cmd/active_change_resolution_test.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/signalridge/slipway/internal/model"
+	"github.com/signalridge/slipway/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveActiveChangeRefReportsBoundElsewhereFromRoot(t *testing.T) {
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		initGitRepoForWorktreeTests(t, root)
+
+		worktreePath := filepath.Join(t.TempDir(), "bound-worktree")
+		runGit(t, root, "worktree", "add", worktreePath, "-b", "bound-worktree")
+		change := model.NewChange("bound-change")
+		change.WorktreePath = worktreePath
+		require.NoError(t, state.SaveChange(root, change))
+
+		_, err := resolveActiveChangeRef(root, "")
+		cliErr := asCLIError(err)
+		require.NotNil(t, cliErr)
+		assert.Equal(t, "change_bound_to_other_worktree", cliErr.ErrorCode)
+		assert.Equal(t, categoryPrecondition, cliErr.Category)
+		assert.Contains(t, cliErr.Message, "bound-change")
+		assert.Contains(t, cliErr.Message, worktreePath)
+		assert.Contains(t, cliErr.Remediation, "--change bound-change")
+		assert.Contains(t, cliErr.Remediation, worktreePath)
+	})
+}
+
+func TestNextChangeFlagFromRootTargetsBoundWorktree(t *testing.T) {
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		initGitRepoForWorktreeTests(t, root)
+
+		worktreePath := filepath.Join(t.TempDir(), "next-bound-worktree")
+		runGit(t, root, "worktree", "add", worktreePath, "-b", "next-bound-worktree")
+		change := model.NewChange("next-bound-change")
+		change.WorktreePath = worktreePath
+		change.CurrentState = model.StateS1Plan
+		change.PlanSubStep = model.PlanSubStepBundle
+		require.NoError(t, state.SaveChange(root, change))
+
+		var out bytes.Buffer
+		cmd := commandForRoot(t, root, makeNextCmd())
+		cmd.SetArgs([]string{"--json", "--change", change.Slug})
+		cmd.SetOut(&out)
+		require.NoError(t, cmd.Execute())
+
+		var view nextView
+		require.NoError(t, json.Unmarshal(out.Bytes(), &view))
+		normalizedWorktreePath, err := state.NormalizePath(worktreePath)
+		require.NoError(t, err)
+		assert.Equal(t, normalizedWorktreePath, view.InputContext.WorkspaceRoot)
+		assert.Equal(t, "next-bound-change", view.Slug)
+	})
+}

--- a/cmd/cli_e2e_test.go
+++ b/cmd/cli_e2e_test.go
@@ -64,14 +64,16 @@ func TestCLIEndToEndDiagnosticsAndCodebaseMapFlow(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, stderr)
 		assert.Contains(t, stdout, "Created:")
+		assert.Contains(t, stdout, "Scaffold-only:")
 
 		stdout, stderr, err = runRootCommandIn(root, []string{"health", "--json"})
 		require.NoError(t, err)
 		assert.Empty(t, stderr)
 		healthPayload = decodeJSONMap(t, stdout)
 		assert.Equal(t, "diagnostics", healthPayload["execution_mode"])
-		_, hasFindings := healthPayload["findings"]
-		assert.False(t, hasFindings)
+		findings, ok = healthPayload["findings"].([]any)
+		require.True(t, ok)
+		require.Len(t, findings, 1)
 
 		stdout, stderr, err = runRootCommandIn(root, []string{"stats", "--json"})
 		require.NoError(t, err)
@@ -79,7 +81,7 @@ func TestCLIEndToEndDiagnosticsAndCodebaseMapFlow(t *testing.T) {
 		statsPayload = decodeJSONMap(t, stdout)
 		codebaseMap, ok = statsPayload["codebase_map"].(map[string]any)
 		require.True(t, ok)
-		assert.Equal(t, "fresh", codebaseMap["freshness"])
+		assert.Equal(t, "scaffold_only", codebaseMap["freshness"])
 	})
 }
 

--- a/cmd/codebase_map.go
+++ b/cmd/codebase_map.go
@@ -18,6 +18,7 @@ type codebaseMapView struct {
 	DocStates        map[string]string `json:"doc_states,omitempty"`
 	MissingDocs      []string          `json:"missing_docs,omitempty"`
 	ScaffoldOnlyDocs []string          `json:"scaffold_only_docs,omitempty"`
+	BaselineDocs     []string          `json:"baseline_docs,omitempty"`
 	PopulatedDocs    []string          `json:"populated_docs,omitempty"`
 	Created          []string          `json:"created,omitempty"`
 }
@@ -57,6 +58,7 @@ func makeCodebaseMapCmd() *cobra.Command {
 				DocStates:        assessment.DocStates,
 				MissingDocs:      assessment.MissingDocs,
 				ScaffoldOnlyDocs: assessment.ScaffoldOnlyDocs,
+				BaselineDocs:     assessment.BaselineDocs,
 				PopulatedDocs:    assessment.PopulatedDocs,
 			}
 			if len(created) > 0 {
@@ -87,6 +89,12 @@ func writeCodebaseMapText(w io.Writer, view codebaseMapView) error {
 	if len(view.ScaffoldOnlyDocs) > 0 {
 		writer.Writef("Scaffold-only:\n")
 		for _, name := range view.ScaffoldOnlyDocs {
+			writer.Writef("  - %s\n", name)
+		}
+	}
+	if len(view.BaselineDocs) > 0 {
+		writer.Writef("Baseline:\n")
+		for _, name := range view.BaselineDocs {
 			writer.Writef("  - %s\n", name)
 		}
 	}

--- a/cmd/codebase_map_command_test.go
+++ b/cmd/codebase_map_command_test.go
@@ -28,10 +28,11 @@ func TestCodebaseMapCommandCreatesDurableDocSet(t *testing.T) {
 		require.NoError(t, json.Unmarshal(out.Bytes(), &view))
 		assert.Equal(t, "advisory", view.ExecutionMode)
 		assert.Equal(t, "artifacts/codebase", view.CodebaseMapDir)
-		assert.Equal(t, "populated", view.Status)
+		assert.Equal(t, "scaffold_only", view.Status)
 		require.Len(t, view.CodebaseMapDocs, 7)
-		require.Empty(t, view.ScaffoldOnlyDocs)
-		require.Len(t, view.PopulatedDocs, 7)
+		require.Empty(t, view.BaselineDocs)
+		require.Len(t, view.ScaffoldOnlyDocs, 7)
+		require.Empty(t, view.PopulatedDocs)
 		require.Len(t, view.Created, 7)
 
 		for _, path := range view.Created {
@@ -75,5 +76,24 @@ func TestCodebaseMapCommandWritesToInvocationWorktree(t *testing.T) {
 		require.NoError(t, err)
 		assert.Contains(t, string(gitignore), state.LocalStateGitIgnoreBlock())
 		require.NoFileExists(t, filepath.Join(root, "artifacts", "codebase", "STACK.md"))
+	})
+}
+
+func TestCodebaseMapCommandReportsBaselineDocsInTextOutput(t *testing.T) {
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		require.NoError(t, os.WriteFile(filepath.Join(root, "Cargo.toml"), []byte("[workspace]\nmembers = []\n"), 0o644))
+
+		var out bytes.Buffer
+		cmd := makeCodebaseMapCmd()
+		cmd.SetOut(&out)
+		require.NoError(t, cmd.Execute())
+
+		text := out.String()
+		assert.Contains(t, text, "Status: baseline")
+		assert.Contains(t, text, "Baseline:")
+		assert.Contains(t, text, "STACK.md")
+		assert.NotContains(t, text, "Status: populated")
 	})
 }

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -355,6 +355,23 @@ func resolveExplicitChange(root string, slug string) (changeRef, error) {
 	change, err := state.LoadChange(root, slug)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
+			if archived, archiveErr := state.LoadArchivedChange(root, slug); archiveErr == nil {
+				archivePath := filepath.ToSlash(filepath.Join("artifacts", "changes", "archived", slug, "change.yaml"))
+				if path, pathErr := state.ArchivedChangeFilePathForRead(root, slug); pathErr == nil {
+					archivePath = state.DisplayPath(root, path)
+				}
+				return changeRef{}, newPreconditionError(
+					"archived_change_not_validatable",
+					fmt.Sprintf("change %q is archived with status=%s; active governance commands only validate active changes", slug, archived.Status),
+					fmt.Sprintf("Inspect archived evidence at %s, or choose an active change with `slipway status`.", archivePath),
+					slug,
+					map[string]any{
+						"archived":     true,
+						"archive_path": archivePath,
+						"status":       string(archived.Status),
+					},
+				)
+			}
 			return changeRef{}, newPreconditionError(
 				"no_active_change",
 				fmt.Sprintf("no change found for slug %q", slug),
@@ -413,6 +430,32 @@ func loadChangeBySlug(root, slug string) (model.Change, error) {
 }
 
 func wrapResolutionError(err error) error {
+	var boundElsewhere *state.ChangeBoundElsewhereError
+	if errors.As(err, &boundElsewhere) {
+		boundChanges := make([]map[string]string, 0, len(boundElsewhere.BoundChanges))
+		parts := make([]string, 0, len(boundElsewhere.BoundChanges))
+		for _, change := range boundElsewhere.BoundChanges {
+			boundChanges = append(boundChanges, map[string]string{
+				"slug":          change.Slug,
+				"worktree_path": change.WorktreePath,
+			})
+			parts = append(parts, fmt.Sprintf("%s at %s", change.Slug, change.WorktreePath))
+		}
+		remediation := "Use `slipway next --change <slug>` / `slipway run --change <slug>`, or cd into the bound worktree."
+		if len(boundElsewhere.BoundChanges) == 1 {
+			change := boundElsewhere.BoundChanges[0]
+			remediation = fmt.Sprintf("Use `slipway next --change %s` / `slipway run --change %s`, or cd into %s.", change.Slug, change.Slug, change.WorktreePath)
+		}
+		return newPreconditionError(
+			"change_bound_to_other_worktree",
+			"active change is bound to another worktree: "+strings.Join(parts, ", "),
+			remediation,
+			"",
+			map[string]any{
+				"bound_changes": boundChanges,
+			},
+		)
+	}
 	if errors.Is(err, state.ErrNoActiveChange) {
 		return newPreconditionError(
 			"no_active_change",

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -80,6 +80,59 @@ func TestResolveExplicitChangeRejectsUnknownSlug(t *testing.T) {
 	assert.Equal(t, "slug-missing", cliErr.Slug)
 }
 
+func TestResolveExplicitChangeRejectsArchivedSlugWithConcreteDiagnostic(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	ensureTestGitRepo(t, root)
+	initTestWorkspace(t, root)
+
+	slug := createGovernedRequest(t, root, "L2", "archived explicit request")
+	change, err := state.LoadChange(root, slug)
+	require.NoError(t, err)
+	_, err = state.ArchiveChange(root, change, model.ChangeStatusDone)
+	require.NoError(t, err)
+
+	_, err = resolveExplicitChange(root, slug)
+	cliErr := asCLIError(err)
+	require.NotNil(t, cliErr)
+	assert.Equal(t, "archived_change_not_validatable", cliErr.ErrorCode)
+	assert.Equal(t, categoryPrecondition, cliErr.Category)
+	assert.Equal(t, exitCodePrecondition, cliErr.ExitCode)
+	assert.Equal(t, slug, cliErr.Slug)
+	assert.Equal(t, string(model.ChangeStatusDone), cliErr.Details["status"])
+	assert.Equal(t, true, cliErr.Details["archived"])
+	assert.Contains(t, fmt.Sprint(cliErr.Details["archive_path"]), filepath.ToSlash(filepath.Join("artifacts", "changes", "archived", slug, "change.yaml")))
+	assert.Contains(t, cliErr.Message, slug)
+	assert.Contains(t, cliErr.Remediation, "archived")
+}
+
+func TestValidateChangeFlagRejectsArchivedSlugWithConcreteDiagnostic(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	ensureTestGitRepo(t, root)
+	initTestWorkspace(t, root)
+
+	slug := createGovernedRequest(t, root, "L2", "validate archived explicit request")
+	change, err := state.LoadChange(root, slug)
+	require.NoError(t, err)
+	_, err = state.ArchiveChange(root, change, model.ChangeStatusDone)
+	require.NoError(t, err)
+
+	cmd := commandForRoot(t, root, makeValidateCmd())
+	cmd.SetArgs([]string{"--json", "--change", slug})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	err = cmd.Execute()
+
+	cliErr := asCLIError(err)
+	require.NotNil(t, cliErr)
+	assert.Equal(t, "archived_change_not_validatable", cliErr.ErrorCode)
+	assert.Equal(t, categoryPrecondition, cliErr.Category)
+	assert.Equal(t, slug, cliErr.Slug)
+	assert.Equal(t, string(model.ChangeStatusDone), cliErr.Details["status"])
+	assert.NotContains(t, out.String(), "no active change or ambiguous")
+}
+
 func TestResolveExplicitChangeSurfacesCorruptState(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()

--- a/cmd/repair.go
+++ b/cmd/repair.go
@@ -34,6 +34,7 @@ type repairSummary struct {
 	RepairedCheckpoints       []string                                 `json:"repaired_checkpoints,omitempty"`
 	PrunedTaskEvidence        []string                                 `json:"pruned_task_evidence,omitempty"`
 	RebuiltExecutionSummaries []string                                 `json:"rebuilt_execution_summaries,omitempty"`
+	RemovedEmptyOrphanBundles []string                                 `json:"removed_empty_orphan_bundles,omitempty"`
 	NonRepairableFindings     []string                                 `json:"non_repairable_findings,omitempty"`
 	AppliedRepairs            []repairAppliedFinding                   `json:"applied_repairs,omitempty"`
 	UnrepairedDrift           []repairDriftFinding                     `json:"unrepaired_drift,omitempty"`
@@ -95,6 +96,11 @@ func makeRepairCmd() *cobra.Command {
 					return err
 				}
 				summary.WorktreeScopeRepairs = worktreeScopeRepairs
+				removedEmptyOrphans, err := state.RepairEmptyOrphanBundleDirs(root)
+				if err != nil {
+					return err
+				}
+				summary.RemovedEmptyOrphanBundles = removedEmptyOrphans
 
 				cfg, err := loadConfigAtRoot(root)
 				if err != nil {
@@ -286,6 +292,7 @@ func writeRepairText(w io.Writer, summary repairSummary) error {
 	writeRepairSection("Repaired checkpoints", summary.RepairedCheckpoints)
 	writeRepairSection("Pruned task evidence", summary.PrunedTaskEvidence)
 	writeRepairSection("Rebuilt execution summaries", summary.RebuiltExecutionSummaries)
+	writeRepairSection("Removed empty orphan bundles", summary.RemovedEmptyOrphanBundles)
 	writeRepairSection("Non-repairable findings", summary.NonRepairableFindings)
 	writeRepairSection("Applied repairs", repairAppliedFindingStrings(summary.AppliedRepairs))
 	writeRepairSection("Unrepaired drift", repairDriftFindingStrings(summary.UnrepairedDrift))
@@ -300,6 +307,7 @@ func writeRepairText(w io.Writer, summary repairSummary) error {
 		len(summary.RepairedCheckpoints) == 0 &&
 		len(summary.PrunedTaskEvidence) == 0 &&
 		len(summary.RebuiltExecutionSummaries) == 0 &&
+		len(summary.RemovedEmptyOrphanBundles) == 0 &&
 		len(summary.NonRepairableFindings) == 0 &&
 		len(summary.AppliedRepairs) == 0 &&
 		len(summary.UnrepairedDrift) == 0 {
@@ -328,6 +336,7 @@ func buildAppliedRepairFindings(summary repairSummary) []repairAppliedFinding {
 	appendItems("repaired_checkpoint", summary.RepairedCheckpoints)
 	appendItems("pruned_task_evidence", summary.PrunedTaskEvidence)
 	appendItems("rebuilt_execution_summary", summary.RebuiltExecutionSummaries)
+	appendItems("empty_orphan_bundle", summary.RemovedEmptyOrphanBundles)
 	if summary.StaleLockCleaned {
 		findings = append(findings, repairAppliedFinding{Kind: "stale_lock_cleaned", Target: "workspace"})
 	}

--- a/cmd/repair_test.go
+++ b/cmd/repair_test.go
@@ -256,6 +256,7 @@ func TestRepairReportsOrphanBundleDirectoryFinding(t *testing.T) {
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 		require.NoError(t, os.MkdirAll(filepath.Join(root, "artifacts", "changes", "orphan-dir"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(root, "artifacts", "changes", "orphan-dir", "intent.md"), []byte("# orphan\n"), 0o644))
 
 		var out bytes.Buffer
 		cmd := makeRepairCmd()
@@ -275,6 +276,29 @@ func TestRepairReportsOrphanBundleDirectoryFinding(t *testing.T) {
 			}
 		}
 		assert.True(t, found, "expected orphan bundle finding in repair summary")
+	})
+}
+
+func TestRepairRemovesEmptyOrphanBundleDirectory(t *testing.T) {
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		emptyResidue := filepath.Join(root, "artifacts", "changes", "empty-residue")
+		require.NoError(t, os.MkdirAll(filepath.Join(emptyResidue, "verification"), 0o755))
+
+		var out bytes.Buffer
+		cmd := makeRepairCmd()
+		cmd.SetArgs([]string{"--json"})
+		cmd.SetOut(&out)
+
+		require.NoError(t, cmd.Execute())
+
+		var summary repairSummary
+		require.NoError(t, json.Unmarshal(out.Bytes(), &summary))
+		assert.Contains(t, summary.RemovedEmptyOrphanBundles, "empty-residue")
+		assert.Contains(t, summary.AppliedRepairs, repairAppliedFinding{Kind: "empty_orphan_bundle", Target: "empty-residue"})
+		assert.Empty(t, summary.NonRepairableFindings)
+		require.NoDirExists(t, emptyResidue)
 	})
 }
 

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -169,7 +169,7 @@ func makeValidateCmd() *cobra.Command {
 			return encodeJSONResponse(cmd, view)
 		},
 	}
-	addChangeSelectorFlags(cmd, &changeSlug, "Explicit change slug")
+	addChangeSelectorFlags(cmd, &changeSlug, "Explicit active change slug")
 	cmd.Flags().StringVar(&focus, "focus", "", "Validate focus (e.g. sast, property, mutation)")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "JSON output (validate currently emits JSON only)")
 	cmd.Flags().BoolVar(&listFocuses, "list-focuses", false, "List public --focus aliases for this command and exit")

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -48,6 +48,11 @@ Workflow profiles shape checks: `code`, `docs`, `research`, `config`, or `meta`.
 | `slipway health` | query | Show repo-local integrity and repairability findings. |
 | `slipway codebase-map` | mutation | Create or refresh advisory repo-scoped context under `artifacts/codebase/`. |
 
+`codebase-map --json` reports `status: "baseline"` when documents contain only
+CLI-detected repository facts. Baseline docs are useful starting context, not
+authored brownfield analysis; callers should refine them with source-backed
+findings before relying on them for planning or review.
+
 ## Useful JSON Invocations
 
 ```bash
@@ -70,7 +75,12 @@ When diagnostics are enabled, review-state handoff JSON can also include:
 
 `validate --json` mirrors actionable review handoff through `actionable_next_skill`, including `required_tokens` for the exact layer references the actionable skill must supply. `status --json` includes `freshness_diagnostics` when execution evidence is known stale and marks each `artifact_dag` node with `blocking` plus `blocking_reason` so draft planning artifacts are not mistaken for current review blockers.
 
-`repair --json` separates `applied_repairs` from `unrepaired_drift`. Applied repairs are bounded local fixes that were actually performed; unrepaired drift includes a target, reason, and `next_action` for evidence or artifact work that Slipway did not mutate automatically. `health --json` findings include `active_change_blocking` and `active_change_impact`; advisory codebase-map warnings are marked non-blocking for the active change.
+`validate --change <slug>` selects an explicit active change. If the slug names
+an archived terminal change, the command fails with
+`archived_change_not_validatable` and returns the terminal status plus archived
+`change.yaml` path instead of the generic no-active diagnostic.
+
+`repair --json` separates `applied_repairs` from `unrepaired_drift`. Applied repairs are bounded local fixes that were actually performed; unrepaired drift includes a target, reason, and `next_action` for evidence or artifact work that Slipway did not mutate automatically. Empty orphan active-bundle directories left behind after archive cleanup are removed as `empty_orphan_bundle` applied repairs; non-empty orphan bundles remain operator-reviewed integrity findings. `health --json` findings include `active_change_blocking` and `active_change_impact`; advisory codebase-map warnings are marked non-blocking for the active change.
 
 ## Resume And Checkpoints
 

--- a/internal/engine/artifact/codebase_map.go
+++ b/internal/engine/artifact/codebase_map.go
@@ -1,6 +1,7 @@
 package artifact
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -95,6 +96,7 @@ const (
 	CodebaseMapStatusMissing      = "missing"
 	CodebaseMapStatusPartial      = "partial"
 	CodebaseMapStatusScaffoldOnly = "scaffold_only"
+	CodebaseMapStatusBaseline     = "baseline"
 	CodebaseMapStatusPopulated    = "populated"
 )
 
@@ -103,6 +105,7 @@ type CodebaseMapAssessment struct {
 	DocStates        map[string]string `json:"doc_states,omitempty"`
 	MissingDocs      []string          `json:"missing_docs,omitempty"`
 	ScaffoldOnlyDocs []string          `json:"scaffold_only_docs,omitempty"`
+	BaselineDocs     []string          `json:"baseline_docs,omitempty"`
 	PopulatedDocs    []string          `json:"populated_docs,omitempty"`
 }
 
@@ -119,16 +122,16 @@ func EnsureCodebaseMapDocs(root string) (created []string, err error) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, err
 	}
+	baselines := codebaseMapBaselines(root)
 
 	for _, name := range codebaseMapDocNames {
 		path := filepath.Join(dir, name)
-		content, ok := codebaseMapDocTemplates[name]
-		if !ok {
+		if _, ok := codebaseMapDocTemplates[name]; !ok {
 			return nil, fmt.Errorf("missing codebase map template for %s", name)
 		}
-		baseline := codebaseMapBaselineDoc(root, name)
+		baseline := baselines[name]
 		if data, err := os.ReadFile(path); err == nil {
-			if CodebaseMapDocIsScaffoldOnly(name, string(data)) {
+			if CodebaseMapDocIsScaffoldOnly(name, string(data)) || codebaseMapDocIsLegacyGenerated(name, string(data)) {
 				if err := os.WriteFile(path, []byte(baseline), 0o644); err != nil {
 					return nil, err
 				}
@@ -138,9 +141,6 @@ func EnsureCodebaseMapDocs(root string) (created []string, err error) {
 			return nil, err
 		}
 
-		if strings.TrimSpace(baseline) == "" {
-			baseline = content
-		}
 		if err := os.WriteFile(path, []byte(baseline), 0o644); err != nil {
 			return nil, err
 		}
@@ -150,175 +150,479 @@ func EnsureCodebaseMapDocs(root string) (created []string, err error) {
 }
 
 type codebaseMapFacts struct {
-	Module      string
-	GoVersion   string
-	Requires    []string
-	TopDirs     []string
-	EntryPoints []string
-	HasTests    bool
+	Languages        []string
+	Frameworks       []string
+	BuildTestTooling []string
+	KeyDependencies  []string
+	Notes            []string
+	TopDirs          []string
+	EntryPoints      []string
+	TestLayout       []string
 }
 
 func inspectCodebaseMapFacts(root string) codebaseMapFacts {
 	facts := codebaseMapFacts{}
+	recordRootLayoutFacts(root, &facts)
 	if data, err := os.ReadFile(filepath.Join(root, "go.mod")); err == nil {
+		inspectGoModFacts(string(data), &facts)
+	}
+	if data, err := os.ReadFile(filepath.Join(root, "Cargo.toml")); err == nil {
+		inspectCargoFacts(string(data), &facts)
+	}
+	if data, err := os.ReadFile(filepath.Join(root, "package.json")); err == nil {
+		inspectPackageJSONFacts(root, data, &facts)
+	} else if _, err := os.Stat(filepath.Join(root, "tsconfig.json")); err == nil {
+		facts.addLanguage("TypeScript")
+		facts.addFramework("TypeScript project")
+	}
+	inspectPythonFacts(root, &facts)
+	inspectJvmFacts(root, &facts)
+	inspectOtherManifestFacts(root, &facts)
+	inspectSourceExtensionFacts(root, &facts)
+	facts.sortAndCompact()
+	return facts
+}
+
+func inspectGoModFacts(content string, facts *codebaseMapFacts) {
+	facts.addLanguage("Go")
+	module := ""
+	goVersion := ""
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(line, "module "):
+			module = strings.TrimSpace(strings.TrimPrefix(line, "module "))
+		case strings.HasPrefix(line, "go "):
+			goVersion = strings.TrimSpace(strings.TrimPrefix(line, "go "))
+		case strings.HasPrefix(line, "require "):
+			fields := strings.Fields(strings.TrimSpace(strings.TrimPrefix(line, "require ")))
+			if len(fields) > 0 && fields[0] != "(" {
+				facts.addDependency(fields[0])
+			}
+		case strings.HasPrefix(line, "github.com/") || strings.HasPrefix(line, "golang.org/") || strings.HasPrefix(line, "gopkg.in/"):
+			fields := strings.Fields(line)
+			if len(fields) > 0 {
+				facts.addDependency(fields[0])
+			}
+		}
+	}
+	if module != "" {
+		facts.addFramework("Go module " + module)
+	} else {
+		facts.addFramework("Go module")
+	}
+	facts.addBuildTestTooling("go build ./...; go test ./...")
+	if goVersion != "" {
+		facts.addNote("go.mod declares Go " + goVersion)
+	}
+}
+
+func inspectCargoFacts(content string, facts *codebaseMapFacts) {
+	facts.addLanguage("Rust")
+	if strings.Contains(content, "[workspace]") {
+		facts.addFramework("Cargo workspace")
+	} else if name := firstTOMLStringValue(content, "name"); name != "" {
+		facts.addFramework("Cargo crate " + name)
+	} else {
+		facts.addFramework("Cargo project")
+	}
+	facts.addBuildTestTooling("cargo build --workspace; cargo test --workspace")
+	facts.addNote("Cargo.toml detected")
+	for _, dep := range firstTOMLSectionKeys(content, "dependencies", 8) {
+		facts.addDependency(dep)
+	}
+}
+
+func inspectPackageJSONFacts(root string, data []byte, facts *codebaseMapFacts) {
+	facts.addLanguage("JavaScript")
+	if _, err := os.Stat(filepath.Join(root, "tsconfig.json")); err == nil {
+		facts.addLanguage("TypeScript")
+	}
+	var pkg struct {
+		Name            string            `json:"name"`
+		Scripts         map[string]string `json:"scripts"`
+		Dependencies    map[string]any    `json:"dependencies"`
+		DevDependencies map[string]any    `json:"devDependencies"`
+	}
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		facts.addFramework("Node.js package")
+		return
+	}
+	if strings.TrimSpace(pkg.Name) != "" {
+		facts.addFramework("Node.js package " + strings.TrimSpace(pkg.Name))
+	} else {
+		facts.addFramework("Node.js package")
+	}
+	if _, ok := pkg.DevDependencies["typescript"]; ok {
+		facts.addLanguage("TypeScript")
+	}
+	commands := []string{}
+	if _, ok := pkg.Scripts["build"]; ok {
+		commands = append(commands, "npm run build")
+	}
+	if _, ok := pkg.Scripts["test"]; ok {
+		commands = append(commands, "npm test")
+	}
+	if len(commands) > 0 {
+		facts.addBuildTestTooling(strings.Join(commands, "; "))
+	}
+	for dep := range pkg.Dependencies {
+		facts.addDependency(dep)
+	}
+	for dep := range pkg.DevDependencies {
+		facts.addDependency(dep)
+	}
+}
+
+func inspectPythonFacts(root string, facts *codebaseMapFacts) {
+	pyproject := filepath.Join(root, "pyproject.toml")
+	setupPy := filepath.Join(root, "setup.py")
+	requirements := filepath.Join(root, "requirements.txt")
+	hasPythonManifest := false
+	if _, err := os.Stat(pyproject); err == nil {
+		hasPythonManifest = true
+		facts.addEntryPoint("pyproject.toml")
+	}
+	if _, err := os.Stat(setupPy); err == nil {
+		hasPythonManifest = true
+		facts.addEntryPoint("setup.py")
+	}
+	if data, err := os.ReadFile(requirements); err == nil {
+		hasPythonManifest = true
+		facts.addEntryPoint("requirements.txt")
 		for _, line := range strings.Split(string(data), "\n") {
 			line = strings.TrimSpace(line)
-			switch {
-			case strings.HasPrefix(line, "module "):
-				facts.Module = strings.TrimSpace(strings.TrimPrefix(line, "module "))
-			case strings.HasPrefix(line, "go "):
-				facts.GoVersion = strings.TrimSpace(strings.TrimPrefix(line, "go "))
-			case strings.HasPrefix(line, "github.com/") || strings.HasPrefix(line, "golang.org/") || strings.HasPrefix(line, "gopkg.in/"):
-				fields := strings.Fields(line)
-				if len(fields) > 0 {
-					facts.Requires = append(facts.Requires, fields[0])
-				}
+			if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "-") {
+				continue
+			}
+			dep := strings.FieldsFunc(line, func(r rune) bool {
+				return r == '=' || r == '<' || r == '>' || r == '~' || r == '!' || r == '['
+			})
+			if len(dep) > 0 {
+				facts.addDependency(dep[0])
 			}
 		}
 	}
-	if entries, err := os.ReadDir(root); err == nil {
-		for _, entry := range entries {
-			name := entry.Name()
-			if strings.HasPrefix(name, ".") || name == "artifacts" {
-				continue
-			}
-			if entry.IsDir() {
-				facts.TopDirs = append(facts.TopDirs, name+"/")
-				continue
-			}
-			if name == "main.go" || name == "go.mod" || strings.HasSuffix(name, ".md") {
-				facts.EntryPoints = append(facts.EntryPoints, name)
-			}
+	if hasPythonManifest {
+		facts.addLanguage("Python")
+		facts.addFramework("Python project")
+		facts.addBuildTestTooling("python -m pytest")
+	}
+}
+
+func inspectJvmFacts(root string, facts *codebaseMapFacts) {
+	if _, err := os.Stat(filepath.Join(root, "pom.xml")); err == nil {
+		facts.addLanguage("Java")
+		facts.addFramework("Maven project")
+		facts.addBuildTestTooling("mvn test")
+	}
+	if _, err := os.Stat(filepath.Join(root, "build.gradle")); err == nil {
+		facts.addLanguage("Java")
+		facts.addFramework("Gradle project")
+		facts.addBuildTestTooling("./gradlew test")
+	}
+	if _, err := os.Stat(filepath.Join(root, "build.gradle.kts")); err == nil {
+		facts.addLanguage("Kotlin")
+		facts.addFramework("Gradle Kotlin project")
+		facts.addBuildTestTooling("./gradlew test")
+	}
+}
+
+func inspectOtherManifestFacts(root string, facts *codebaseMapFacts) {
+	if _, err := os.Stat(filepath.Join(root, "Gemfile")); err == nil {
+		facts.addLanguage("Ruby")
+		facts.addFramework("Bundler project")
+		facts.addBuildTestTooling("bundle exec rspec")
+	}
+	if _, err := os.Stat(filepath.Join(root, "composer.json")); err == nil {
+		facts.addLanguage("PHP")
+		facts.addFramework("Composer project")
+		facts.addBuildTestTooling("composer test")
+	}
+	if matches, _ := filepath.Glob(filepath.Join(root, "*.csproj")); len(matches) > 0 {
+		facts.addLanguage("C#")
+		facts.addFramework(".NET project")
+		facts.addBuildTestTooling("dotnet test")
+	}
+	if matches, _ := filepath.Glob(filepath.Join(root, "*.sln")); len(matches) > 0 {
+		facts.addLanguage("C#")
+		facts.addFramework(".NET solution")
+		facts.addBuildTestTooling("dotnet test")
+	}
+}
+
+func recordRootLayoutFacts(root string, facts *codebaseMapFacts) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if shouldSkipCodebaseMapDir(name) {
+			continue
+		}
+		if entry.IsDir() {
+			facts.addTopDir(name + "/")
+			continue
+		}
+		if isCodebaseMapEntryPoint(name) {
+			facts.addEntryPoint(name)
 		}
 	}
+}
+
+func inspectSourceExtensionFacts(root string, facts *codebaseMapFacts) {
+	extensionLanguages := map[string]string{
+		".go":   "Go",
+		".rs":   "Rust",
+		".js":   "JavaScript",
+		".jsx":  "JavaScript",
+		".ts":   "TypeScript",
+		".tsx":  "TypeScript",
+		".py":   "Python",
+		".java": "Java",
+		".kt":   "Kotlin",
+		".kts":  "Kotlin",
+		".rb":   "Ruby",
+		".php":  "PHP",
+		".cs":   "C#",
+	}
+	scanned := 0
+	const scanLimit = 500
 	_ = filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
-		if err != nil || facts.HasTests {
+		if err != nil {
 			return nil
 		}
 		if entry.IsDir() {
-			name := entry.Name()
-			if strings.HasPrefix(name, ".") || name == "artifacts" {
+			if path != root && shouldSkipCodebaseMapDir(entry.Name()) {
 				return filepath.SkipDir
 			}
 			return nil
 		}
-		if strings.HasSuffix(entry.Name(), "_test.go") {
-			facts.HasTests = true
+		if scanned >= scanLimit {
+			return filepath.SkipAll
+		}
+		scanned++
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			rel = entry.Name()
+		}
+		rel = filepath.ToSlash(rel)
+		ext := strings.ToLower(filepath.Ext(entry.Name()))
+		if language := extensionLanguages[ext]; language != "" {
+			facts.addLanguage(language)
+			if isSourceEntryPoint(rel) {
+				facts.addEntryPoint(rel)
+			}
+		}
+		switch {
+		case strings.HasSuffix(entry.Name(), "_test.go"):
+			facts.addTestLayout("Go *_test.go files")
+		case strings.HasSuffix(entry.Name(), "_test.rs") || strings.HasSuffix(entry.Name(), "_spec.rs") || strings.HasPrefix(rel, "tests/"):
+			facts.addTestLayout("Rust tests")
+		case strings.HasSuffix(entry.Name(), ".test.js") || strings.HasSuffix(entry.Name(), ".test.ts") || strings.HasPrefix(rel, "test/") || strings.HasPrefix(rel, "tests/"):
+			facts.addTestLayout("JavaScript/TypeScript tests")
+		case strings.HasPrefix(entry.Name(), "test_") && strings.HasSuffix(entry.Name(), ".py"):
+			facts.addTestLayout("Python tests")
 		}
 		return nil
 	})
-	slices.Sort(facts.Requires)
-	facts.Requires = slices.Compact(facts.Requires)
-	slices.Sort(facts.TopDirs)
-	slices.Sort(facts.EntryPoints)
-	return facts
 }
 
-func codebaseMapBaselineDoc(root, name string) string {
+func codebaseMapBaselines(root string) map[string]string {
 	facts := inspectCodebaseMapFacts(root)
-	module := nonEmptyFact(facts.Module, "not detected")
-	goVersion := nonEmptyFact(facts.GoVersion, "not detected")
-	topDirs := strings.Join(facts.TopDirs, ", ")
-	if topDirs == "" {
-		topDirs = "not detected"
+	baselines := make(map[string]string, len(codebaseMapDocNames))
+	for _, name := range codebaseMapDocNames {
+		baselines[name] = renderCodebaseMapBaselineDoc(facts, name)
 	}
-	entryPoints := strings.Join(facts.EntryPoints, ", ")
-	if entryPoints == "" {
-		entryPoints = "not detected"
-	}
-	deps := firstFacts(facts.Requires, 6)
-	tests := "Go tests not detected by baseline scan"
-	if facts.HasTests {
-		tests = "Go *_test.go files are present"
-	}
+	return baselines
+}
 
+func renderCodebaseMapBaselineDoc(facts codebaseMapFacts, name string) string {
+	if !facts.hasDetectedFacts() {
+		return codebaseMapDocTemplates[name]
+	}
 	switch name {
 	case "STACK.md":
 		return fmt.Sprintf(`# Stack
 
-- Languages: Go
-- Frameworks and runtimes: Cobra-based CLI module %s
-- Build and test tooling: go build ./...; go test ./...
+- Languages: %s
+- Frameworks and runtimes: %s
+- Build and test tooling: %s
 - Key dependencies: %s
-- Notes: go.mod declares Go %s
-`, module, deps, goVersion)
-	case "INTEGRATIONS.md":
-		return `# Integrations
-
-- External APIs: Git CLI is used for repository and worktree inspection.
-- Infrastructure bindings: Local filesystem state under artifacts/, .slipway.yaml, and git-local runtime directories.
-- Datastores and queues: No service datastore detected by baseline scan; Slipway stores YAML, JSON, JSONL, and Markdown artifacts on disk.
-- File formats and protocols: YAML change authority, JSON CLI output, JSONL lifecycle events, Markdown governed artifacts.
-- Notes: Integration inventory is deterministic baseline context; refine with project-specific external services when present.
-`
-	case "ARCHITECTURE.md":
-		return `# Architecture
-
-- Module responsibilities: cmd/ owns CLI surfaces; internal/state owns change authority and filesystem layout; internal/engine owns progression, governance, artifact, and gate logic.
-- Dependency flow: CLI commands assemble model state and delegate durable state changes to internal/state and workflow decisions to internal/engine.
-- Coupling hotspots: lifecycle progression, artifact readiness, worktree binding, and archive migration share change.yaml path authority.
-- Current change blast radius: governed workflow creation, codebase-map context, and done/archive reporting.
-- Notes: Baseline was generated from repository layout and known Slipway package boundaries.
-`
+- Notes: %s
+`, joinFacts(facts.Languages, 0), joinFacts(facts.Frameworks, 0), joinFacts(facts.BuildTestTooling, 0), joinFacts(facts.KeyDependencies, 6), joinFacts(facts.Notes, 0))
 	case "STRUCTURE.md":
 		return fmt.Sprintf(`# Structure
 
 - Directory layout: %s
 - Entry points: %s
-- Generated versus handwritten boundaries: internal/tmpl contains generated prompt/skill surfaces; cmd/ and internal/ contain handwritten Go runtime code.
-- Ownership hints: Tests are colocated as *_test.go files under cmd/ and internal/.
-- Notes: %s.
-`, topDirs, entryPoints, tests)
-	case "CONVENTIONS.md":
-		return `# Conventions
-
-- Naming: CLI commands live in cmd/ with make<Command>Cmd constructors; workflow states and durable schemas live in internal/model.
-- File organization: Runtime state helpers belong under internal/state; progression decisions belong under internal/engine/progression.
-- Error handling: CLI-facing failures use structured reason codes and typed CLI errors where user remediation matters.
-- Configuration: .slipway.yaml is the project-local governance configuration authority.
-- State management: change.yaml is current-state authority; lifecycle.jsonl is append-only audit evidence.
-- Notes: Generated host-skill templates should stay synchronized with runtime contracts.
-`
+- Generated versus handwritten boundaries:
+- Ownership hints:
+- Notes:
+`, joinFacts(facts.TopDirs, 0), joinFacts(facts.EntryPoints, 0))
 	case "TESTING.md":
-		return `# Testing
+		return fmt.Sprintf(`# Testing
 
-- Test layout: cmd/*_test.go covers CLI contracts; internal/**/*_test.go covers state, artifact, progression, governance, and template behavior.
-- Coverage hotspots: next/run/status JSON contracts, governed lifecycle gates, archive migration, worktree binding, and generated skill/template drift.
-- Coverage gaps: End-to-end governed workflow tests are intentionally heavier and should use explicit timeouts.
-- Verification commands: go test -timeout=20m ./... -count=1; go build ./...
-- Fixture patterns: Tests commonly create temp workspaces, seed governed bundles, write verification YAML, and assert JSON command output.
-- Notes: Prefer focused regression tests before full-suite verification.
-`
-	case "CONCERNS.md":
-		return `# Concerns
-
-- Architectural pressure points: Worktree binding must happen before canonical governed artifacts are treated as reviewed execution inputs.
-- Brittle areas: Scaffold-only codebase maps, planning-vs-execution evidence freshness, and archive relocation can create misleading authority signals.
-- Migration traps: Changing artifact roots must preserve repairability, archive discoverability, and change.yaml as the single current-state authority.
-- Recheck routing: Planning artifacts invalidate planning evidence; task execution drift invalidates execution evidence; assurance-only edits stay in verification/closeout checks.
-- Notes: Treat placeholder files as advisory until populated with concrete repository facts.
-`
+- Test layout: %s
+- Coverage hotspots:
+- Coverage gaps:
+- Verification commands: %s
+- Fixture patterns:
+- Notes:
+`, joinFacts(facts.TestLayout, 0), joinFacts(facts.BuildTestTooling, 0))
 	default:
 		return codebaseMapDocTemplates[name]
 	}
 }
 
-func nonEmptyFact(value, fallback string) string {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return fallback
-	}
-	return value
+func (facts codebaseMapFacts) hasDetectedFacts() bool {
+	return len(facts.Languages) > 0 ||
+		len(facts.Frameworks) > 0 ||
+		len(facts.BuildTestTooling) > 0 ||
+		len(facts.KeyDependencies) > 0 ||
+		len(facts.Notes) > 0 ||
+		len(facts.TestLayout) > 0
 }
 
-func firstFacts(values []string, max int) string {
-	if len(values) == 0 {
-		return "not detected"
+func (facts *codebaseMapFacts) addLanguage(value string) {
+	facts.Languages = appendFact(facts.Languages, value)
+}
+
+func (facts *codebaseMapFacts) addFramework(value string) {
+	facts.Frameworks = appendFact(facts.Frameworks, value)
+}
+
+func (facts *codebaseMapFacts) addBuildTestTooling(value string) {
+	facts.BuildTestTooling = appendFact(facts.BuildTestTooling, value)
+}
+
+func (facts *codebaseMapFacts) addDependency(value string) {
+	facts.KeyDependencies = appendFact(facts.KeyDependencies, value)
+}
+
+func (facts *codebaseMapFacts) addNote(value string) {
+	facts.Notes = appendFact(facts.Notes, value)
+}
+
+func (facts *codebaseMapFacts) addTopDir(value string) {
+	facts.TopDirs = appendFact(facts.TopDirs, value)
+}
+
+func (facts *codebaseMapFacts) addEntryPoint(value string) {
+	facts.EntryPoints = appendFact(facts.EntryPoints, value)
+}
+
+func (facts *codebaseMapFacts) addTestLayout(value string) {
+	facts.TestLayout = appendFact(facts.TestLayout, value)
+}
+
+func (facts *codebaseMapFacts) sortAndCompact() {
+	sortCompact := func(values []string) []string {
+		slices.Sort(values)
+		return slices.Compact(values)
 	}
-	if len(values) > max {
+	facts.Languages = sortCompact(facts.Languages)
+	facts.Frameworks = sortCompact(facts.Frameworks)
+	facts.BuildTestTooling = sortCompact(facts.BuildTestTooling)
+	facts.KeyDependencies = sortCompact(facts.KeyDependencies)
+	facts.Notes = sortCompact(facts.Notes)
+	facts.TopDirs = sortCompact(facts.TopDirs)
+	facts.EntryPoints = sortCompact(facts.EntryPoints)
+	facts.TestLayout = sortCompact(facts.TestLayout)
+}
+
+func appendFact(values []string, value string) []string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return values
+	}
+	return append(values, value)
+}
+
+func joinFacts(values []string, max int) string {
+	if len(values) == 0 {
+		return ""
+	}
+	if max > 0 && len(values) > max {
 		values = values[:max]
 	}
 	return strings.Join(values, ", ")
+}
+
+func firstTOMLStringValue(content, key string) string {
+	prefix := key + " = "
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, prefix) {
+			continue
+		}
+		value := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+		return strings.TrimSpace(strings.Trim(value, `"'`))
+	}
+	return ""
+}
+
+func firstTOMLSectionKeys(content, section string, max int) []string {
+	keys := []string{}
+	inSection := false
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			inSection = strings.Trim(line, "[]") == section
+			continue
+		}
+		if !inSection {
+			continue
+		}
+		key, _, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(strings.Trim(key, `"'`))
+		if key != "" {
+			keys = append(keys, key)
+		}
+		if max > 0 && len(keys) >= max {
+			break
+		}
+	}
+	return keys
+}
+
+func shouldSkipCodebaseMapDir(name string) bool {
+	if strings.HasPrefix(name, ".") {
+		return true
+	}
+	switch name {
+	case "artifacts", "node_modules", "target", "dist", "build", "vendor", "__pycache__":
+		return true
+	default:
+		return false
+	}
+}
+
+func isCodebaseMapEntryPoint(name string) bool {
+	switch name {
+	case "go.mod", "Cargo.toml", "package.json", "tsconfig.json", "pyproject.toml", "setup.py",
+		"requirements.txt", "pom.xml", "build.gradle", "build.gradle.kts", "Gemfile", "composer.json",
+		"main.go", "README.md":
+		return true
+	default:
+		return strings.HasSuffix(name, ".csproj") || strings.HasSuffix(name, ".sln")
+	}
+}
+
+func isSourceEntryPoint(path string) bool {
+	switch path {
+	case "main.go", "src/main.rs", "src/lib.rs", "src/index.js", "src/index.ts", "index.js", "index.ts", "main.py":
+		return true
+	default:
+		return false
+	}
 }
 
 func AssessCodebaseMapDocs(root string) (CodebaseMapAssessment, error) {
@@ -327,6 +631,7 @@ func AssessCodebaseMapDocs(root string) (CodebaseMapAssessment, error) {
 		Status:    CodebaseMapStatusMissing,
 		DocStates: map[string]string{},
 	}
+	baselines := codebaseMapBaselines(root)
 
 	for _, name := range codebaseMapDocNames {
 		key := codebaseMapDocKeys[name]
@@ -345,20 +650,28 @@ func AssessCodebaseMapDocs(root string) (CodebaseMapAssessment, error) {
 			assessment.ScaffoldOnlyDocs = append(assessment.ScaffoldOnlyDocs, name)
 			continue
 		}
+		if normalizeCodebaseMapDoc(string(data)) == normalizeCodebaseMapDoc(baselines[name]) {
+			assessment.DocStates[key] = CodebaseMapStatusBaseline
+			assessment.BaselineDocs = append(assessment.BaselineDocs, name)
+			continue
+		}
 		assessment.DocStates[key] = CodebaseMapStatusPopulated
 		assessment.PopulatedDocs = append(assessment.PopulatedDocs, name)
 	}
 
 	slices.Sort(assessment.MissingDocs)
 	slices.Sort(assessment.ScaffoldOnlyDocs)
+	slices.Sort(assessment.BaselineDocs)
 	slices.Sort(assessment.PopulatedDocs)
 
 	switch {
 	case len(assessment.PopulatedDocs) == len(codebaseMapDocNames):
 		assessment.Status = CodebaseMapStatusPopulated
-	case len(assessment.PopulatedDocs) == 0 && len(assessment.ScaffoldOnlyDocs) > 0 && len(assessment.MissingDocs) == 0:
+	case len(assessment.PopulatedDocs) == 0 && len(assessment.BaselineDocs) > 0 && len(assessment.MissingDocs) == 0:
+		assessment.Status = CodebaseMapStatusBaseline
+	case len(assessment.PopulatedDocs) == 0 && len(assessment.BaselineDocs) == 0 && len(assessment.ScaffoldOnlyDocs) > 0 && len(assessment.MissingDocs) == 0:
 		assessment.Status = CodebaseMapStatusScaffoldOnly
-	case len(assessment.PopulatedDocs) == 0 && len(assessment.ScaffoldOnlyDocs) == 0:
+	case len(assessment.PopulatedDocs) == 0 && len(assessment.BaselineDocs) == 0 && len(assessment.ScaffoldOnlyDocs) == 0:
 		assessment.Status = CodebaseMapStatusMissing
 	default:
 		assessment.Status = CodebaseMapStatusPartial
@@ -371,6 +684,103 @@ func CodebaseMapDocIsScaffoldOnly(name, content string) bool {
 		return true
 	}
 	return !hasSubstantiveCodebaseMapContent(content)
+}
+
+func codebaseMapDocIsLegacyGenerated(name, content string) bool {
+	lines := substantiveCodebaseMapLines(content)
+	switch name {
+	case "STACK.md":
+		return len(lines) == 6 &&
+			lines[0] == "# Stack" &&
+			lines[1] == "- Languages: Go" &&
+			strings.HasPrefix(lines[2], "- Frameworks and runtimes: Cobra-based CLI module ") &&
+			lines[3] == "- Build and test tooling: go build ./...; go test ./..." &&
+			strings.HasPrefix(lines[4], "- Key dependencies: ") &&
+			strings.HasPrefix(lines[5], "- Notes: go.mod declares Go ")
+	case "INTEGRATIONS.md":
+		return linesEqual(lines, []string{
+			"# Integrations",
+			"- External APIs: Git CLI is used for repository and worktree inspection.",
+			"- Infrastructure bindings: Local filesystem state under artifacts/, .slipway.yaml, and git-local runtime directories.",
+			"- Datastores and queues: No service datastore detected by baseline scan; Slipway stores YAML, JSON, JSONL, and Markdown artifacts on disk.",
+			"- File formats and protocols: YAML change authority, JSON CLI output, JSONL lifecycle events, Markdown governed artifacts.",
+			"- Notes: Integration inventory is deterministic baseline context; refine with project-specific external services when present.",
+		})
+	case "ARCHITECTURE.md":
+		return linesEqual(lines, []string{
+			"# Architecture",
+			"- Module responsibilities: cmd/ owns CLI surfaces; internal/state owns change authority and filesystem layout; internal/engine owns progression, governance, artifact, and gate logic.",
+			"- Dependency flow: CLI commands assemble model state and delegate durable state changes to internal/state and workflow decisions to internal/engine.",
+			"- Coupling hotspots: lifecycle progression, artifact readiness, worktree binding, and archive migration share change.yaml path authority.",
+			"- Current change blast radius: governed workflow creation, codebase-map context, and done/archive reporting.",
+			"- Notes: Baseline was generated from repository layout and known Slipway package boundaries.",
+		})
+	case "STRUCTURE.md":
+		return len(lines) == 6 &&
+			lines[0] == "# Structure" &&
+			strings.HasPrefix(lines[1], "- Directory layout: ") &&
+			strings.HasPrefix(lines[2], "- Entry points: ") &&
+			lines[3] == "- Generated versus handwritten boundaries: internal/tmpl contains generated prompt/skill surfaces; cmd/ and internal/ contain handwritten Go runtime code." &&
+			lines[4] == "- Ownership hints: Tests are colocated as *_test.go files under cmd/ and internal/." &&
+			(lines[5] == "- Notes: Go tests not detected by baseline scan." ||
+				lines[5] == "- Notes: Go *_test.go files are present.")
+	case "CONVENTIONS.md":
+		return linesEqual(lines, []string{
+			"# Conventions",
+			"- Naming: CLI commands live in cmd/ with make<Command>Cmd constructors; workflow states and durable schemas live in internal/model.",
+			"- File organization: Runtime state helpers belong under internal/state; progression decisions belong under internal/engine/progression.",
+			"- Error handling: CLI-facing failures use structured reason codes and typed CLI errors where user remediation matters.",
+			"- Configuration: .slipway.yaml is the project-local governance configuration authority.",
+			"- State management: change.yaml is current-state authority; lifecycle.jsonl is append-only audit evidence.",
+			"- Notes: Generated host-skill templates should stay synchronized with runtime contracts.",
+		})
+	case "TESTING.md":
+		return linesEqual(lines, []string{
+			"# Testing",
+			"- Test layout: cmd/*_test.go covers CLI contracts; internal/**/*_test.go covers state, artifact, progression, governance, and template behavior.",
+			"- Coverage hotspots: next/run/status JSON contracts, governed lifecycle gates, archive migration, worktree binding, and generated skill/template drift.",
+			"- Coverage gaps: End-to-end governed workflow tests are intentionally heavier and should use explicit timeouts.",
+			"- Verification commands: go test -timeout=20m ./... -count=1; go build ./...",
+			"- Fixture patterns: Tests commonly create temp workspaces, seed governed bundles, write verification YAML, and assert JSON command output.",
+			"- Notes: Prefer focused regression tests before full-suite verification.",
+		})
+	case "CONCERNS.md":
+		return linesEqual(lines, []string{
+			"# Concerns",
+			"- Architectural pressure points: Worktree binding must happen before canonical governed artifacts are treated as reviewed execution inputs.",
+			"- Brittle areas: Scaffold-only codebase maps, planning-vs-execution evidence freshness, and archive relocation can create misleading authority signals.",
+			"- Migration traps: Changing artifact roots must preserve repairability, archive discoverability, and change.yaml as the single current-state authority.",
+			"- Recheck routing: Planning artifacts invalidate planning evidence; task execution drift invalidates execution evidence; assurance-only edits stay in verification/closeout checks.",
+			"- Notes: Treat placeholder files as advisory until populated with concrete repository facts.",
+		})
+	default:
+		return false
+	}
+}
+
+func substantiveCodebaseMapLines(content string) []string {
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+	lines := []string{}
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		lines = append(lines, line)
+	}
+	return lines
+}
+
+func linesEqual(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for idx := range got {
+		if got[idx] != want[idx] {
+			return false
+		}
+	}
+	return true
 }
 
 func hasSubstantiveCodebaseMapContent(content string) bool {

--- a/internal/engine/artifact/codebase_map_test.go
+++ b/internal/engine/artifact/codebase_map_test.go
@@ -1,0 +1,218 @@
+package artifact
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/signalridge/slipway/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnsureCodebaseMapDocsDetectsRustCargoBaseline(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "Cargo.toml"), []byte(`[package]
+name = "lattice-demo"
+version = "0.1.0"
+
+[dependencies]
+serde = "1"
+`), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "src"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "src", "lib.rs"), []byte("pub fn run() {}\n"), 0o644))
+
+	created, err := EnsureCodebaseMapDocs(root)
+	require.NoError(t, err)
+	require.Len(t, created, len(codebaseMapDocNames))
+
+	stack := readCodebaseMapDoc(t, root, "STACK.md")
+	assert.Contains(t, stack, "- Languages: Rust")
+	assert.Contains(t, stack, "cargo build --workspace; cargo test --workspace")
+	assert.Contains(t, stack, "serde")
+	assert.NotContains(t, stack, "Languages: Go")
+	assert.NotContains(t, stack, "go build ./...")
+
+	architecture := readCodebaseMapDoc(t, root, "ARCHITECTURE.md")
+	assert.True(t, CodebaseMapDocIsScaffoldOnly("ARCHITECTURE.md", architecture))
+	assert.NotContains(t, architecture, "cmd/ owns CLI surfaces")
+	assert.NotContains(t, architecture, "internal/state owns change authority")
+
+	assessment, err := AssessCodebaseMapDocs(root)
+	require.NoError(t, err)
+	assert.Equal(t, CodebaseMapStatusBaseline, assessment.Status)
+	assert.Contains(t, assessment.BaselineDocs, "STACK.md")
+	assert.Contains(t, assessment.BaselineDocs, "STRUCTURE.md")
+	assert.Contains(t, assessment.BaselineDocs, "TESTING.md")
+	assert.Contains(t, assessment.ScaffoldOnlyDocs, "ARCHITECTURE.md")
+	assert.Empty(t, assessment.PopulatedDocs)
+}
+
+func TestEnsureCodebaseMapDocsDetectsGoModuleBaseline(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "go.mod"), []byte(`module example.com/slipway-like
+
+go 1.26.3
+
+require github.com/spf13/cobra v1.10.1
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0o644))
+
+	_, err := EnsureCodebaseMapDocs(root)
+	require.NoError(t, err)
+
+	stack := readCodebaseMapDoc(t, root, "STACK.md")
+	assert.Contains(t, stack, "- Languages: Go")
+	assert.Contains(t, stack, "Go module example.com/slipway-like")
+	assert.Contains(t, stack, "go build ./...; go test ./...")
+	assert.Contains(t, stack, "github.com/spf13/cobra")
+	assert.Contains(t, stack, "go.mod declares Go 1.26.3")
+
+	assessment, err := AssessCodebaseMapDocs(root)
+	require.NoError(t, err)
+	assert.Equal(t, CodebaseMapStatusBaseline, assessment.Status)
+	assert.Contains(t, assessment.BaselineDocs, "STACK.md")
+}
+
+func TestEnsureCodebaseMapDocsUsesBlankScaffoldWhenNoFactsDetected(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "README.md"), []byte("# notes\n"), 0o644))
+
+	_, err := EnsureCodebaseMapDocs(root)
+	require.NoError(t, err)
+
+	for _, name := range codebaseMapDocNames {
+		assert.Equal(t, normalizeCodebaseMapDoc(codebaseMapDocTemplates[name]), normalizeCodebaseMapDoc(readCodebaseMapDoc(t, root, name)))
+	}
+	assessment, err := AssessCodebaseMapDocs(root)
+	require.NoError(t, err)
+	assert.Equal(t, CodebaseMapStatusScaffoldOnly, assessment.Status)
+	assert.Empty(t, assessment.BaselineDocs)
+	assert.Empty(t, assessment.PopulatedDocs)
+}
+
+func TestEnsureCodebaseMapDocsDetectsNodeAndPythonFacts(t *testing.T) {
+	t.Run("node typescript package", func(t *testing.T) {
+		root := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(root, "package.json"), []byte(`{
+  "name": "web-client",
+  "scripts": {"build": "tsc", "test": "vitest"},
+  "dependencies": {"react": "latest"},
+  "devDependencies": {"typescript": "latest", "vitest": "latest"}
+}`), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(root, "tsconfig.json"), []byte("{}\n"), 0o644))
+
+		_, err := EnsureCodebaseMapDocs(root)
+		require.NoError(t, err)
+
+		stack := readCodebaseMapDoc(t, root, "STACK.md")
+		assert.Contains(t, stack, "JavaScript")
+		assert.Contains(t, stack, "TypeScript")
+		assert.Contains(t, stack, "Node.js package web-client")
+		assert.Contains(t, stack, "npm run build; npm test")
+		assert.Contains(t, stack, "react")
+	})
+
+	t.Run("python requirements project", func(t *testing.T) {
+		root := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(root, "requirements.txt"), []byte("pytest==8.0.0\nrequests>=2\n"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(root, "main.py"), []byte("print('ok')\n"), 0o644))
+
+		_, err := EnsureCodebaseMapDocs(root)
+		require.NoError(t, err)
+
+		stack := readCodebaseMapDoc(t, root, "STACK.md")
+		assert.Contains(t, stack, "Python")
+		assert.Contains(t, stack, "Python project")
+		assert.Contains(t, stack, "python -m pytest")
+		assert.Contains(t, stack, "pytest")
+		assert.Contains(t, stack, "requests")
+	})
+}
+
+func TestEnsureCodebaseMapDocsRefreshesLegacyGeneratedGoSlipwayDocs(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "Cargo.toml"), []byte(`[package]
+name = "lattice-demo"
+version = "0.1.0"
+`), 0o644))
+	docDir := state.CodebaseMapDir(root)
+	require.NoError(t, os.MkdirAll(docDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(docDir, "STACK.md"), []byte(`# Stack
+
+- Languages: Go
+- Frameworks and runtimes: Cobra-based CLI module github.com/signalridge/slipway
+- Build and test tooling: go build ./...; go test ./...
+- Key dependencies: github.com/spf13/cobra
+- Notes: go.mod declares Go not detected
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(docDir, "ARCHITECTURE.md"), []byte(`# Architecture
+
+- Module responsibilities: cmd/ owns CLI surfaces; internal/state owns change authority and filesystem layout; internal/engine owns progression, governance, artifact, and gate logic.
+- Dependency flow: CLI commands assemble model state and delegate durable state changes to internal/state and workflow decisions to internal/engine.
+- Coupling hotspots: lifecycle progression, artifact readiness, worktree binding, and archive migration share change.yaml path authority.
+- Current change blast radius: governed workflow creation, codebase-map context, and done/archive reporting.
+- Notes: Baseline was generated from repository layout and known Slipway package boundaries.
+`), 0o644))
+
+	_, err := EnsureCodebaseMapDocs(root)
+	require.NoError(t, err)
+
+	stack := readCodebaseMapDoc(t, root, "STACK.md")
+	assert.Contains(t, stack, "- Languages: Rust")
+	assert.NotContains(t, stack, "Languages: Go")
+	assert.NotContains(t, stack, "go build ./...")
+
+	architecture := readCodebaseMapDoc(t, root, "ARCHITECTURE.md")
+	assert.True(t, CodebaseMapDocIsScaffoldOnly("ARCHITECTURE.md", architecture))
+	assert.NotContains(t, architecture, "cmd/ owns CLI surfaces")
+}
+
+func TestEnsureCodebaseMapDocsPreservesAuthoredAnalysis(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "Cargo.toml"), []byte("[workspace]\nmembers = [\"crates/core\"]\n"), 0o644))
+	docDir := state.CodebaseMapDir(root)
+	require.NoError(t, os.MkdirAll(docDir, 0o755))
+	authored := "# Architecture\n\n- Module responsibilities: crates/core owns the domain model.\n"
+	require.NoError(t, os.WriteFile(filepath.Join(docDir, "ARCHITECTURE.md"), []byte(authored), 0o644))
+
+	_, err := EnsureCodebaseMapDocs(root)
+	require.NoError(t, err)
+
+	assert.Equal(t, normalizeCodebaseMapDoc(authored), normalizeCodebaseMapDoc(readCodebaseMapDoc(t, root, "ARCHITECTURE.md")))
+	assessment, err := AssessCodebaseMapDocs(root)
+	require.NoError(t, err)
+	assert.Contains(t, assessment.PopulatedDocs, "ARCHITECTURE.md")
+}
+
+func TestEnsureCodebaseMapDocsPreservesLegacyDocWithAuthoredSupplement(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "Cargo.toml"), []byte("[workspace]\nmembers = []\n"), 0o644))
+	docDir := state.CodebaseMapDir(root)
+	require.NoError(t, os.MkdirAll(docDir, 0o755))
+	authored := `# Architecture
+
+- Module responsibilities: cmd/ owns CLI surfaces; internal/state owns change authority and filesystem layout; internal/engine owns progression, governance, artifact, and gate logic.
+- Dependency flow: CLI commands assemble model state and delegate durable state changes to internal/state and workflow decisions to internal/engine.
+- Coupling hotspots: lifecycle progression, artifact readiness, worktree binding, and archive migration share change.yaml path authority.
+- Current change blast radius: governed workflow creation, codebase-map context, and done/archive reporting.
+- Notes: Baseline was generated from repository layout and known Slipway package boundaries.
+- Project-specific finding: crates/core owns the domain model.
+`
+	require.NoError(t, os.WriteFile(filepath.Join(docDir, "ARCHITECTURE.md"), []byte(authored), 0o644))
+
+	_, err := EnsureCodebaseMapDocs(root)
+	require.NoError(t, err)
+
+	assert.Equal(t, normalizeCodebaseMapDoc(authored), normalizeCodebaseMapDoc(readCodebaseMapDoc(t, root, "ARCHITECTURE.md")))
+	assessment, err := AssessCodebaseMapDocs(root)
+	require.NoError(t, err)
+	assert.Contains(t, assessment.PopulatedDocs, "ARCHITECTURE.md")
+}
+
+func readCodebaseMapDoc(t *testing.T, root, name string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(state.CodebaseMapDir(root), name))
+	require.NoError(t, err)
+	return string(data)
+}

--- a/internal/state/health.go
+++ b/internal/state/health.go
@@ -659,6 +659,13 @@ func OrphanBundleSlugs(root string) ([]string, error) {
 			changeYaml := filepath.Join(ActiveBundlesDir(workspaceRoot), entry.Name(), "change.yaml")
 			if _, err := os.Stat(changeYaml); err != nil {
 				if errors.Is(err, fs.ErrNotExist) {
+					hasFiles, emptyErr := orphanBundleDirHasFiles(filepath.Dir(changeYaml))
+					if emptyErr != nil {
+						return nil, emptyErr
+					}
+					if !hasFiles {
+						continue
+					}
 					orphans = append(orphans, entry.Name())
 					continue
 				}

--- a/internal/state/health_test.go
+++ b/internal/state/health_test.go
@@ -699,6 +699,7 @@ func TestCollectHealthReportFindsOrphanBundleDirsAcrossWorktrees(t *testing.T) {
 	require.NoError(t, EnsureWorkspaceScopeMarker(root, worktreeRoot))
 	orphanDir := filepath.Join(worktreeRoot, "artifacts", "changes", "orphan-worktree-bundle")
 	require.NoError(t, os.MkdirAll(orphanDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(orphanDir, "intent.md"), []byte("# orphan\n"), 0o644))
 
 	report, err := CollectHealthReport(root)
 	require.NoError(t, err)
@@ -726,6 +727,7 @@ func TestCollectHealthReportDeduplicatesMatchingOrphanBundleDirsAcrossWorktrees(
 		require.NoError(t, EnsureWorkspaceScopeMarker(root, worktreeRoot))
 		orphanDir := filepath.Join(worktreeRoot, "artifacts", "changes", "shared-orphan")
 		require.NoError(t, os.MkdirAll(orphanDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(orphanDir, "intent.md"), []byte("# orphan\n"), 0o644))
 	}
 
 	report, err := CollectHealthReport(root)
@@ -753,6 +755,7 @@ func TestCollectHealthReportFindsHiddenWorktreeOrphanBundleDirs(t *testing.T) {
 
 	orphanDir := filepath.Join(worktreeRoot, "artifacts", "changes", "hidden-orphan-worktree-bundle")
 	require.NoError(t, os.MkdirAll(orphanDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(orphanDir, "intent.md"), []byte("# orphan\n"), 0o644))
 
 	report, err := CollectHealthReport(root)
 	require.NoError(t, err)
@@ -766,6 +769,22 @@ func TestCollectHealthReportFindsHiddenWorktreeOrphanBundleDirs(t *testing.T) {
 		}
 	}
 	assert.Contains(t, orphanReasons, "hidden-orphan-worktree-bundle")
+}
+
+func TestCollectHealthReportIgnoresEmptyOrphanBundleDirs(t *testing.T) {
+	t.Parallel()
+
+	root := createRuntimeRepoLayout(t)
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "artifacts", "changes", "empty-residue", "verification"), 0o755))
+
+	report, err := CollectHealthReport(root)
+	require.NoError(t, err)
+
+	for _, finding := range report.Findings {
+		for _, reason := range finding.Reasons {
+			assert.NotEqual(t, "empty-residue", reason.Detail)
+		}
+	}
 }
 
 func TestCollectHealthReportMarksInvalidWorktreeBindingNonRepairable(t *testing.T) {

--- a/internal/state/lifecycle.go
+++ b/internal/state/lifecycle.go
@@ -32,6 +32,14 @@ func LoadArchivedChange(root, slug string) (model.Change, error) {
 	return loadChangeFromCandidates(root, paths)
 }
 
+func ArchivedChangeFilePathForRead(root, slug string) (string, error) {
+	_, candidate, err := loadArchivedChangeWithCandidate(root, slug)
+	if err != nil {
+		return "", err
+	}
+	return candidate.Path, nil
+}
+
 // ValidateDoneArchivePreconditions checks if a change can be archived as done.
 func ValidateDoneArchivePreconditions(change model.Change) error {
 	if change.Status != model.ChangeStatusActive && change.Status != model.ChangeStatusDone {

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -22,6 +22,26 @@ var (
 	errMissingBundleAuthority = errors.New("change bundle missing authority file")
 )
 
+type BoundChangeRef struct {
+	Slug         string
+	WorktreePath string
+}
+
+type ChangeBoundElsewhereError struct {
+	BoundChanges []BoundChangeRef
+}
+
+func (err *ChangeBoundElsewhereError) Error() string {
+	if err == nil || len(err.BoundChanges) == 0 {
+		return "active changes are bound to other worktrees"
+	}
+	parts := make([]string, 0, len(err.BoundChanges))
+	for _, change := range err.BoundChanges {
+		parts = append(parts, fmt.Sprintf("%s -> %s", change.Slug, change.WorktreePath))
+	}
+	return "active changes are bound to other worktrees: " + strings.Join(parts, ", ")
+}
+
 // RuntimeDir returns the parent directory for all non-authoritative runtime state.
 func RuntimeDir(root string) string {
 	return GitRuntimeDir(root)
@@ -264,6 +284,16 @@ func discoverActiveChangeSlugsAcrossRoots(root string, includeHidden, bestEffort
 			if _, err := os.Stat(bundlePath); err != nil {
 				if !errors.Is(err, fs.ErrNotExist) {
 					return nil, err
+				}
+				hasFiles, emptyErr := orphanBundleDirHasFiles(filepath.Dir(bundlePath))
+				if emptyErr != nil {
+					return nil, emptyErr
+				}
+				if !hasFiles {
+					if !discovery.HasAuthority && discovery.FirstOrphanDir == "" {
+						delete(found, slug)
+					}
+					continue
 				}
 				if discovery.FirstOrphanDir == "" {
 					discovery.FirstOrphanDir = filepath.Dir(bundlePath)
@@ -582,6 +612,7 @@ func FindActiveChangeForWorktree(root, currentWorktreePath string) (model.Change
 	// Phase 1: Match by worktree path.
 	var worktreeMatches []model.Change
 	var unboundActive []model.Change
+	var boundElsewhere []BoundChangeRef
 	for _, c := range changes {
 		if c.Status != model.ChangeStatusActive {
 			continue
@@ -596,6 +627,8 @@ func FindActiveChangeForWorktree(root, currentWorktreePath string) (model.Change
 		}
 		if normalizedChange == normalizedCurrent {
 			worktreeMatches = append(worktreeMatches, c)
+		} else {
+			boundElsewhere = append(boundElsewhere, BoundChangeRef{Slug: c.Slug, WorktreePath: c.WorktreePath})
 		}
 	}
 
@@ -613,8 +646,76 @@ func FindActiveChangeForWorktree(root, currentWorktreePath string) (model.Change
 	if len(unboundActive) > 1 {
 		return model.Change{}, ErrMultipleActiveChanges
 	}
+	if len(boundElsewhere) > 0 {
+		slices.SortFunc(boundElsewhere, func(a, b BoundChangeRef) int {
+			if a.Slug != b.Slug {
+				return strings.Compare(a.Slug, b.Slug)
+			}
+			return strings.Compare(a.WorktreePath, b.WorktreePath)
+		})
+		return model.Change{}, &ChangeBoundElsewhereError{BoundChanges: boundElsewhere}
+	}
 
 	return model.Change{}, ErrNoActiveChange
+}
+
+func RepairEmptyOrphanBundleDirs(root string) ([]string, error) {
+	workspaceRoots, err := allWorkspaceRoots(root)
+	if err != nil {
+		return nil, err
+	}
+	removed := []string{}
+	for _, workspaceRoot := range workspaceRoots {
+		entries, err := os.ReadDir(ActiveBundlesDir(workspaceRoot))
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				continue
+			}
+			return nil, err
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() || entry.Name() == "archived" {
+				continue
+			}
+			bundleDir := filepath.Join(ActiveBundlesDir(workspaceRoot), entry.Name())
+			changeYaml := filepath.Join(bundleDir, "change.yaml")
+			if _, err := os.Stat(changeYaml); err == nil {
+				continue
+			} else if !errors.Is(err, fs.ErrNotExist) {
+				return nil, err
+			}
+			hasFiles, err := orphanBundleDirHasFiles(bundleDir)
+			if err != nil {
+				return nil, err
+			}
+			if hasFiles {
+				continue
+			}
+			if err := os.RemoveAll(bundleDir); err != nil {
+				return nil, err
+			}
+			removed = append(removed, entry.Name())
+		}
+	}
+	slices.Sort(removed)
+	return slices.Compact(removed), nil
+}
+
+func orphanBundleDirHasFiles(dir string) (bool, error) {
+	hasFiles := false
+	err := filepath.WalkDir(dir, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == dir {
+			return nil
+		}
+		if !entry.IsDir() {
+			hasFiles = true
+		}
+		return nil
+	})
+	return hasFiles, err
 }
 
 // ListChanges returns all changes found in the changes directory.

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -315,7 +315,13 @@ func TestFindActiveChangeForWorktreeNoMatchNoFallback(t *testing.T) {
 	require.NoError(t, SaveChange(root, ch2))
 
 	_, err := FindActiveChangeForWorktree(root, queryDir)
-	require.ErrorIs(t, err, ErrNoActiveChange)
+	var boundErr *ChangeBoundElsewhereError
+	require.ErrorAs(t, err, &boundErr)
+	require.Len(t, boundErr.BoundChanges, 2)
+	assert.Equal(t, "other-a", boundErr.BoundChanges[0].Slug)
+	assert.Equal(t, ch1.WorktreePath, boundErr.BoundChanges[0].WorktreePath)
+	assert.Equal(t, "other-b", boundErr.BoundChanges[1].Slug)
+	assert.Equal(t, ch2.WorktreePath, boundErr.BoundChanges[1].WorktreePath)
 }
 
 func TestTwoConcurrentChangesDifferentWorktreesCoexist(t *testing.T) {
@@ -721,6 +727,7 @@ func TestListChangesReportsOrphanBundleDirectoryAsIntegrityError(t *testing.T) {
 	// Create a bundle directory without change.yaml (orphan).
 	orphanDir := filepath.Join(root, "artifacts", "changes", "orphan-dir")
 	require.NoError(t, os.MkdirAll(orphanDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(orphanDir, "intent.md"), []byte("# orphan\n"), 0o644))
 
 	// Also create a valid change so we can verify orphan integrity is not hidden
 	// just because another bundle is still readable.
@@ -733,6 +740,21 @@ func TestListChangesReportsOrphanBundleDirectoryAsIntegrityError(t *testing.T) {
 	normalizedOrphanDir, normalizeErr := NormalizePath(orphanDir)
 	require.NoError(t, normalizeErr)
 	assert.Contains(t, err.Error(), normalizedOrphanDir)
+}
+
+func TestListChangesIgnoresEmptyOrphanBundleDirectory(t *testing.T) {
+	t.Parallel()
+	root := createRuntimeLayout(t)
+
+	emptyResidue := filepath.Join(root, "artifacts", "changes", "empty-residue", "verification")
+	require.NoError(t, os.MkdirAll(emptyResidue, 0o755))
+	validChange := model.NewChange("valid-change")
+	require.NoError(t, SaveChange(root, validChange))
+
+	changes, err := ListChanges(root)
+	require.NoError(t, err)
+	require.Len(t, changes, 1)
+	assert.Equal(t, "valid-change", changes[0].Slug)
 }
 
 func TestSaveChangeDoesNotCreateUnusedSidecarDir(t *testing.T) {

--- a/internal/tmpl/templates/skills/codebase-mapping/SKILL.md
+++ b/internal/tmpl/templates/skills/codebase-mapping/SKILL.md
@@ -31,6 +31,12 @@ Write a durable brownfield map under `artifacts/codebase/` using this fixed docu
 These documents are advisory but canonical. Downstream skills consume them by
 path instead of relying on transient chat context.
 
+`slipway codebase-map --json` may report `status: "baseline"` and
+`baseline_docs` when the CLI has written only detected repository facts. Baseline
+docs are not finished mapping work; refine them with file:line citations,
+module-boundary findings, and change-specific risks before treating the map as
+reviewed context.
+
 ## Process
 
 ### 1. Resolve Output Paths

--- a/internal/tmpl/templates/skills/context-assembly/references/codebase-map.md
+++ b/internal/tmpl/templates/skills/context-assembly/references/codebase-map.md
@@ -48,6 +48,9 @@ extra top-level files expecting downstream consumers to discover them.
    scaffold-only, or stale. The command is idempotent; reruns populate missing
    or scaffold-only files with deterministic baseline repository facts and do
    not overwrite hand-authored substantive content.
+   - `status: baseline` means the documents contain CLI-detected facts only.
+     Treat them as a starting point awaiting authored verification, not as
+     completed brownfield analysis.
 3. Refine each baseline document with file:line citations or command
    transcripts when the task needs stronger evidence. The artifact is a
    reviewable handoff, not free-form notes.
@@ -85,6 +88,7 @@ skill.
 | Symptom | Remediation |
 |---------|-------------|
 | Doc exists but contains only the scaffold | Run `slipway codebase-map`; if it remains scaffold-only, treat it as missing and fill with citations before handoff. |
+| `codebase-map --json` reports `status: "baseline"` | Keep the detected facts, then add source-backed findings and citations before treating the map as reviewed context. |
 | Citations reference files that no longer exist | Rerun on the affected scope; annotate historical files as removed. |
 | Two docs disagree (e.g., `STRUCTURE.md` names an entry point that `ARCHITECTURE.md` ignores) | The inconsistency itself is a finding; surface it in `CONCERNS.md` rather than silently picking one. |
 | Command fails with workspace-uninitialized error | Run `slipway init` first; the command assumes workspace state. |


### PR DESCRIPTION
## Summary
- replace hardcoded Go/Slipway codebase-map baselines with repository fact detection and a distinct `baseline` status
- refresh only exact legacy generated map docs while preserving authored analysis, including docs with project-specific supplements
- improve issue #17 workflow diagnostics for bound worktrees, empty stale active bundles, repair, and archived `validate --change` selectors

## Verification
- `go test ./internal/engine/artifact -run 'TestEnsureCodebaseMapDocs(RefreshesLegacyGeneratedGoSlipwayDocs|PreservesAuthoredAnalysis|PreservesLegacyDocWithAuthoredSupplement|DetectsRustCargoBaseline)' -count=1`
- `go test ./cmd ./internal/state ./internal/engine/artifact -run 'Test(CodebaseMap|EnsureCodebaseMap|ResolveActive|NextChangeFlag|ResolveExplicit|ValidateChangeFlag|ListChangesIgnoresEmpty|RepairRemovesEmpty|RepairReportsOrphan|CollectHealthReportIgnoresEmpty|CollectHealthReportFindsOrphan)' -count=1`
- `go test -count=1 ./...`
- `go build ./...`
- `go run . validate --json --change fix-codebase-map-fabricating-go-slipway-repository-context-f`

Closes #17