### PR TITLE
fix(governance): align review blockers with execution handoff

### DIFF
--- a/cmd/status_json.go
+++ b/cmd/status_json.go
@@ -71,11 +71,18 @@ func buildGovernanceSummaryView(view statusView) *governanceSummaryView {
 		requiredActions = append(requiredActions, description)
 	}
 
+	// required_actions is the full pending-obligation queue: every unsatisfied
+	// action, advisory or blocking. It must NOT feed blocked_by. An unsatisfied
+	// action only blocks when it is blocking-mode AND gates the current state —
+	// a determination already made authoritatively by RequiredActionBlockers
+	// (mode + state-scope filtered) and surfaced as governance_action_required
+	// blockers below. Deriving blocked_by from raw unsatisfied actions here
+	// reports advisory or not-yet-applicable controls (e.g. an advisory
+	// independent-review at S2) as blockers, contradicting the real gate.
 	for _, action := range view.RequiredActions {
 		if action.Satisfied {
 			continue
 		}
-		addControl(action.ControlID)
 		addAction(action.Description)
 	}
 	for _, blocker := range view.Blockers {

--- a/cmd/status_json_test.go
+++ b/cmd/status_json_test.go
@@ -64,7 +64,12 @@ func TestStatusJSONResponseShapesGovernanceSummary(t *testing.T) {
 	assert.NotContains(t, payload, "required_actions")
 	summary, ok := payload["governance_summary"].(map[string]any)
 	require.True(t, ok)
-	assert.Equal(t, []any{"domain-review", "independent-review"}, summary["blocked_by"])
+	// blocked_by comes only from authoritative governance_action_required
+	// blockers. domain-review is one; independent-review is an unsatisfied
+	// blocking action but is NOT a governance_action_required blocker here, so
+	// it stays in required_actions (the pending queue) without inflating
+	// blocked_by.
+	assert.Equal(t, []any{"domain-review"}, summary["blocked_by"])
 	assert.Equal(t, []any{"record domain review evidence", "record independent review evidence"}, summary["required_actions"])
 	assert.Equal(t, []any{
 		"artifacts/changes/auth-change/change.yaml",
@@ -127,6 +132,54 @@ func TestStatusJSONResponseDoesNotTreatNonGovernanceBlockersAsGovernanceSummary(
 	assert.NotContains(t, payload, "governance_summary")
 	assert.NotContains(t, payload, "active_controls")
 	assert.NotContains(t, payload, "required_actions")
+}
+
+func TestStatusJSONResponseExcludesAdvisoryActionFromBlockedBy(t *testing.T) {
+	t.Parallel()
+
+	// Mirrors the Lattice S2 report (issue #36, comment 1): the real blocker is
+	// the missing execution host (wave-orchestration); independent-review is an
+	// unsatisfied review-scope action that does not gate S2. The pending action
+	// must surface as a required_action with post-execution wording, but must NOT
+	// be reported as blocked_by, since no governance_action_required blocker
+	// names it.
+	view := statusView{
+		ExecutionMode:     governedExecutionMode,
+		Slug:              "advisory-pending",
+		Phase:             model.PhaseBuilding,
+		LifecycleStatus:   string(model.ChangeStatusActive),
+		CurrentState:      model.StateS2Execute,
+		EvidenceFreshness: "fresh",
+		Blockers: []model.ReasonCode{
+			model.NewReasonCode("required_skill_missing", "wave-orchestration"),
+		},
+		ActiveControls: []governanceControlView{
+			{ControlID: "independent-review", Mode: "advisory", Scope: "review"},
+		},
+		RequiredActions: []governanceActionView{
+			{
+				ControlID:   "independent-review",
+				Mode:        "advisory",
+				Description: "run independent review after wave execution produces execution evidence",
+				Satisfied:   false,
+			},
+		},
+	}
+
+	raw, err := json.Marshal(buildStatusJSONResponse(view))
+	require.NoError(t, err)
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(raw, &payload))
+	summary, ok := payload["governance_summary"].(map[string]any)
+	require.True(t, ok)
+	// Advisory independent-review is a pending action, not a blocker, and its
+	// wording must not claim it runs before execution.
+	assert.NotContains(t, summary, "blocked_by")
+	actions, ok := summary["required_actions"].([]any)
+	require.True(t, ok)
+	require.Len(t, actions, 1)
+	assert.Equal(t, "run independent review after wave execution produces execution evidence", actions[0])
+	assert.NotContains(t, actions[0], "before further execution")
 }
 
 func TestStatusJSONResponseBuildsGovernanceSummaryFromGovernanceBlocker(t *testing.T) {

--- a/internal/engine/governance/actions.go
+++ b/internal/engine/governance/actions.go
@@ -47,7 +47,12 @@ func ResolveRequiredActions(input RequiredActionsInput) []RequiredAction {
 			action.Satisfied = input.DomainReviewDone
 
 		case model.ControlIndependentReview:
-			action.Description = "run independent review before further execution"
+			// Independent review is a review-scope gate (S3/S4), so it runs on
+			// execution evidence — not before execution. Wording that says
+			// "before further execution" contradicts the gate and the review
+			// command (which requires an execution summary), misdirecting agents
+			// at the S2 handoff (issue #36, comment 1).
+			action.Description = "run independent review after wave execution produces execution evidence"
 			action.Satisfied = input.IndependentReviewDone
 
 		case model.ControlWorktreeIsolation:

--- a/internal/engine/governance/actions_test.go
+++ b/internal/engine/governance/actions_test.go
@@ -96,6 +96,27 @@ func TestAdvisoryActionsDoNotBlock(t *testing.T) {
 	assert.Empty(t, UnsatisfiedBlockingActions(actions))
 }
 
+func TestIndependentReviewActionDescribesPostExecutionTiming(t *testing.T) {
+	t.Parallel()
+	// Independent review is a review-scope gate (S3/S4): it runs on execution
+	// evidence, not before execution. The wording must not tell agents to run it
+	// "before further execution" at S2, which contradicts the gate and the
+	// review command's execution-summary requirement (issue #36, comment 1).
+	controls := []model.ControlActivation{
+		makeControl(model.ControlIndependentReview, model.ControlModeBlocking, model.ControlScopeReview),
+	}
+
+	actions := ResolveRequiredActions(RequiredActionsInput{
+		ActiveControls: controls,
+	})
+
+	if assert.Len(t, actions, 1) {
+		desc := actions[0].Description
+		assert.NotContains(t, desc, "before further execution")
+		assert.Contains(t, desc, "after wave execution")
+	}
+}
+
 func TestAdvisoryModeOverrideDoesNotBlock(t *testing.T) {
 	t.Parallel()
 	// Simulate independent-review activated as advisory via mode override.


### PR DESCRIPTION
## Summary
- Derive status JSON governance_summary.blocked_by only from authoritative governance_action_required blockers.
- Reword independent-review required action so S2 handoff points to post-wave execution review evidence instead of pre-execution review.
- Add regression coverage for issue #36 comment 1.

## Scope
Addresses the S2 handoff contradiction reported in #36 comment 1. This intentionally does not close #36 because the plan-audit depth concern and failing-review-evidence diagnostic concern remain separate.

## Verification
- git diff --check origin/main...HEAD
- go test ./... -count=1
- go build ./...
