### PR TITLE
fix(#44): record-timestamp stale_planning_evidence display + spec-compliance review fidelity

### DIFF
--- a/internal/state/execution_summary.go
+++ b/internal/state/execution_summary.go
@@ -644,7 +644,7 @@ func stalePlanningEvidenceChain(root, bundleDir, executionSummaryArtifact string
 
 	pairs := []ExecutionFreshnessPair{}
 	for _, stagePath := range stagePaths {
-		stageCapturedAt := fileModTimeUTC(stagePath)
+		stageCapturedAt := stageEvidenceCapturedAt(stagePath)
 		pairs = append(pairs, ExecutionFreshnessPair{
 			SourceArtifact:     sourceArtifact,
 			EvidenceArtifact:   DisplayPath(root, stagePath),
@@ -678,12 +678,37 @@ func nextActionForPlanningStage(path string) string {
 	}
 }
 
-func fileModTimeUTC(path string) time.Time {
-	info, err := os.Stat(path)
+// stageEvidenceCapturedAt returns the captured timestamp embedded in a
+// planning-stage evidence record (plan-audit.yaml's verification timestamp or
+// wave-plan.yaml's generated_at).
+//
+// The embedded record timestamp — not the file mtime — is the semantic capture
+// time the staleness comparison treats as the evidence age. A record can be
+// rewritten after capture (e.g. adding DEC->REQ trace references) without
+// re-running the stage; that drifts the file mtime ahead of the real capture
+// time and makes a genuinely stale pair read as fresh. Reading the mtime here
+// is exactly the bug, so it is never consulted: an unreadable record or one
+// without an embedded timestamp reports a zero (unknown) capture time.
+func stageEvidenceCapturedAt(path string) time.Time {
+	raw, err := os.ReadFile(path)
 	if err != nil {
 		return time.Time{}
 	}
-	return info.ModTime().UTC()
+	var record struct {
+		Timestamp   time.Time `yaml:"timestamp"`
+		GeneratedAt time.Time `yaml:"generated_at"`
+	}
+	if err := yaml.Unmarshal(raw, &record); err != nil {
+		return time.Time{}
+	}
+	switch filepath.Base(path) {
+	case planAuditFileName:
+		return record.Timestamp.UTC()
+	case WavePlanFileName:
+		return record.GeneratedAt.UTC()
+	default:
+		return time.Time{}
+	}
 }
 
 func normalizeFreshnessPairs(pairs []ExecutionFreshnessPair) []ExecutionFreshnessPair {

--- a/internal/state/execution_summary_test.go
+++ b/internal/state/execution_summary_test.go
@@ -488,6 +488,84 @@ func TestExecutionSummaryFreshnessDiagnosticsIncludesPlanningEvidenceChain(t *te
 	assert.True(t, containsFreshnessChainEdge(diagnostics.DownstreamEvidenceChain, WavePlanFileName, ExecutionSummaryFileName))
 }
 
+// TestExecutionSummaryFreshnessDiagnosticsUsesRecordTimestampNotFileMtime is the
+// regression for issue #44: a planning-stage evidence record (plan-audit.yaml)
+// can be rewritten after capture (e.g. adding DEC->REQ trace references),
+// pushing its file mtime ahead of the source while its recorded capture
+// timestamp stays older. The diagnostic must report the embedded record
+// timestamp as evidence_captured_at — so the stale pair reads consistently
+// (source newer than evidence) — and surface the file mtime separately rather
+// than letting it masquerade as the capture time.
+func TestExecutionSummaryFreshnessDiagnosticsUsesRecordTimestampNotFileMtime(t *testing.T) {
+	t.Parallel()
+
+	root := createRuntimeRepoLayout(t)
+	change := saveActiveChangeForTest(t, root, "planning-evidence-record-time")
+	change.CurrentState = model.StateS3Review
+	change.PlanSubStep = model.PlanSubStepNone
+	require.NoError(t, SaveChange(root, change))
+
+	bundleDir, err := GovernedBundleDir(root, change)
+	require.NoError(t, err)
+	verifyDir := filepath.Join(bundleDir, "verification")
+	require.NoError(t, os.MkdirAll(verifyDir, 0o755))
+
+	// Mirror the issue #44 comment timeline (date shifted safely into the past):
+	//   plan-audit record    10:06:17  (embedded capture time — older than source)
+	//   decision.md          10:07:09  (source edited after the audit ran)
+	//   plan-audit file mtime 10:07:42 (file rewritten after capture)
+	summaryCapturedAt := time.Date(2026, 5, 29, 9, 0, 0, 0, time.UTC)
+	recordCapturedAt := time.Date(2026, 5, 29, 10, 6, 17, 0, time.UTC)
+	sourceUpdatedAt := time.Date(2026, 5, 29, 10, 7, 9, 0, time.UTC)
+	fileModifiedAt := time.Date(2026, 5, 29, 10, 7, 42, 0, time.UTC)
+
+	decisionPath := filepath.Join(bundleDir, "decision.md")
+	require.NoError(t, os.WriteFile(decisionPath, []byte("# Decision\n\nDEC-001 -> REQ-005\n"), 0o644))
+	require.NoError(t, os.Chtimes(decisionPath, sourceUpdatedAt, sourceUpdatedAt))
+
+	planAuditPath := filepath.Join(verifyDir, planAuditFileName)
+	planAuditBody := "verdict: pass\nblockers: []\nrun_version: 1\ntimestamp: " +
+		recordCapturedAt.Format(time.RFC3339) + "\n"
+	require.NoError(t, os.WriteFile(planAuditPath, []byte(planAuditBody), 0o644))
+	// The file is rewritten well after the audit was captured, drifting its
+	// mtime ahead of both the embedded timestamp and the source.
+	require.NoError(t, os.Chtimes(planAuditPath, fileModifiedAt, fileModifiedAt))
+
+	summary := &model.ExecutionSummary{
+		Version:           model.ExecutionSummaryVersion,
+		RunSummaryVersion: 1,
+		CapturedAt:        summaryCapturedAt,
+		OverallVerdict:    model.ExecutionVerdictPass,
+		CompletedTasks:    []string{"task-a"},
+		Tasks: []model.ExecutionTaskSummary{{
+			TaskID:          "task-a",
+			Verdict:         model.TaskVerdictPass,
+			TaskKind:        model.TaskKindCode,
+			CapturedAt:      summaryCapturedAt,
+			FreshnessInputs: ExpectedExecutionTaskFreshnessInputs(change, 1, "task-a"),
+		}},
+	}
+
+	diagnostics := ExecutionSummaryFreshnessDiagnostics(root, change, summary)
+
+	assert.Equal(t, "stale", diagnostics.Status)
+	require.NotNil(t, diagnostics.FirstStaleCause)
+	cause := diagnostics.FirstStaleCause
+	assert.Contains(t, cause.SourceArtifact, "decision.md")
+	assert.Contains(t, cause.EvidenceArtifact, planAuditFileName)
+
+	// The fix: evidence_captured_at is the embedded record timestamp, and the
+	// (newer) file mtime is never consulted — so the pair is internally
+	// consistent (source newer than evidence), matching the stale verdict.
+	assert.Equal(t, recordCapturedAt.Format(time.RFC3339Nano), cause.EvidenceCapturedAt)
+	assert.NotEqual(t, fileModifiedAt.Format(time.RFC3339Nano), cause.EvidenceCapturedAt)
+	assert.Equal(t, sourceUpdatedAt.Format(time.RFC3339Nano), cause.SourceUpdatedAt)
+
+	// Sanity: as displayed, the stale pair no longer contradicts the verdict.
+	assert.Greater(t, cause.SourceUpdatedAt, cause.EvidenceCapturedAt,
+		"source should read newer than evidence for a stale pair")
+}
+
 func TestLoadExecutionSummaryReturnsErrorOnInvalidSummary(t *testing.T) {
 	t.Parallel()
 

--- a/internal/state/execution_summary_test.go
+++ b/internal/state/execution_summary_test.go
@@ -494,8 +494,8 @@ func TestExecutionSummaryFreshnessDiagnosticsIncludesPlanningEvidenceChain(t *te
 // pushing its file mtime ahead of the source while its recorded capture
 // timestamp stays older. The diagnostic must report the embedded record
 // timestamp as evidence_captured_at — so the stale pair reads consistently
-// (source newer than evidence) — and surface the file mtime separately rather
-// than letting it masquerade as the capture time.
+// (source newer than evidence) — and never consult the file mtime, so the
+// drifted mtime can no longer masquerade as the capture time.
 func TestExecutionSummaryFreshnessDiagnosticsUsesRecordTimestampNotFileMtime(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tmpl/templates/skills/spec-compliance-review/SKILL.md.tmpl
+++ b/internal/tmpl/templates/skills/spec-compliance-review/SKILL.md.tmpl
@@ -47,7 +47,15 @@ implemented change stayed simple, surgical, and goal-driven.
 ## Required Checks
 ### Forward Alignment (Spec -> Code)
 - each spec requirement maps to concrete implementation
-- acceptance criteria are satisfied by tests
+- acceptance criteria are satisfied by tests that exercise the *literal*
+  requirement clause: open the cited test and confirm it asserts the clause's
+  behavior, not merely an adjacent or narrower scenario. Test presence is not
+  clause coverage — a green suite can pass while the clause stays unimplemented.
+- when the implementation intentionally narrows, defers, or reinterprets a
+  requirement clause (e.g. a documented fallback that skips a mandated check),
+  treat it as a forward-alignment gap, not a benign detail: either block the
+  code gap or require the requirement prose to be tightened to match the built
+  behavior. "Related tests exist" does not close this gap.
 - no spec requirement is silently dropped or deferred without explicit tracking
 
 ### Reverse Alignment (Code -> Spec)
@@ -126,6 +134,9 @@ After confirmation: proceed to code-quality-review.
 
 ## Block If
 - A spec requirement lacks implementation or an accepted skip justification.
+- A requirement clause is satisfied only in appearance: the cited tests cover a
+  narrower scenario than the clause states, or the implementation narrows the
+  clause without the requirement prose being tightened to match.
 - Code behavior is undocumented or contradicts the approved artifacts.
 - Locked decisions are violated.
 - Claimed-complete work is still stubbed, placeholder-only, or assertion-free.

--- a/internal/tmpl/templates/skills/spec-trace/CHECKLIST.tmpl
+++ b/internal/tmpl/templates/skills/spec-trace/CHECKLIST.tmpl
@@ -1,5 +1,8 @@
 ## Checklist
 - [ ] Spec-to-code: every acceptance signal cites a file:line or test.
+- [ ] Spec-to-code: each cited test exercises the literal clause it maps to, not
+      a narrower scenario; a clause narrowed in code without the requirement
+      prose being tightened is `drift`, not `covered`.
 - [ ] Spec-to-code: every skipped item has reviewer-accepted justification.
 - [ ] Code-to-spec: every non-trivial diff hunk cites the plan item it implements.
 - [ ] Code-to-spec: unlinked diff hunks are flagged as drift, not silently accepted.

--- a/internal/tmpl/templates_test.go
+++ b/internal/tmpl/templates_test.go
@@ -748,6 +748,26 @@ func TestReviewTemplatesRequireNegativePathAndToolchainEvidence(t *testing.T) {
 	assert.Contains(t, codeQuality, "toolchain_compat:pass")
 }
 
+// TestSpecComplianceReviewGuardsAgainstTestPresenceOverTrust pins the issue #44
+// review-fidelity guidance: spec-compliance-review must require that cited tests
+// exercise the literal requirement clause and must block when the implementation
+// narrows a clause without tightening the requirement prose, so review evidence
+// cannot over-trust the mere presence of (narrower) tests.
+func TestSpecComplianceReviewGuardsAgainstTestPresenceOverTrust(t *testing.T) {
+	t.Parallel()
+
+	data := map[string]string{"ToolID": "claude", "Trigger": "/slipway:test", "Description": "test"}
+
+	specCompliance, err := Render("skills/spec-compliance-review/SKILL.md.tmpl", data)
+	require.NoError(t, err)
+	assert.Contains(t, specCompliance, "Test presence is not")
+	assert.Contains(t, specCompliance, "satisfied only in appearance")
+
+	specTrace, err := Content("skills/spec-trace/CHECKLIST.tmpl")
+	require.NoError(t, err)
+	assert.Contains(t, specTrace, "exercises the literal clause it maps to")
+}
+
 func TestRootCauseTracingAbsorbsSystematicDebuggingDoctrine(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Issue #44 (the broad "Lattice development feedback" log) carries three distinct
threads. This PR addresses the two that are scoped to a concrete behavior change:

1. **Part B — `stale_planning_evidence` diagnostic display (issue #44 comment).**
   The diagnostic reported each planning-stage evidence artifact's
   `evidence_captured_at` from the **file mtime**. A record can be rewritten after
   capture (e.g. adding `DEC->REQ` trace references) without re-running the stage,
   which drifts the file mtime ahead of the source while the embedded capture
   timestamp stays older. The result was a self-contradictory stale pair —
   `source_updated_at < evidence_captured_at` (looks fresh) — even though Slipway
   correctly treated the record as stale.

   Now the diagnostic reads the **embedded record timestamp**
   (`plan-audit.yaml` `timestamp` / `wave-plan.yaml` `generated_at`), so the
   displayed pair matches the verdict. The file mtime — the source of the bug — is
   no longer consulted (no fallback, no parallel field; clean replacement).

2. **Part A — review over-trusting test presence (issue #44 body).**
   `spec-compliance-review` could pass with `Gaps: none` when an implementation
   narrowed a requirement clause and the tests only covered the narrower scenario.
   Forward Alignment now requires the cited test to exercise the **literal**
   requirement clause, and treats intentional clause narrowing without tightened
   requirement prose as a forward-alignment gap (plus a matching Block-If
   condition and a `spec-trace` checklist row: narrowing-without-prose = `drift`).

**Out of scope (third thread):** issue #44's second comment reports a separate
concern — a Change 7 review-repair pass blocked by missing runtime wave evidence
(`required_skill_not_ready` / `wave-orchestration:run_summary_missing`), raising
an open design question about whether repair/review-resume should offer a
supported way to regenerate runtime task evidence. That is not a display or
review-fidelity bug and is intentionally left for separate follow-up; it is why
issue #44 should stay open after this PR merges.

## Changes

| File | Change |
|---|---|
| `internal/state/execution_summary.go` | `stageEvidenceCapturedAt` reads the record's embedded timestamp; removed the now-unused `fileModTimeUTC` |
| `internal/state/execution_summary_test.go` | Regression test reproducing the issue #44 comment timeline (record `10:06:17` < source `10:07:09` < file mtime `10:07:42`) |
| `internal/tmpl/.../spec-compliance-review/SKILL.md.tmpl` | Literal-clause Forward Alignment + Block-If condition |
| `internal/tmpl/.../spec-trace/CHECKLIST.tmpl` | Checklist row: clause narrowed without tightened prose = `drift` |
| `internal/tmpl/templates_test.go` | Pins the new review-fidelity guidance |

## Testing

- `go build ./...`
- `go test ./...` — full suite green

## Notes

- This branch is direct (non-Slipway) worktree work: `slipway new` was blocked by
  an unrelated, unbound intake-stage change at the time. That friction is filed
  separately as #48.
- Leaving issue #44 open for the maintainer to close — only two of its three
  threads (Part A + Part B above) are addressed here; the Change 7 runtime
  wave-evidence concern remains open.
