### PR TITLE
fix(state): ignore summary timestamp for task freshness

### DIFF
--- a/artifacts/changes/archived/fix-execution-summary-freshness-and-clarify-validate-diagnos/assurance.md
+++ b/artifacts/changes/archived/fix-execution-summary-freshness-and-clarify-validate-diagnos/assurance.md
@@ -1,0 +1,57 @@
+# Assurance
+
+## Project Context
+- Tech Stack: Go
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Scope Summary
+Planned scope is limited to #28 execution-summary freshness correction, #29
+active validate wording clarification, #32 validate zero-write regression
+coverage, and evidence-backed issue closeout for #30/#32/#34. Deferred
+enhancements are archived audit, tracked archived runtime evidence defense, and
+structured orphan-bundle diagnostics.
+
+## Verification Verdict
+Pass. Fresh proof captured in this worktree:
+- RED: `go test -count=1 ./internal/state -run TestExecutionSummaryFreshnessIgnoresSummaryCapturedAtForPerTaskFreshness` failed before the fix with stale execution freshness.
+- GREEN targeted: `go test -count=1 ./internal/state -run 'TestExecutionSummaryFreshness(IgnoresSummaryCapturedAtForPerTaskFreshness|DiagnosticsDetectsManualTaskTimestampDrift|TreatsTasksPlanHashMismatchAsStale|DiagnosticsIncludesPlanningEvidenceChain)'` passed.
+- Validate zero-write targeted: `go test -count=1 ./cmd -run 'TestValidate(NoActiveDiagnostic|ArchivedExplicitSlug|OrphanActiveBundle)IsZeroWrite|TestValidateChangeFlagRejectsArchivedSlugWithConcreteDiagnostic'` passed.
+- Regression package checks: `go test -count=1 ./internal/state`, `go test -count=1 ./cmd`, and `go test -count=1 ./internal/tmpl` passed after fixes.
+- Full suite: `go test -count=1 ./...` passed.
+- Build: `go build ./...` passed.
+- Whitespace: `git diff --check` passed.
+- Issue tracker: #29, #30, #32, and #34 are closed with evidence-backed comments; #28 remains open for the code fix/merge path.
+
+## Evidence Index
+- Intake clarification: `verification/intake-clarification.yaml`
+- Research: `verification/research-orchestration.yaml`
+- Plan audit: `verification/plan-audit.yaml`
+- Wave orchestration: `verification/wave-orchestration.yaml`
+- Execution summary: `verification/execution-summary.yaml`
+- Spec compliance review: `verification/spec-compliance-review.yaml`
+- Code quality review: `verification/code-quality-review.yaml`
+- Goal verification/final closeout: pending lifecycle handoff
+
+## Requirement Coverage
+- REQ-001: `t-01`, `t-02`
+- REQ-002: `t-02`
+- REQ-003: `t-03`
+- REQ-004: `t-04`
+- REQ-005: `t-05`
+
+## Residual Risks and Exceptions
+- #30 tracked archived runtime evidence defense is intentionally deferred.
+- #34 structured orphan-bundle diagnostic enhancement is intentionally deferred.
+- #32 remains closed/request-repro unless a version-specific write path is
+  provided.
+
+## Rollback Readiness
+Rollback is a normal Git revert of this change. No persisted schema or external
+runtime state is migrated by the code change.
+
+## Archive Decision
+Ready for final closeout handoff. The final archive decision must use the active
+`validate --json` gate before `done`; archived bundles are not described as
+revalidated through that active gate.

--- a/artifacts/changes/archived/fix-execution-summary-freshness-and-clarify-validate-diagnos/change.yaml
+++ b/artifacts/changes/archived/fix-execution-summary-freshness-and-clarify-validate-diagnos/change.yaml
@@ -1,0 +1,56 @@
+version: 1
+slug: fix-execution-summary-freshness-and-clarify-validate-diagnos
+description: fix execution-summary freshness and clarify validate diagnostics issues
+status: done
+current_state: DONE
+needs_discovery: true
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-05-31T05:47:54.884803Z
+quality_mode: standard
+workflow_preset: standard
+worktree_branch: feat/fix-execution-summary-freshness-and-clarify-validate-diagnos
+artifact_schema: expanded
+project_context:
+    tech_stack: Go
+    test_cmd: go test ./...
+    build_cmd: go build ./...
+    languages:
+        - Go
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: 36af5519ec94151b4f4a5c7a2f60192ba3d02ab7951d56d32c97e55f50291ae9
+        updated_at: 2026-05-31T06:16:04.550456404Z
+    decision:
+        id: decision
+        path: decision.md
+        state: frozen
+        content_hash: 8900dfaed2e48a0b36bd0edd7f4f949db8e1874b0fa9078de91ce1ecc18f499e
+        updated_at: 2026-05-31T06:01:02.658237555Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: 3ea3f18dadf044ed0ba68234ef83d05ff35b0da10bc52261394baa6ff1484eef
+        updated_at: 2026-05-31T05:50:26.698038724Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: fe3fcb2c8647eafbacce56ed1512798b2b92faf9f531e36c6dfcf59d8be3cf9f
+        updated_at: 2026-05-31T06:00:42.788237724Z
+    research:
+        id: research
+        path: research.md
+        state: frozen
+        content_hash: 2206e9f198a63da3e26ef684f51b05f2aaba5ff087d4602e42dbcf98e8b6a0e5
+        updated_at: 2026-05-31T05:59:44.748845083Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: f5c664fadea30e06b0b899aaa70c4f78db1a7bbcd7ff40aaeab440e22bf9bafc
+        updated_at: 2026-05-31T06:07:41.314287434Z

--- a/artifacts/changes/archived/fix-execution-summary-freshness-and-clarify-validate-diagnos/decision.md
+++ b/artifacts/changes/archived/fix-execution-summary-freshness-and-clarify-validate-diagnos/decision.md
@@ -1,0 +1,68 @@
+# Decision
+
+## Project Context
+- Tech Stack: Go
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Alternatives Considered
+
+### Approach A: Minimal freshness DAG correction plus docs/tests
+Remove summary/task captured timestamps from the normal per-task freshness
+baseline, preserve unreadable-artifact fail-closed behavior, add validate
+zero-write tests, and clarify active-only validate wording.
+
+Tradeoffs: fixes the confirmed core bug with the smallest behavioral change, but
+defers #30 tracked-runtime defense and #34 orphan-bundle diagnostic polish.
+
+### Approach B: Broaden archive and repair defenses now
+Add `done`/`repair` checks for tracked archived runtime evidence and structured
+orphan-bundle diagnostics in the same delivery.
+
+Tradeoffs: useful hardening, but it expands the blast radius beyond the only
+must-fix issue and changes behavior for reports whose original root cause is not
+confirmed on current HEAD.
+
+### Approach C: Reinterpret `validate --change` as archived audit
+Allow `validate --change <slug>` to read archived bundles after `done`.
+
+Tradeoffs: conflicts with the current active-only readiness contract and mixes
+active runtime state validation with frozen archive inspection.
+
+## Selected Approach
+Approach A. It matches the user's final triage: fix #28, clarify #29 wording,
+add #32 zero-write regression coverage, and close #30/#32/#34 when current
+evidence shows they are not must-fix implementation bugs.
+
+## Interfaces and Data Flow
+- No public command interface changes.
+- `latestExecutionRelevantUpdateAt` continues to feed
+  `ExecutionSummaryFreshness` and diagnostics, but its normal baseline now comes
+  only from upstream planning artifacts (`intent.md`, `requirements.md`,
+  `research.md`, `decision.md`, and semantically relevant `tasks.md` changes).
+- `executionSummaryFreshnessEvaluation` keeps summary-level fallback freshness
+  for summaries without detailed task inputs.
+- Unreadable upstream artifact errors use a fail-closed helper anchored to the
+  latest known summary/task evidence timestamp, so error paths remain stale.
+- `validate --json` behavior is unchanged; tests assert no writes on diagnostic
+  and failure paths.
+
+## Rollout and Rollback
+- Rollout: merge the code, docs/templates, tests, and governed bundle together.
+  Close relevant GitHub issues after local verification passes.
+- Rollback: revert the commit. The old behavior may reintroduce #28
+  self-staleness, but no schema migration or irreversible data operation is
+  involved.
+- Verification commands: targeted package tests, then `go test -count=1 ./...`
+  and `go build ./...`.
+
+## Risk
+- Main risk: weakening stale detection. Mitigation is explicit regression
+  coverage for unreadable artifact fail-closed behavior and task structural
+  timestamp drift.
+- Secondary risk: over-closing #30/#32/#34. Mitigation is evidence-backed issue
+  comments that ask for version/reproduction details if the reports are reopened.
+- Contract risk: docs must not imply archived validation support. Mitigation is
+  explicit active-readiness wording in `docs/commands.md`,
+  `docs/operator-guide.md`, final-closeout template, and assurance template.

--- a/artifacts/changes/archived/fix-execution-summary-freshness-and-clarify-validate-diagnos/intent.md
+++ b/artifacts/changes/archived/fix-execution-summary-freshness-and-clarify-validate-diagnos/intent.md
@@ -1,0 +1,82 @@
+# Intent
+
+## Project Context
+<!-- Auto-filled by InferProjectContext(); .slipway.yaml overrides -->
+- Tech Stack: Go
+- Languages: Go
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Conventions:
+
+## Summary
+Fix the confirmed execution-summary freshness bug and close out related Lattice
+diagnostic issues according to the user's final triage.
+## Complexity Assessment
+complex
+Rationale: the change touches execution freshness semantics, regression tests,
+documentation/assurance wording, and issue-tracker closeout for multiple linked
+reports. The code change is bounded but the workflow contract needs precision.
+
+## Guardrail Domains
+<!-- none detected -->
+
+## In Scope
+- #28: remove the per-task freshness loop where `execution-summary.yaml`
+  `captured_at` makes earlier task evidence stale, and add regression coverage.
+- #29: clarify final-assurance/documentation wording so active `validate --json`
+  is described as a pre-`done` freshness gate, not a post-archive replay
+  promise.
+- #32: add no-active/archived/missing-authority validate zero-write regression
+  coverage where useful, then close or request reproduction because the reported
+  write path is not present on current HEAD.
+- GitHub closeout for #30, #32, and #34 when current evidence shows they are not
+  must-fix implementation bugs.
+
+## Out of Scope
+- Do not change the active-only semantics of `validate --change <slug>` for
+  archived changes.
+- Do not implement #30's tracked archived runtime evidence defense in this
+  change.
+- Do not implement #34's orphan bundle diagnostic enhancement in this change.
+- Do not redesign archived audit surfaces; that remains a future product
+  surface if needed.
+
+## Constraints
+- Keep the diff surgical and aligned with the existing execution-summary
+  freshness model.
+- Treat `execution-summary.yaml` as downstream aggregate evidence; its own
+  `captured_at` must not be an upstream per-task freshness baseline.
+- Preserve non-empty orphan bundle behavior: diagnostic/reporting improvements
+  may be future work, but automatic deletion is out of scope.
+- Use fresh Go test/build verification before closeout.
+
+## Acceptance Signals
+- A regression test fails before the #28 fix and passes after it, proving
+  summary `captured_at` alone does not stale older task evidence.
+- Validate zero-write regression coverage exists for no-active/archived or
+  missing-authority failure paths relevant to #32.
+- Final-assurance wording no longer implies archived bundles can be revalidated
+  through active `validate --json` after `done`.
+- `go test -count=1 ./...` and `go build ./...` pass in the governed worktree.
+- GitHub issues #30, #32, and #34 are closed with evidence-backed comments; #29
+  is closed after the wording clarification; #28 is closed by the fix.
+
+## Open Questions
+None.
+
+## Deferred Ideas
+- Add a read-only archived audit surface such as `slipway audit --archived
+  --change <slug>`.
+- Add `done`/`repair` checks for tracked archived runtime evidence.
+- Add a structured orphan-bundle diagnostic code for non-empty active bundle
+  directories missing `change.yaml`.
+- Ask reporters for #30/#32/#34 versions and reproduction details if those
+  closed reports are later reopened as enhancements.
+
+## Approved Summary
+User-confirmed on 2026-05-31T05:49:11Z from the request's final triage:
+implement #28, clarify #29 wording, add #32 zero-write regression coverage, and
+close #30/#32/#34 when current evidence shows they are not must-fix bugs. The
+change must not expand `validate --change` into archived validation, must not
+implement #30's defensive archive check, and must not implement #34's diagnostic
+enhancement in this delivery.

--- a/artifacts/changes/archived/fix-execution-summary-freshness-and-clarify-validate-diagnos/requirements.md
+++ b/artifacts/changes/archived/fix-execution-summary-freshness-and-clarify-validate-diagnos/requirements.md
@@ -1,0 +1,65 @@
+# Requirements
+
+## Project Context
+- Tech Stack: Go
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Requirements
+
+### Requirement: #28 per-task freshness excludes downstream summary timestamps
+REQ-001: Execution task evidence freshness MUST NOT use `execution-summary.yaml`
+`captured_at` or sibling task `captured_at` values as the latest relevant
+upstream update for every task.
+
+#### Scenario: Summary regenerated after task evidence
+GIVEN an execution summary with multiple task records whose runtime task
+evidence timestamps match their per-task `captured_at` values
+AND the summary `captured_at` is later than those task timestamps
+WHEN execution-summary freshness is evaluated
+THEN the task evidence remains fresh unless a task structural input or upstream
+planning artifact is newer than that task evidence.
+
+### Requirement: Freshness failure paths remain fail-closed
+REQ-002: Execution freshness MUST still return stale when an upstream planning
+artifact needed for freshness evaluation exists but cannot be read.
+
+#### Scenario: Unreadable planning artifact
+GIVEN a ready execution summary
+AND a freshness-relevant planning artifact path returns a non-not-exist read or
+stat error
+WHEN freshness is evaluated
+THEN Slipway reports stale execution evidence rather than silently passing.
+
+### Requirement: Validate failure paths remain read-only
+REQ-003: `validate --json` MUST NOT create, rewrite, or repair files when it
+returns no-active diagnostics, rejects an archived explicit slug, or encounters a
+non-empty active bundle directory without `change.yaml`.
+
+#### Scenario: Residual review artifact in orphan bundle
+GIVEN an orphan active bundle directory containing only review artifacts
+WHEN `validate --json` runs
+THEN no new files are written and the residual directory contents are unchanged.
+
+### Requirement: Active validate contract is documented
+REQ-004: User-facing command docs and closeout/assurance templates MUST describe
+`validate --json` as an active pre-`done` freshness/readiness gate, not as a
+post-archive audit surface for frozen bundles.
+
+#### Scenario: Archived slug after done
+GIVEN a terminal archived change
+WHEN an operator reads command or closeout guidance
+THEN the guidance says active `validate --change <slug>` rejects archived slugs
+and that archived audit would require a separate read-only surface.
+
+### Requirement: Issue tracker closeout follows evidence
+REQ-005: Issues #29, #30, #32, and #34 MUST be closed or commented according to
+current evidence; #28 MUST remain tied to the implementation fix.
+
+#### Scenario: Non-must-fix reports
+GIVEN current HEAD does not support the reported root causes for #30 and #32
+AND #34 is an orphan-bundle diagnostic enhancement rather than a core logic bug
+WHEN local verification and final review pass
+THEN the issues are closed with concise evidence-backed comments and deferred
+enhancement framing where appropriate.

--- a/artifacts/changes/archived/fix-execution-summary-freshness-and-clarify-validate-diagnos/research.md
+++ b/artifacts/changes/archived/fix-execution-summary-freshness-and-clarify-validate-diagnos/research.md
@@ -1,0 +1,82 @@
+# Research
+
+## Research Findings
+
+### Architecture
+- Affected modules:
+  - `internal/state/execution_summary.go` owns execution-summary freshness evaluation, diagnostics, planning-drift pairs, runtime task evidence timestamp checks, and active/archived summary path authority.
+  - `internal/model/execution_summary.go` owns `ExecutionSummary.LatestRelevantUpdateAt()`, which returns the max of summary `CapturedAt` and task `CapturedAt`; it remains useful for summary coverage/fail-closed paths but must not seed per-task freshness.
+  - `cmd/validate.go` resolves active changes before building validation views; the no-active fallback returns diagnostic JSON without entering `buildValidateViewForSlug`.
+  - `cmd/common.go` rejects archived explicit slugs with `archived_change_not_validatable`, preserving active-only validate semantics.
+  - `internal/state/local_ignore.go` confirms current Slipway HEAD ignores `artifacts/changes/**/{evidence,events,verification}/` and does not generate archived-path negations.
+  - `cmd/repair.go` reports non-empty orphan bundles as non-repairable findings rather than deleting them automatically.
+- Dependency chains:
+  - `validate/status/review/next` -> `LoadRelevantExecutionSummaryContext` -> `ExecutionSummaryFreshnessDiagnostics` -> `executionSummaryFreshnessEvaluation` -> `latestExecutionRelevantUpdateAt` + `collectTaskEvidenceFreshnessInputs`.
+  - `validate --json` -> `resolveActiveChangeRef` -> no-active diagnostic or `buildValidateViewForSlug`; archived explicit slugs stop in `resolveExplicitChange`.
+- Blast radius: bounded to execution freshness logic, validate read-only regression coverage, and operator-facing docs/templates. No command semantics or archive lifecycle behavior should change.
+- Constraints:
+  - `execution-summary.yaml` is downstream aggregate evidence.
+  - Per-task freshness may compare task evidence to structural inputs and upstream artifacts, but not to the summary's own `CapturedAt` or sibling task timestamps.
+  - Planning-source drift still needs fail-closed behavior when an upstream artifact is unreadable.
+
+### Patterns
+- Existing conventions:
+  - Freshness is expressed through `ctxpack.EvidenceFreshnessInput`, with structural field maps and timestamp comparisons.
+  - Current task input diffs already compare task `freshness_inputs` and runtime task evidence `captured_at` before generic timestamp freshness evaluation.
+  - Read-only command surfaces have regression tests proving they do not persist artifact reconciliation or governance snapshots.
+- Reusable abstractions:
+  - Reuse `ExpectedExecutionTaskFreshnessInputs`, `taskEvidenceCapturedAt`, and `ExecutionSummaryFreshnessDiagnostics` for #28 tests.
+  - Reuse command test helpers (`commandForRoot`, `createGovernedRequest`, `state.ArchiveChange`) for #32 zero-write tests.
+- Convention deviations: none required. The minimal code change keeps existing freshness APIs and narrows only the baseline used for per-task evidence timestamp comparison.
+
+### Risks
+- Technical risks:
+  - High: removing summary/task timestamps from the per-task baseline could accidentally make unreadable upstream artifacts non-stale. Mitigation: keep a fail-closed helper that uses summary/task evidence timestamps only on error paths.
+  - Medium: summary-level blocker-only evidence can become `unknown` if no per-task inputs exist and there is no upstream timestamp. Mitigation: fallback no-task evaluation treats the summary timestamp as its own baseline.
+  - Low: docs wording could be over-broad. Mitigation: state only the active vs archived validate contract, not a new audit feature.
+- Guardrail domains: none. The change does not modify auth, credentials, PII, financial, schema migration, irreversible operations, or external API contracts.
+- Reversibility: straightforward revert of freshness baseline, tests, and docs if regressions appear.
+
+### Test Strategy
+- Existing coverage:
+  - `internal/state/execution_summary_test.go` covers structural freshness inputs, manual task timestamp drift, planning-source-first diagnostics, task-plan hash mismatch, planning evidence chains, unreadable freshness artifacts, and archived summary sanitization.
+  - `cmd/common_test.go` already covers archived explicit slug diagnostics.
+  - `cmd/status_context_repair_test.go` already covers validate read-only artifact reconcile.
+- New coverage:
+  - Add a RED test proving summary `CapturedAt` newer than all task evidence no longer makes matching per-task evidence stale.
+  - Add validate zero-write tests for no-active diagnostic fallback, archived explicit slug rejection, and non-empty orphan active bundle residue.
+- Verification approach:
+  - Targeted RED/GREEN: `go test -count=1 ./internal/state -run TestExecutionSummaryFreshnessIgnoresSummaryCapturedAtForPerTaskFreshness`.
+  - Targeted read-only checks: `go test -count=1 ./cmd -run 'TestValidate(NoActiveDiagnostic|ArchivedExplicitSlug|OrphanActiveBundle)IsZeroWrite'`.
+  - Broader package checks: `go test -count=1 ./internal/state`, `go test -count=1 ./cmd`, `go test -count=1 ./internal/tmpl`.
+  - Final repo checks: `go test -count=1 ./...` and `go build ./...`.
+
+## Alternatives Considered
+- Approach A: Minimal freshness DAG correction plus docs/tests. Remove summary/task captured timestamps from the normal per-task freshness baseline, preserve fail-closed unreadable-artifact behavior, add #32 zero-write tests, and clarify #29 wording. Tradeoff: #30/#34 remain deferred enhancements.
+- Approach B: Broaden repair/done to enforce tracked archived runtime evidence checks and orphan bundle diagnostics now. Tradeoff: higher blast radius and not required by the confirmed issue evidence; risks expanding beyond the user's final priority.
+- Approach C: Change `validate --change` to read archived bundles. Tradeoff: violates active-only validate contract and mixes active runtime readiness with frozen archive audit.
+- Selected: Approach A, matching the user's final triage. It fixes the only confirmed core bug (#28), clarifies #29 without changing semantics, and locks #32/#34 read-only boundaries without implementing deferred enhancements.
+
+## Unknowns
+- Resolved: Is #28 caused by summary self-staleness? -> Yes. The RED test reproduced stale freshness when summary `CapturedAt` was newer than otherwise matching task evidence.
+- Resolved: Does current HEAD generate archived gitignore negations for runtime directories? -> No. `internal/state/local_ignore.go` has only positive ignore patterns for runtime dirs.
+- Resolved: Does current validate no-active path write stale review artifacts? -> No current write path was found; zero-write regression tests now guard the no-active, archived explicit, and orphan active-bundle paths.
+- Remaining: None for this change.
+
+## Assumptions
+- The user's final issue disposition is scope authority for this governed change. Evidence: request text and `intent.md`.
+- Current HEAD behavior is authoritative for closing #30/#32/#34 unless reporters provide version-specific reproduction details. Evidence: `gh issue view` for #28/#34, current source inspection, and local tests.
+- Non-empty orphan bundles should remain operator-reviewed integrity findings, not auto-deleted in this change. Evidence: `cmd/repair.go` non-repairable finding behavior and existing repair tests.
+
+## Canonical References
+- `artifacts/changes/fix-execution-summary-freshness-and-clarify-validate-diagnos/intent.md`
+- `internal/state/execution_summary.go`
+- `internal/model/execution_summary.go`
+- `internal/state/execution_summary_test.go`
+- `cmd/validate.go`
+- `cmd/common.go`
+- `cmd/validate_readonly_test.go`
+- `docs/commands.md`
+- `docs/operator-guide.md`
+- `internal/tmpl/templates/skills/final-closeout/SKILL.md.tmpl`
+- `internal/tmpl/templates/artifacts/assurance.md`

--- a/artifacts/changes/archived/fix-execution-summary-freshness-and-clarify-validate-diagnos/tasks.md
+++ b/artifacts/changes/archived/fix-execution-summary-freshness-and-clarify-validate-diagnos/tasks.md
@@ -1,0 +1,54 @@
+# Tasks
+
+## Project Context
+- Tech Stack: Go
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Task List
+
+- [x] `t-01` Add RED regression coverage for execution-summary self-staleness.
+  - wave: 1
+  - depends_on: []
+  - target_files: ["internal/state/execution_summary_test.go"]
+  - task_kind: code
+  - covers: [REQ-001]
+  - evidence: failing then passing targeted `go test -count=1 ./internal/state -run TestExecutionSummaryFreshnessIgnoresSummaryCapturedAtForPerTaskFreshness`
+  - acceptance: test models two matching task evidence timestamps and a later summary `captured_at`, and expects fresh diagnostics.
+
+- [x] `t-02` Correct per-task freshness baseline while preserving fail-closed behavior.
+  - wave: 1
+  - depends_on: []
+  - target_files: ["internal/state/execution_summary.go"]
+  - task_kind: code
+  - covers: [REQ-001, REQ-002]
+  - evidence: targeted `internal/state` tests for #28 and unreadable freshness artifacts.
+  - acceptance: normal per-task freshness uses upstream artifacts only; unreadable upstream artifacts still stale the execution summary.
+
+- [x] `t-03` Add validate zero-write regression tests for no-active, archived, and orphan-bundle paths.
+  - wave: 1
+  - depends_on: []
+  - target_files: ["cmd/validate_readonly_test.go"]
+  - task_kind: code
+  - covers: [REQ-003]
+  - evidence: targeted `go test -count=1 ./cmd -run 'TestValidate(NoActiveDiagnostic|ArchivedExplicitSlug|OrphanActiveBundle)IsZeroWrite'`
+  - acceptance: tests snapshot non-git files and prove `validate --json` does not write on those failure/diagnostic paths.
+
+- [x] `t-04` Clarify active validate contract in docs and templates.
+  - wave: 1
+  - depends_on: []
+  - target_files: ["docs/commands.md", "docs/operator-guide.md", "internal/tmpl/templates/skills/final-closeout/SKILL.md.tmpl", "internal/tmpl/templates/artifacts/assurance.md"]
+  - task_kind: code
+  - covers: [REQ-004]
+  - evidence: docs/template diff plus `go test -count=1 ./internal/tmpl`.
+  - acceptance: wording says `validate --json` is active pre-`done` readiness proof and archived audit is a separate future surface.
+
+- [x] `t-05` Verify full change and close tracker issues according to evidence.
+  - wave: 2
+  - depends_on: [t-01, t-02, t-03, t-04]
+  - target_files: ["artifacts/changes/fix-execution-summary-freshness-and-clarify-validate-diagnos/assurance.md", "artifacts/changes/fix-execution-summary-freshness-and-clarify-validate-diagnos/tasks.md", "artifacts/changes/fix-execution-summary-freshness-and-clarify-validate-diagnos/verification/", "artifacts/codebase/ARCHITECTURE.md", "artifacts/codebase/CONCERNS.md", "artifacts/codebase/CONVENTIONS.md", "artifacts/codebase/INTEGRATIONS.md", "artifacts/codebase/STACK.md", "artifacts/codebase/STRUCTURE.md", "artifacts/codebase/TESTING.md"]
+  - task_kind: verification
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004, REQ-005]
+  - evidence: `go test -count=1 ./...`, `go build ./...`, `go run . validate --json`, and GitHub issue comments/closures.
+  - acceptance: #28 fix is verified; #29/#30/#32/#34 are closed or commented with evidence-backed reasoning matching the user's final disposition.

--- a/artifacts/codebase/ARCHITECTURE.md
+++ b/artifacts/codebase/ARCHITECTURE.md
@@ -1,0 +1,7 @@
+# Architecture
+
+- Module responsibilities:
+- Dependency flow:
+- Coupling hotspots:
+- Current change blast radius:
+- Notes:

--- a/artifacts/codebase/CONCERNS.md
+++ b/artifacts/codebase/CONCERNS.md
@@ -1,0 +1,7 @@
+# Concerns
+
+- Architectural pressure points:
+- Brittle areas:
+- Migration traps:
+- Recheck routing:
+- Notes:

--- a/artifacts/codebase/CONVENTIONS.md
+++ b/artifacts/codebase/CONVENTIONS.md
@@ -1,0 +1,8 @@
+# Conventions
+
+- Naming:
+- File organization:
+- Error handling:
+- Configuration:
+- State management:
+- Notes:

--- a/artifacts/codebase/INTEGRATIONS.md
+++ b/artifacts/codebase/INTEGRATIONS.md
@@ -1,0 +1,7 @@
+# Integrations
+
+- External APIs:
+- Infrastructure bindings:
+- Datastores and queues:
+- File formats and protocols:
+- Notes:

--- a/artifacts/codebase/STACK.md
+++ b/artifacts/codebase/STACK.md
@@ -1,0 +1,7 @@
+# Stack
+
+- Languages: Go, Python
+- Frameworks and runtimes: Go module github.com/signalridge/slipway
+- Build and test tooling: go build ./...; go test ./...
+- Key dependencies: github.com/davecgh/go-spew, github.com/gofrs/flock, github.com/google/uuid, github.com/inconshreveable/mousetrap, github.com/kr/text, github.com/pmezard/go-difflib
+- Notes: go.mod declares Go 1.26.3

--- a/artifacts/codebase/STRUCTURE.md
+++ b/artifacts/codebase/STRUCTURE.md
@@ -1,0 +1,7 @@
+# Structure
+
+- Directory layout: cmd/, docs/, internal/
+- Entry points: README.md, go.mod, main.go
+- Generated versus handwritten boundaries:
+- Ownership hints:
+- Notes:

--- a/artifacts/codebase/TESTING.md
+++ b/artifacts/codebase/TESTING.md
@@ -1,0 +1,8 @@
+# Testing
+
+- Test layout: Go *_test.go files
+- Coverage hotspots:
+- Coverage gaps:
+- Verification commands: go build ./...; go test ./...
+- Fixture patterns:
+- Notes:

--- a/cmd/validate_readonly_test.go
+++ b/cmd/validate_readonly_test.go
@@ -1,0 +1,118 @@
+package cmd
+
+import (
+	"bytes"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/signalridge/slipway/internal/model"
+	"github.com/signalridge/slipway/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func snapshotNonGitTree(t *testing.T, root string) map[string]string {
+	t.Helper()
+
+	entries := map[string]string{}
+	require.NoError(t, filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		if rel == ".git" {
+			return filepath.SkipDir
+		}
+		if strings.HasPrefix(rel, ".git"+string(os.PathSeparator)) {
+			return nil
+		}
+		if entry.IsDir() {
+			entries["dir:"+filepath.ToSlash(rel)] = ""
+			return nil
+		}
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		entries["file:"+filepath.ToSlash(rel)] = string(raw)
+		return nil
+	}))
+	return entries
+}
+
+func TestValidateNoActiveDiagnosticIsZeroWrite(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	ensureTestGitRepo(t, root)
+	initTestWorkspace(t, root)
+
+	before := snapshotNonGitTree(t, root)
+
+	cmd := commandForRoot(t, root, makeValidateCmd())
+	cmd.SetArgs([]string{"--json"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	require.NoError(t, cmd.Execute())
+
+	assert.Equal(t, before, snapshotNonGitTree(t, root))
+	assert.Contains(t, out.String(), "no active change or ambiguous")
+}
+
+func TestValidateArchivedExplicitSlugIsZeroWrite(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	ensureTestGitRepo(t, root)
+	initTestWorkspace(t, root)
+
+	slug := createGovernedRequest(t, root, "L2", "validate archived zero write")
+	change, err := state.LoadChange(root, slug)
+	require.NoError(t, err)
+	_, err = state.ArchiveChange(root, change, model.ChangeStatusDone)
+	require.NoError(t, err)
+
+	before := snapshotNonGitTree(t, root)
+
+	cmd := commandForRoot(t, root, makeValidateCmd())
+	cmd.SetArgs([]string{"--json", "--change", slug})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	err = cmd.Execute()
+
+	cliErr := asCLIError(err)
+	require.NotNil(t, cliErr)
+	assert.Equal(t, "archived_change_not_validatable", cliErr.ErrorCode)
+	assert.Equal(t, before, snapshotNonGitTree(t, root))
+}
+
+func TestValidateOrphanActiveBundleIsZeroWrite(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	ensureTestGitRepo(t, root)
+	initTestWorkspace(t, root)
+
+	orphanDir := filepath.Join(root, "artifacts", "changes", "orphan-active-bundle", "review")
+	require.NoError(t, os.MkdirAll(orphanDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(orphanDir, "00-build-test.md"), []byte("stale review artifact\n"), 0o644))
+
+	before := snapshotNonGitTree(t, root)
+
+	cmd := commandForRoot(t, root, makeValidateCmd())
+	cmd.SetArgs([]string{"--json"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	_ = cmd.Execute()
+
+	assert.Equal(t, before, snapshotNonGitTree(t, root))
+}

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -95,7 +95,9 @@ When diagnostics are enabled, review-state handoff JSON can also include:
 `validate --change <slug>` selects an explicit active change. If the slug names
 an archived terminal change, the command fails with
 `archived_change_not_validatable` and returns the terminal status plus archived
-`change.yaml` path instead of the generic no-active diagnostic.
+`change.yaml` path instead of the generic no-active diagnostic. This is an
+active-readiness contract: `validate` proves the currently active governed state
+before `done`; it is not a post-archive audit surface for frozen bundles.
 
 `repair --json` separates `applied_repairs` from `unrepaired_drift`. Applied repairs are bounded local fixes that were actually performed; unrepaired drift includes a target, reason, and `next_action` for evidence or artifact work that Slipway did not mutate automatically. Ready execution summaries that are stale only because runtime task evidence is newer can be rebuilt from current wave-backed task evidence; stale planning-source drift remains unrepaired. Empty orphan active-bundle directories left behind after archive cleanup are removed as `empty_orphan_bundle` applied repairs; non-empty orphan bundles remain operator-reviewed integrity findings. Missing task-evidence blockers include the runtime task evidence path and the required flat JSON fields: `task_id,run_summary_version,task_kind,verdict,evidence_ref,captured_at,freshness_inputs`. `health --json` findings include `active_change_blocking` and `active_change_impact`; advisory codebase-map warnings are marked non-blocking for the active change.
 

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -123,7 +123,9 @@ Check generated path changes before committing. Codex prompt files may be writte
 
 Before `done`:
 
-1. Confirm `go run . validate --json` reports the relevant gates approved.
+1. Confirm `go run . validate --json` reports the relevant active-change gates
+   approved. This is a pre-archive freshness/readiness gate, not a promise that
+   the same archived bundle can be revalidated after `done`.
 2. Confirm task evidence is fresh for the current run version.
 3. Confirm `git diff --check`.
 4. Stage intended files only.
@@ -131,3 +133,8 @@ Before `done`:
 6. Run `slipway done --json` when the change is done-ready.
 7. If `worktree_dirty_warning` is present, inspect or commit the listed source
    files before removing the worktree.
+
+After `done`, use the archived `change.yaml` and bundle contents as frozen
+project records. `validate --change <slug>` intentionally rejects archived
+slugs with `archived_change_not_validatable`; a read-only archived audit would be
+a separate command surface.

--- a/internal/state/execution_summary.go
+++ b/internal/state/execution_summary.go
@@ -354,6 +354,9 @@ func executionSummaryFreshnessEvaluation(
 	}
 	inputs := collectTaskEvidenceFreshnessInputs(change, summary, latestRelevantUpdateAt, evidenceTimestamp)
 	if len(inputs) == 0 {
+		if latestRelevantUpdateAt.IsZero() {
+			latestRelevantUpdateAt = evidenceTimestamp
+		}
 		inputs = []ctxpack.EvidenceFreshnessInput{{
 			EvidenceTimestamp:      evidenceTimestamp,
 			LatestRelevantUpdateAt: latestRelevantUpdateAt,
@@ -726,14 +729,22 @@ func failClosedFreshnessUpdateAt(latest time.Time) time.Time {
 	return latest.Add(time.Nanosecond)
 }
 
-func latestExecutionRelevantUpdateAt(root string, change model.Change, summary *model.ExecutionSummary) time.Time {
-	var latest time.Time
+func failClosedExecutionRelevantUpdateAt(latest time.Time, summary *model.ExecutionSummary) time.Time {
 	if summary != nil {
-		latest = summary.LatestRelevantUpdateAt().UTC()
-		if captured := summary.CapturedAt.UTC(); captured.After(latest) {
-			latest = captured
+		evidenceLatest := summary.LatestRelevantUpdateAt().UTC()
+		if evidenceLatest.After(latest) {
+			latest = evidenceLatest
 		}
 	}
+	return failClosedFreshnessUpdateAt(latest)
+}
+
+func latestExecutionRelevantUpdateAt(root string, change model.Change, summary *model.ExecutionSummary) time.Time {
+	// This is the upstream baseline for per-task evidence freshness. Do not
+	// seed it from execution-summary.yaml or sibling task timestamps: the
+	// summary is downstream aggregate evidence, and each task evidence item must
+	// only be compared with its own structural inputs and upstream artifacts.
+	var latest time.Time
 	if strings.TrimSpace(root) == "" || strings.TrimSpace(change.Slug) == "" {
 		return latest
 	}
@@ -754,7 +765,7 @@ func latestExecutionRelevantUpdateAt(root string, change model.Change, summary *
 			if errors.Is(err, fs.ErrNotExist) {
 				continue
 			}
-			return failClosedFreshnessUpdateAt(latest)
+			return failClosedExecutionRelevantUpdateAt(latest, summary)
 		}
 		modTime := info.ModTime().UTC()
 		if modTime.After(latest) {
@@ -770,7 +781,7 @@ func latestExecutionRelevantUpdateAt(root string, change model.Change, summary *
 				latest = modTime
 			}
 		} else if !errors.Is(err, fs.ErrNotExist) {
-			return failClosedFreshnessUpdateAt(latest)
+			return failClosedExecutionRelevantUpdateAt(latest, summary)
 		}
 	}
 	return latest

--- a/internal/state/execution_summary_test.go
+++ b/internal/state/execution_summary_test.go
@@ -237,6 +237,63 @@ func TestExecutionSummaryFreshnessDiagnosticsDetectsManualTaskTimestampDrift(t *
 	assert.Contains(t, diff.NextAction, "do not edit timestamps by hand")
 }
 
+func TestExecutionSummaryFreshnessIgnoresSummaryCapturedAtForPerTaskFreshness(t *testing.T) {
+	t.Parallel()
+
+	root := createRuntimeRepoLayout(t)
+	change := saveActiveChangeForTest(t, root, "summary-captured-at-not-task-input")
+	change.CurrentState = model.StateS3Review
+	change.PlanSubStep = model.PlanSubStepNone
+	require.NoError(t, SaveChange(root, change))
+
+	taskAAt := time.Date(2026, 5, 31, 1, 0, 0, 0, time.UTC)
+	taskBAt := taskAAt.Add(10 * time.Minute)
+	summaryCapturedAt := taskBAt.Add(30 * time.Minute)
+
+	taskEvidenceDir := EvidenceTasksDir(root, change.Slug)
+	require.NoError(t, os.MkdirAll(taskEvidenceDir, 0o755))
+	for taskID, capturedAt := range map[string]time.Time{
+		"task-a": taskAAt,
+		"task-b": taskBAt,
+	} {
+		require.NoError(t, os.WriteFile(
+			filepath.Join(taskEvidenceDir, taskID+".json"),
+			[]byte(`{"run_summary_version":3,"captured_at":"`+capturedAt.Format(time.RFC3339Nano)+`"}`),
+			0o644,
+		))
+	}
+
+	summary := &model.ExecutionSummary{
+		Version:           model.ExecutionSummaryVersion,
+		RunSummaryVersion: 3,
+		CapturedAt:        summaryCapturedAt,
+		OverallVerdict:    model.ExecutionVerdictPass,
+		CompletedTasks:    []string{"task-a", "task-b"},
+		Tasks: []model.ExecutionTaskSummary{
+			{
+				TaskID:          "task-a",
+				Verdict:         model.TaskVerdictPass,
+				TaskKind:        model.TaskKindCode,
+				CapturedAt:      taskAAt,
+				FreshnessInputs: ExpectedExecutionTaskFreshnessInputs(change, 3, "task-a"),
+			},
+			{
+				TaskID:          "task-b",
+				Verdict:         model.TaskVerdictPass,
+				TaskKind:        model.TaskKindVerification,
+				CapturedAt:      taskBAt,
+				FreshnessInputs: ExpectedExecutionTaskFreshnessInputs(change, 3, "task-b"),
+			},
+		},
+	}
+
+	assert.Equal(t, ctxpack.EvidenceFreshnessFresh, ExecutionSummaryFreshness(root, change, summary))
+	diagnostics := ExecutionSummaryFreshnessDiagnostics(root, change, summary)
+	assert.Equal(t, "fresh", diagnostics.Status)
+	assert.Empty(t, diagnostics.StalePairs)
+	assert.Empty(t, diagnostics.TaskInputDiffs)
+}
+
 func TestTaskEvidenceCapturedAtIgnoresMismatchedRunVersion(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tmpl/templates/artifacts/assurance.md
+++ b/internal/tmpl/templates/artifacts/assurance.md
@@ -29,4 +29,6 @@ List remaining risks or accepted exceptions.
 Summarize rollback constraints, prerequisites, and verification status when rollback planning is required.
 
 ## Archive Decision
-Record archive readiness decision.
+Record archive readiness decision. Include whether active `validate --json`
+freshness/readiness proof was captured before `done`; do not describe archived
+bundles as revalidated through the active validate gate.

--- a/internal/tmpl/templates/skills/final-closeout/SKILL.md.tmpl
+++ b/internal/tmpl/templates/skills/final-closeout/SKILL.md.tmpl
@@ -35,6 +35,8 @@ Verify ALL of the following before producing closeout verification:
 - [ ] verification records match current `run_version`
 - [ ] every required governance skill has a passing verification record
 - [ ] full test suite runs green (not cached, not partial)
+- [ ] `validate --json` proves active-change freshness/readiness before `done`;
+      archived bundles are frozen records, not inputs to this active gate
 - [ ] blocker list is empty
 - [ ] `assurance.md` is complete on standard/strict preset
 - [ ] both review skills have passing verification
@@ -60,7 +62,8 @@ On light preset, skip this section — `assurance.md` is optional.
 - verification verdict with references
 - verification index
 - residual risks
-- archive decision with rationale
+- archive decision with rationale, including that active `validate --json`
+  proof was captured before `done`
 
 If any required section is empty or missing, closeout is blocked.
 


### PR DESCRIPTION
## Summary
- Fix execution-summary freshness so downstream summary timestamps do not stale earlier per-task evidence.
- Add validate zero-write regression coverage for no-active, archived explicit slug, and orphan active-bundle paths.
- Clarify validate as an active pre-done gate and archive the governed change bundle.

## Verification
- go build -o /tmp/slipway-fix-execution-summary-freshness .
- go test -count=1 ./...
- git diff --check
- /tmp/slipway-fix-execution-summary-freshness validate --json
- /tmp/slipway-fix-execution-summary-freshness done --json

Closes #28