### PR TITLE
docs(toolgen): clarify new JSON stdin classification contract

### DIFF
--- a/artifacts/changes/archived/resolve-issue-21-clarify-json-stdin-classification-contract/assurance.md
+++ b/artifacts/changes/archived/resolve-issue-21-clarify-json-stdin-classification-contract/assurance.md
@@ -1,0 +1,48 @@
+# Assurance
+
+## Project Context
+- Tech Stack:
+- Conventions:
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go, Markdown
+
+## Scope Summary
+Delivered scope is limited to clarifying the exported `slipway new --json` JSON stdin classification contract in generated agent-facing surfaces and tests.
+
+## Verification Verdict
+Pass. The change satisfies all governed requirements with fresh verification from the current worktree:
+- `go test ./internal/toolgen` passed.
+- `go test ./internal/toolgen -cover` passed with 76.8% statement coverage.
+- `go test -count=1 ./...` passed.
+- `go build ./...` passed.
+
+## Evidence Index
+- `requirements.md`
+- `decision.md`
+- `tasks.md`
+- `research.md`
+- `verification/plan-audit.yaml`
+- `verification/wave-orchestration.yaml`
+- `verification/execution-summary.yaml`
+- `verification/spec-compliance-review.yaml`
+- `verification/code-quality-review.yaml`
+- `verification/coverage-analysis.yaml`
+- `verification/goal-verification.yaml`
+- `verification/final-closeout.yaml`
+
+## Requirement Coverage
+- REQ-001: covered by `task-01` and `task-02`.
+- REQ-002: covered by `task-01` and `task-02`.
+- REQ-003: covered by `task-01` and `task-02`.
+- REQ-004: covered by `task-01` and `task-02`.
+- REQ-005: covered by `task-01`.
+
+## Residual Risks and Exceptions
+No accepted exceptions. Residual risk is wording drift across generated surfaces; mitigated by generated-surface assertions for workflow skill, command reference, and Codex/Claude `slipway-new` outputs.
+
+## Rollback Readiness
+Rollback is a clean revert of template, toolgen metadata, and test changes. No runtime migration or data mutation is involved.
+
+## Archive Decision
+Archive-ready after `goal-verification` passes, final closeout evidence is fresh, and `slipway next --json --diagnostics` reports `done-ready`.

--- a/artifacts/changes/archived/resolve-issue-21-clarify-json-stdin-classification-contract/change.yaml
+++ b/artifacts/changes/archived/resolve-issue-21-clarify-json-stdin-classification-contract/change.yaml
@@ -1,0 +1,56 @@
+version: 1
+slug: resolve-issue-21-clarify-json-stdin-classification-contract
+description: 'resolve issue 21: clarify JSON stdin classification contract in exported agent surfaces'
+status: done
+current_state: DONE
+needs_discovery: true
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-05-30T14:26:24.477975Z
+quality_mode: standard
+workflow_preset: standard
+worktree_branch: feat/resolve-issue-21-clarify-json-stdin-classification-contract
+artifact_schema: expanded
+project_context:
+    test_cmd: go test ./...
+    build_cmd: go build ./...
+    languages:
+        - Go
+        - Markdown
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: a4ce25963262ab844b428215ddb5fe9418b9ee2f6dee823c905bda2e0e976c2b
+        updated_at: 2026-05-30T14:48:54.561754955Z
+    decision:
+        id: decision
+        path: decision.md
+        state: frozen
+        content_hash: 82c3ad0b99e90431538428a87d8e58504c8c2eaff60568bf6022f08078e87861
+        updated_at: 2026-05-30T14:33:21.993579033Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: ebe527448fbf93e93df95b4534ad9bfe01e00993ae1ffc7881278a1a82a17d84
+        updated_at: 2026-05-30T15:11:19Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: 3c36b178dda687a020db93a36a607eaf9b0c899940720cedff4e0de8db4fbbf2
+        updated_at: 2026-05-30T14:33:21.993303742Z
+    research:
+        id: research
+        path: research.md
+        state: frozen
+        content_hash: a5852cf65a441e462869e60cb1f5c9f1d51488f1f168b1b09d44a78d0eb28666
+        updated_at: 2026-05-30T14:31:33.655123598Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: 74a824d60f94436013ef8691c98b0ce87c40fcb69a17abc1a20e266503b43922
+        updated_at: 2026-05-30T14:40:48.885524561Z

--- a/artifacts/changes/archived/resolve-issue-21-clarify-json-stdin-classification-contract/decision.md
+++ b/artifacts/changes/archived/resolve-issue-21-clarify-json-stdin-classification-contract/decision.md
@@ -1,0 +1,34 @@
+# Decision
+
+## Alternatives Considered
+
+### Option A: Template-only wording
+Update only `internal/tmpl/templates/skills/workflow/SKILL.md.tmpl` and `internal/tmpl/templates/_partials/command-new-body.tmpl`.
+
+Tradeoff: lowest diff size, but leaves `references/command-reference.md` incomplete and does not resolve all surfaces named by issue #21.
+
+### Option B: Metadata-backed command-reference notes plus targeted templates
+Add command-specific notes to the shared toolgen command metadata, render those notes in workflow command references, and update the workflow skill plus `/slipway-new` body.
+
+Tradeoff: slightly expands command metadata, but keeps command-reference prose generated from one source of truth and limits runtime blast radius.
+
+### Option C: Add CLI classification flags
+Introduce `--guardrail-domain`, `--complexity`, and `--needs-discovery` flags to `slipway new`.
+
+Tradeoff: broadens runtime behavior and contradicts issue #21's explicit non-problem ruling.
+
+## Selected Approach
+Use Option B. Clarify JSON stdin classification in the workflow skill template, `/slipway-new` prompt partial, and generated workflow command reference through shared command metadata. Add generated-surface tests for Codex and Claude outputs. Do not add CLI flags or change runtime classification behavior.
+
+## Interfaces and Data Flow
+- `internal/toolgen/toolgen.go` remains the source of command metadata for generated command reference entries.
+- `internal/tmpl/templates/skills/workflow/command-reference.md.tmpl` renders command metadata notes under the relevant command entry.
+- `internal/tmpl/templates/skills/workflow/SKILL.md.tmpl` renders the primary exported workflow guidance.
+- `internal/tmpl/templates/_partials/command-new-body.tmpl` renders generated command/prompt bodies such as Codex `slipway-new.md` and Claude command entries.
+- `internal/toolgen/toolgen_test.go` generates temporary adapter surfaces and asserts the exported contract text.
+
+## Rollout and Rollback
+Roll forward by changing templates, shared toolgen metadata, and tests in one commit. Roll back by reverting those files; no persisted runtime state or migration is affected.
+
+## Risk
+Low. The change is limited to generated documentation surfaces and tests. Main risks are wording drift between surfaces or accidentally implying unsupported CLI flags; tests will assert the JSON stdin and not-flags wording directly.

--- a/artifacts/changes/archived/resolve-issue-21-clarify-json-stdin-classification-contract/intent.md
+++ b/artifacts/changes/archived/resolve-issue-21-clarify-json-stdin-classification-contract/intent.md
@@ -1,0 +1,51 @@
+# Intent
+
+## Project Context
+<!-- Auto-filled by InferProjectContext(); .slipway.yaml overrides -->
+- Tech Stack:
+- Languages: Go, Markdown
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Conventions:
+
+## Summary
+resolve issue 21: clarify JSON stdin classification contract in exported agent surfaces
+## Complexity Assessment
+complex
+<!-- Rationale: provide justification for the assessed complexity level -->
+
+## Guardrail Domains
+<!-- none detected -->
+
+## In Scope
+- Update `internal/tmpl/templates/skills/workflow/SKILL.md.tmpl` so the primary exported workflow skill states that explicit classification for `slipway new --json` is supplied through JSON stdin, not command-line flags.
+- Add a minimal JSON stdin example for `slipway new --json` in at least one exported agent-facing surface.
+- Update `internal/tmpl/templates/_partials/command-new-body.tmpl` so `/slipway-new` documents the explicit JSON stdin classification path for AI callers that already know the classification.
+- Update generated command-reference metadata or rendering so the `slipway new` entry includes stdin classification notes in addition to CLI flags.
+- Add or update template/toolgen tests proving generated Codex and Claude surfaces preserve the JSON stdin contract.
+
+## Out of Scope
+- Do not add `--guardrail-domain`, `--complexity`, or `--needs-discovery` CLI flags.
+- Do not change `cmd/new.go` runtime classification behavior beyond what tests require for generated surfaces.
+- Do not redesign the broader agent command-surface documentation system.
+
+## Constraints
+- Keep the change scoped to exported agent-facing contract clarity.
+- Preserve the existing guidance that normal users should not manually choose internal routing labels when Slipway can infer them.
+- Keep generated Codex and Claude surfaces aligned.
+
+## Acceptance Signals
+- Generated workflow skill explicitly says `guardrail_domain`, `complexity`, and `needs_discovery` are JSON stdin fields for `slipway new --json`, not CLI flags.
+- `/slipway-new` mentions the explicit JSON stdin classification path without encouraging unsupported flags.
+- Generated command reference includes JSON stdin classification shape notes for `slipway new`.
+- Template/toolgen tests fail if the JSON stdin contract text or minimal example disappears.
+- `go test ./...` and `go build ./...` pass.
+
+## Open Questions
+- [x] Verify the exact generated-surface test helpers before choosing whether to update snapshot expectations, direct string assertions, or both. Resolved in `research.md`: direct generated-surface string assertions in `internal/toolgen/toolgen_test.go` cover the relevant Codex and Claude outputs without adding snapshots.
+
+## Deferred Ideas
+- Future richer stdin schema metadata for every command that accepts structured stdin.
+
+## Approved Summary
+Approved by user on 2026-05-30T14:28:02Z. Resolve GitHub issue #21 by clarifying exported agent-facing contracts for `slipway new --json`: explicit classification fields are provided via JSON stdin, not unsupported CLI flags. The implementation will update the workflow skill template, `/slipway-new` prompt partial, command-reference generation, and regression tests. It will not add new CLI flags or change the runtime classification semantics.

--- a/artifacts/changes/archived/resolve-issue-21-clarify-json-stdin-classification-contract/requirements.md
+++ b/artifacts/changes/archived/resolve-issue-21-clarify-json-stdin-classification-contract/requirements.md
@@ -1,0 +1,25 @@
+# Requirements
+
+## Project Context
+- Tech Stack:
+- Conventions:
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go, Markdown
+
+## Requirements
+
+### Requirement: WorkflowSkillTransportClarity
+REQ-001: The primary exported workflow skill MUST state that explicit `slipway new --json` classification uses JSON stdin fields, not command-line flags.
+
+### Requirement: MinimalJSONExample
+REQ-002: At least one exported agent-facing surface MUST show a minimal `echo '{...}' | slipway new --json` example including `description`, `guardrail_domain`, `needs_discovery`, and `complexity`.
+
+### Requirement: CommandPromptCompleteness
+REQ-003: The `/slipway-new` command prompt surface MUST document the explicit JSON stdin classification path for AI callers that already know classification, while preserving guidance against unsupported manual routing labels.
+
+### Requirement: CommandReferenceCompleteness
+REQ-004: The generated workflow command reference MUST include stdin classification notes for `slipway new` in addition to CLI arguments.
+
+### Requirement: RegressionCoverage
+REQ-005: Generated-surface tests MUST fail if the JSON stdin classification contract, minimal example, or no-flag wording disappears from generated Codex and Claude surfaces.

--- a/artifacts/changes/archived/resolve-issue-21-clarify-json-stdin-classification-contract/research.md
+++ b/artifacts/changes/archived/resolve-issue-21-clarify-json-stdin-classification-contract/research.md
@@ -1,0 +1,49 @@
+# Research
+
+## Research Findings
+
+### Architecture
+- Affected modules: `internal/tmpl/templates/skills/workflow/SKILL.md.tmpl`, `internal/tmpl/templates/_partials/command-new-body.tmpl`, `internal/toolgen/toolgen.go`, and `internal/toolgen/toolgen_test.go`.
+- Dependency chains: `commandRegistry` metadata feeds `buildCommandRenderData`, `buildWorkflowCommandEntries`, `renderStandaloneWorkflowCommandReference`, and generated per-command prompt entries. Workflow skill content comes from the workflow skill template and command-reference template.
+- Blast radius: low; the change updates exported generated documentation and tests, not command execution or lifecycle state.
+- Constraints: `cmd/new.go` remains the runtime authority for JSON stdin parsing. The generated surfaces must not imply unsupported `--guardrail-domain`, `--complexity`, or `--needs-discovery` flags.
+
+### Patterns
+- Existing conventions: command argument and prerequisite text are centralized in `commandRegistry`; workflow command references are rendered from shared toolgen data; generated-surface tests assert important strings in temp generated outputs.
+- Reusable abstractions: extend command metadata with command-specific notes instead of hand-maintaining the same text in each generated workflow reference section.
+- Convention deviations: none required.
+
+### Risks
+- Technical risks: low risk of stale generated prose if tests only check one adapter; mitigate by checking generated workflow content for every registered adapter and Codex/Claude prompt surfaces where relevant.
+- Guardrail domains: none.
+- Reversibility: safe to roll back because the change is documentation/test-only except for metadata used to render generated references.
+
+### Test Strategy
+- Existing coverage: `internal/toolgen/toolgen_test.go` already generates Codex, Claude, Cursor, Gemini, and OpenCode surfaces in temp directories and asserts key workflow/command reference contracts.
+- Infrastructure needs: no new fixtures or snapshots are required.
+- Verification approach: add assertions that generated workflow skill text explains JSON stdin classification, generated command reference includes `slipway new` stdin notes, and generated Codex/Claude `/slipway-new` surfaces document the explicit JSON stdin path without unsupported flags.
+
+## Alternatives Considered
+- Template-only wording: update only workflow and command-new templates. Tradeoff: fixes two visible surfaces but leaves generated command reference incomplete, which issue #21 calls out directly.
+- Metadata-backed command reference notes: add command-specific notes to toolgen metadata and render them in the workflow command reference. Tradeoff: slightly expands metadata shape, but keeps command reference generated from the same registry path.
+- Runtime flag support: add `--guardrail-domain`, `--complexity`, and `--needs-discovery` flags. Tradeoff: contradicts the issue's non-problem ruling and broadens runtime behavior unnecessarily.
+- Selected: metadata-backed command reference notes plus targeted template updates and generated-surface tests, because it resolves the documented contract gap without changing CLI behavior.
+
+## Unknowns
+- Resolved: exact generated-surface test helpers -> `TestWorkflowSkillGenerationAndReference`, `TestCommandEntryPrerequisitesAreCommandSpecific`, `TestCodexPromptsUseCommandSpecificPrerequisites`, and generated prompt tests provide direct string assertion coverage.
+- Remaining: None.
+
+## Assumptions
+- The checked issue state at HEAD `0f92e5d` is the relevant baseline. Evidence: GitHub issue #21 and local `git rev-parse --short HEAD`.
+- The correct fix is contract clarity, not new flags. Evidence: issue #21 explicitly classifies this as documentation UX gap and says stale-flag framing is not the bug.
+- `cmd/new.go` JSON stdin behavior is already functional. Evidence: `stdinClassificationInput` includes `guardrail_domain`, `needs_discovery`, and `complexity`; `readStdinClassificationInput` is used only in JSON mode when stdin is non-terminal.
+
+## Canonical References
+- `https://github.com/signalridge/slipway/issues/21`
+- `internal/tmpl/templates/skills/workflow/SKILL.md.tmpl`
+- `internal/tmpl/templates/_partials/command-new-body.tmpl`
+- `internal/tmpl/templates/skills/workflow/command-reference.md.tmpl`
+- `internal/toolgen/toolgen.go`
+- `internal/toolgen/toolgen_test.go`
+- `cmd/new.go`
+- `artifacts/codebase/TESTING.md`

--- a/artifacts/changes/archived/resolve-issue-21-clarify-json-stdin-classification-contract/tasks.md
+++ b/artifacts/changes/archived/resolve-issue-21-clarify-json-stdin-classification-contract/tasks.md
@@ -1,0 +1,28 @@
+# Tasks
+
+## Project Context
+- Tech Stack:
+- Conventions:
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go, Markdown
+
+## Task List
+
+- [x] `task-01` add generated-surface regression assertions
+  - wave: 1
+  - depends_on: []
+  - target_files: ["internal/toolgen/toolgen_test.go"]
+  - task_kind: test
+  - evidence: targeted toolgen test result
+  - acceptance: generated workflow, command reference, and command prompt assertions cover JSON stdin classification and unsupported-flag wording
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004, REQ-005]
+
+- [x] `task-02` implement JSON stdin contract wording in generated surfaces
+  - wave: 2
+  - depends_on: ["task-01"]
+  - target_files: ["internal/toolgen/toolgen.go", "internal/tmpl/templates/skills/workflow/SKILL.md.tmpl", "internal/tmpl/templates/skills/workflow/command-reference.md.tmpl", "internal/tmpl/templates/_partials/command-new-body.tmpl"]
+  - task_kind: code
+  - evidence: targeted and full Go verification results
+  - acceptance: templates and metadata satisfy generated-surface assertions and full `go test ./...` plus `go build ./...` pass
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004]

--- a/internal/tmpl/templates/_partials/command-new-body.tmpl
+++ b/internal/tmpl/templates/_partials/command-new-body.tmpl
@@ -9,6 +9,14 @@ governed change. This is the primary entry point for governed work.
 slipway new "<description>" --preset standard --json
 ```
 
+## Explicit JSON Classification
+If the AI caller already knows the classification, provide it as JSON stdin with `--json`.
+`guardrail_domain`, `needs_discovery`, and `complexity` are JSON stdin fields, not command-line flags.
+
+```bash
+echo '{"description":"fix typo","guardrail_domain":"","needs_discovery":false,"complexity":"simple"}' | slipway new --json
+```
+
 ## Runtime Contract
 - Always creates a governed change at `S0_INTAKE/clarify`.
 - Sets `needs_discovery=true` when the description implies guardrail domains or

--- a/internal/tmpl/templates/skills/workflow/SKILL.md.tmpl
+++ b/internal/tmpl/templates/skills/workflow/SKILL.md.tmpl
@@ -33,10 +33,16 @@ workflow gates and can be finalized; `done` happens only after explicit `slipway
 When starting governed work and you can classify intent directly, enter through
 `slipway new --json`.
 
-Provide these fields when known:
+These are JSON stdin fields for `slipway new --json`, not command-line flags.
+Provide them when known:
 - `guardrail_domain`
 - `complexity`: `trivial`, `simple`, `complex`, or `critical`
 - `needs_discovery`
+
+Minimal explicit-classification example:
+```bash
+echo '{"description":"fix typo","guardrail_domain":"","needs_discovery":false,"complexity":"simple"}' | slipway new --json
+```
 
 If these fields are omitted, the CLI applies conservative fallback defaults.
 

--- a/internal/tmpl/templates/skills/workflow/command-reference.md.tmpl
+++ b/internal/tmpl/templates/skills/workflow/command-reference.md.tmpl
@@ -22,6 +22,12 @@ single workflow entry skill.
 {{- range .Prerequisites }}
   - {{ . }}
 {{- end }}
+{{- if .Notes }}
+- Notes:
+{{- range .Notes }}
+  - {{ . }}
+{{- end }}
+{{- end }}
 {{- if .Focuses }}
 - Public focuses:
 {{- range .Focuses }}
@@ -41,6 +47,12 @@ single workflow entry skill.
 {{- range .Prerequisites }}
   - {{ . }}
 {{- end }}
+{{- if .Notes }}
+- Notes:
+{{- range .Notes }}
+  - {{ . }}
+{{- end }}
+{{- end }}
 {{- if .Focuses }}
 - Public focuses:
 {{- range .Focuses }}
@@ -59,6 +71,12 @@ single workflow entry skill.
 - Prerequisites:
 {{- range .Prerequisites }}
   - {{ . }}
+{{- end }}
+{{- if .Notes }}
+- Notes:
+{{- range .Notes }}
+  - {{ . }}
+{{- end }}
 {{- end }}
 {{- if .Focuses }}
 - Public focuses:

--- a/internal/toolgen/toolgen.go
+++ b/internal/toolgen/toolgen.go
@@ -133,6 +133,7 @@ type CommandDef struct {
 	Description      string
 	Arguments        string
 	Prerequisites    []string
+	Notes            []string
 	Tier             string // "core" | "situational" | "diagnostics"
 	HasPromptSurface bool   // true = generates inline command prompt surface; false for CLI-only commands
 }
@@ -143,7 +144,11 @@ var commandRegistry = []CommandDef{
 	// Core (5)
 	{ID: "new", Class: CommandClassMutation, Description: "Create a governed change with intake-first workflow", Tier: "core", HasPromptSurface: true,
 		Arguments:     `"<description>" [--preset light|standard|strict] [--profile code|docs|research|config|meta] [--discuss] [--full] [--trivial] [--from-doc <path>] [--json]`,
-		Prerequisites: []string{"`.slipway.yaml` must exist (run `slipway init` first)", "No conflicting active change should already exist in the workspace."}},
+		Prerequisites: []string{"`.slipway.yaml` must exist (run `slipway init` first)", "No conflicting active change should already exist in the workspace."},
+		Notes: []string{
+			"JSON stdin fields for `slipway new --json`, not command-line flags: `guardrail_domain`, `needs_discovery`, and `complexity`.",
+			"Minimal explicit-classification example: `echo '{\"description\":\"fix typo\",\"guardrail_domain\":\"\",\"needs_discovery\":false,\"complexity\":\"simple\"}' | slipway new --json`.",
+		}},
 	{ID: "next", Class: CommandClassQuery, Description: "Query next actionable skill (read-only, does not advance state)", Tier: "core", HasPromptSurface: true,
 		Arguments: "[--json] [--diagnostics] [--context-guard] [--change <slug>]"},
 	{ID: "run", Class: CommandClassMutation, Description: "Advance governed execution until a skill, blocker, checkpoint, or done-ready outcome is surfaced", Tier: "core", HasPromptSurface: true,
@@ -323,6 +328,7 @@ type commandEntry struct {
 	Description   string
 	Arguments     string
 	Prerequisites []string
+	Notes         []string
 	Focuses       []commandFocusEntry
 }
 
@@ -432,6 +438,7 @@ type commandRenderData struct {
 	Description   string
 	Arguments     string
 	Prerequisites []string
+	Notes         []string
 }
 
 func commandPrerequisites(id string) []string {
@@ -457,6 +464,7 @@ func buildCommandRenderData(id string) (commandRenderData, error) {
 		Description:   commandDescriptions[id],
 		Arguments:     commandArguments(id),
 		Prerequisites: commandPrerequisites(id),
+		Notes:         append([]string(nil), def.Notes...),
 	}, nil
 }
 
@@ -475,6 +483,7 @@ func buildWorkflowCommandEntries(ids []string, expectedTier string) ([]commandEn
 			Description:   meta.Description,
 			Arguments:     meta.Arguments,
 			Prerequisites: meta.Prerequisites,
+			Notes:         append([]string(nil), meta.Notes...),
 			Focuses:       buildCommandFocusEntries(meta.ID),
 		})
 	}

--- a/internal/toolgen/toolgen_test.go
+++ b/internal/toolgen/toolgen_test.go
@@ -454,6 +454,11 @@ func TestWorkflowSkillGenerationAndReference(t *testing.T) {
 		assert.Contains(t, s, "`done-ready` means", "%s: missing done-ready semantics", cfg.ID)
 		assert.Contains(t, s, "explicit `slipway done`", "%s: missing done finalization semantics", cfg.ID)
 		assert.Contains(t, s, "`slipway new --json`", "%s: missing governed entry guidance", cfg.ID)
+		assert.Contains(t, s, "JSON stdin fields for `slipway new --json`, not command-line flags", "%s: missing JSON stdin classification transport contract", cfg.ID)
+		assert.Contains(t, s, `echo '{"description":"fix typo","guardrail_domain":"","needs_discovery":false,"complexity":"simple"}' | slipway new --json`, "%s: missing minimal JSON stdin example", cfg.ID)
+		assert.NotContains(t, s, "--guardrail-domain", "%s: unsupported guardrail flag leaked", cfg.ID)
+		assert.NotContains(t, s, "--needs-discovery", "%s: unsupported discovery flag leaked", cfg.ID)
+		assert.NotContains(t, s, "--complexity", "%s: unsupported complexity flag leaked", cfg.ID)
 		assert.Contains(t, s, "`next_skill.name`", "%s: missing governed host handoff", cfg.ID)
 		assert.Contains(t, s, "slipway-{name}", "%s: missing caller-owned skill path contract", cfg.ID)
 		assert.NotContains(t, s, "`next_skill.agent_hint`", "%s: stale agent hint contract leaked", cfg.ID)
@@ -473,6 +478,8 @@ func TestWorkflowSkillGenerationAndReference(t *testing.T) {
 		assert.Contains(t, ref, "## Supporting Commands", "%s: missing supporting section", cfg.ID)
 		assert.Contains(t, ref, "## Diagnostics", "%s: missing diagnostics section", cfg.ID)
 		assert.Contains(t, ref, "### `slipway new`", "%s: missing new command entry", cfg.ID)
+		assert.Contains(t, ref, "JSON stdin fields for `slipway new --json`, not command-line flags", "%s: missing new stdin contract notes", cfg.ID)
+		assert.Contains(t, ref, "`guardrail_domain`, `needs_discovery`, and `complexity`", "%s: missing new stdin classification shape", cfg.ID)
 		assert.Contains(t, ref, "### `slipway run`", "%s: missing run command entry", cfg.ID)
 		assert.Contains(t, ref, "### `slipway repair`", "%s: missing repair command entry", cfg.ID)
 		assert.Contains(t, ref, "### `slipway codebase-map`", "%s: missing diagnostics command entry", cfg.ID)
@@ -493,6 +500,31 @@ func TestWorkflowSkillGenerationAndReference(t *testing.T) {
 
 	_, err := os.Stat(filepath.Join(codexHome, "prompts", "slipway.md"))
 	assert.True(t, os.IsNotExist(err), "codex should not emit a workflow global prompt")
+}
+
+func TestGeneratedNewCommandSurfacesDocumentJSONStdinClassification(t *testing.T) {
+	root := t.TempDir()
+	codexHome := t.TempDir()
+	t.Setenv("CODEX_HOME", codexHome)
+
+	require.NoError(t, Generate(root, []string{"claude", "codex"}, true))
+
+	surfaces := map[string]string{
+		"claude": filepath.Join(root, ".claude", "commands", "slipway", "new.md"),
+		"codex":  filepath.Join(codexHome, "prompts", "slipway-new.md"),
+	}
+	for id, path := range surfaces {
+		content, err := os.ReadFile(path)
+		require.NoError(t, err, "%s: missing generated new command surface", id)
+		s := string(content)
+
+		assert.Contains(t, s, "If the AI caller already knows the classification, provide it as JSON stdin with `--json`.", "%s: missing explicit JSON stdin path", id)
+		assert.Contains(t, s, "`guardrail_domain`, `needs_discovery`, and `complexity` are JSON stdin fields, not command-line flags.", "%s: missing classification field transport", id)
+		assert.Contains(t, s, `echo '{"description":"fix typo","guardrail_domain":"","needs_discovery":false,"complexity":"simple"}' | slipway new --json`, "%s: missing minimal JSON stdin example", id)
+		assert.NotContains(t, s, "--guardrail-domain", "%s: unsupported guardrail flag leaked", id)
+		assert.NotContains(t, s, "--needs-discovery", "%s: unsupported discovery flag leaked", id)
+		assert.NotContains(t, s, "--complexity", "%s: unsupported complexity flag leaked", id)
+	}
 }
 
 func TestRenderCatalogSkillUsesFixedTypedTemplateOrder(t *testing.T) {


### PR DESCRIPTION
## Summary
- Clarify that `guardrail_domain`, `needs_discovery`, and `complexity` are JSON stdin fields for `slipway new --json`, not CLI flags.
- Add a minimal explicit-classification example to generated workflow and command surfaces.
- Extend generated command-reference metadata/tests and archive the governed change evidence.

## Verification
- `go test ./internal/toolgen -count=1`
- `go test -count=1 ./...`
- `go build ./...`
- `go vet ./...`
- `mkdocs build --strict`
- `git diff --check origin/main...HEAD`

Closes #21