### PR TITLE
fix(state): stop persisting absolute worktree_path in tracked change.yaml (#46)

### DIFF
--- a/cmd/active_change_resolution_test.go
+++ b/cmd/active_change_resolution_test.go
@@ -23,6 +23,8 @@ func TestResolveActiveChangeRefReportsBoundElsewhereFromRoot(t *testing.T) {
 		change := model.NewChange("bound-change")
 		change.WorktreePath = worktreePath
 		require.NoError(t, state.SaveChange(root, change))
+		normalizedWorktreePath, normalizeErr := state.NormalizePath(worktreePath)
+		require.NoError(t, normalizeErr)
 
 		_, err := resolveActiveChangeRef(root, "")
 		cliErr := asCLIError(err)
@@ -30,9 +32,9 @@ func TestResolveActiveChangeRefReportsBoundElsewhereFromRoot(t *testing.T) {
 		assert.Equal(t, "change_bound_to_other_worktree", cliErr.ErrorCode)
 		assert.Equal(t, categoryPrecondition, cliErr.Category)
 		assert.Contains(t, cliErr.Message, "bound-change")
-		assert.Contains(t, cliErr.Message, worktreePath)
+		assert.Contains(t, cliErr.Message, normalizedWorktreePath)
 		assert.Contains(t, cliErr.Remediation, "--change bound-change")
-		assert.Contains(t, cliErr.Remediation, worktreePath)
+		assert.Contains(t, cliErr.Remediation, normalizedWorktreePath)
 	})
 }
 

--- a/internal/engine/progression/validation_test.go
+++ b/internal/engine/progression/validation_test.go
@@ -429,7 +429,9 @@ func TestDeriveAndApplyWorktreeMetadataSeedsScopeMetadataForBoundWorktree(t *tes
 
 	loaded, err := state.LoadChange(root, change.Slug)
 	require.NoError(t, err)
-	require.Equal(t, updated.WorktreePath, loaded.WorktreePath)
+	wantWorktree, err := state.NormalizePath(updated.WorktreePath)
+	require.NoError(t, err)
+	require.Equal(t, wantWorktree, loaded.WorktreePath)
 }
 
 func runGitForValidationTests(t *testing.T, dir string, args ...string) {

--- a/internal/model/change.go
+++ b/internal/model/change.go
@@ -38,7 +38,13 @@ type Change struct {
 	SuggestedWorkflowPreset WorkflowPreset  `yaml:"suggested_workflow_preset,omitempty" json:"suggested_workflow_preset,omitempty"`
 
 	// Worktree
-	WorktreePath   string `yaml:"worktree_path,omitempty" json:"worktree_path,omitempty"`
+	// WorktreePath is machine-local runtime state, resolved at load time from the
+	// git-local worktree binding (or, as a self-healing fallback, the bundle's own
+	// location). It is never persisted to the tracked change.yaml (yaml:"-"), so a
+	// tracked bundle that still carries worktree_path is rejected by strict
+	// decoding rather than tolerated — there is no migration shim. The JSON handoff
+	// surfaces still expose it as ephemeral runtime info.
+	WorktreePath   string `yaml:"-" json:"worktree_path,omitempty"`
 	WorktreeBranch string `yaml:"worktree_branch,omitempty" json:"worktree_branch,omitempty"`
 
 	// Governance
@@ -260,13 +266,9 @@ func (c Change) EffectiveWorkflowProfile() WorkflowProfile {
 func (c Change) MarshalYAML() (interface{}, error) {
 	normalized := c
 	normalized.Normalize()
-	// WorktreePath is a machine-local absolute path and is never persisted to
-	// tracked change.yaml. The bound worktree is resolved at load time from the
-	// governed bundle's own location (SaveChange always writes the bundle under
-	// the bound worktree), so the path is redundant runtime state, not durable
-	// governance state. Zeroing it here makes every Change YAML write (active
-	// SaveChange, archive snapshot, repair rewrite) drop it through one chokepoint.
-	normalized.WorktreePath = ""
+	// WorktreePath carries yaml:"-", so it is dropped from every Change YAML write
+	// (active SaveChange, archive snapshot, repair rewrite) without an explicit
+	// strip here.
 	type alias Change
 	return alias(normalized), nil
 }

--- a/internal/model/change.go
+++ b/internal/model/change.go
@@ -260,6 +260,13 @@ func (c Change) EffectiveWorkflowProfile() WorkflowProfile {
 func (c Change) MarshalYAML() (interface{}, error) {
 	normalized := c
 	normalized.Normalize()
+	// WorktreePath is a machine-local absolute path and is never persisted to
+	// tracked change.yaml. The bound worktree is resolved at load time from the
+	// governed bundle's own location (SaveChange always writes the bundle under
+	// the bound worktree), so the path is redundant runtime state, not durable
+	// governance state. Zeroing it here makes every Change YAML write (active
+	// SaveChange, archive snapshot, repair rewrite) drop it through one chokepoint.
+	normalized.WorktreePath = ""
 	type alias Change
 	return alias(normalized), nil
 }

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -183,6 +183,10 @@ func TestChangeMarshalUnmarshalRoundTripNewFormat(t *testing.T) {
 	assert.Contains(t, string(raw), "evidence_refs:")
 	assert.Contains(t, string(raw), "review_intent_drift_failures:")
 	assert.Contains(t, string(raw), "interrupted_execution_at:")
+	// The machine-local absolute worktree path is never persisted to tracked
+	// change.yaml; the portable branch metadata still is.
+	assert.NotContains(t, string(raw), "worktree_path:")
+	assert.Contains(t, string(raw), "worktree_branch:")
 
 	var decoded Change
 	require.NoError(t, yaml.Unmarshal(raw, &decoded))
@@ -196,7 +200,7 @@ func TestChangeMarshalUnmarshalRoundTripNewFormat(t *testing.T) {
 	assert.Equal(t, change.CurrentState, decoded.CurrentState)
 	assert.True(t, change.CreatedAt.Equal(decoded.CreatedAt))
 	assert.Equal(t, change.GuardrailDomain, decoded.GuardrailDomain)
-	assert.Equal(t, change.WorktreePath, decoded.WorktreePath)
+	assert.Empty(t, decoded.WorktreePath, "worktree_path must not round-trip through tracked change.yaml")
 	assert.Equal(t, change.WorktreeBranch, decoded.WorktreeBranch)
 	assert.Equal(t, change.ArtifactSchema, decoded.ArtifactSchema)
 	assert.Equal(t, change.CustomArtifacts, decoded.CustomArtifacts)

--- a/internal/state/bundle_root_test.go
+++ b/internal/state/bundle_root_test.go
@@ -94,7 +94,9 @@ func TestRelocateGovernedBundleSeedsVisibleTargetAuthority(t *testing.T) {
 
 	loaded, err := LoadChange(root, change.Slug)
 	require.NoError(t, err)
-	assert.Equal(t, worktreeDir, loaded.WorktreePath)
+	wantWorktree, err := NormalizePath(worktreeDir)
+	require.NoError(t, err)
+	assert.Equal(t, wantWorktree, loaded.WorktreePath)
 	assert.Equal(t, "bundle-visible-authority", loaded.WorktreeBranch)
 
 	_, err = os.Stat(filepath.Join(worktreeDir, ".slipway.yaml"))

--- a/internal/state/health.go
+++ b/internal/state/health.go
@@ -595,6 +595,7 @@ func hiddenBoundWorktreeDiagnostics(root string) (hiddenBoundWorktreeScan, error
 				})
 				continue
 			}
+			HydrateWorktreeBinding(root, workspaceRoot, &change)
 			boundWorkspace, err := scopeRootInWorkspace(root, change.WorktreePath)
 			if err != nil {
 				return hiddenBoundWorktreeScan{}, err

--- a/internal/state/repair.go
+++ b/internal/state/repair.go
@@ -220,6 +220,7 @@ func RepairBoundWorktreeScopeMetadata(root string) ([]string, error) {
 			if err != nil {
 				continue
 			}
+			HydrateWorktreeBinding(root, workspaceRoot, &change)
 			if strings.TrimSpace(change.WorktreePath) == "" {
 				continue
 			}

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -369,6 +369,9 @@ func loadChangeFromCandidatesWithLoaderAndCandidate(
 	for _, candidate := range paths {
 		change, err := load(candidate.Path)
 		if err == nil {
+			if !candidate.Archived {
+				HydrateWorktreeBinding(root, candidate.WorkspaceRoot, &change)
+			}
 			if !changeVisibleFromRoot(root, candidate.WorkspaceRoot, change, candidate.Archived) {
 				continue
 			}
@@ -510,6 +513,13 @@ func SaveChange(root string, st model.Change) error {
 		return err
 	}
 	if err := fsutil.WriteFileAtomic(bundlePath, b, 0o644); err != nil {
+		return err
+	}
+	// Record the machine-local worktree binding in git-local runtime state.
+	// The tracked bundle above carries no absolute path (Change.MarshalYAML
+	// strips it); this runtime record is the authority for resolving the bound
+	// worktree, with the bundle's own location as a self-healing fallback.
+	if err := writeWorktreeBinding(root, st); err != nil {
 		return err
 	}
 	return nil

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -17,9 +17,10 @@ import (
 )
 
 var (
-	ErrNoActiveChange         = errors.New("no active change")
-	ErrMultipleActiveChanges  = errors.New("multiple active changes")
-	errMissingBundleAuthority = errors.New("change bundle missing authority file")
+	ErrNoActiveChange           = errors.New("no active change")
+	ErrMultipleActiveChanges    = errors.New("multiple active changes")
+	errMissingBundleAuthority   = errors.New("change bundle missing authority file")
+	errAmbiguousWorktreeBinding = errors.New("ambiguous worktree binding")
 )
 
 type BoundChangeRef struct {
@@ -366,13 +367,26 @@ func loadChangeFromCandidatesWithLoaderAndCandidate(
 	load func(string) (model.Change, error),
 ) (model.Change, bundleCandidate, error) {
 	var firstAuthorityErr error
+	var locationFallbackChange model.Change
+	var locationFallbackCandidate bundleCandidate
+	var locationFallbackSet bool
 	for _, candidate := range paths {
 		change, err := load(candidate.Path)
 		if err == nil {
+			resolution := worktreeBindingUnresolved
 			if !candidate.Archived {
-				HydrateWorktreeBinding(root, candidate.WorkspaceRoot, &change)
+				resolution = HydrateWorktreeBinding(root, candidate.WorkspaceRoot, &change)
 			}
 			if !changeVisibleFromRoot(root, candidate.WorkspaceRoot, change, candidate.Archived) {
+				continue
+			}
+			if !candidate.Archived && resolution == worktreeBindingFromLocation {
+				if locationFallbackSet {
+					return model.Change{}, bundleCandidate{}, ambiguousWorktreeBindingError(change.Slug, locationFallbackCandidate, candidate)
+				}
+				locationFallbackChange = change
+				locationFallbackCandidate = candidate
+				locationFallbackSet = true
 				continue
 			}
 			return change, candidate, nil
@@ -394,10 +408,23 @@ func loadChangeFromCandidatesWithLoaderAndCandidate(
 		}
 		return model.Change{}, bundleCandidate{}, err
 	}
+	if locationFallbackSet {
+		return locationFallbackChange, locationFallbackCandidate, nil
+	}
 	if firstAuthorityErr != nil {
 		return model.Change{}, bundleCandidate{}, firstAuthorityErr
 	}
 	return model.Change{}, bundleCandidate{}, fs.ErrNotExist
+}
+
+func ambiguousWorktreeBindingError(slug string, first, second bundleCandidate) error {
+	return fmt.Errorf(
+		"%w for %q: runtime binding is missing and multiple bundle locations are visible (%s, %s); run `slipway repair` or remove the stale bundle copy",
+		errAmbiguousWorktreeBinding,
+		slug,
+		first.Path,
+		second.Path,
+	)
 }
 
 // LoadChange loads the active change state for the given slug from the canonical bundle paths.
@@ -836,7 +863,9 @@ func restoreChangeAuthorityIfNeeded(root string, expected model.Change) error {
 		current, decodeErr := decodeAndValidateChange(raw)
 		if decodeErr == nil {
 			current.Normalize()
-			if reflect.DeepEqual(current, expected) {
+			expectedOnDisk := expected
+			expectedOnDisk.WorktreePath = ""
+			if reflect.DeepEqual(current, expectedOnDisk) {
 				return nil
 			}
 		}

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -319,9 +319,13 @@ func TestFindActiveChangeForWorktreeNoMatchNoFallback(t *testing.T) {
 	require.ErrorAs(t, err, &boundErr)
 	require.Len(t, boundErr.BoundChanges, 2)
 	assert.Equal(t, "other-a", boundErr.BoundChanges[0].Slug)
-	assert.Equal(t, ch1.WorktreePath, boundErr.BoundChanges[0].WorktreePath)
+	ch1Worktree, err := NormalizePath(ch1.WorktreePath)
+	require.NoError(t, err)
+	assert.Equal(t, ch1Worktree, boundErr.BoundChanges[0].WorktreePath)
 	assert.Equal(t, "other-b", boundErr.BoundChanges[1].Slug)
-	assert.Equal(t, ch2.WorktreePath, boundErr.BoundChanges[1].WorktreePath)
+	ch2Worktree, err := NormalizePath(ch2.WorktreePath)
+	require.NoError(t, err)
+	assert.Equal(t, ch2Worktree, boundErr.BoundChanges[1].WorktreePath)
 }
 
 func TestTwoConcurrentChangesDifferentWorktreesCoexist(t *testing.T) {
@@ -559,7 +563,9 @@ func TestLoadChangeSkipsSiblingBundleWhoseAuthorityPointsAtDifferentWorktree(t *
 	loaded, err := LoadChange(scopeRoot, change.Slug)
 	require.NoError(t, err)
 	assert.Equal(t, "owning bundle", loaded.Description)
-	assert.Equal(t, owningWorktree, loaded.WorktreePath)
+	wantWorktree, err := NormalizePath(owningWorktree)
+	require.NoError(t, err)
+	assert.Equal(t, wantWorktree, loaded.WorktreePath)
 }
 
 func TestLoadChangeSkipsLocalStaleBundleWhenAuthorityOwnedBySiblingWorktree(t *testing.T) {
@@ -586,7 +592,9 @@ func TestLoadChangeSkipsLocalStaleBundleWhenAuthorityOwnedBySiblingWorktree(t *t
 	loaded, err := LoadChange(root, change.Slug)
 	require.NoError(t, err)
 	assert.Equal(t, "owning bundle", loaded.Description)
-	assert.Equal(t, worktreeRoot, loaded.WorktreePath)
+	wantWorktree, err := NormalizePath(worktreeRoot)
+	require.NoError(t, err)
+	assert.Equal(t, wantWorktree, loaded.WorktreePath)
 }
 
 func TestLoadChangeDoesNotReadRegistryOnlyMirror(t *testing.T) {
@@ -707,7 +715,9 @@ func TestLoadChangeFallsBackToSiblingWorktreeAuthorityWhenLocalBundleDirIsOrphan
 
 	loaded, err := LoadChange(root, change.Slug)
 	require.NoError(t, err)
-	assert.Equal(t, worktreeRoot, loaded.WorktreePath)
+	wantWorktree, err := NormalizePath(worktreeRoot)
+	require.NoError(t, err)
+	assert.Equal(t, wantWorktree, loaded.WorktreePath)
 }
 
 func TestListChangesSkipsSiblingWorktreeWithoutConfigEvenWhenBoundWorktreeMatches(t *testing.T) {
@@ -802,7 +812,9 @@ func TestListChangesFindsNestedScopeBundleInsideWorktree(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, changes, 1)
 	assert.Equal(t, change.Slug, changes[0].Slug)
-	assert.Equal(t, worktreeRoot, changes[0].WorktreePath)
+	wantWorktree, err := NormalizePath(worktreeRoot)
+	require.NoError(t, err)
+	assert.Equal(t, wantWorktree, changes[0].WorktreePath)
 }
 
 func TestListChangesSkipsStaleSiblingWorktreeScopeMarkerWithoutConfig(t *testing.T) {

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -451,7 +451,12 @@ func TestLoadChangeFindsWorktreeBundleWithoutRegistryMirror(t *testing.T) {
 	loaded, err := LoadChange(root, "worktree-bundle")
 	require.NoError(t, err)
 	assert.Equal(t, model.StateS2Execute, loaded.CurrentState)
-	assert.Equal(t, worktreeRoot, loaded.WorktreePath)
+	// ChangeDir removal also drops the git-local worktree binding, so this
+	// exercises the location-inference fallback, which resolves to the canonical
+	// (symlink-resolved) worktree root.
+	wantWorktree, err := NormalizePath(worktreeRoot)
+	require.NoError(t, err)
+	assert.Equal(t, wantWorktree, loaded.WorktreePath)
 }
 
 func TestLoadChangeSkipsMarkerlessSiblingWorktreeAtRepoRoot(t *testing.T) {
@@ -503,7 +508,12 @@ func TestLoadChangeFindsNestedScopeBundleInsideWorktree(t *testing.T) {
 	loaded, err := LoadChange(scopeRoot, change.Slug)
 	require.NoError(t, err)
 	assert.Equal(t, model.StateS2Execute, loaded.CurrentState)
-	assert.Equal(t, worktreeRoot, loaded.WorktreePath)
+	// ChangeDir removal also drops the git-local worktree binding, so this
+	// exercises the location-inference fallback, which resolves to the canonical
+	// (symlink-resolved) worktree root.
+	wantWorktree, err := NormalizePath(worktreeRoot)
+	require.NoError(t, err)
+	assert.Equal(t, wantWorktree, loaded.WorktreePath)
 
 	_, err = os.Stat(filepath.Join(worktreeRoot, "services", "billing", "artifacts", "changes", change.Slug, "change.yaml"))
 	require.NoError(t, err)

--- a/internal/state/worktree.go
+++ b/internal/state/worktree.go
@@ -52,22 +52,21 @@ type worktreeBindingResolution int
 const (
 	worktreeBindingUnresolved worktreeBindingResolution = iota
 	worktreeBindingFromRuntime
-	worktreeBindingFromLegacyChange
 	worktreeBindingFromLocation
 )
 
 // HydrateWorktreeBinding resolves change.WorktreePath for an active governed
 // bundle that was loaded from a tracked change.yaml.
 //
-// The absolute worktree path is never persisted to tracked change.yaml (see
-// Change.MarshalYAML). Resolution authority, in order:
+// The absolute worktree path is never persisted to tracked change.yaml; the
+// WorktreePath field is yaml:"-", so a tracked bundle that still carries
+// worktree_path is rejected by strict decoding before it ever reaches here.
+// Resolution authority, in order:
 //
 //  1. The git-local worktree-binding record (writeWorktreeBinding), which keeps
 //     a change's binding unambiguous even when a stale copy of the bundle exists
 //     in another workspace.
-//  2. A legacy worktree_path still present in an old active change.yaml. This is
-//     a one-time read-only disambiguation signal; the next SaveChange strips it.
-//  3. Fallback: the bundle's own location. SaveChange always writes the bundle
+//  2. Fallback: the bundle's own location. SaveChange always writes the bundle
 //     under changeWorkspaceRoot(root, change), which equals the bound worktree,
 //     so a bundle's location is a faithful, machine-local encoding of the
 //     binding. This makes resolution self-healing when the runtime record is
@@ -82,12 +81,6 @@ func HydrateWorktreeBinding(projectRoot, workspaceRoot string, change *model.Cha
 	if binding, ok := readWorktreeBinding(projectRoot, change.Slug); ok {
 		change.WorktreePath = binding.WorktreePath
 		return worktreeBindingFromRuntime
-	}
-	if legacyPath := strings.TrimSpace(change.WorktreePath); legacyPath != "" {
-		if normalized, err := NormalizePath(legacyPath); err == nil {
-			change.WorktreePath = normalized
-			return worktreeBindingFromLegacyChange
-		}
 	}
 	if inferWorktreeBindingFromLocation(projectRoot, workspaceRoot, change) {
 		return worktreeBindingFromLocation

--- a/internal/state/worktree.go
+++ b/internal/state/worktree.go
@@ -47,18 +47,27 @@ var worktreeListCache = struct {
 	entries: map[string]worktreeListCacheEntry{},
 }
 
+type worktreeBindingResolution int
+
+const (
+	worktreeBindingUnresolved worktreeBindingResolution = iota
+	worktreeBindingFromRuntime
+	worktreeBindingFromLegacyChange
+	worktreeBindingFromLocation
+)
+
 // HydrateWorktreeBinding resolves change.WorktreePath for an active governed
 // bundle that was loaded from a tracked change.yaml.
 //
 // The absolute worktree path is never persisted to tracked change.yaml (see
-// Change.MarshalYAML); any value still present in a legacy file is ignored and
-// overwritten here, so there is no migration path or compatibility branch to
-// maintain. Resolution authority, in order:
+// Change.MarshalYAML). Resolution authority, in order:
 //
 //  1. The git-local worktree-binding record (writeWorktreeBinding), which keeps
 //     a change's binding unambiguous even when a stale copy of the bundle exists
 //     in another workspace.
-//  2. Fallback: the bundle's own location. SaveChange always writes the bundle
+//  2. A legacy worktree_path still present in an old active change.yaml. This is
+//     a one-time read-only disambiguation signal; the next SaveChange strips it.
+//  3. Fallback: the bundle's own location. SaveChange always writes the bundle
 //     under changeWorkspaceRoot(root, change), which equals the bound worktree,
 //     so a bundle's location is a faithful, machine-local encoding of the
 //     binding. This makes resolution self-healing when the runtime record is
@@ -66,44 +75,54 @@ var worktreeListCache = struct {
 //
 // Callers must skip archived bundles, which are portable, terminal, and
 // intentionally unbound.
-func HydrateWorktreeBinding(projectRoot, workspaceRoot string, change *model.Change) {
+func HydrateWorktreeBinding(projectRoot, workspaceRoot string, change *model.Change) worktreeBindingResolution {
 	if change == nil {
-		return
+		return worktreeBindingUnresolved
 	}
 	if binding, ok := readWorktreeBinding(projectRoot, change.Slug); ok {
 		change.WorktreePath = binding.WorktreePath
-		return
+		return worktreeBindingFromRuntime
 	}
-	inferWorktreeBindingFromLocation(projectRoot, workspaceRoot, change)
+	if legacyPath := strings.TrimSpace(change.WorktreePath); legacyPath != "" {
+		if normalized, err := NormalizePath(legacyPath); err == nil {
+			change.WorktreePath = normalized
+			return worktreeBindingFromLegacyChange
+		}
+	}
+	if inferWorktreeBindingFromLocation(projectRoot, workspaceRoot, change) {
+		return worktreeBindingFromLocation
+	}
+	return worktreeBindingUnresolved
 }
 
 // inferWorktreeBindingFromLocation reconstructs the bound worktree from the
 // workspace root where the bundle physically lives. A bundle in the project's
 // own worktree (or a non-git context) is treated as unbound.
-func inferWorktreeBindingFromLocation(projectRoot, workspaceRoot string, change *model.Change) {
+func inferWorktreeBindingFromLocation(projectRoot, workspaceRoot string, change *model.Change) bool {
 	change.WorktreePath = ""
 
 	worktreeRoot, err := gitWorkspaceRoot(workspaceRoot)
 	if err != nil {
-		return
+		return false
 	}
 	projectWorktreeRoot, err := gitWorkspaceRoot(projectRoot)
 	if err != nil {
-		return
+		return false
 	}
 	normalizedWorktree, err := NormalizePath(worktreeRoot)
 	if err != nil {
-		return
+		return false
 	}
 	normalizedProject, err := NormalizePath(projectWorktreeRoot)
 	if err != nil {
-		return
+		return false
 	}
 	if normalizedWorktree == normalizedProject {
-		// Bundle lives in the project worktree itself → unbound.
-		return
+		// Bundle lives in the project worktree itself, so it is unbound.
+		return false
 	}
 	change.WorktreePath = normalizedWorktree
+	return true
 }
 
 func PersistScopeWorktreeMetadata(change *model.Change, worktreePath, worktreeBranch string) error {

--- a/internal/state/worktree.go
+++ b/internal/state/worktree.go
@@ -47,6 +47,65 @@ var worktreeListCache = struct {
 	entries: map[string]worktreeListCacheEntry{},
 }
 
+// HydrateWorktreeBinding resolves change.WorktreePath for an active governed
+// bundle that was loaded from a tracked change.yaml.
+//
+// The absolute worktree path is never persisted to tracked change.yaml (see
+// Change.MarshalYAML); any value still present in a legacy file is ignored and
+// overwritten here, so there is no migration path or compatibility branch to
+// maintain. Resolution authority, in order:
+//
+//  1. The git-local worktree-binding record (writeWorktreeBinding), which keeps
+//     a change's binding unambiguous even when a stale copy of the bundle exists
+//     in another workspace.
+//  2. Fallback: the bundle's own location. SaveChange always writes the bundle
+//     under changeWorkspaceRoot(root, change), which equals the bound worktree,
+//     so a bundle's location is a faithful, machine-local encoding of the
+//     binding. This makes resolution self-healing when the runtime record is
+//     missing (e.g. a fresh clone, or git-local state cleared).
+//
+// Callers must skip archived bundles, which are portable, terminal, and
+// intentionally unbound.
+func HydrateWorktreeBinding(projectRoot, workspaceRoot string, change *model.Change) {
+	if change == nil {
+		return
+	}
+	if binding, ok := readWorktreeBinding(projectRoot, change.Slug); ok {
+		change.WorktreePath = binding.WorktreePath
+		return
+	}
+	inferWorktreeBindingFromLocation(projectRoot, workspaceRoot, change)
+}
+
+// inferWorktreeBindingFromLocation reconstructs the bound worktree from the
+// workspace root where the bundle physically lives. A bundle in the project's
+// own worktree (or a non-git context) is treated as unbound.
+func inferWorktreeBindingFromLocation(projectRoot, workspaceRoot string, change *model.Change) {
+	change.WorktreePath = ""
+
+	worktreeRoot, err := gitWorkspaceRoot(workspaceRoot)
+	if err != nil {
+		return
+	}
+	projectWorktreeRoot, err := gitWorkspaceRoot(projectRoot)
+	if err != nil {
+		return
+	}
+	normalizedWorktree, err := NormalizePath(worktreeRoot)
+	if err != nil {
+		return
+	}
+	normalizedProject, err := NormalizePath(projectWorktreeRoot)
+	if err != nil {
+		return
+	}
+	if normalizedWorktree == normalizedProject {
+		// Bundle lives in the project worktree itself → unbound.
+		return
+	}
+	change.WorktreePath = normalizedWorktree
+}
+
 func PersistScopeWorktreeMetadata(change *model.Change, worktreePath, worktreeBranch string) error {
 	if change == nil {
 		return fmt.Errorf("change is required")

--- a/internal/state/worktree_binding.go
+++ b/internal/state/worktree_binding.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -23,7 +24,9 @@ const worktreeBindingFileName = "worktree-binding.yaml"
 // (see Change.MarshalYAML); resolution reads this runtime record instead, and
 // falls back to the bundle's own location when the record is absent.
 type worktreeBinding struct {
-	WorktreePath   string `yaml:"worktree_path"`
+	WorktreePath string `yaml:"worktree_path"`
+	// WorktreeBranch is diagnostic metadata. The portable branch authority stays
+	// in tracked change.yaml, so hydration only reads WorktreePath.
 	WorktreeBranch string `yaml:"worktree_branch,omitempty"`
 	// GitCommonDir records the repo identity at write time so a binding that was
 	// copied into a different repository checkout is ignored rather than trusted.
@@ -50,9 +53,13 @@ func writeWorktreeBinding(root string, change model.Change) error {
 		}
 		return nil
 	}
+	normalizedWorktreePath, err := NormalizePath(change.WorktreePath)
+	if err != nil {
+		return fmt.Errorf("normalize worktree binding path: %w", err)
+	}
 
 	binding := worktreeBinding{
-		WorktreePath:   change.WorktreePath,
+		WorktreePath:   normalizedWorktreePath,
 		WorktreeBranch: change.WorktreeBranch,
 		GitCommonDir:   gitCommonDirIdentity(root),
 	}
@@ -81,6 +88,11 @@ func readWorktreeBinding(root, slug string) (worktreeBinding, bool) {
 	if strings.TrimSpace(binding.WorktreePath) == "" {
 		return worktreeBinding{}, false
 	}
+	normalizedWorktreePath, err := NormalizePath(binding.WorktreePath)
+	if err != nil {
+		return worktreeBinding{}, false
+	}
+	binding.WorktreePath = normalizedWorktreePath
 	if recorded := strings.TrimSpace(binding.GitCommonDir); recorded != "" {
 		if current := gitCommonDirIdentity(root); current != "" && current != recorded {
 			// Binding belongs to a different repository checkout; do not trust it.

--- a/internal/state/worktree_binding.go
+++ b/internal/state/worktree_binding.go
@@ -1,0 +1,99 @@
+package state
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/signalridge/slipway/internal/fsutil"
+	"github.com/signalridge/slipway/internal/model"
+	"gopkg.in/yaml.v3"
+)
+
+// worktreeBindingFileName is the git-local runtime record that binds an active
+// change to its dedicated worktree. It lives under the per-change runtime dir so
+// it is removed together with the rest of that change's local runtime state on
+// archive/cancel, and is never part of the portable, tracked change bundle.
+const worktreeBindingFileName = "worktree-binding.yaml"
+
+// worktreeBinding is the git-local authority for a change's machine-local
+// worktree path. The tracked change.yaml intentionally carries no absolute path
+// (see Change.MarshalYAML); resolution reads this runtime record instead, and
+// falls back to the bundle's own location when the record is absent.
+type worktreeBinding struct {
+	WorktreePath   string `yaml:"worktree_path"`
+	WorktreeBranch string `yaml:"worktree_branch,omitempty"`
+	// GitCommonDir records the repo identity at write time so a binding that was
+	// copied into a different repository checkout is ignored rather than trusted.
+	GitCommonDir string `yaml:"git_common_dir,omitempty"`
+}
+
+// WorktreeBindingPath returns the git-local worktree-binding record path for slug.
+func WorktreeBindingPath(root, slug string) string {
+	return filepath.Join(ChangeDir(root, slug), worktreeBindingFileName)
+}
+
+// writeWorktreeBinding persists (or clears) the git-local worktree binding for a
+// change. An empty WorktreePath removes any existing record so an unbound change
+// leaves no stale binding behind.
+func writeWorktreeBinding(root string, change model.Change) error {
+	slug := strings.TrimSpace(change.Slug)
+	if slug == "" {
+		return errors.New("slug is required")
+	}
+	path := WorktreeBindingPath(root, slug)
+	if strings.TrimSpace(change.WorktreePath) == "" {
+		if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return err
+		}
+		return nil
+	}
+
+	binding := worktreeBinding{
+		WorktreePath:   change.WorktreePath,
+		WorktreeBranch: change.WorktreeBranch,
+		GitCommonDir:   gitCommonDirIdentity(root),
+	}
+	raw, err := yaml.Marshal(binding)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return fsutil.WriteFileAtomic(path, raw, 0o644)
+}
+
+// readWorktreeBinding returns the recorded worktree binding for slug. The second
+// return is false when no usable binding exists (missing, unreadable, blank, or
+// written against a different repository).
+func readWorktreeBinding(root, slug string) (worktreeBinding, bool) {
+	raw, err := os.ReadFile(WorktreeBindingPath(root, slug))
+	if err != nil {
+		return worktreeBinding{}, false
+	}
+	var binding worktreeBinding
+	if err := yaml.Unmarshal(raw, &binding); err != nil {
+		return worktreeBinding{}, false
+	}
+	if strings.TrimSpace(binding.WorktreePath) == "" {
+		return worktreeBinding{}, false
+	}
+	if recorded := strings.TrimSpace(binding.GitCommonDir); recorded != "" {
+		if current := gitCommonDirIdentity(root); current != "" && current != recorded {
+			// Binding belongs to a different repository checkout; do not trust it.
+			return worktreeBinding{}, false
+		}
+	}
+	return binding, true
+}
+
+func gitCommonDirIdentity(root string) string {
+	normalized, err := NormalizePath(GitCommonDir(root))
+	if err != nil {
+		return filepath.Clean(GitCommonDir(root))
+	}
+	return normalized
+}

--- a/internal/state/worktree_binding_test.go
+++ b/internal/state/worktree_binding_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/signalridge/slipway/internal/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 // TestSaveChangeOmitsWorktreePathFromTrackedBundle is the core acceptance check
@@ -59,7 +60,9 @@ func TestLoadChangeResolvesBoundWorktreeFromRepoRoot(t *testing.T) {
 
 	loaded, err := LoadChange(root, change.Slug)
 	require.NoError(t, err)
-	assert.Equal(t, worktreeRoot, loaded.WorktreePath)
+	wantWorktree, err := NormalizePath(worktreeRoot)
+	require.NoError(t, err)
+	assert.Equal(t, wantWorktree, loaded.WorktreePath)
 }
 
 // TestFindActiveChangeFromInsideWorktreeResolves covers commands invoked from
@@ -78,7 +81,9 @@ func TestFindActiveChangeFromInsideWorktreeResolves(t *testing.T) {
 	resolved, err := FindActiveChangeForWorktree(worktreeRoot, worktreeRoot)
 	require.NoError(t, err)
 	assert.Equal(t, change.Slug, resolved.Slug)
-	assert.Equal(t, worktreeRoot, resolved.WorktreePath)
+	wantWorktree, err := NormalizePath(worktreeRoot)
+	require.NoError(t, err)
+	assert.Equal(t, wantWorktree, resolved.WorktreePath)
 }
 
 // TestResolutionRecoversWhenBindingMissing proves the design is self-healing:
@@ -165,6 +170,117 @@ func TestLegacyChangeYamlWithWorktreePathStillResolves(t *testing.T) {
 	wantWorktree, err := NormalizePath(worktreeRoot)
 	require.NoError(t, err)
 	assert.Equal(t, wantWorktree, loaded.WorktreePath)
+}
+
+// TestLegacyWorktreePathDisambiguatesStaleSiblingWhenBindingMissing covers the
+// migration edge where the git-local binding is missing, but legacy active
+// change.yaml files still carry the old durable worktree_path field. The legacy
+// field is not persisted again, but it remains a one-time disambiguation signal
+// so stale sibling copies are not selected before the owning bundle.
+func TestLegacyWorktreePathDisambiguatesStaleSiblingWhenBindingMissing(t *testing.T) {
+	t.Parallel()
+
+	root := createRuntimeRepoLayout(t)
+	scopeRoot := filepath.Join(root, "services", "billing")
+	require.NoError(t, os.MkdirAll(scopeRoot, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(scopeRoot, ".slipway.yaml"), []byte("{}"), 0o644))
+
+	worktreeBase := t.TempDir()
+	staleWorktree := filepath.Join(worktreeBase, "aaa-stale")
+	owningWorktree := filepath.Join(worktreeBase, "bbb-owner")
+	runGit(t, root, "worktree", "add", staleWorktree, "-b", "aaa-stale")
+	runGit(t, root, "worktree", "add", owningWorktree, "-b", "bbb-owner")
+
+	staleScopeRoot := filepath.Join(staleWorktree, "services", "billing")
+	owningScopeRoot := filepath.Join(owningWorktree, "services", "billing")
+	for _, workspace := range []string{staleScopeRoot, owningScopeRoot} {
+		require.NoError(t, os.MkdirAll(workspace, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(workspace, ".slipway.yaml"), []byte("{}"), 0o644))
+	}
+	require.NoError(t, ensureScopeMarkerFile(WorkspaceScopeMarkerPath(staleScopeRoot)))
+
+	change := model.NewChange("legacy-disambiguates")
+	change.CurrentState = model.StateS2Execute
+	change.PlanSubStep = model.PlanSubStepNone
+	change.WorktreePath = owningWorktree
+	change.WorktreeBranch = "bbb-owner"
+	change.Description = "owning bundle"
+	require.NoError(t, SaveChange(scopeRoot, change))
+	require.NoError(t, os.Remove(WorktreeBindingPath(scopeRoot, change.Slug)))
+
+	ownerPath := BundleChangeFilePath(owningScopeRoot, change.Slug)
+	raw, err := os.ReadFile(ownerPath)
+	require.NoError(t, err)
+	legacyRaw := appendLegacyWorktreePath(raw, owningWorktree)
+	require.NoError(t, os.WriteFile(ownerPath, legacyRaw, 0o644))
+
+	staleCopy := change
+	staleCopy.Description = "stale sibling bundle"
+	staleRaw, err := yaml.Marshal(staleCopy)
+	require.NoError(t, err)
+	stalePath := BundleChangeFilePath(staleScopeRoot, change.Slug)
+	require.NoError(t, os.MkdirAll(filepath.Dir(stalePath), 0o755))
+	require.NoError(t, os.WriteFile(stalePath, appendLegacyWorktreePath(staleRaw, owningWorktree), 0o644))
+
+	loaded, err := LoadChange(scopeRoot, change.Slug)
+	require.NoError(t, err)
+	assert.Equal(t, "owning bundle", loaded.Description)
+	wantWorktree, err := NormalizePath(owningWorktree)
+	require.NoError(t, err)
+	assert.Equal(t, wantWorktree, loaded.WorktreePath)
+}
+
+// TestLoadChangeFailsClosedWhenBindingMissingAndLocationFallbackAmbiguous
+// covers the new-format edge where neither the git-local binding nor a legacy
+// worktree_path exists, and multiple same-slug bundle locations are visible. In
+// that state bundle location is no longer a unique authority, so loading must
+// fail closed instead of selecting whichever candidate sorts first.
+func TestLoadChangeFailsClosedWhenBindingMissingAndLocationFallbackAmbiguous(t *testing.T) {
+	t.Parallel()
+
+	root := createRuntimeRepoLayout(t)
+	scopeRoot := filepath.Join(root, "services", "billing")
+	require.NoError(t, os.MkdirAll(scopeRoot, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(scopeRoot, ".slipway.yaml"), []byte("{}"), 0o644))
+
+	worktreeBase := t.TempDir()
+	staleWorktree := filepath.Join(worktreeBase, "aaa-stale")
+	owningWorktree := filepath.Join(worktreeBase, "bbb-owner")
+	runGit(t, root, "worktree", "add", staleWorktree, "-b", "aaa-stale")
+	runGit(t, root, "worktree", "add", owningWorktree, "-b", "bbb-owner")
+
+	staleScopeRoot := filepath.Join(staleWorktree, "services", "billing")
+	owningScopeRoot := filepath.Join(owningWorktree, "services", "billing")
+	for _, workspace := range []string{staleScopeRoot, owningScopeRoot} {
+		require.NoError(t, os.MkdirAll(workspace, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(workspace, ".slipway.yaml"), []byte("{}"), 0o644))
+	}
+	require.NoError(t, ensureScopeMarkerFile(WorkspaceScopeMarkerPath(staleScopeRoot)))
+
+	change := model.NewChange("ambiguous-location-fallback")
+	change.CurrentState = model.StateS2Execute
+	change.PlanSubStep = model.PlanSubStepNone
+	change.WorktreePath = owningWorktree
+	change.WorktreeBranch = "bbb-owner"
+	change.Description = "owning bundle"
+	require.NoError(t, SaveChange(scopeRoot, change))
+	require.NoError(t, os.Remove(WorktreeBindingPath(scopeRoot, change.Slug)))
+
+	staleCopy := change
+	staleCopy.Description = "stale sibling bundle"
+	staleRaw, err := yaml.Marshal(staleCopy)
+	require.NoError(t, err)
+	stalePath := BundleChangeFilePath(staleScopeRoot, change.Slug)
+	require.NoError(t, os.MkdirAll(filepath.Dir(stalePath), 0o755))
+	require.NoError(t, os.WriteFile(stalePath, staleRaw, 0o644))
+
+	_, err = LoadChange(scopeRoot, change.Slug)
+	require.ErrorIs(t, err, errAmbiguousWorktreeBinding)
+	assert.Contains(t, err.Error(), change.Slug)
+}
+
+func appendLegacyWorktreePath(raw []byte, worktreePath string) []byte {
+	return []byte(string(raw) + "worktree_path: " + worktreePath + "\n")
 }
 
 // TestTrackedChangeBundlesOmitWorktreePath is a static repository hygiene guard:

--- a/internal/state/worktree_binding_test.go
+++ b/internal/state/worktree_binding_test.go
@@ -139,102 +139,38 @@ func TestArchiveRemovesWorktreeBindingAndStripsPath(t *testing.T) {
 		"archived change.yaml must remain portable with no worktree path")
 }
 
-// TestLegacyChangeYamlWithWorktreePathStillResolves proves an existing active
-// change whose tracked change.yaml still carries a legacy worktree_path is not
-// rejected by strict decoding and still resolves its bound worktree — the legacy
-// value is ignored in favour of the location-based binding, and the field ages
-// out on the next save (Change.MarshalYAML drops it).
-func TestLegacyChangeYamlWithWorktreePathStillResolves(t *testing.T) {
+// TestTrackedChangeYamlWithWorktreePathIsRejected proves the field is
+// fail-closed on read: WorktreePath is yaml:"-", so a tracked change.yaml that
+// still carries a worktree_path is rejected by strict decoding rather than
+// silently tolerated. There is no migration shim — a stale field must be removed
+// (the next clean SaveChange never writes it again).
+func TestTrackedChangeYamlWithWorktreePathIsRejected(t *testing.T) {
 	t.Parallel()
 	root, worktreeRoot := setupRepoWithWorktree(t)
 
-	change := model.NewChange("legacy-worktree-path")
+	change := model.NewChange("reject-worktree-path")
 	change.CurrentState = model.StateS2Execute
 	change.PlanSubStep = model.PlanSubStepNone
 	change.WorktreePath = worktreeRoot
 	change.WorktreeBranch = "feature"
 	require.NoError(t, SaveChange(root, change))
 
-	// Rewrite the tracked bundle in the legacy shape (carrying worktree_path) and
-	// drop the git-local binding, so resolution must tolerate the legacy field
-	// and recover the worktree from the bundle location.
+	// Inject a stale worktree_path into the otherwise-clean tracked bundle.
 	bundlePath := BundleChangeFilePath(worktreeRoot, change.Slug)
 	raw, err := os.ReadFile(bundlePath)
 	require.NoError(t, err)
-	legacy := string(raw) + "worktree_path: " + worktreeRoot + "\n"
-	require.NoError(t, os.WriteFile(bundlePath, []byte(legacy), 0o644))
-	require.NoError(t, os.Remove(WorktreeBindingPath(root, change.Slug)))
+	require.NoError(t, os.WriteFile(bundlePath, appendLegacyWorktreePath(raw, worktreeRoot), 0o644))
 
-	loaded, err := LoadChange(root, change.Slug)
-	require.NoError(t, err, "a legacy change.yaml carrying worktree_path must still decode")
-	wantWorktree, err := NormalizePath(worktreeRoot)
-	require.NoError(t, err)
-	assert.Equal(t, wantWorktree, loaded.WorktreePath)
-}
-
-// TestLegacyWorktreePathDisambiguatesStaleSiblingWhenBindingMissing covers the
-// migration edge where the git-local binding is missing, but legacy active
-// change.yaml files still carry the old durable worktree_path field. The legacy
-// field is not persisted again, but it remains a one-time disambiguation signal
-// so stale sibling copies are not selected before the owning bundle.
-func TestLegacyWorktreePathDisambiguatesStaleSiblingWhenBindingMissing(t *testing.T) {
-	t.Parallel()
-
-	root := createRuntimeRepoLayout(t)
-	scopeRoot := filepath.Join(root, "services", "billing")
-	require.NoError(t, os.MkdirAll(scopeRoot, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(scopeRoot, ".slipway.yaml"), []byte("{}"), 0o644))
-
-	worktreeBase := t.TempDir()
-	staleWorktree := filepath.Join(worktreeBase, "aaa-stale")
-	owningWorktree := filepath.Join(worktreeBase, "bbb-owner")
-	runGit(t, root, "worktree", "add", staleWorktree, "-b", "aaa-stale")
-	runGit(t, root, "worktree", "add", owningWorktree, "-b", "bbb-owner")
-
-	staleScopeRoot := filepath.Join(staleWorktree, "services", "billing")
-	owningScopeRoot := filepath.Join(owningWorktree, "services", "billing")
-	for _, workspace := range []string{staleScopeRoot, owningScopeRoot} {
-		require.NoError(t, os.MkdirAll(workspace, 0o755))
-		require.NoError(t, os.WriteFile(filepath.Join(workspace, ".slipway.yaml"), []byte("{}"), 0o644))
-	}
-	require.NoError(t, ensureScopeMarkerFile(WorkspaceScopeMarkerPath(staleScopeRoot)))
-
-	change := model.NewChange("legacy-disambiguates")
-	change.CurrentState = model.StateS2Execute
-	change.PlanSubStep = model.PlanSubStepNone
-	change.WorktreePath = owningWorktree
-	change.WorktreeBranch = "bbb-owner"
-	change.Description = "owning bundle"
-	require.NoError(t, SaveChange(scopeRoot, change))
-	require.NoError(t, os.Remove(WorktreeBindingPath(scopeRoot, change.Slug)))
-
-	ownerPath := BundleChangeFilePath(owningScopeRoot, change.Slug)
-	raw, err := os.ReadFile(ownerPath)
-	require.NoError(t, err)
-	legacyRaw := appendLegacyWorktreePath(raw, owningWorktree)
-	require.NoError(t, os.WriteFile(ownerPath, legacyRaw, 0o644))
-
-	staleCopy := change
-	staleCopy.Description = "stale sibling bundle"
-	staleRaw, err := yaml.Marshal(staleCopy)
-	require.NoError(t, err)
-	stalePath := BundleChangeFilePath(staleScopeRoot, change.Slug)
-	require.NoError(t, os.MkdirAll(filepath.Dir(stalePath), 0o755))
-	require.NoError(t, os.WriteFile(stalePath, appendLegacyWorktreePath(staleRaw, owningWorktree), 0o644))
-
-	loaded, err := LoadChange(scopeRoot, change.Slug)
-	require.NoError(t, err)
-	assert.Equal(t, "owning bundle", loaded.Description)
-	wantWorktree, err := NormalizePath(owningWorktree)
-	require.NoError(t, err)
-	assert.Equal(t, wantWorktree, loaded.WorktreePath)
+	_, err = LoadChange(root, change.Slug)
+	require.Error(t, err, "a tracked change.yaml carrying worktree_path must be rejected by strict decoding")
+	assert.Contains(t, err.Error(), "worktree_path")
 }
 
 // TestLoadChangeFailsClosedWhenBindingMissingAndLocationFallbackAmbiguous
-// covers the new-format edge where neither the git-local binding nor a legacy
-// worktree_path exists, and multiple same-slug bundle locations are visible. In
-// that state bundle location is no longer a unique authority, so loading must
-// fail closed instead of selecting whichever candidate sorts first.
+// covers the edge where the git-local binding is missing and multiple same-slug
+// bundle locations are visible. In that state bundle location is no longer a
+// unique authority, so loading must fail closed instead of selecting whichever
+// candidate sorts first.
 func TestLoadChangeFailsClosedWhenBindingMissingAndLocationFallbackAmbiguous(t *testing.T) {
 	t.Parallel()
 

--- a/internal/state/worktree_binding_test.go
+++ b/internal/state/worktree_binding_test.go
@@ -1,0 +1,197 @@
+package state
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/signalridge/slipway/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSaveChangeOmitsWorktreePathFromTrackedBundle is the core acceptance check
+// for issue #46: a worktree-bound change must not write the machine-local
+// absolute worktree_path into the tracked change.yaml, while keeping the
+// portable worktree_branch.
+func TestSaveChangeOmitsWorktreePathFromTrackedBundle(t *testing.T) {
+	t.Parallel()
+	root, worktreeRoot := setupRepoWithWorktree(t)
+
+	change := model.NewChange("omit-worktree-path")
+	change.CurrentState = model.StateS2Execute
+	change.PlanSubStep = model.PlanSubStepNone
+	change.WorktreePath = worktreeRoot
+	change.WorktreeBranch = "feature"
+	require.NoError(t, SaveChange(root, change))
+
+	bundlePath := BundleChangeFilePath(worktreeRoot, change.Slug)
+	raw, err := os.ReadFile(bundlePath)
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "worktree_path:",
+		"tracked change.yaml must not persist a machine-local absolute worktree path")
+	assert.NotContains(t, string(raw), worktreeRoot,
+		"tracked change.yaml must not leak the developer-local worktree path")
+	assert.Contains(t, string(raw), "worktree_branch: feature",
+		"portable worktree_branch should remain in the tracked bundle")
+
+	// The git-local runtime binding carries the absolute path instead.
+	bindingRaw, err := os.ReadFile(WorktreeBindingPath(root, change.Slug))
+	require.NoError(t, err)
+	assert.Contains(t, string(bindingRaw), "worktree_path:")
+}
+
+// TestLoadChangeResolvesBoundWorktreeFromRepoRoot covers `--change <slug>`
+// invocations from the repo root: the bound worktree resolves from the git-local
+// binding even though the tracked bundle carries no path.
+func TestLoadChangeResolvesBoundWorktreeFromRepoRoot(t *testing.T) {
+	t.Parallel()
+	root, worktreeRoot := setupRepoWithWorktree(t)
+
+	change := model.NewChange("resolve-from-root")
+	change.CurrentState = model.StateS2Execute
+	change.PlanSubStep = model.PlanSubStepNone
+	change.WorktreePath = worktreeRoot
+	change.WorktreeBranch = "feature"
+	require.NoError(t, SaveChange(root, change))
+
+	loaded, err := LoadChange(root, change.Slug)
+	require.NoError(t, err)
+	assert.Equal(t, worktreeRoot, loaded.WorktreePath)
+}
+
+// TestFindActiveChangeFromInsideWorktreeResolves covers commands invoked from
+// inside the dedicated worktree.
+func TestFindActiveChangeFromInsideWorktreeResolves(t *testing.T) {
+	t.Parallel()
+	root, worktreeRoot := setupRepoWithWorktree(t)
+
+	change := model.NewChange("resolve-from-worktree")
+	change.CurrentState = model.StateS2Execute
+	change.PlanSubStep = model.PlanSubStepNone
+	change.WorktreePath = worktreeRoot
+	change.WorktreeBranch = "feature"
+	require.NoError(t, SaveChange(root, change))
+
+	resolved, err := FindActiveChangeForWorktree(worktreeRoot, worktreeRoot)
+	require.NoError(t, err)
+	assert.Equal(t, change.Slug, resolved.Slug)
+	assert.Equal(t, worktreeRoot, resolved.WorktreePath)
+}
+
+// TestResolutionRecoversWhenBindingMissing proves the design is self-healing:
+// with the git-local binding deleted (e.g. a fresh clone, or cleared runtime
+// state) the bound worktree is still recovered from the bundle's own location.
+func TestResolutionRecoversWhenBindingMissing(t *testing.T) {
+	t.Parallel()
+	root, worktreeRoot := setupRepoWithWorktree(t)
+
+	change := model.NewChange("recover-binding")
+	change.CurrentState = model.StateS2Execute
+	change.PlanSubStep = model.PlanSubStepNone
+	change.WorktreePath = worktreeRoot
+	change.WorktreeBranch = "feature"
+	require.NoError(t, SaveChange(root, change))
+
+	require.NoError(t, os.Remove(WorktreeBindingPath(root, change.Slug)))
+
+	loaded, err := LoadChange(root, change.Slug)
+	require.NoError(t, err)
+	wantWorktree, err := NormalizePath(worktreeRoot)
+	require.NoError(t, err)
+	assert.Equal(t, wantWorktree, loaded.WorktreePath,
+		"resolution must fall back to the bundle's worktree location when the binding is missing")
+}
+
+// TestArchiveRemovesWorktreeBindingAndStripsPath confirms archived records stay
+// portable: the binding is cleared and the archived change.yaml carries no path.
+func TestArchiveRemovesWorktreeBindingAndStripsPath(t *testing.T) {
+	t.Parallel()
+	root, worktreeRoot := setupRepoWithWorktree(t)
+
+	change := model.NewChange("archive-strips-path")
+	change.CurrentState = model.StateS2Execute
+	change.PlanSubStep = model.PlanSubStepNone
+	change.WorktreePath = worktreeRoot
+	change.WorktreeBranch = "feature"
+	require.NoError(t, SaveChange(root, change))
+	require.FileExists(t, WorktreeBindingPath(root, change.Slug))
+
+	archived, err := ArchiveChange(root, change, model.ChangeStatusDone)
+	require.NoError(t, err)
+	assert.Empty(t, archived.WorktreePath)
+
+	_, statErr := os.Stat(WorktreeBindingPath(root, change.Slug))
+	assert.True(t, os.IsNotExist(statErr), "archive must remove the git-local worktree binding")
+
+	archivedPath, err := ArchivedChangeFilePathForRead(root, change.Slug)
+	require.NoError(t, err)
+	raw, err := os.ReadFile(archivedPath)
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "worktree_path:",
+		"archived change.yaml must remain portable with no worktree path")
+}
+
+// TestLegacyChangeYamlWithWorktreePathStillResolves proves an existing active
+// change whose tracked change.yaml still carries a legacy worktree_path is not
+// rejected by strict decoding and still resolves its bound worktree — the legacy
+// value is ignored in favour of the location-based binding, and the field ages
+// out on the next save (Change.MarshalYAML drops it).
+func TestLegacyChangeYamlWithWorktreePathStillResolves(t *testing.T) {
+	t.Parallel()
+	root, worktreeRoot := setupRepoWithWorktree(t)
+
+	change := model.NewChange("legacy-worktree-path")
+	change.CurrentState = model.StateS2Execute
+	change.PlanSubStep = model.PlanSubStepNone
+	change.WorktreePath = worktreeRoot
+	change.WorktreeBranch = "feature"
+	require.NoError(t, SaveChange(root, change))
+
+	// Rewrite the tracked bundle in the legacy shape (carrying worktree_path) and
+	// drop the git-local binding, so resolution must tolerate the legacy field
+	// and recover the worktree from the bundle location.
+	bundlePath := BundleChangeFilePath(worktreeRoot, change.Slug)
+	raw, err := os.ReadFile(bundlePath)
+	require.NoError(t, err)
+	legacy := string(raw) + "worktree_path: " + worktreeRoot + "\n"
+	require.NoError(t, os.WriteFile(bundlePath, []byte(legacy), 0o644))
+	require.NoError(t, os.Remove(WorktreeBindingPath(root, change.Slug)))
+
+	loaded, err := LoadChange(root, change.Slug)
+	require.NoError(t, err, "a legacy change.yaml carrying worktree_path must still decode")
+	wantWorktree, err := NormalizePath(worktreeRoot)
+	require.NoError(t, err)
+	assert.Equal(t, wantWorktree, loaded.WorktreePath)
+}
+
+// TestTrackedChangeBundlesOmitWorktreePath is a static repository hygiene guard:
+// no git-tracked artifacts/changes/**/change.yaml may persist a worktree_path.
+func TestTrackedChangeBundlesOmitWorktreePath(t *testing.T) {
+	t.Parallel()
+
+	toplevelOut, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		t.Skipf("not a git repository: %v", err)
+	}
+	toplevel := strings.TrimSpace(string(toplevelOut))
+
+	out, err := exec.Command("git", "-C", toplevel, "ls-files", "artifacts/changes").Output()
+	require.NoError(t, err)
+
+	checked := 0
+	for _, rel := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		rel = strings.TrimSpace(rel)
+		if rel == "" || filepath.Base(rel) != "change.yaml" {
+			continue
+		}
+		raw, err := os.ReadFile(filepath.Join(toplevel, rel))
+		require.NoError(t, err)
+		assert.NotContainsf(t, string(raw), "worktree_path:",
+			"tracked %s must not persist a machine-local worktree_path", rel)
+		checked++
+	}
+	t.Logf("checked %d tracked change.yaml file(s)", checked)
+}


### PR DESCRIPTION
Closes #46.

## Problem
Active governed changes persisted a normalized **absolute** `worktree_path`
(e.g. a developer-local `/Users/.../.worktrees/<slug>`) into the tracked
`artifacts/changes/<slug>/change.yaml`. That leaked machine-local filesystem
details into committed/reviewed governance artifacts and mixed two concerns in
one file: portable governance state and local runtime worktree binding. Archived
records were already portable (archive scrubs the path), so active behavior was
inconsistent with the archived record.

## Root cause
The absolute path was **redundant**. `SaveChange` always writes the governed
bundle under `changeWorkspaceRoot(root, change)`, which equals the bound
worktree — so the bundle's own location already encodes the binding. The tracked
file never needed to carry the path.

## Approach
Separate the machine-local binding from tracked governance state:

- **Never persisted, fail-closed on read** — `WorktreePath` carries `yaml:"-"`,
  so *every* `Change` YAML write (active `SaveChange`, archive snapshot, repair
  rewrite) drops it, and a tracked `change.yaml` that still carries
  `worktree_path` is **rejected by strict `KnownFields` decoding** rather than
  silently tolerated. The field stays in the struct as runtime-only state (read
  all over the engine; still exposed on JSON handoff surfaces). **No migration
  shim, no compatibility branch** — a stale field must be removed, and a clean
  `SaveChange` never writes it again.
- **Git-local runtime binding authority** — new
  `.git/slipway/runtime/changes/<slug>/worktree-binding.yaml` holding
  `worktree_path`, `worktree_branch`, and a `git_common_dir` repo-identity guard
  (a binding copied into another checkout is ignored).
- **Binding-first resolution with a self-healing fallback** —
  `HydrateWorktreeBinding` resolves from the git-local binding, falling back to
  the bundle's own worktree location when the binding is missing (fresh clone,
  cleared runtime state). Ambiguous location fallback (multiple visible
  same-slug bundles, no binding) fails closed. Wired into the central load funnel
  plus the `repair` and `health` load sites.
- `SaveChange` writes/clears the binding; archive/cancel removes it via the
  existing per-change runtime cleanup. Portable `worktree_branch` stays in
  `change.yaml`.

## Tests
- tracked bundle omits `worktree_path` (keeps `worktree_branch`)
- resolves the bound worktree from the repo root **and** from inside the worktree
- self-heals when the git-local binding is missing (location inference)
- **a tracked `change.yaml` carrying `worktree_path` is rejected** by strict
  decoding (fail-closed, no silent tolerance)
- ambiguous location fallback (no binding, multiple visible bundles) fails closed
- archive removes the binding and the archived `change.yaml` carries no path
- **static hygiene guard**: fails if any git-tracked
  `artifacts/changes/**/change.yaml` contains `worktree_path:`

`go build`, `go vet`, `golangci-lint` (0 issues) and the full `go test ./...`
suite pass; verified end-to-end via the `slipway` CLI (`slipway new` →
no `worktree_path` in the bundle; `status --change` and `next` both resolve).

## Out of scope
Dedicated-worktree authenticity validation is unchanged; runtime JSON handoff
surfaces (`next`/`run`/`status --json`) may still report `worktree_path` as
ephemeral runtime info; the governed bundle's physical location is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)