### PR TITLE
feat(codebase-map): nudge discovery-scoped changes off an empty map

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,5 +125,10 @@ without `--diagnostics`. Values mirror the `codebase-map` assessment (`missing`,
 `"missing"` with per-doc `missing` states rather than an omitted field. Treat
 `scaffold_only`/`baseline` maps as non-durable. When research-orchestration or
 plan-audit is the next skill and the status is `scaffold_only` or `baseline`,
-`warnings` carries a non-blocking codebase-map advisory; inspect
+`warnings` carries a non-blocking consume-time codebase-map advisory. For
+discovery-scoped changes (`needs_discovery`), a `missing` map at those same
+planning skills also carries a non-blocking discovery advisory routing the host
+to the `slipway-codebase-mapping` skill; both advisories share the
+`codebase_map_advisory:` prefix, at most one fires, and neither blocks
+progression. Non-discovery changes never receive the discovery advisory. Inspect
 `codebase_map_doc_states` for `partial` maps, which get no whole-map advisory.

--- a/cmd/next_skill_capability_hints_test.go
+++ b/cmd/next_skill_capability_hints_test.go
@@ -61,6 +61,43 @@ func TestCodebaseMapStatusHasNoDurableDocs(t *testing.T) {
 	assert.False(t, codebaseMapStatusHasNoDurableDocs(artifact.CodebaseMapStatusPopulated))
 }
 
+// TestCodebaseMapDiscoveryAdvisoryMatrix pins the discovery-phase advisory. For a
+// discovery-scoped change (needs_discovery) it fires across every non-durable
+// status — including the fully missing map the consume-time advisory omits — when
+// a map-consuming planning skill is next, and routes to the slipway-codebase-mapping
+// skill. It is silent for populated/partial maps, for non-consuming skills, and
+// for every status when needs_discovery is false (a change that opted out of
+// discovery must not be nagged to map the repository).
+func TestCodebaseMapDiscoveryAdvisoryMatrix(t *testing.T) {
+	t.Parallel()
+	nonDurable := []string{
+		artifact.CodebaseMapStatusMissing,
+		artifact.CodebaseMapStatusScaffoldOnly,
+		artifact.CodebaseMapStatusBaseline,
+	}
+	for _, skillName := range []string{progression.SkillResearchOrchestration, progression.SkillPlanAudit} {
+		for _, status := range nonDurable {
+			advisory := codebaseMapDiscoveryAdvisory(status, skillName, true)
+			assert.NotEmpty(t, advisory,
+				"%s map for discovery change consumed by %s should warn", status, skillName)
+			assert.Contains(t, advisory, "slipway-codebase-mapping",
+				"discovery advisory must route to the mapping skill")
+			assert.Contains(t, advisory, "codebase_map_advisory")
+			// needs_discovery=false silences every status.
+			assert.Empty(t, codebaseMapDiscoveryAdvisory(status, skillName, false),
+				"%s map must not warn when needs_discovery is false", status)
+		}
+		// Durable maps never warn.
+		assert.Empty(t, codebaseMapDiscoveryAdvisory(artifact.CodebaseMapStatusPopulated, skillName, true))
+		assert.Empty(t, codebaseMapDiscoveryAdvisory(artifact.CodebaseMapStatusPartial, skillName, true))
+	}
+	// Non-consuming skills never receive the discovery advisory, even for a
+	// missing map on a discovery-scoped change.
+	for _, skillName := range []string{progression.SkillWaveOrchestration, progression.SkillIntakeClarification, ""} {
+		assert.Empty(t, codebaseMapDiscoveryAdvisory(artifact.CodebaseMapStatusMissing, skillName, true))
+	}
+}
+
 // writePopulatedCodebaseMapDocs writes the full durable doc set with
 // substantive, non-baseline content so AssessCodebaseMapDocs classifies the
 // whole map populated.
@@ -257,6 +294,65 @@ func TestNextOmitsCodebaseMapAdvisoryForPopulatedMap(t *testing.T) {
 			"populated map must not surface a codebase_map_advisory warning; got %v", view.Warnings)
 		assert.False(t, hasNoDurableCodebaseMapHint(view),
 			"populated map must not surface the empty-map technique hint")
+	})
+}
+
+// TestNextSurfacesMissingMapDiscoveryAdvisoryEndToEnd drives a real next
+// invocation for a discovery-scoped (L3) change with NO codebase map. The map is
+// missing — the case the consume-time advisory omits — so the broader discovery
+// advisory must fire, route to the slipway-codebase-mapping skill, and reach both
+// the standard view and the compact handoff projection. The empty-map technique
+// hint must also now point at the mapping skill rather than the scaffold command.
+func TestNextSurfacesMissingMapDiscoveryAdvisoryEndToEnd(t *testing.T) {
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		require.NoError(t, bootstrap.InitWorkspace(root, []string{"codex"}, false))
+		// L3 => needs_discovery; lands at S1_PLAN/research with no map written.
+		createGovernedRequest(t, root, "L3", "missing map discovery advisory surfaces")
+
+		var view nextView
+		decodeNextJSON(t, []string{"--json", "--diagnostics"}, &view)
+		require.NotNil(t, view.NextSkill)
+		require.Equal(t, "research-orchestration", view.NextSkill.Name)
+		require.Equal(t, artifact.CodebaseMapStatusMissing, view.InputContext.CodebaseMapStatus)
+
+		assert.True(t, warningsContainCodebaseMapAdvisory(view.Warnings),
+			"missing map on a discovery change should surface a codebase_map_advisory warning; got %v", view.Warnings)
+		assert.Contains(t, strings.Join(view.Warnings, "\n"), "slipway-codebase-mapping",
+			"discovery advisory must route the host to the mapping skill")
+
+		// The empty-map technique hint routes to the mapping skill now.
+		var hintName string
+		for _, hint := range view.NextSkill.TechniqueHints {
+			if strings.Contains(hint.Reason, "No durable codebase-map documents found") {
+				hintName = hint.Name
+			}
+		}
+		assert.Equal(t, "skill:codebase-mapping", hintName,
+			"empty-map hint should route to the mapping skill")
+
+		var handoff nextHandoffView
+		decodeNextJSON(t, []string{"--json"}, &handoff)
+		assert.True(t, warningsContainCodebaseMapAdvisory(handoff.Warnings),
+			"run/handoff surface should carry the discovery advisory; got %v", handoff.Warnings)
+	})
+}
+
+// TestNextOmitsDiscoveryAdvisoryForNonDiscoveryChange is the negative path: a
+// non-discovery (L2) change with a missing map must NOT surface a discovery
+// advisory — opting out of discovery means no nag to map the repository.
+func TestNextOmitsDiscoveryAdvisoryForNonDiscoveryChange(t *testing.T) {
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		require.NoError(t, bootstrap.InitWorkspace(root, []string{"codex"}, false))
+		createGovernedRequest(t, root, "L2", "non-discovery change omits discovery advisory")
+
+		var view nextView
+		decodeNextJSON(t, []string{"--json", "--diagnostics"}, &view)
+		require.NotNil(t, view.NextSkill)
+		require.Equal(t, artifact.CodebaseMapStatusMissing, view.InputContext.CodebaseMapStatus)
+		assert.False(t, warningsContainCodebaseMapAdvisory(view.Warnings),
+			"non-discovery change with a missing map must not surface a codebase_map_advisory; got %v", view.Warnings)
 	})
 }
 

--- a/cmd/next_skill_view.go
+++ b/cmd/next_skill_view.go
@@ -239,15 +239,21 @@ func assembleSkillViewWithOptions(
 		// fires for missing/scaffold_only, matching the old probe's truth set.
 		if codebaseMapStatusHasNoDurableDocs(mapStatus) {
 			ns.TechniqueHints = append(ns.TechniqueHints, techniqueHint{
-				Name:   "slipway codebase-map",
-				Reason: "No durable codebase-map documents found. Run `slipway codebase-map` to establish brownfield context before planning.",
+				Name:   "skill:codebase-mapping",
+				Reason: "No durable codebase-map documents found. Run the slipway-codebase-mapping skill to write source-backed artifacts/codebase/* documents before planning; `slipway codebase-map` only scaffolds the empty document set.",
 			})
 		}
-		// Consume-time advisory: a map-consuming planning skill (research/plan-audit)
-		// is about to rely on a non-durable (scaffold_only/baseline) map. This adds
-		// consume-time framing on top of the hint and never blocks progression. It
-		// reaches both surfaces because the handoff projection copies view.Warnings.
+		// Codebase-map advisories (non-blocking; surfaced via view.Warnings, which
+		// the compact handoff projection copies). The consume-time advisory takes
+		// priority for the map-consuming planning skills (research/plan-audit) when
+		// the map is scaffold_only/baseline. The broader discovery advisory covers
+		// the gap it leaves — chiefly a fully missing map for a discovery-scoped
+		// change — and routes the host to the slipway-codebase-mapping skill. The
+		// two are mutually exclusive, so at most one codebase_map_advisory fires and
+		// neither ever blocks progression.
 		if advisory := codebaseMapConsumeAdvisory(mapStatus, nextSkillName); advisory != "" {
+			view.Warnings = append(view.Warnings, advisory)
+		} else if advisory := codebaseMapDiscoveryAdvisory(mapStatus, nextSkillName, governedChange.NeedsDiscovery); advisory != "" {
 			view.Warnings = append(view.Warnings, advisory)
 		}
 	}
@@ -318,6 +324,37 @@ func codebaseMapConsumeAdvisory(status, nextSkillName string) string {
 		return fmt.Sprintf(
 			"codebase_map_advisory: %s is consuming a non-durable codebase map (status: %s); refine artifacts/codebase with source-backed findings before relying on it as reviewed context, or inspect input_context.codebase_map_doc_states for per-doc gaps.",
 			nextSkillName, status,
+		)
+	default:
+		return ""
+	}
+}
+
+// codebaseMapDiscoveryAdvisory returns a non-blocking discovery-phase advisory
+// nudging the host to populate a durable codebase map before planning. It fires
+// only for discovery-scoped changes (needs_discovery) while a planning skill that
+// consumes the map (research-orchestration or plan-audit) is next and the map is
+// non-durable. The call site gives the narrower consume-time advisory priority,
+// so in practice this carries the case that one omits: a fully missing map — the
+// "nothing but templates" state this nudge exists to break. It routes to the
+// slipway-codebase-mapping skill (which writes source-backed content) rather than
+// `slipway codebase-map` (which only scaffolds the document set). Non-discovery
+// changes get nothing: a change that opted out of discovery should not be nagged
+// to map the repository.
+func codebaseMapDiscoveryAdvisory(status, nextSkillName string, needsDiscovery bool) string {
+	if !needsDiscovery {
+		return ""
+	}
+	switch nextSkillName {
+	case progression.SkillResearchOrchestration, progression.SkillPlanAudit:
+	default:
+		return ""
+	}
+	switch status {
+	case artifact.CodebaseMapStatusMissing, artifact.CodebaseMapStatusScaffoldOnly, artifact.CodebaseMapStatusBaseline:
+		return fmt.Sprintf(
+			"codebase_map_advisory: no durable codebase map (status: %s) for this discovery-scoped change; run the slipway-codebase-mapping skill to write source-backed artifacts/codebase/* documents before %s consumes it for planning. Advisory only — this does not block progression.",
+			status, nextSkillName,
 		)
 	default:
 		return ""


### PR DESCRIPTION
## Why

The codebase map's narrative documents (`ARCHITECTURE.md`, `CONVENTIONS.md`, `INTEGRATIONS.md`, `CONCERNS.md`) are populated by the AI `slipway-codebase-mapping` skill, which is **advisory and non-blocking**. So a governed change can run all the way through planning while `artifacts/codebase/` stays empty templates — the "it's just a template" problem.

The widest blind spot was a fully **`missing`** map: during `S1_PLAN` it surfaced only a weak technique hint, never a warning — and that hint pointed at `slipway codebase-map`, which merely scaffolds *empty* docs rather than the skill that writes real content.

## What

Strengthen the discovery-phase guidance **without changing the non-blocking contract** (the map stays guidance, not a single source of truth):

- **Retarget the empty-map technique hint** from `slipway codebase-map` → the `slipway-codebase-mapping` skill (which writes source-backed content).
- **Add `codebaseMapDiscoveryAdvisory`**: for `needs_discovery` changes, a `missing` map at the map-consuming planning skills (`research-orchestration`, `plan-audit`) now surfaces a non-blocking `codebase_map_advisory` routing to the mapping skill. It is **mutually exclusive** with the existing consume-time advisory (at most one fires), and stays **silent** for non-discovery changes and durable maps.

### Deliberately out of scope
- No advisory at `S0_INTAKE` — the map has no consumer until planning starts; `S1_PLAN/research` is the first/correct moment.
- baseline refresh-on-change, `new` auto-creating baseline, and inline detected-facts display were all discussed and **intentionally deferred** to keep this change focused and non-blocking.

## Behavior (live)

For a `needs_discovery` change at `S1_PLAN/research` with no map:

```
next_skill          : research-orchestration   # still advances — warning, not blocker
codebase_map_status : missing
warnings            : codebase_map_advisory: no durable codebase map (status: missing) ...
                      run the slipway-codebase-mapping skill ... Advisory only — does not block.
technique_hints     : skill:codebase-mapping :: Run the slipway-codebase-mapping skill ...
```

## Tests

- `TestCodebaseMapDiscoveryAdvisoryMatrix` — unit matrix (status × skill × needs_discovery).
- `TestNextSurfacesMissingMapDiscoveryAdvisoryEndToEnd` — L3 missing map surfaces the advisory + retargeted hint on both `next` and the compact handoff.
- `TestNextOmitsDiscoveryAdvisoryForNonDiscoveryChange` — L2 (non-discovery) missing map stays silent.

`go build ./...`, `gofmt`, `go vet ./cmd`, and the full `go test ./...` suite all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)