### PR TITLE
fix: address issue 24 workflow feedback

### DIFF
--- a/artifacts/changes/archived/fix-issue-24-governed-workflow-feedback/assurance.md
+++ b/artifacts/changes/archived/fix-issue-24-governed-workflow-feedback/assurance.md
@@ -1,0 +1,51 @@
+# Assurance
+
+## Project Context
+- Tech Stack: Go
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Scope Summary
+This change resolves issue #24 workflow feedback across repair, runtime
+evidence diagnostics, done/archive warnings, and governed review guidance.
+
+## Verification Verdict
+Pass. All four requirements have implementation, regression coverage, review
+evidence, and fresh command verification.
+
+## Evidence Index
+- Focused regression tests:
+  `go test ./cmd -run 'TestRepairRebuildsReadyButStaleExecutionSummaryDrift|TestRepairDoesNotRewriteReadyButStaleExecutionSummaryWhenTaskEvidenceInvalid|TestRepairDoesNotRebuildWhenPlanningEvidenceIsStale'`
+  passed.
+- Focused issue #24 regression suite:
+  `go test ./cmd ./internal/engine/progression ./internal/tmpl -run 'TestRepairRebuildsReadyButStaleExecutionSummaryDrift|TestRepairDoesNotRewriteReadyButStaleExecutionSummaryWhenTaskEvidenceInvalid|TestRepairDoesNotRebuildWhenPlanningEvidenceIsStale|TestEvaluateRequiredSkills_FailsClosedWhenRunSummaryBoundSkillHasNoSummary|TestNextS6GovernedBlocksWithoutTaskEvidenceForWaveRunSummary|TestDoneJSONWarnsWhenWorktreeSourceChangesAreUncommitted|TestReviewTemplatesRequireNegativePathAndToolchainEvidence'`
+  passed.
+- Full test suite: `go test ./...` passed.
+- Build: `go build ./...` passed.
+- Diff hygiene: `git diff --check` passed.
+- Governance: `go run . validate --json` reported fresh execution evidence and
+  passing scope contract after execution evidence synchronization.
+
+## Requirement Coverage
+- REQ-001: pass. `repair --json` rebuilds ready stale execution summaries from
+  current runtime task evidence when planning evidence is not stale. Invalid
+  task evidence and planning drift remain unrepaired; invalid evidence does not
+  rewrite `execution-summary.yaml`.
+- REQ-002: pass. Missing run-summary and task evidence blockers now include the
+  runtime task evidence path and required flat JSON fields.
+- REQ-003: pass. `done --json` returns worktree dirty warning fields for
+  worktree-bound dirty source files without making Git commits mandatory.
+- REQ-004: pass. Review templates and template tests require
+  requirement-named negative/error path evidence and dependency/toolchain
+  compatibility, including MSRV language.
+
+## Residual Risks and Exceptions
+No accepted exceptions.
+
+## Rollback Readiness
+Changes are confined to CLI behavior, generated skill text, docs, and tests.
+Rollback is reverting this patch.
+
+## Archive Decision
+Ready after goal-verification evidence and final Slipway validation.

--- a/artifacts/changes/archived/fix-issue-24-governed-workflow-feedback/change.yaml
+++ b/artifacts/changes/archived/fix-issue-24-governed-workflow-feedback/change.yaml
@@ -1,0 +1,42 @@
+version: 1
+slug: fix-issue-24-governed-workflow-feedback
+description: fix issue 24 governed workflow feedback
+status: done
+current_state: DONE
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-05-30T17:53:15.355081Z
+quality_mode: standard
+workflow_preset: standard
+artifact_schema: core
+project_context:
+    tech_stack: Go
+    test_cmd: go test ./...
+    build_cmd: go build ./...
+    languages:
+        - Go
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: 98a875349afbf2f85edafa79ec9dc7732193ad1ff325a1a57bc0f02e45f09556
+        updated_at: 2026-05-30T18:42:34Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: f80dfa5cb3610ddd93f4d7d5838538facdf0ce8d05ce101102c1766afe6ca0d8
+        updated_at: 2026-05-30T17:55:02.573571434Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: c4b60bb54674cafd1293070081881ac1773683b21d0e5c5bfcd71d5e880380da
+        updated_at: 2026-05-30T17:57:49.788339401Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: 9b17f8061ec96cffe1851846774436893c493d23fe5b99b57c356e3859f92d7b
+        updated_at: 2026-05-30T18:12:42.905313772Z

--- a/artifacts/changes/archived/fix-issue-24-governed-workflow-feedback/intent.md
+++ b/artifacts/changes/archived/fix-issue-24-governed-workflow-feedback/intent.md
@@ -1,0 +1,64 @@
+# Intent
+
+## Project Context
+<!-- Auto-filled by InferProjectContext(); .slipway.yaml overrides -->
+- Tech Stack: Go
+- Languages: Go
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Conventions:
+
+## Summary
+Fix the four workflow feedback items tracked in GitHub issue #24.
+
+## Complexity Assessment
+complex
+Rationale: the change spans CLI recovery behavior, diagnostic JSON, generated
+host-skill guidance, review checklist expectations, and regression tests.
+
+## Guardrail Domains
+<!-- none detected -->
+
+## In Scope
+- Make stale execution evidence recoverable through a supported command path,
+  or expose an exact safe route when automatic repair is not possible.
+- Make run-summary-missing and missing task evidence blockers actionable by
+  naming runtime task evidence paths and the required JSON envelope fields.
+- Surface a clear done/status-time warning when a worktree-bound archived change
+  still has source changes only in dirty or untracked Git state.
+- Tighten governed review guidance so requirement-named negative paths and
+  dependency/toolchain compatibility, including Rust MSRV drift, are explicit
+  review evidence expectations.
+
+## Out of Scope
+- Changing Lattice implementation code.
+- Requiring every `slipway done` invocation to commit or push Git changes.
+- Reworking Slipway's full workflow preset or worktree provisioning policy.
+
+## Constraints
+- Preserve existing governance gates and fail-closed behavior.
+- Keep generated templates and exported `.codex` / `.claude` skills in sync
+  where the repository already tracks both.
+- Keep changes scoped to issue #24 feedback rather than broad workflow redesign.
+
+## Acceptance Signals
+- Focused Go tests cover stale execution summary repair from runtime task
+  evidence, unrepaired stale planning/invalid task evidence, actionable missing
+  task evidence diagnostics, dirty worktree archive warnings, and review
+  template content.
+- `go test ./...` passes.
+- `go run . validate --json` reports the governed change ready for its current
+  stage after evidence is written.
+
+## Open Questions
+<!-- none -->
+
+## Deferred Ideas
+<!-- Identified but postponed ideas -->
+
+## Approved Summary
+Confirmed by user request on 2026-05-30T17:54:33Z: fix all issue #24 feedback
+items in Slipway. The change will add a supported stale execution evidence
+repair path, improve run-summary/task-evidence diagnostics, warn about dirty
+worktree implementation state at done/status surfaces, and strengthen governed
+review guidance for negative-path and dependency/toolchain checks.

--- a/artifacts/changes/archived/fix-issue-24-governed-workflow-feedback/requirements.md
+++ b/artifacts/changes/archived/fix-issue-24-governed-workflow-feedback/requirements.md
@@ -1,0 +1,49 @@
+# Requirements
+
+## Project Context
+- Tech Stack: Go
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Requirements
+
+### Requirement: Supported Stale Execution Evidence Repair
+REQ-001: `slipway repair --json` MUST safely rebuild a ready-but-stale
+`verification/execution-summary.yaml` from current wave-backed runtime task
+evidence when the stale cause is execution evidence drift and the current task
+plan remains compatible. If planning evidence is stale or runtime task evidence
+is invalid/missing, repair MUST leave the change unrepaired and report an
+actionable target and next action.
+
+#### Scenario: Ready summary is stale only against runtime task evidence
+GIVEN an active governed change in S3 or S4 with a passing wave-orchestration
+record and valid flat runtime task evidence
+WHEN `execution-summary.yaml` has stale task timestamps or freshness fields
+THEN `slipway repair --json` rebuilds the execution summary from runtime task
+evidence and reports the rebuild as an applied repair.
+
+#### Scenario: Planning evidence is stale
+GIVEN a ready execution summary whose planning artifacts changed after
+execution evidence
+WHEN `slipway repair --json` runs
+THEN the command does not overwrite execution evidence and reports unrepaired
+planning drift.
+
+### Requirement: Actionable Runtime Task Evidence Diagnostics
+REQ-002: Missing run-summary and missing task-evidence blockers MUST name the
+runtime task evidence directory and the required flat JSON fields so a human or
+non-agent executor can produce the supported evidence envelope without code
+spelunking.
+
+### Requirement: Dirty Worktree Archive Warning
+REQ-003: `slipway done --json` MUST warn when a worktree-bound change is
+archived while source files still exist only as dirty or untracked workspace
+changes, and MUST list the affected non-governance files. The warning MUST NOT
+turn Git commit state into a hard governance requirement.
+
+### Requirement: Review Checklist Coverage For Negative Paths And Toolchains
+REQ-004: Generated governed review skills MUST explicitly require evidence for
+requirement-named negative/error paths and dependency/toolchain compatibility
+checks, including Rust workspace MSRV drift when dependency manifests or
+lockfiles change.

--- a/artifacts/changes/archived/fix-issue-24-governed-workflow-feedback/tasks.md
+++ b/artifacts/changes/archived/fix-issue-24-governed-workflow-feedback/tasks.md
@@ -1,0 +1,37 @@
+# Tasks
+
+## Project Context
+- Tech Stack: Go
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Task List
+
+- [x] `task-01` repair stale execution evidence from runtime task evidence
+  - wave: 1
+  - depends_on: []
+  - target_files: ["cmd/repair.go", "cmd/repair_test.go", "internal/engine/progression/wave_sync.go", "internal/engine/progression/evidence.go", "internal/engine/progression/evidence_test.go", "internal/state/execution_summary.go", "cmd/progression_next_test.go", "docs/operator-guide.md", "docs/commands.md"]
+  - task_kind: code
+  - covers: [REQ-001, REQ-002]
+
+- [x] `task-02` warn when done archives dirty worktree source changes
+  - wave: 2
+  - depends_on: ["task-01"]
+  - target_files: ["cmd/done.go", "cmd/lifecycle_commands_test.go", "internal/engine/progression/readiness.go", "internal/engine/progression/readiness_optimization_test.go", "docs/operator-guide.md"]
+  - task_kind: code
+  - covers: [REQ-003]
+
+- [x] `task-03` tighten governed review templates
+  - wave: 3
+  - depends_on: ["task-02"]
+  - target_files: ["internal/tmpl/templates/skills/spec-compliance-review/SKILL.md.tmpl", "internal/tmpl/templates/skills/code-quality-review/SKILL.md.tmpl", ".codex/skills/slipway-spec-compliance-review/SKILL.md", ".codex/skills/slipway-code-quality-review/SKILL.md", ".claude/skills/slipway-spec-compliance-review/SKILL.md", ".claude/skills/slipway-code-quality-review/SKILL.md", "internal/tmpl/templates_test.go"]
+  - task_kind: code
+  - covers: [REQ-004]
+
+- [x] `task-04` run integrated verification and close governance evidence
+  - wave: 4
+  - depends_on: ["task-01", "task-02", "task-03"]
+  - target_files: ["artifacts/changes/fix-issue-24-governed-workflow-feedback/assurance.md", "artifacts/changes/fix-issue-24-governed-workflow-feedback/verification/"]
+  - task_kind: verification
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004]

--- a/cmd/done.go
+++ b/cmd/done.go
@@ -32,15 +32,19 @@ type doneView struct {
 	ArchivePath             string                   `json:"archive_path,omitempty"`
 	ArchiveKind             string                   `json:"archive_kind,omitempty"`
 	ArchiveCommitRequired   bool                     `json:"archive_commit_required,omitempty"`
+	WorktreeDirtyWarning    string                   `json:"worktree_dirty_warning,omitempty"`
+	WorktreeDirtyFiles      []string                 `json:"worktree_dirty_files,omitempty"`
 	RemediationSources      []model.ArchiveReference `json:"remediation_sources,omitempty"`
 }
 
 type doneBulkItem struct {
-	Slug        string             `json:"slug,omitempty"`
-	Status      string             `json:"status,omitempty"`
-	Reason      string             `json:"reason,omitempty"`
-	ErrorDetail string             `json:"error_detail,omitempty"`
-	ReasonCodes []model.ReasonCode `json:"reason_codes,omitempty"`
+	Slug                 string             `json:"slug,omitempty"`
+	Status               string             `json:"status,omitempty"`
+	Reason               string             `json:"reason,omitempty"`
+	ErrorDetail          string             `json:"error_detail,omitempty"`
+	ReasonCodes          []model.ReasonCode `json:"reason_codes,omitempty"`
+	WorktreeDirtyWarning string             `json:"worktree_dirty_warning,omitempty"`
+	WorktreeDirtyFiles   []string           `json:"worktree_dirty_files,omitempty"`
 }
 
 type doneBulkView struct {
@@ -84,6 +88,23 @@ func newDoneBulkFailed(slug, reason, errorDetail string) doneBulkItem {
 func markChangeDone(change *model.Change) {
 	change.Status = model.ChangeStatusDone
 	change.CurrentState = model.StateDone
+}
+
+const doneWorktreeDirtyWarning = "worktree has uncommitted source changes; commit or review these files before removing the worktree"
+
+func doneWorktreeDirtyState(root string, change model.Change) (string, []string) {
+	if strings.TrimSpace(change.WorktreePath) == "" {
+		return "", nil
+	}
+	paths, err := state.ResolveChangePaths(root, change)
+	if err != nil {
+		return "", nil
+	}
+	files := progression.WorkspaceChangedFiles(paths)
+	if len(files) == 0 {
+		return "", nil
+	}
+	return doneWorktreeDirtyWarning, files
 }
 
 func detectRemediationSources(root string, change model.Change) []model.ArchiveReference {
@@ -273,6 +294,7 @@ func makeDoneCmd() *cobra.Command {
 				if shipBlocked {
 					return shipGateBlockedError(change, shipEval)
 				}
+				worktreeDirtyWarning, worktreeDirtyFiles := doneWorktreeDirtyState(root, change)
 				beforeChange := change
 				markChangeDone(&change)
 				change.RemediationSources = mergeArchiveReferences(
@@ -322,6 +344,8 @@ func makeDoneCmd() *cobra.Command {
 					ArchivePath:             state.DisplayPath(root, archivePaths.GovernedBundleArchive),
 					ArchiveKind:             archiveKind,
 					ArchiveCommitRequired:   strings.TrimSpace(change.WorktreePath) != "",
+					WorktreeDirtyWarning:    worktreeDirtyWarning,
+					WorktreeDirtyFiles:      worktreeDirtyFiles,
 					RemediationSources:      archived.RemediationSources,
 				}
 
@@ -443,6 +467,7 @@ func archiveSingleDoneReady(root, slug string, change model.Change) doneBulkItem
 			append([]model.ReasonCode(nil), shipEval.ReasonCodes...),
 		)
 	}
+	worktreeDirtyWarning, worktreeDirtyFiles := doneWorktreeDirtyState(root, change)
 	beforeChange := change
 	markChangeDone(&change)
 
@@ -461,7 +486,10 @@ func archiveSingleDoneReady(root, slug string, change model.Change) doneBulkItem
 	if _, err := state.ArchiveChange(root, change, model.ChangeStatusDone); err != nil {
 		return newDoneBulkFailed(slug, "archive_failed", err.Error())
 	}
-	return newDoneBulkArchived(slug)
+	item := newDoneBulkArchived(slug)
+	item.WorktreeDirtyWarning = worktreeDirtyWarning
+	item.WorktreeDirtyFiles = worktreeDirtyFiles
+	return item
 }
 
 func reconcileDoneFilesystemState(root string, change *model.Change) error {

--- a/cmd/lifecycle_commands_test.go
+++ b/cmd/lifecycle_commands_test.go
@@ -122,6 +122,56 @@ func TestDoneJSONReportsWorktreeArchivePathWhenRunFromWorktree(t *testing.T) {
 	})
 }
 
+func TestDoneJSONWarnsWhenWorktreeSourceChangesAreUncommitted(t *testing.T) {
+	root := t.TempDir()
+	initGitRepoForWorktreeTests(t, root)
+	withWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+
+		slug := "done-worktree-dirty-warning"
+		branch := "feat/" + slug
+		worktreeRoot := filepath.Join(t.TempDir(), slug)
+		runGit(t, root, "worktree", "add", worktreeRoot, "-b", branch)
+		normalizedWT, err := state.NormalizePath(worktreeRoot)
+		require.NoError(t, err)
+
+		change := model.NewChange(slug)
+		change.WorktreePath = normalizedWT
+		change.WorktreeBranch = branch
+		change.CurrentState = model.StateS4Verify
+		change.PlanSubStep = model.PlanSubStepNone
+		require.NoError(t, state.SaveChange(root, change))
+
+		writeShipReadyGovernedBundle(t, normalizedWT, change)
+		writeAssuranceMD(t, normalizedWT, slug, validAssuranceContent())
+		writePassingExecutionSummary(t, root, slug, 1, "t-01")
+		writePassingWaveEvidence(t, root, slug, 1)
+		writePassingReviewEvidencePack(t, root, slug, 1)
+		writePassingGoalVerificationEvidence(t, root, slug, 1)
+
+		require.NoError(t, os.MkdirAll(filepath.Join(normalizedWT, "cmd"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(normalizedWT, "cmd", "done.go"), []byte("package cmd\n"), 0o644))
+
+		previousWD, err := os.Getwd()
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(normalizedWT))
+		defer func() {
+			_ = os.Chdir(previousWD)
+		}()
+
+		var out bytes.Buffer
+		doneCmd := makeDoneCmd()
+		doneCmd.SetOut(&out)
+		doneCmd.SetArgs([]string{"--json"})
+		require.NoError(t, doneCmd.Execute())
+
+		var view doneView
+		require.NoError(t, json.Unmarshal(out.Bytes(), &view))
+		assert.Contains(t, view.WorktreeDirtyWarning, "uncommitted source changes")
+		assert.Contains(t, view.WorktreeDirtyFiles, "cmd/done.go")
+	})
+}
+
 func TestDoneJSONOmitsArchiveCommitRequiredForRepoScopedChange(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {

--- a/cmd/progression_next_test.go
+++ b/cmd/progression_next_test.go
@@ -3442,7 +3442,16 @@ func TestNextS6GovernedBlocksWithoutTaskEvidenceForWaveRunSummary(t *testing.T) 
 	view, err := buildNextView(root, changeRef{Slug: slug}, "", false, true, false)
 	require.NoError(t, err)
 
-	assert.Contains(t, model.ReasonSpecs(view.Blockers), "missing_task_evidence_for_run_summary:run_summary_version=1")
+	var missingEvidenceBlocker string
+	for _, blocker := range model.ReasonSpecs(view.Blockers) {
+		if strings.HasPrefix(blocker, "missing_task_evidence_for_run_summary:run_summary_version=1") {
+			missingEvidenceBlocker = blocker
+			break
+		}
+	}
+	require.NotEmpty(t, missingEvidenceBlocker)
+	assert.Contains(t, missingEvidenceBlocker, ".git/slipway/runtime/changes/"+slug+"/evidence/tasks")
+	assert.Contains(t, missingEvidenceBlocker, "required_fields=task_id,run_summary_version,task_kind,verdict,evidence_ref,captured_at,freshness_inputs")
 	assert.Equal(t, model.StateS2Execute, view.CurrentState)
 }
 

--- a/cmd/repair.go
+++ b/cmd/repair.go
@@ -708,6 +708,18 @@ func rebuildExecutionSummaries(root string, now time.Time) ([]string, []string, 
 
 		summary, err := state.LoadOptionalRelevantExecutionSummary(root, change)
 		if err == nil && state.ExecutionSummaryReady(summary) {
+			diagnostics := state.ExecutionSummaryFreshnessDiagnostics(root, change, summary)
+			if diagnostics.Status != "stale" || executionFreshnessHasPlanningDrift(diagnostics) {
+				continue
+			}
+		}
+		_, parseIssues, taskEvidenceErr := progression.LoadExecutionTasksFromEvidence(root, change.Slug, record.RunVersion)
+		if taskEvidenceErr != nil {
+			findings = append(findings, fmt.Sprintf("%s: execution summary recovery preflight failed: %v", change.Slug, taskEvidenceErr))
+			continue
+		}
+		if len(parseIssues) > 0 {
+			findings = append(findings, fmt.Sprintf("%s: rebuild execution summary from task evidence: %s", change.Slug, strings.Join(model.ReasonSpecs(model.ReasonCodesFromSpecs(parseIssues)), ",")))
 			continue
 		}
 
@@ -731,17 +743,24 @@ func rebuildExecutionSummaries(root string, now time.Time) ([]string, []string, 
 			findings = append(findings, fmt.Sprintf("%s: rebuild execution summary from task evidence: %v", change.Slug, syncErr))
 			continue
 		}
+		if len(syncResult.Blockers) > 0 {
+			restoreUnreadableExecutionSummaryBackup(root, change, backupPath)
+			findings = append(findings, fmt.Sprintf("%s: rebuild execution summary from task evidence: %s", change.Slug, strings.Join(model.ReasonSpecs(syncResult.Blockers), ",")))
+			continue
+		}
 
 		rebuiltSummary, loadErr := state.LoadOptionalRelevantExecutionSummary(root, change)
 		if loadErr != nil || !state.ExecutionSummaryReady(rebuiltSummary) {
 			restoreUnreadableExecutionSummaryBackup(root, change, backupPath)
 			if loadErr != nil {
 				findings = append(findings, fmt.Sprintf("%s: rebuilt execution summary still unreadable: %v", change.Slug, loadErr))
-			} else if len(syncResult.Blockers) > 0 {
-				findings = append(findings, fmt.Sprintf("%s: rebuild execution summary from task evidence: %s", change.Slug, strings.Join(model.ReasonSpecs(syncResult.Blockers), ",")))
 			} else {
 				findings = append(findings, fmt.Sprintf("%s: rebuilt execution summary is still incomplete", change.Slug))
 			}
+			continue
+		}
+		if diagnostics := state.ExecutionSummaryFreshnessDiagnostics(root, change, rebuiltSummary); diagnostics.Status == "stale" {
+			findings = append(findings, fmt.Sprintf("%s: rebuilt execution summary is still stale: %s", change.Slug, executionFreshnessRepairReason(diagnostics)))
 			continue
 		}
 		rebuilt = append(rebuilt, change.Slug)
@@ -750,6 +769,26 @@ func rebuildExecutionSummaries(root string, now time.Time) ([]string, []string, 
 	slices.Sort(rebuilt)
 	slices.Sort(findings)
 	return slices.Compact(rebuilt), slices.Compact(findings), nil
+}
+
+func executionFreshnessHasPlanningDrift(diagnostics state.ExecutionFreshnessDiagnostics) bool {
+	for _, pair := range diagnostics.StalePairs {
+		if pair.Reason == state.StalePlanningEvidenceBlockerToken {
+			return true
+		}
+	}
+	return false
+}
+
+func executionFreshnessRepairReason(diagnostics state.ExecutionFreshnessDiagnostics) string {
+	if diagnostics.FirstStaleCause != nil && strings.TrimSpace(diagnostics.FirstStaleCause.Reason) != "" {
+		return diagnostics.FirstStaleCause.Reason
+	}
+	if len(diagnostics.TaskInputDiffs) > 0 {
+		diff := diagnostics.TaskInputDiffs[0]
+		return fmt.Sprintf("%s task=%s field=%s", state.StaleExecutionEvidenceBlockerToken, diff.TaskID, diff.Field)
+	}
+	return state.StaleExecutionEvidenceBlockerToken
 }
 
 func backupUnreadableExecutionSummary(root string, change model.Change, now time.Time) (string, error) {

--- a/cmd/repair_test.go
+++ b/cmd/repair_test.go
@@ -821,7 +821,7 @@ func TestRepairDoesNotRewriteHistoricalExecutionStateWhenTasksDrifted(t *testing
 	})
 }
 
-func TestRepairReportsReadyButStaleExecutionSummaryDrift(t *testing.T) {
+func TestRepairRebuildsReadyButStaleExecutionSummaryDrift(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
@@ -832,6 +832,22 @@ func TestRepairReportsReadyButStaleExecutionSummaryDrift(t *testing.T) {
 		change.CurrentState = model.StateS3Review
 		change.PlanSubStep = model.PlanSubStepNone
 		require.NoError(t, state.SaveChange(root, change))
+
+		bundlePath := filepath.Join(root, "artifacts", "changes", slug)
+		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
+
+- [ ] `+"`t-01`"+` rebuild first stale task
+  - wave: 1
+  - depends_on: []
+  - target_files: ["cmd/repair.go"]
+  - task_kind: code
+- [ ] `+"`t-02`"+` rebuild second stale task
+  - wave: 1
+  - depends_on: []
+  - target_files: ["docs/commands.md"]
+  - task_kind: code
+`)))
+		writePassingWaveEvidence(t, root, slug, 1)
 
 		runtimeCapturedAt := time.Now().UTC()
 		summaryCapturedAt := runtimeCapturedAt.Add(time.Hour)
@@ -860,7 +876,7 @@ func TestRepairReportsReadyButStaleExecutionSummaryDrift(t *testing.T) {
 				TaskID:          "t-02",
 				Verdict:         model.TaskVerdictPass,
 				TaskKind:        model.TaskKindCode,
-				ChangedFiles:    []string{"cmd/repair.go"},
+				ChangedFiles:    []string{"docs/commands.md"},
 				CapturedAt:      summaryCapturedAt,
 				FreshnessInputs: state.ExpectedExecutionTaskFreshnessInputs(change, 1, "t-02"),
 			}},
@@ -875,23 +891,182 @@ func TestRepairReportsReadyButStaleExecutionSummaryDrift(t *testing.T) {
 		var summary repairSummary
 		require.NoError(t, json.Unmarshal(out.Bytes(), &summary))
 
-		require.NotEmpty(t, summary.UnrepairedDrift)
-		foundTasks := map[string]bool{}
+		assert.Contains(t, summary.RebuiltExecutionSummaries, slug)
 		for _, drift := range summary.UnrepairedDrift {
-			for _, taskID := range []string{"t-01", "t-02"} {
-				if !strings.Contains(drift.Target, ".git/slipway/runtime/changes/"+slug+"/evidence/tasks/"+taskID+".json") {
-					continue
-				}
-				if strings.Contains(drift.Reason, state.StaleExecutionEvidenceBlockerToken) &&
-					strings.Contains(drift.Reason, "field=captured_at") &&
-					strings.Contains(drift.NextAction, "do not edit") {
-					foundTasks[taskID] = true
-				}
-			}
+			assert.False(t, strings.Contains(drift.Target, slug), "rebuilt stale summary must not remain unrepaired: %+v", drift)
 		}
-		assert.Equal(t, map[string]bool{"t-01": true, "t-02": true}, foundTasks, "expected repair to report each stale task input drift")
 		require.Contains(t, summary.PathAuthority, slug)
 		assert.Contains(t, summary.PathAuthority[slug].TaskEvidencePath, ".git/slipway/runtime/changes/"+slug+"/evidence/tasks")
+
+		rebuilt, err := state.LoadExecutionSummary(root, slug)
+		require.NoError(t, err)
+		require.Len(t, rebuilt.Tasks, 2)
+		for _, task := range rebuilt.Tasks {
+			assert.True(t, runtimeCapturedAt.Equal(task.CapturedAt), "task %s captured_at was not rebuilt from runtime evidence", task.TaskID)
+		}
+	})
+}
+
+func TestRepairDoesNotRewriteReadyButStaleExecutionSummaryWhenTaskEvidenceInvalid(t *testing.T) {
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+
+		slug := createGovernedRequest(t, root, "L2", "repair leaves invalid task evidence alone")
+		change, err := state.LoadChange(root, slug)
+		require.NoError(t, err)
+		change.CurrentState = model.StateS3Review
+		change.PlanSubStep = model.PlanSubStepNone
+		require.NoError(t, state.SaveChange(root, change))
+
+		bundlePath := filepath.Join(root, "artifacts", "changes", slug)
+		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
+
+- [ ] `+"`t-01`"+` keep valid stale task
+  - wave: 1
+  - depends_on: []
+  - target_files: ["cmd/repair.go"]
+  - task_kind: code
+- [ ] `+"`t-02`"+` leave invalid task evidence unrepaired
+  - wave: 1
+  - depends_on: []
+  - target_files: ["docs/commands.md"]
+  - task_kind: code
+`)))
+		writePassingWaveEvidence(t, root, slug, 1)
+
+		runtimeCapturedAt := time.Now().UTC()
+		summaryCapturedAt := runtimeCapturedAt.Add(time.Hour)
+		writeTaskEvidenceFile(t, root, slug, 1, "t-01", map[string]any{
+			"task_id":     "t-01",
+			"captured_at": runtimeCapturedAt.Format(time.RFC3339Nano),
+		})
+		writeTaskEvidenceFile(t, root, slug, 1, "t-02", map[string]any{
+			"task_id":     "t-02",
+			"task_kind":   "not-a-task-kind",
+			"captured_at": runtimeCapturedAt.Format(time.RFC3339Nano),
+		})
+		writeExecutionSummary(t, root, slug, model.ExecutionSummary{
+			Version:           model.ExecutionSummaryVersion,
+			RunSummaryVersion: 1,
+			CapturedAt:        summaryCapturedAt,
+			OverallVerdict:    model.ExecutionVerdictPass,
+			CompletedTasks:    []string{"t-01", "t-02"},
+			Tasks: []model.ExecutionTaskSummary{{
+				TaskID:          "t-01",
+				Verdict:         model.TaskVerdictPass,
+				TaskKind:        model.TaskKindCode,
+				ChangedFiles:    []string{"cmd/repair.go"},
+				CapturedAt:      summaryCapturedAt,
+				FreshnessInputs: state.ExpectedExecutionTaskFreshnessInputs(change, 1, "t-01"),
+			}, {
+				TaskID:          "t-02",
+				Verdict:         model.TaskVerdictPass,
+				TaskKind:        model.TaskKindCode,
+				ChangedFiles:    []string{"docs/commands.md"},
+				CapturedAt:      summaryCapturedAt,
+				FreshnessInputs: state.ExpectedExecutionTaskFreshnessInputs(change, 1, "t-02"),
+			}},
+		})
+		summaryPath := executionSummaryPathForTest(root, slug)
+		before, err := os.ReadFile(summaryPath)
+		require.NoError(t, err)
+
+		var out bytes.Buffer
+		cmd := makeRepairCmd()
+		cmd.SetArgs([]string{"--json"})
+		cmd.SetOut(&out)
+		require.NoError(t, cmd.Execute())
+
+		var summary repairSummary
+		require.NoError(t, json.Unmarshal(out.Bytes(), &summary))
+		assert.NotContains(t, summary.RebuiltExecutionSummaries, slug)
+
+		foundInvalidEvidence := false
+		for _, drift := range summary.UnrepairedDrift {
+			if drift.Target == slug && strings.Contains(drift.Reason, "task_evidence_invalid:t-02.json") {
+				foundInvalidEvidence = true
+				assert.Contains(t, drift.NextAction, "execution-summary.yaml")
+			}
+		}
+		assert.True(t, foundInvalidEvidence, "expected invalid task evidence to remain unrepaired")
+
+		after, err := os.ReadFile(summaryPath)
+		require.NoError(t, err)
+		assert.Equal(t, string(before), string(after), "repair must not rewrite execution-summary.yaml when task evidence is invalid")
+	})
+}
+
+func TestRepairDoesNotRebuildWhenPlanningEvidenceIsStale(t *testing.T) {
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+
+		slug := createGovernedRequest(t, root, "L2", "repair leaves stale planning evidence alone")
+		change, err := state.LoadChange(root, slug)
+		require.NoError(t, err)
+		change.CurrentState = model.StateS3Review
+		change.PlanSubStep = model.PlanSubStepNone
+		require.NoError(t, state.SaveChange(root, change))
+
+		bundlePath := filepath.Join(root, "artifacts", "changes", slug)
+		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "requirements.md", []byte(`# Requirements
+### Requirement: Original
+REQ-001: Original requirement.
+`)))
+		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
+
+- [ ] `+"`t-01`"+` preserve planning drift
+  - wave: 1
+  - depends_on: []
+  - target_files: ["cmd/repair.go"]
+  - task_kind: code
+`)))
+		writePassingWaveEvidence(t, root, slug, 1)
+
+		capturedAt := time.Now().UTC()
+		writeTaskEvidenceFile(t, root, slug, 1, "t-01", map[string]any{
+			"captured_at": capturedAt.Format(time.RFC3339Nano),
+		})
+		writeExecutionSummary(t, root, slug, model.ExecutionSummary{
+			Version:           model.ExecutionSummaryVersion,
+			RunSummaryVersion: 1,
+			CapturedAt:        capturedAt,
+			OverallVerdict:    model.ExecutionVerdictPass,
+			CompletedTasks:    []string{"t-01"},
+			Tasks: []model.ExecutionTaskSummary{{
+				TaskID:          "t-01",
+				Verdict:         model.TaskVerdictPass,
+				TaskKind:        model.TaskKindCode,
+				ChangedFiles:    []string{"cmd/repair.go"},
+				CapturedAt:      capturedAt,
+				FreshnessInputs: state.ExpectedExecutionTaskFreshnessInputs(change, 1, "t-01"),
+			}},
+		})
+
+		requirementsPath := filepath.Join(bundlePath, "requirements.md")
+		stalePlanningAt := capturedAt.Add(time.Hour)
+		require.NoError(t, os.Chtimes(requirementsPath, stalePlanningAt, stalePlanningAt))
+
+		var out bytes.Buffer
+		cmd := makeRepairCmd()
+		cmd.SetArgs([]string{"--json"})
+		cmd.SetOut(&out)
+		require.NoError(t, cmd.Execute())
+
+		var summary repairSummary
+		require.NoError(t, json.Unmarshal(out.Bytes(), &summary))
+		assert.NotContains(t, summary.RebuiltExecutionSummaries, slug)
+
+		foundPlanningDrift := false
+		for _, drift := range summary.UnrepairedDrift {
+			if strings.Contains(drift.Target, "requirements.md") &&
+				strings.Contains(drift.Reason, state.StalePlanningEvidenceBlockerToken) {
+				foundPlanningDrift = true
+				assert.Contains(t, drift.NextAction, "plan-audit")
+			}
+		}
+		assert.True(t, foundPlanningDrift, "expected stale planning evidence to remain unrepaired")
 	})
 }
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -80,7 +80,12 @@ an archived terminal change, the command fails with
 `archived_change_not_validatable` and returns the terminal status plus archived
 `change.yaml` path instead of the generic no-active diagnostic.
 
-`repair --json` separates `applied_repairs` from `unrepaired_drift`. Applied repairs are bounded local fixes that were actually performed; unrepaired drift includes a target, reason, and `next_action` for evidence or artifact work that Slipway did not mutate automatically. Empty orphan active-bundle directories left behind after archive cleanup are removed as `empty_orphan_bundle` applied repairs; non-empty orphan bundles remain operator-reviewed integrity findings. `health --json` findings include `active_change_blocking` and `active_change_impact`; advisory codebase-map warnings are marked non-blocking for the active change.
+`repair --json` separates `applied_repairs` from `unrepaired_drift`. Applied repairs are bounded local fixes that were actually performed; unrepaired drift includes a target, reason, and `next_action` for evidence or artifact work that Slipway did not mutate automatically. Ready execution summaries that are stale only because runtime task evidence is newer can be rebuilt from current wave-backed task evidence; stale planning-source drift remains unrepaired. Empty orphan active-bundle directories left behind after archive cleanup are removed as `empty_orphan_bundle` applied repairs; non-empty orphan bundles remain operator-reviewed integrity findings. Missing task-evidence blockers include the runtime task evidence path and the required flat JSON fields: `task_id,run_summary_version,task_kind,verdict,evidence_ref,captured_at,freshness_inputs`. `health --json` findings include `active_change_blocking` and `active_change_impact`; advisory codebase-map warnings are marked non-blocking for the active change.
+
+`done --json` archives done-ready worktree-bound changes even when source files
+are still uncommitted, but returns `worktree_dirty_warning` and
+`worktree_dirty_files` so operators do not delete a worktree while implementation
+changes are still only local.
 
 ## Resume And Checkpoints
 

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -29,6 +29,10 @@ go run . status --json
 
 Avoid deciding readiness from `main...HEAD` alone. Pair branch comparisons with direct worktree status and diff checks.
 After `slipway done`, Git-safe archived records remain in the owning worktree; commit or merge them before removing that worktree.
+When a worktree-bound change still has uncommitted source changes, `done --json`
+archives the governed bundle but returns `worktree_dirty_warning` and
+`worktree_dirty_files` so the operator can commit or inspect the source diff
+before deleting the worktree.
 
 ## Health And Repair
 
@@ -51,6 +55,10 @@ In JSON output, `applied_repairs` lists fixes that were performed, while
 `unrepaired_drift` lists drift that still needs operator action with a target,
 reason, and next action. Do not edit freshness fields or timestamps by hand;
 regenerate the named evidence or rescope the source artifact instead.
+For ready execution summaries that are stale only because runtime task evidence
+is newer, repair can rebuild the summary from current wave-backed task evidence.
+Planning-source drift remains unrepaired and points back to planning or review
+evidence refresh instead.
 
 Health findings include active-change impact. Codebase-map warnings are
 advisory by default and should be marked non-blocking for the current gate,
@@ -67,6 +75,9 @@ summaries are treated as stale and must be regenerated.
 `status --json` expose freshness failures with stale source/evidence pairs,
 first stale cause, downstream evidence chain, expected/current task input
 values, authoritative bundle and runtime paths, and a safe next action.
+Missing task evidence blockers include the runtime task evidence directory and
+the required flat JSON fields:
+`task_id,run_summary_version,task_kind,verdict,evidence_ref,captured_at,freshness_inputs`.
 
 Review handoffs use exact layer tokens. Spec-compliance evidence records
 `layer:R0=pass` and, when the guardrail domain requires it, `layer:R3=pass`.
@@ -118,3 +129,5 @@ Before `done`:
 4. Stage intended files only.
 5. Confirm `git diff --cached --check`.
 6. Run `slipway done --json` when the change is done-ready.
+7. If `worktree_dirty_warning` is present, inspect or commit the listed source
+   files before removing the worktree.

--- a/internal/engine/progression/evidence.go
+++ b/internal/engine/progression/evidence.go
@@ -95,7 +95,7 @@ func evaluateRequiredSkills(
 		}
 
 		if def.RunSummaryBound && latestRunSummaryVersion < 1 {
-			blockers = append(blockers, "required_skill_not_ready:"+skillName+":run_summary_missing")
+			blockers = append(blockers, "required_skill_not_ready:"+runSummaryMissingDetail(root, slug, skillName))
 			continue
 		}
 

--- a/internal/engine/progression/evidence_test.go
+++ b/internal/engine/progression/evidence_test.go
@@ -1,6 +1,7 @@
 package progression
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -91,7 +92,16 @@ func TestEvaluateRequiredSkills_FailsClosedWhenRunSummaryBoundSkillHasNoSummary(
 	passing, blockers, err := EvaluateRequiredSkillsForChange(root, change, model.StateS3Review, 0, false)
 	require.NoError(t, err)
 	assert.Empty(t, passing)
-	assert.Contains(t, blockers, "required_skill_not_ready:spec-compliance-review:run_summary_missing")
+	var runSummaryBlocker string
+	for _, blocker := range blockers {
+		if strings.HasPrefix(blocker, "required_skill_not_ready:spec-compliance-review:run_summary_missing") {
+			runSummaryBlocker = blocker
+			break
+		}
+	}
+	require.NotEmpty(t, runSummaryBlocker)
+	assert.Contains(t, runSummaryBlocker, "task_evidence_path=")
+	assert.Contains(t, runSummaryBlocker, "required_fields=task_id,run_summary_version,task_kind,verdict,evidence_ref,captured_at,freshness_inputs")
 }
 
 func TestEvaluateRequiredSkillsForChange_RequiresExplicitPlanSubStep(t *testing.T) {

--- a/internal/engine/progression/readiness.go
+++ b/internal/engine/progression/readiness.go
@@ -648,6 +648,12 @@ func scopeContractWorkspaceChangedFiles(paths state.ResolvedChangePaths) []strin
 	return stringutil.UniqueSorted(filtered)
 }
 
+// WorkspaceChangedFiles returns implementation-side changed files for the
+// resolved workspace, excluding governed bundle files.
+func WorkspaceChangedFiles(paths state.ResolvedChangePaths) []string {
+	return scopeContractWorkspaceChangedFiles(paths)
+}
+
 func scopeContractUntrackedChangedFile(workspaceRoot, file string) bool {
 	file = filepath.ToSlash(strings.TrimSpace(file))
 	file = strings.TrimPrefix(file, "./")

--- a/internal/engine/progression/wave_sync.go
+++ b/internal/engine/progression/wave_sync.go
@@ -39,6 +39,28 @@ type TaskEvidenceRunVersionMismatchError struct {
 	Got      int
 }
 
+const taskEvidenceRequiredFields = "task_id,run_summary_version,task_kind,verdict,evidence_ref,captured_at,freshness_inputs"
+
+func taskEvidenceActionDetail(root, slug string, runSummaryVersion int) string {
+	parts := []string{}
+	if runSummaryVersion > 0 {
+		parts = append(parts, fmt.Sprintf("run_summary_version=%d", runSummaryVersion))
+	}
+	if strings.TrimSpace(root) != "" && strings.TrimSpace(slug) != "" {
+		parts = append(parts, "task_evidence_path="+state.DisplayPath(root, state.EvidenceTasksDir(root, slug)))
+	}
+	parts = append(parts, "required_fields="+taskEvidenceRequiredFields)
+	return strings.Join(parts, "; ")
+}
+
+func runSummaryMissingDetail(root, slug, skillName string) string {
+	detail := skillName + ":run_summary_missing"
+	if actionDetail := taskEvidenceActionDetail(root, slug, 0); actionDetail != "" {
+		detail += "; " + actionDetail
+	}
+	return detail
+}
+
 func (e TaskEvidenceRunVersionMismatchError) Error() string {
 	return fmt.Sprintf("run_summary_version mismatch: expected=%d got=%d", e.Expected, e.Got)
 }
@@ -64,7 +86,7 @@ func SyncGovernedWaveExecution(root string, change model.Change) (WaveSyncResult
 	}
 	if len(tasks) == 0 {
 		blockers := []model.ReasonCode{
-			model.NewReasonCode("missing_task_evidence_for_run_summary", fmt.Sprintf("run_summary_version=%d", record.RunVersion)),
+			model.NewReasonCode("missing_task_evidence_for_run_summary", taskEvidenceActionDetail(root, change.Slug, record.RunVersion)),
 		}
 		blockers = append(blockers, model.ReasonCodesFromSpecs(parseIssues)...)
 		return WaveSyncResult{Blockers: model.NormalizeReasonCodes(blockers)}, nil

--- a/internal/state/execution_summary.go
+++ b/internal/state/execution_summary.go
@@ -669,7 +669,7 @@ func nextActionForPlanningStage(path string) string {
 	case planAuditFileName:
 		return "rerun plan-audit before rebuilding downstream wave and execution evidence"
 	case WavePlanFileName:
-		return "regenerate wave-plan.yaml from current planning evidence before rerunning execution"
+		return "rerun plan-audit and regenerate wave-plan.yaml from current planning evidence before rerunning execution"
 	default:
 		return "regenerate stale planning evidence before repairing downstream execution evidence"
 	}

--- a/internal/tmpl/templates/skills/code-quality-review/SKILL.md.tmpl
+++ b/internal/tmpl/templates/skills/code-quality-review/SKILL.md.tmpl
@@ -66,6 +66,14 @@ small diffs, and goal-driven execution.
 - config changes are reflected in docs
 - API contracts match between layers
 
+### Dependency And Toolchain Compatibility
+- dependency/toolchain compatibility is checked when manifests, lockfiles, or
+  generated tool surfaces change
+- MSRV and declared tool versions match dependency metadata and CI/runtime
+  expectations
+- dependency updates do not silently raise the required compiler, runtime, or
+  external tool version
+
 ## Review Layers
 - `layer:IR1=pass|fail`: mandatory baseline implementation quality review.
 - `layer:IR3=pass|fail`: mandatory when
@@ -86,6 +94,7 @@ run_version: 1
 references:
   - "layer:IR1=pass"
   - "layer:IR3=pass" # include only when review_context requires IR3
+  - "toolchain_compat:pass" # include when dependency/toolchain files changed
 notes: |
   Gaps (code_to_artifact): <code patterns not reflected in artifacts>
   Gaps (artifact_to_code): <artifact expectations not met by code>
@@ -109,3 +118,5 @@ After confirmation: `slipway next`
 - Changed code fails readability, maintainability, duplication, or convention checks.
 - Tests are weak, misleading, or missing for important paths.
 - Safety or cross-artifact consistency gaps remain unresolved.
+- Dependency/toolchain compatibility evidence is missing for manifest, lockfile,
+  or generated tool-surface changes.

--- a/internal/tmpl/templates/skills/spec-compliance-review/SKILL.md.tmpl
+++ b/internal/tmpl/templates/skills/spec-compliance-review/SKILL.md.tmpl
@@ -62,6 +62,12 @@ When `validate --json`, `status --json`, or `review --json` exposes
 `scope_contract:fail:<reason>` and treated as artifact-to-code drift until the
 contract is amended or the change is reverted.
 
+### Negative Path Evidence
+When requirements describe rejection, error, blocker, stale, or repair-failure
+behavior, verify requirement-named negative/error paths with concrete tests or
+runtime evidence. A pass requires `negative_path:pass`; a fail must name the
+missing requirement path and block the review.
+
 ### Intent Drift Detection
 - compare original proposal intent with the final implementation
 - flag semantic drift between what was proposed and what was built
@@ -99,6 +105,7 @@ references:
   - "layer:R0=pass"
   - "layer:R3=pass" # include only when review_context requires R3
   - "scope_contract:pass"
+  - "negative_path:pass" # include when requirements name negative/error paths
 notes: |
   Gaps (code_to_artifact): <code behaviors not documented in spec>
   Gaps (artifact_to_code): <spec requirements not implemented in code>
@@ -122,3 +129,4 @@ After confirmation: proceed to code-quality-review.
 - Code behavior is undocumented or contradicts the approved artifacts.
 - Locked decisions are violated.
 - Claimed-complete work is still stubbed, placeholder-only, or assertion-free.
+- Requirement-named negative/error paths lack tests or runtime evidence.

--- a/internal/tmpl/templates_test.go
+++ b/internal/tmpl/templates_test.go
@@ -740,6 +740,23 @@ func TestGovernedHostTemplatesReferenceCodingDiscipline(t *testing.T) {
 	}
 }
 
+func TestReviewTemplatesRequireNegativePathAndToolchainEvidence(t *testing.T) {
+	t.Parallel()
+
+	data := map[string]string{"ToolID": "claude", "Trigger": "/slipway:test", "Description": "test"}
+
+	specCompliance, err := Render("skills/spec-compliance-review/SKILL.md.tmpl", data)
+	require.NoError(t, err)
+	assert.Contains(t, specCompliance, "requirement-named negative/error paths")
+	assert.Contains(t, specCompliance, "negative_path:pass")
+
+	codeQuality, err := Render("skills/code-quality-review/SKILL.md.tmpl", data)
+	require.NoError(t, err)
+	assert.Contains(t, codeQuality, "dependency/toolchain compatibility")
+	assert.Contains(t, codeQuality, "MSRV")
+	assert.Contains(t, codeQuality, "toolchain_compat:pass")
+}
+
 func TestRootCauseTracingAbsorbsSystematicDebuggingDoctrine(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- rebuild ready-but-stale execution summaries from valid runtime task evidence during repair
- add actionable runtime task evidence diagnostics and dirty worktree done warnings
- tighten review skill templates for negative-path and toolchain/MSRV evidence

## Verification
- git diff --check
- go build ./...
- go test -count=1 ./...

Fixes #24