### PR TITLE
fix(toolgen): harden find-polluter go list handling

### DIFF
--- a/artifacts/changes/archived/fix-issue-18-harden-find-polluter-go-go-list-handling/assurance.md
+++ b/artifacts/changes/archived/fix-issue-18-harden-find-polluter-go-go-list-handling/assurance.md
@@ -1,0 +1,65 @@
+# Assurance
+## Project Context
+- Tech Stack: Go, Bash
+- Conventions: governed artifact bundle, fixture-contract tests, shipped helper
+  scripts under `internal/tmpl/templates/skills`
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go, Shell
+
+## Scope Summary
+Delivered the issue #18 fix for `find-polluter-go.sh` package discovery:
+`go list` stderr is captured separately from stdout, stderr diagnostics are
+re-emitted, and only stdout is parsed into package candidates. Added deterministic
+fixture coverage for both a hard `go list` failure and the ancestor-module /
+empty-child no-package case.
+
+Out of scope remained unchanged: no codebase-map / issue #17 behavior, no
+unrelated root-cause-tracing rewrite, and no CLI/interface changes to the helper.
+
+## Verification Verdict
+Pass. Governance validation reports G_plan, G_scope, and G_ship approved with
+fresh evidence. Fresh closeout commands after the final code change:
+- Manual ancestor-module empty-child reproduction exited 1 with
+  `no test packages found under ./...` and did not run `go test go: warning`.
+- `go test -count=1 ./internal/toolgen` exited 0.
+- `go test -count=1 ./...` exited 0.
+- `go build ./...` exited 0.
+- `go test -count=1 -cover ./internal/toolgen` exited 0 with 76.8% statement
+  coverage for the package.
+
+## Evidence Index
+- `verification/intake-clarification.yaml`
+- `verification/research-orchestration.yaml`
+- `verification/plan-audit.yaml`
+- `verification/wave-orchestration.yaml`
+- `verification/execution-summary.yaml`
+- `verification/spec-compliance-review.yaml`
+- `verification/code-quality-review.yaml`
+- `verification/goal-verification.yaml`
+
+## Requirement Coverage
+- REQ-001 covered by `find-polluter-go.sh` stdout/stderr separation and the
+  warning-not-as-package fixture.
+- REQ-002 covered by distinct fixture cases for `go list failed for
+  ./does-not-exist/...` and `no test packages found under ./...`.
+- REQ-003 covered by `TestScriptFixtureContracts/find-polluter-go ignores go
+  list warnings when no packages match`.
+
+## Residual Risks and Exceptions
+No accepted blockers. Residual risk is low: the script still depends on Bash as
+before, and warnings from successful `go list` runs are re-emitted for operator
+visibility. Stub/placeholder scan hits were limited to pre-existing test fixture
+TODO strings and the required `XXXXXX` mktemp template.
+
+## Rollback Readiness
+Rollback is a file-level revert of:
+- `internal/tmpl/templates/skills/root-cause-tracing/scripts/find-polluter-go.sh`
+- `internal/toolgen/toolgen_test.go`
+
+After rollback, run `go test ./internal/toolgen` and `go test ./...`.
+
+## Archive Decision
+Ready to archive after `slipway done`. Rationale: all required governance skill
+evidence is passing, execution evidence is fresh, scope contract passes, full
+test/build verification is green, and no residual blockers remain.

--- a/artifacts/changes/archived/fix-issue-18-harden-find-polluter-go-go-list-handling/change.yaml
+++ b/artifacts/changes/archived/fix-issue-18-harden-find-polluter-go-go-list-handling/change.yaml
@@ -1,0 +1,56 @@
+version: 1
+slug: fix-issue-18-harden-find-polluter-go-go-list-handling
+description: 'fix issue #18: harden find-polluter-go go list handling'
+status: done
+current_state: DONE
+needs_discovery: true
+complexity_level: simple
+base_ref: HEAD
+created_at: 2026-05-30T13:35:28.738752Z
+quality_mode: standard
+workflow_preset: standard
+worktree_branch: feat/fix-issue-18-harden-find-polluter-go-go-list-handling
+artifact_schema: expanded
+project_context:
+    test_cmd: go test ./...
+    build_cmd: go build ./...
+    languages:
+        - Go
+        - Shell
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: 1aece7d225545cee71e34bd7110414ae98febfd5903bc8c3b9606ff0d6a012f4
+        updated_at: 2026-05-30T13:53:53.887894784Z
+    decision:
+        id: decision
+        path: decision.md
+        state: frozen
+        content_hash: 24765559b19be00222154676bae4ab166f3d7ddefaa27bd11d83eb84dd2c12d9
+        updated_at: 2026-05-30T13:42:10.396875488Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: d7461cea2e0b35966ebce0c757585c90babba8a46ea32785f90d0d5ff4f87232
+        updated_at: 2026-05-30T13:37:16.580168058Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: eeeb8a5cb89bc23167f602dd58b77716715fa44a8b47edd887d1ea93d39d0f62
+        updated_at: 2026-05-30T13:42:10.396413447Z
+    research:
+        id: research
+        path: research.md
+        state: frozen
+        content_hash: 37f0255a3408d2d7d9fc35055d8951380578a56ba4abf83fc02ad104167a5cd4
+        updated_at: 2026-05-30T13:40:36.218297406Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: e3f68f0f8942ffb8039ab7b6d80b5df8a3db09439d47785a937750384f1f0464
+        updated_at: 2026-05-30T13:48:32.071019798Z

--- a/artifacts/changes/archived/fix-issue-18-harden-find-polluter-go-go-list-handling/decision.md
+++ b/artifacts/changes/archived/fix-issue-18-harden-find-polluter-go-go-list-handling/decision.md
@@ -1,0 +1,61 @@
+# Decision
+## Project Context
+- Tech Stack: Go, Bash
+- Conventions: keep helper scripts deterministic; fixture contracts exercise
+  shipped script behavior through `runCommandInDir`
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go, Shell
+
+## Alternatives Considered
+
+1. Test-only tolerance for either `go list failed` or `matched no packages`.
+   - Pros: smallest test change.
+   - Cons: leaves the shipped helper parsing stderr warnings as package names.
+2. Force the test temp directory outside every module.
+   - Pros: preserves the old assertion.
+   - Cons: misses the issue #18 developer-machine failure mode and is brittle
+     across environments.
+3. Fix script package discovery and add deterministic fixture coverage.
+   - Pros: fixes the real helper robustness defect, keeps hard failures distinct,
+     and covers the ancestor-module/no-package case directly.
+   - Cons: small increase in script complexity to manage a temporary stderr file.
+
+## Selected Approach
+Use approach 3. Capture `go list` stdout into the package list and stderr into a
+temporary file. Re-emit stderr for operator visibility, but only parse stdout
+into `PKGS`. Keep empty stdout on the existing `no test packages found` branch,
+and keep non-zero `go list` exits on the `go list failed for <glob>` branch.
+
+This direction honors the documented constraints:
+- Keep the exported script's CLI unchanged:
+  `find-polluter-go.sh <pollution-path> <package-glob> [-run <regex>]`.
+- Preserve useful diagnostics for both hard `go list` failures and empty package
+  results.
+- Stay inside the existing Bash implementation style.
+
+## Interfaces and Data Flow
+No public interface changes.
+
+Internal data flow changes:
+- Before: `go list` stdout and stderr were merged into `LIST_OUTPUT`, then
+  non-empty lines were sorted into `PKGS`.
+- After: `go list` stdout remains `LIST_OUTPUT`; stderr is captured separately,
+  re-emitted, and never sorted into `PKGS`.
+
+## Rollout and Rollback
+Rollout is a normal source change to the script template and fixture tests.
+Rollback is a file-level revert of:
+- `internal/tmpl/templates/skills/root-cause-tracing/scripts/find-polluter-go.sh`
+- `internal/toolgen/toolgen_test.go`
+
+Verification commands:
+- `go test ./internal/toolgen`
+- `go test ./...`
+
+## Risk
+- Low: script remains offline and preserves the existing CLI.
+- Low: temp stderr file cleanup is managed with a trap and is scoped to script
+  execution.
+- Residual risk: `go list` may emit useful warnings even with valid packages;
+  this implementation re-emits them so operator diagnostics are preserved.

--- a/artifacts/changes/archived/fix-issue-18-harden-find-polluter-go-go-list-handling/intent.md
+++ b/artifacts/changes/archived/fix-issue-18-harden-find-polluter-go-go-list-handling/intent.md
@@ -1,0 +1,54 @@
+# Intent
+
+## Project Context
+<!-- Auto-filled by InferProjectContext(); .slipway.yaml overrides -->
+- Tech Stack:
+- Languages: Go, Shell
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Conventions:
+
+## Summary
+fix issue #18: harden find-polluter-go go list handling
+## Complexity Assessment
+simple
+Issue #18 identifies a bounded robustness defect in one shipped shell script and
+its fixture-contract test. The blast radius is limited to tool generation
+fixtures and the exported root-cause-tracing helper.
+
+## In Scope
+- Harden `internal/tmpl/templates/skills/root-cause-tracing/scripts/find-polluter-go.sh`
+  so `go list` stderr warnings are not parsed as package import paths.
+- Treat an empty package set from `go list ./...` as a stable "no test packages
+  found" failure path even when an ancestor `go.mod` makes `go list` exit 0.
+- Update `internal/toolgen/toolgen_test.go` fixture contracts to cover the
+  ancestor-module/no-packages case described in issue #18.
+
+## Out of Scope
+- Changes to codebase-map / issue #17 behavior.
+- Broad rewrites of root-cause-tracing skills or unrelated generated scripts.
+- Removing or weakening existing successful polluter-detection coverage.
+
+## Constraints
+- Keep the exported script portable POSIX shell.
+- Preserve the existing command-line interface:
+  `find-polluter-go.sh <pollution-path> <package-glob> [-run <regex>]`.
+- Keep diagnostics useful for both `go list` hard failures and empty package
+  results.
+
+## Acceptance Signals
+- Targeted `go test ./internal/toolgen` passes.
+- Full `go test ./...` passes.
+- The updated fixture does not treat `go: warning: "./..." matched no packages`
+  as a package name.
+
+## Open Questions
+None.
+
+## Approved Summary
+Confirmed from the user request to solve GitHub issue #18 on 2026-05-30T13:36:37Z:
+fix the `find-polluter-go.sh` package discovery path so stderr warnings from
+`go list` cannot become bogus package names, update the fixture contract for
+the ancestor-module/no-package environment, and verify with targeted and full Go
+tests. Excludes issue #17/codebase-map work and unrelated root-cause-tracing
+changes.

--- a/artifacts/changes/archived/fix-issue-18-harden-find-polluter-go-go-list-handling/requirements.md
+++ b/artifacts/changes/archived/fix-issue-18-harden-find-polluter-go-go-list-handling/requirements.md
@@ -1,0 +1,50 @@
+# Requirements
+## Project Context
+- Tech Stack: Go, Bash
+- Conventions: small scoped fixes, fixture contracts in Go tests, shipped helper
+  scripts under `internal/tmpl/templates/skills`
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go, Shell
+
+## Requirements
+
+### Requirement: Separate `go list` stdout from stderr in `find-polluter-go.sh`
+REQ-001: `find-polluter-go.sh` MUST build its package candidate list only from
+`go list` stdout, not from stderr diagnostics or warnings.
+
+#### Scenario: `go list` emits a warning while returning success
+GIVEN `go list ./...` exits 0 and writes `go: warning: "./..." matched no packages` to stderr
+WHEN `find-polluter-go.sh` enumerates packages
+THEN the warning is not passed to `go test` as a package import path
+AND the script does not report that it is checking one package.
+
+### Requirement: Preserve distinct no-package and hard-failure diagnostics
+REQ-002: `find-polluter-go.sh` MUST return a stable non-zero "no test packages
+found" diagnostic when `go list` succeeds with no package stdout, and MUST keep
+hard `go list` failures on the `go list failed for <glob>` path.
+
+#### Scenario: no test packages match under an ancestor module
+GIVEN a child directory below an ancestor `go.mod` contains no Go packages
+WHEN `find-polluter-go.sh <pollution-path> ./...` runs from the child directory
+THEN the script exits non-zero
+AND output contains `no test packages found under ./...`
+AND output does not contain `-- go test go: warning`.
+
+#### Scenario: `go list` fails for a missing package tree
+GIVEN a module root has no `./does-not-exist/...` package tree
+WHEN `find-polluter-go.sh <pollution-path> ./does-not-exist/...` runs
+THEN the script exits non-zero
+AND output contains `go list failed for ./does-not-exist/...`
+AND output does not collapse into `no test packages found`.
+
+### Requirement: Cover issue #18 with deterministic fixture tests
+REQ-003: `internal/toolgen/toolgen_test.go` MUST include fixture-contract
+coverage for the ancestor-module/no-package case without relying on ambient
+`$TMPDIR` ancestry.
+
+#### Scenario: fixture constructs the issue #18 environment directly
+GIVEN the test creates a temporary parent module and an empty child directory
+WHEN it runs `find-polluter-go.sh` from the child directory
+THEN the contract asserts the no-package diagnostic
+AND asserts the `go list` warning was not parsed as a package.

--- a/artifacts/changes/archived/fix-issue-18-harden-find-polluter-go-go-list-handling/research.md
+++ b/artifacts/changes/archived/fix-issue-18-harden-find-polluter-go-go-list-handling/research.md
@@ -1,0 +1,74 @@
+# Research
+
+## Research Findings
+
+### Architecture
+- Affected modules:
+  - `internal/tmpl/templates/skills/root-cause-tracing/scripts/find-polluter-go.sh`
+  - `internal/toolgen/toolgen_test.go`
+- Dependency chains: toolgen fixture tests execute shipped skill scripts from
+  `internal/tmpl/templates/skills/...`; generated skill surfaces depend on those
+  templates staying executable and deterministic.
+- Blast radius: low. The change affects package enumeration in one diagnostic
+  helper script and fixture-contract tests for that helper.
+- Constraints: preserve the script CLI and bash implementation; keep `go list`
+  hard failures distinct from "no test packages found"; preserve external
+  `_test` package discovery.
+
+### Patterns
+- Existing conventions: scripts emit `find-polluter-go.sh:` diagnostics to
+  stderr and return non-zero for usage, pre-existing pollution, go-list failures,
+  empty package sets, and detected polluters.
+- Reusable abstractions: existing `runCommandInDir` fixture helper covers script
+  execution in controlled temporary modules.
+- Convention deviations: none required. The script already depends on bash
+  arrays/process substitution, so a bash-specific temp stderr file is consistent.
+
+### Risks
+- Technical risks: low. Capturing stderr separately could hide useful go-list
+  diagnostics unless they are re-emitted; the implementation re-emits stderr.
+- Guardrail domains: none.
+- Reversibility: simple file-level revert restores prior behavior.
+
+### Test Strategy
+- Existing coverage: `TestScriptFixtureContracts` already covers usage errors,
+  go-list failure reporting, and external-test-only package enumeration.
+- Infrastructure needs: a temp parent module with an empty child directory to
+  reproduce the ancestor-`go.mod`/no-package case without writing `/tmp/go.mod`.
+- Verification approach:
+  - Reproduce the issue with the script in an empty child under a temp `go.mod`.
+  - Assert `go list` hard failures still report `go list failed for ...`.
+  - Assert `go: warning: "./..." matched no packages` is not treated as a
+    package name.
+  - Run `go test ./internal/toolgen`, then `go test ./...`.
+
+## Alternatives Considered
+- Accept either `go list failed` or `matched no packages` in the test only:
+  cheap, but leaves the shipped script parsing stderr warnings as packages.
+- Force the test into a module-free temp root: narrows the test environment, but
+  does not cover the developer-machine failure mode from issue #18.
+- Selected: capture `go list` stdout and stderr separately in the script, treat
+  empty stdout as `no test packages found`, and add a fixture for the
+  ancestor-module/no-package case. This fixes the real script robustness defect
+  and makes the test deterministic.
+
+## Unknowns
+- Resolved: whether the issue reproduces without writing `/tmp/go.mod` ->
+  yes, a temp parent module plus empty child reproduces the bad path.
+- Resolved: whether external `_test` package enumeration must be preserved ->
+  yes, existing fixture coverage asserts `example.com/polluter/polluter`.
+- Remaining: None.
+
+## Assumptions
+- The script may continue requiring bash. Evidence: existing implementation uses
+  bash arrays and process substitution in
+  `internal/tmpl/templates/skills/root-cause-tracing/scripts/find-polluter-go.sh`.
+- `go test ./internal/toolgen` is the targeted test signal. Evidence:
+  `internal/toolgen/toolgen_test.go` owns `TestScriptFixtureContracts`.
+
+## Canonical References
+- `https://github.com/signalridge/slipway/issues/18`
+- `internal/tmpl/templates/skills/root-cause-tracing/scripts/find-polluter-go.sh`
+- `internal/toolgen/toolgen_test.go`
+- `artifacts/codebase/TESTING.md`
+- `artifacts/changes/fix-issue-18-harden-find-polluter-go-go-list-handling/intent.md`

--- a/artifacts/changes/archived/fix-issue-18-harden-find-polluter-go-go-list-handling/tasks.md
+++ b/artifacts/changes/archived/fix-issue-18-harden-find-polluter-go-go-list-handling/tasks.md
@@ -1,0 +1,55 @@
+# Tasks
+## Project Context
+- Tech Stack: Go, Bash
+- Conventions: surgical script/test changes; fixture contracts verify shipped
+  helper behavior
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go, Shell
+
+## Task List
+
+- [x] `t-01` Split `go list` stdout and stderr in `find-polluter-go.sh`.
+  - wave: 1
+  - depends_on: []
+  - target_files: ["internal/tmpl/templates/skills/root-cause-tracing/scripts/find-polluter-go.sh"]
+  - task_kind: code
+  - covers: [REQ-001, REQ-002]
+  - evidence: package list populated only from stdout; stderr re-emitted but never passed to go test
+  - acceptance: issue #18 ancestor-module reproduction exits with no test packages found and no go test warning package
+
+- [x] `t-02` Keep hard `go list` failures distinct from empty package results.
+  - wave: 2
+  - depends_on: ["t-01"]
+  - target_files: ["internal/tmpl/templates/skills/root-cause-tracing/scripts/find-polluter-go.sh", "internal/toolgen/toolgen_test.go"]
+  - task_kind: code
+  - covers: [REQ-002]
+  - evidence: missing package tree reports go list failed for ./does-not-exist/...
+  - acceptance: go test ./internal/toolgen passes
+
+- [x] `t-03` Add deterministic issue #18 fixture coverage.
+  - wave: 3
+  - depends_on: ["t-01"]
+  - target_files: ["internal/toolgen/toolgen_test.go"]
+  - task_kind: code
+  - covers: [REQ-001, REQ-003]
+  - evidence: fixture creates temp parent module and empty child directory
+  - acceptance: fixture asserts go list warning is not treated as a package name
+
+- [x] `t-04` Run targeted verification.
+  - wave: 4
+  - depends_on: ["t-01", "t-02", "t-03"]
+  - target_files: ["artifacts/changes/fix-issue-18-harden-find-polluter-go-go-list-handling/verification"]
+  - task_kind: verification
+  - covers: [REQ-001, REQ-002, REQ-003]
+  - evidence: targeted command result for go test ./internal/toolgen and manual reproduction result
+  - acceptance: targeted command exits 0
+
+- [x] `t-05` Run full repository verification.
+  - wave: 5
+  - depends_on: ["t-04"]
+  - target_files: ["artifacts/changes/fix-issue-18-harden-find-polluter-go-go-list-handling/verification"]
+  - task_kind: verification
+  - covers: [REQ-001, REQ-002, REQ-003]
+  - evidence: full go test ./... result
+  - acceptance: full command exits 0

--- a/internal/tmpl/templates/skills/root-cause-tracing/scripts/find-polluter-go.sh
+++ b/internal/tmpl/templates/skills/root-cause-tracing/scripts/find-polluter-go.sh
@@ -70,15 +70,16 @@ fi
 # includes packages with either in-package tests or external `_test` packages.
 LIST_OUTPUT=""
 LIST_STDERR_FILE="$(mktemp "${TMPDIR:-/tmp}/find-polluter-go-list-stderr.XXXXXX")"
-cleanup_list_stderr() {
-	rm -f "$LIST_STDERR_FILE"
-}
-trap cleanup_list_stderr EXIT
+trap 'rm -f "$LIST_STDERR_FILE"' EXIT
 
 if LIST_OUTPUT="$(go list -f '{{if or .TestGoFiles .XTestGoFiles}}{{.ImportPath}}{{end}}' "$PKG_GLOB" 2>"$LIST_STDERR_FILE")"; then
-	LIST_STDERR="$(cat "$LIST_STDERR_FILE")"
+	LIST_STATUS=0
 else
-	LIST_STDERR="$(cat "$LIST_STDERR_FILE")"
+	LIST_STATUS=$?
+fi
+LIST_STDERR="$(cat "$LIST_STDERR_FILE")"
+
+if [ "$LIST_STATUS" -ne 0 ]; then
 	echo "find-polluter-go.sh: go list failed for $PKG_GLOB" >&2
 	if [ -n "$LIST_STDERR" ]; then
 		printf '%s\n' "$LIST_STDERR" >&2
@@ -88,6 +89,7 @@ else
 	fi
 	exit 1
 fi
+
 if [ -n "$LIST_STDERR" ]; then
 	printf '%s\n' "$LIST_STDERR" >&2
 fi

--- a/internal/tmpl/templates/skills/root-cause-tracing/scripts/find-polluter-go.sh
+++ b/internal/tmpl/templates/skills/root-cause-tracing/scripts/find-polluter-go.sh
@@ -69,10 +69,27 @@ fi
 # Enumerate candidate packages. `go list` keeps output deterministic and
 # includes packages with either in-package tests or external `_test` packages.
 LIST_OUTPUT=""
-if ! LIST_OUTPUT="$(go list -f '{{if or .TestGoFiles .XTestGoFiles}}{{.ImportPath}}{{end}}' "$PKG_GLOB" 2>&1)"; then
+LIST_STDERR_FILE="$(mktemp "${TMPDIR:-/tmp}/find-polluter-go-list-stderr.XXXXXX")"
+cleanup_list_stderr() {
+	rm -f "$LIST_STDERR_FILE"
+}
+trap cleanup_list_stderr EXIT
+
+if LIST_OUTPUT="$(go list -f '{{if or .TestGoFiles .XTestGoFiles}}{{.ImportPath}}{{end}}' "$PKG_GLOB" 2>"$LIST_STDERR_FILE")"; then
+	LIST_STDERR="$(cat "$LIST_STDERR_FILE")"
+else
+	LIST_STDERR="$(cat "$LIST_STDERR_FILE")"
 	echo "find-polluter-go.sh: go list failed for $PKG_GLOB" >&2
-	echo "$LIST_OUTPUT" >&2
+	if [ -n "$LIST_STDERR" ]; then
+		printf '%s\n' "$LIST_STDERR" >&2
+	fi
+	if [ -n "$LIST_OUTPUT" ]; then
+		printf '%s\n' "$LIST_OUTPUT" >&2
+	fi
 	exit 1
+fi
+if [ -n "$LIST_STDERR" ]; then
+	printf '%s\n' "$LIST_STDERR" >&2
 fi
 
 PKGS=()

--- a/internal/toolgen/toolgen_test.go
+++ b/internal/toolgen/toolgen_test.go
@@ -2020,11 +2020,38 @@ func TestScriptFixtureContracts(t *testing.T) {
 		_, err = os.Stat(script)
 		require.NoError(t, err)
 
-		emptyDir := t.TempDir()
-		out, cerr := runCommandInDir(emptyDir, bashPath, script, filepath.Join(emptyDir, ".pollution"), "./...")
-		assert.Errorf(t, cerr, "expected go list failure outside a Go module")
-		assert.Contains(t, out, "go list failed for ./...")
+		modRoot := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(modRoot, "go.mod"), []byte("module example.com/listfail\n\ngo 1.22\n"), 0o644))
+		out, cerr := runCommandInDir(modRoot, bashPath, script, filepath.Join(modRoot, ".pollution"), "./does-not-exist/...")
+		assert.Errorf(t, cerr, "expected go list failure for missing package tree")
+		assert.Contains(t, out, "go list failed for ./does-not-exist/...")
 		assert.NotContains(t, out, "no test packages found", "go list failures must not collapse into an empty-package diagnostic")
+	})
+
+	t.Run("find-polluter-go ignores go list warnings when no packages match", func(t *testing.T) {
+		t.Parallel()
+		bashPath, err := execLookPath("bash")
+		if err != nil {
+			t.Skipf("bash unavailable: %v", err)
+		}
+		if _, err := execLookPath("go"); err != nil {
+			t.Skipf("go unavailable: %v", err)
+		}
+
+		script := scriptPathForTest(t, root, "root-cause-tracing", "find-polluter-go.sh")
+		_, err = os.Stat(script)
+		require.NoError(t, err)
+
+		modRoot := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(modRoot, "go.mod"), []byte("module example.com/emptyparent\n\ngo 1.22\n"), 0o644))
+		emptyDir := filepath.Join(modRoot, "empty")
+		require.NoError(t, os.MkdirAll(emptyDir, 0o755))
+
+		out, cerr := runCommandInDir(emptyDir, bashPath, script, filepath.Join(emptyDir, ".pollution"), "./...")
+		assert.Errorf(t, cerr, "expected no matching test packages to exit non-zero")
+		assert.Contains(t, out, "no test packages found under ./...")
+		assert.NotContains(t, out, "-- go test go: warning", "go list stderr must not be parsed as a package")
+		assert.NotContains(t, out, "checking 1 package(s)", "go list warning must not become a package entry")
 	})
 
 	t.Run("find-polluter-go external tests", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Separate `go list` stderr from stdout so warnings cannot become package candidates.
- Treat successful `go list` runs with empty stdout as `no test packages found`, preserving hard failure diagnostics separately.
- Add deterministic fixture coverage for the issue #18 ancestor-module empty-directory case.
- Clean post-review stderr handling by reading stderr once and using an inline EXIT trap.

Closes #18.

## Verification
- `bash -n internal/tmpl/templates/skills/root-cause-tracing/scripts/find-polluter-go.sh`
- `shellcheck internal/tmpl/templates/skills/root-cause-tracing/scripts/find-polluter-go.sh`
- `go test -count=1 ./internal/toolgen -run "TestScriptFixtureContracts/find-polluter-go" -v`
- manual ancestor-module empty-dir reproduction
- manual missing-package-tree reproduction
- `go test -count=1 ./internal/toolgen`
- `go test -count=1 ./...`
- `go build ./...`
- `golangci-lint run --timeout 5m`
- `go test -count=1 -cover ./internal/toolgen`