### PR TITLE
fix(governance): enforce authored closeout assurance

### DIFF
--- a/artifacts/changes/archived/reject-placeholder-scaffold-assurance-md-content-before-do-2/change.yaml
+++ b/artifacts/changes/archived/reject-placeholder-scaffold-assurance-md-content-before-do-2/change.yaml
@@ -1,0 +1,35 @@
+version: 1
+slug: reject-placeholder-scaffold-assurance-md-content-before-do-2
+description: 'Reject placeholder/scaffold assurance.md content before done so standard/strict changes cannot archive with boilerplate-only closeout sections (issue #47)'
+status: done
+current_state: DONE
+complexity_level: simple
+base_ref: HEAD
+created_at: 2026-06-01T12:44:27.754537Z
+quality_mode: standard
+workflow_preset: light
+artifact_schema: core
+project_context:
+    test_cmd: go test ./...
+    build_cmd: go build ./...
+    languages:
+        - Go
+artifacts:
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: 4cbdf9742c7c184f71f9d1677b37d749bfa9eda771e9520ebecf912a602e999b
+        updated_at: 2026-06-01T14:03:57.75989216Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: b4a173178c5e596faf957f4dbbb3920866101fac419545e9f8838cbbe5e3d2e6
+        updated_at: 2026-06-01T14:40:54.400528372Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: d7c1720b25313498b1ad76b3485b49302b77c8f6c97cc99366bdf31f70fff021
+        updated_at: 2026-06-01T14:40:54.400701997Z

--- a/artifacts/changes/archived/reject-placeholder-scaffold-assurance-md-content-before-do-2/intent.md
+++ b/artifacts/changes/archived/reject-placeholder-scaffold-assurance-md-content-before-do-2/intent.md
@@ -1,0 +1,103 @@
+# Intent
+
+## Project Context
+<!-- Auto-filled by InferProjectContext(); .slipway.yaml overrides -->
+- Tech Stack: Go
+- Languages: Go
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Conventions: repo-native (slipway governed change)
+
+## Summary
+Reject placeholder/scaffold assurance.md content before done so standard/strict changes cannot archive with boilerplate-only closeout sections (issue #47)
+## Complexity Assessment
+simple
+<!-- Rationale: bounded change, low coordination, no sensitive guardrail domain.
+Per user direction it is a durable root-cause fix using a two-layer (hybrid)
+architecture, not a one-line phrase-list patch. Design is already settled. -->
+
+## In Scope
+- **Layer 2 — deterministic floor** in `internal/engine/artifact` (manager.go):
+  a template-derived scaffold detector for `assurance.md` sections. The embedded
+  `assurance.md` template is the single source of truth for "unedited scaffold"
+  per section, so detection cannot drift from the template wording. Extend
+  `AssuranceStructureBlockers` to emit `assurance_section_placeholder:<heading>`
+  when a structurally non-empty required section still holds only scaffold prose
+  (verbatim, or the seeded sentence left in place). One change covers both
+  `slipway done` (`ValidateAssuranceStructure`) and `slipway validate`/advance
+  (`AssuranceContractBlockers`) — they share this validator.
+- **Layer 1 — AI attestation enforcement** in
+  `internal/engine/progression`: under a standard/strict effective preset,
+  S4 readiness requires `final-closeout`, and ship authority
+  requires its passing verification record to carry the
+  `closeout:assurance_complete=pass` reference. Emit
+  `closeout_assurance_attestation_missing` when the record is missing or the
+  passing record omits it (fail-closed against rubber-stamping).
+- **final-closeout skill** (`internal/tmpl/templates/skills/final-closeout/SKILL.md.tmpl`
+  + regenerated `.claude`/`.codex` copies): add per-section authored-vs-scaffold
+  judgment guidance and promote `closeout:assurance_complete=pass` from advisory
+  to a required reference on standard/strict.
+- Tests: placeholder-only, partial-placeholder, fully-authored, and
+  template-drift safety (Layer 2); attestation-missing enforcement (Layer 1);
+  update `internal/tmpl/templates_test.go` to the new required-reference
+  contract; update CLI done/next fixtures for standard required closeout and
+  light optional closeout.
+
+## Out of Scope
+- Rewriting or migrating existing archived `assurance.md` records (AC: existing
+  archives are not rewritten unless explicitly repaired/migrated).
+- Enabling placeholder *rejection* for the other governed artifacts' done-gating
+  (detector stays assurance-specific in this change).
+- Changing light-preset closeout semantics: `assurance.md` stays optional there.
+
+## Constraints
+- `go build ./...` and `go test ./...` must pass.
+- Single source of truth: Layer 2 detection derives from the embedded template,
+  not a hand-maintained phrase list.
+- No change to light-preset closeout semantics.
+
+## Acceptance Signals
+- `slipway done` blocks on standard/strict preset when an assurance.md section
+  still contains scaffold placeholders; a fully authored assurance.md passes.
+- `slipway validate` reports the same placeholder blocker (shared validator).
+- Under standard/strict, a missing `final-closeout` record or a record missing
+  `closeout:assurance_complete=pass` blocks the ship gate.
+- The blocker names the offending section so the author knows what needs content.
+- Tests cover placeholder-only / partial-placeholder / authored / template-drift
+  (Layer 2) plus attestation-missing (Layer 1).
+- Light preset still finalizes without `assurance.md`.
+
+## Open Questions
+<!-- None: the two-layer (hybrid) design is settled and codebase paths are traced. -->
+
+## Approved Summary
+<!-- User-confirmed 2026-06-01 -->
+Two-layer (hybrid) fix for issue #47.
+
+**Layer 2 — deterministic floor.** A template-derived scaffold detector for
+`assurance.md` sections lands in `internal/engine/artifact`; the embedded
+template is the single source of truth so detection cannot drift.
+`AssuranceStructureBlockers` is extended to emit
+`assurance_section_placeholder:<heading>` for any required section still holding
+scaffold prose, naming the section. One change covers both `slipway done` and
+`slipway validate`/advance because they share this validator.
+
+**Layer 1 — AI attestation enforcement.** The `final-closeout` host skill (AI)
+judges each assurance section authored-vs-scaffold and records its verdict as
+references in `verification/final-closeout.yaml`, including the required
+`closeout:assurance_complete=pass`. The CLI does not re-read prose; under a
+standard/strict effective preset it deterministically requires a passing
+final-closeout record with that reference, emitting
+`closeout_assurance_attestation_missing` when the record or reference is absent.
+CLI enforces the single aggregate reference; per-section
+`closeout:assurance_section:<name>=authored` lines are skill-side evidence detail
+(kernel stays decoupled from section names). The skill template is strengthened
+and `.claude`/`.codex` copies regenerated.
+
+**Boundaries.** No migration of archived records; no placeholder rejection for
+other artifacts; light-preset closeout semantics unchanged (assurance.md stays
+optional there). Primary acceptance: `done`/`validate` block scaffold sections
+(naming them); a standard/strict change missing `final-closeout` or its
+attestation blocks ship; tests cover placeholder-only / partial / authored /
+template-drift + attestation-missing; light preset still finalizes without
+assurance.md.

--- a/artifacts/changes/archived/reject-placeholder-scaffold-assurance-md-content-before-do-2/requirements.md
+++ b/artifacts/changes/archived/reject-placeholder-scaffold-assurance-md-content-before-do-2/requirements.md
@@ -1,0 +1,77 @@
+# Requirements
+## Project Context
+- Tech Stack: Go
+- Conventions: governance kernel; AI is always the host, kernel enforces evidence. Key paths — `internal/engine/artifact/manager.go` (`AssuranceStructureBlockers`, `requiredSectionsForArtifact`, `markdownSectionLines`, `TemplateContent`); `internal/engine/progression/authority.go` (`buildShipAuthorityFromReadiness`, `FinalCloseoutEvidenceRequired`); S4 readiness/advance wiring in `internal/engine/progression/readiness.go` and `internal/engine/progression/advance_governed.go`; `internal/engine/progression/validation.go:521` (`ComputeVerificationReadiness`); `cmd/next_skill_view.go` (`skill_evidence` diagnostics rendering); `internal/tmpl/templates/skills/final-closeout/SKILL.md.tmpl`; `internal/tmpl/templates_test.go`. Assurance template scaffold lives in `internal/tmpl/templates/artifacts/assurance.md`.
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Requirements
+
+### Requirement: Deterministic floor rejects scaffold assurance sections (Layer 2).
+REQ-001: `AssuranceStructureBlockers` MUST, after the existing structure check passes, reject any required `assurance.md` section whose body is still only template scaffold (verbatim, or the seeded scaffold sentence left in place with extra prose appended). A structurally non-empty but semantically-scaffold section MUST NOT satisfy the assurance gate.
+
+#### Scenario: Placeholder-only assurance is blocked
+GIVEN an `assurance.md` with all seven required headings present and each body equal to the embedded template scaffold prose
+WHEN `AssuranceStructureBlockers` runs
+THEN it returns one `assurance_section_placeholder:<heading>` blocker per scaffold section and the result is non-empty.
+
+#### Scenario: Fully authored assurance passes
+GIVEN an `assurance.md` whose required sections all contain concrete, non-scaffold content
+WHEN `AssuranceStructureBlockers` runs
+THEN it returns no blockers.
+
+### Requirement: The placeholder blocker names the offending section.
+REQ-002: Each placeholder blocker MUST identify the specific section still holding scaffold content so the author knows what needs real content.
+
+#### Scenario: Partial-placeholder names only the scaffold sections
+GIVEN an `assurance.md` where some sections are authored and others remain scaffold
+WHEN `AssuranceStructureBlockers` runs
+THEN it returns `assurance_section_placeholder:<heading>` only for the still-scaffold sections, naming each.
+
+### Requirement: Detection derives from the embedded template (single source of truth).
+REQ-003: Layer 2 scaffold detection MUST derive its per-section canonical scaffold from the embedded `assurance.md` template, not a hand-maintained phrase list, so detection cannot drift from the template wording.
+
+#### Scenario: Detector follows the template
+GIVEN the per-section scaffold strings used for detection
+WHEN they are compared to the bodies extracted from the embedded `assurance.md` template
+THEN every required section's detection string matches the template-derived body (template drift would update detection automatically).
+
+### Requirement: done and validate enforce the floor consistently (one validator).
+REQ-004: The new floor MUST be applied through the shared `AssuranceStructureBlockers` so both `slipway done` (`ValidateAssuranceStructure`) and `slipway validate`/advance (`AssuranceContractBlockers`) reject scaffold assurance without duplicated logic.
+
+#### Scenario: Both surfaces reject the same placeholder content
+GIVEN a standard/strict change whose `assurance.md` still contains scaffold sections
+WHEN `slipway done` and `slipway validate` evaluate it
+THEN both report the placeholder blocker via the shared validator.
+
+### Requirement: AI attestation is a required, enforced reference on standard/strict (Layer 1).
+REQ-005: Under a standard/strict effective preset, the ship authority MUST require a passing `final-closeout` verification record that carries the `closeout:assurance_complete=pass` reference. When the record is missing or the passing record omits the reference, the ship authority MUST emit a `closeout_assurance_attestation_missing` blocker (fail-closed). The CLI MUST NOT re-read assurance prose to make this decision — it enforces presence of the AI's attestation only. JSON diagnostics MUST use the same final-closeout-required predicate when rendering `skill_evidence`, so API clients see the same required skills that route `next_skill` and block ship.
+
+#### Scenario: Missing attestation blocks ship under standard/strict
+GIVEN a standard/strict change with a passing `final-closeout` record whose `references` omit `closeout:assurance_complete=pass`
+WHEN the ship authority is computed
+THEN `closeout_assurance_attestation_missing` is present and the ship gate is not ready.
+
+#### Scenario: Missing closeout record blocks ship under plain standard
+GIVEN a plain standard change where `CloseoutRefreshRequired` is false and `goal-verification` is passing
+WHEN the ship authority is computed without a `final-closeout` record
+THEN `closeout_assurance_attestation_missing` is present and the ship gate is not ready.
+
+#### Scenario: Diagnostics list missing closeout under plain standard
+GIVEN a plain standard S4 change where `goal-verification` is passing and `final-closeout` is missing
+WHEN `slipway next --json --diagnostics` renders `skill_evidence`
+THEN `skill_evidence` includes `goal-verification` as passing and `final-closeout` as missing, matching the `next_skill: final-closeout` route and `required_skill_missing:final-closeout` blocker.
+
+#### Scenario: Attestation present clears the Layer 1 check
+GIVEN the same record with `closeout:assurance_complete=pass` in `references`
+WHEN the ship authority is computed
+THEN no `closeout_assurance_attestation_missing` blocker is raised by this check.
+
+### Requirement: Boundaries — light preset and archived records unchanged.
+REQ-006: Light-preset closeout semantics MUST remain unchanged (`assurance.md` optional; no attestation requirement). Existing archived `assurance.md` records MUST NOT be rewritten or migrated by this change.
+
+#### Scenario: Light preset still finalizes without assurance
+GIVEN a light-preset change with no `assurance.md`
+WHEN closeout/done evaluation runs
+THEN no assurance placeholder or attestation blocker is raised.

--- a/artifacts/changes/archived/reject-placeholder-scaffold-assurance-md-content-before-do-2/tasks.md
+++ b/artifacts/changes/archived/reject-placeholder-scaffold-assurance-md-content-before-do-2/tasks.md
@@ -1,0 +1,44 @@
+# Tasks
+## Project Context
+- Tech Stack: Go
+- Conventions: governance kernel; deterministic kernel + AI host. Single-validator reuse (`AssuranceStructureBlockers`) covers done + validate. Skill template source of truth is `internal/tmpl/templates/skills/final-closeout/SKILL.md.tmpl`; `.claude`/`.codex` copies are generated.
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Task List
+
+- [x] `t-01` Layer 2 deterministic floor: in `internal/engine/artifact/manager.go` add a template-derived assurance scaffold detector (lazily derive each required section's canonical scaffold body from the embedded `assurance.md` template via `TemplateContent` + `markdownSectionLines`; normalize whitespace; cache once). Extend `AssuranceStructureBlockers` so that, after `validateSectionStructure` passes, each required section whose normalized body equals or still contains its template scaffold or derived seed sentence yields an `assurance_section_placeholder:<heading>` blocker. Empty-body case stays owned by the structure check.
+  - wave: 1
+  - depends_on: []
+  - target_files: [internal/engine/artifact/manager.go, internal/engine/progression/validation.go]
+  - task_kind: code
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004]
+
+- [x] `t-02` Layer 1 attestation enforcement: in `internal/engine/progression/authority.go` (`buildShipAuthorityFromReadiness`) and the S4 readiness/advance wiring, when the effective preset is standard/strict, require a passing `final-closeout` record to carry the `closeout:assurance_complete=pass` reference; when the record is missing or the passing record omits the reference, append a `closeout_assurance_attestation_missing` reason code to the verify-skill blockers (mirroring the `parseReviewLayerOutcomes`/`reviewLayerBlockerSpecs` reference pattern). Route `cmd/next_skill_view.go` through the same final-closeout-required predicate so diagnostics `skill_evidence` matches the S4 route/blockers. Do not re-read assurance prose. Light preset is unaffected.
+  - wave: 1
+  - depends_on: []
+  - target_files: [cmd/next_skill_view.go, internal/engine/progression/advance_governed.go, internal/engine/progression/authority.go, internal/engine/progression/readiness.go]
+  - task_kind: code
+  - covers: [REQ-005, REQ-006]
+
+- [x] `t-03` Strengthen `final-closeout` skill: edit `internal/tmpl/templates/skills/final-closeout/SKILL.md.tmpl` to require per-section authored-vs-scaffold judgment and promote `closeout:assurance_complete=pass` from advisory ("also add") to a required reference on standard/strict. Regenerate the `.claude/skills/slipway-final-closeout/SKILL.md` and `.codex/skills/slipway-final-closeout/SKILL.md` copies so generated surfaces match the template.
+  - wave: 1
+  - depends_on: []
+  - target_files: [internal/tmpl/templates/skills/final-closeout/SKILL.md.tmpl, .claude/skills/slipway-final-closeout/SKILL.md, .codex/skills/slipway-final-closeout/SKILL.md]
+  - task_kind: code
+  - covers: [REQ-005]
+
+- [x] `t-04` Tests: in `internal/engine/artifact/manager_test.go` add placeholder-only, partial-placeholder, old Archive Decision seed-sentence, fully-authored, and template-drift-safety cases for `AssuranceStructureBlockers`. Add Layer 1 authority/readiness tests asserting `closeout_assurance_attestation_missing` fires when a standard/strict change lacks `final-closeout` or has a passing record that omits the attestation, and clears when present. Update `internal/tmpl/templates_test.go` (currently `TestFinalCloseoutTemplateKeepsAssuranceReferenceConditional`, lines 81-93) to the new required-reference contract, and update CLI done/next fixtures so standard done-ready paths carry the required final-closeout attestation, diagnostics `skill_evidence` lists missing plain-standard final-closeout, and light optional-closeout behavior stays covered.
+  - wave: 2
+  - depends_on: [t-01, t-02, t-03]
+  - target_files: [cmd/lifecycle_commands_test.go, cmd/progression_next_test.go, internal/engine/artifact/manager_test.go, internal/engine/progression/authority_test.go, internal/tmpl/templates_test.go]
+  - task_kind: code
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-005, REQ-006]
+
+- [x] `t-05` Mechanical verification: run `go build ./...` and `go test ./...`; both MUST pass on the worktree. Confirm no unrelated test regressions from the new blockers or diagnostic evidence predicate sharing.
+  - wave: 3
+  - depends_on: [t-04]
+  - target_files: [cmd/next_skill_view.go, internal/engine/artifact/manager.go, internal/engine/progression/authority.go, internal/tmpl/templates/skills/final-closeout/SKILL.md.tmpl]
+  - task_kind: verification
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004, REQ-005, REQ-006]

--- a/cmd/lifecycle_commands_test.go
+++ b/cmd/lifecycle_commands_test.go
@@ -98,6 +98,7 @@ func TestDoneJSONReportsWorktreeArchivePathWhenRunFromWorktree(t *testing.T) {
 		writePassingWaveEvidence(t, root, slug, 1)
 		writePassingReviewEvidencePack(t, root, slug, 1)
 		writePassingGoalVerificationEvidence(t, root, slug, 1)
+		writePassingFinalCloseoutEvidence(t, root, slug, 1)
 
 		previousWD, err := os.Getwd()
 		require.NoError(t, err)
@@ -148,6 +149,7 @@ func TestDoneJSONWarnsWhenWorktreeSourceChangesAreUncommitted(t *testing.T) {
 		writePassingWaveEvidence(t, root, slug, 1)
 		writePassingReviewEvidencePack(t, root, slug, 1)
 		writePassingGoalVerificationEvidence(t, root, slug, 1)
+		writePassingFinalCloseoutEvidence(t, root, slug, 1)
 
 		require.NoError(t, os.MkdirAll(filepath.Join(normalizedWT, "cmd"), 0o755))
 		require.NoError(t, os.WriteFile(filepath.Join(normalizedWT, "cmd", "done.go"), []byte("package cmd\n"), 0o644))
@@ -189,6 +191,7 @@ func TestDoneJSONOmitsArchiveCommitRequiredForRepoScopedChange(t *testing.T) {
 		writePassingWaveEvidence(t, root, slug, 1)
 		writePassingReviewEvidencePack(t, root, slug, 1)
 		writePassingGoalVerificationEvidence(t, root, slug, 1)
+		writePassingFinalCloseoutEvidence(t, root, slug, 1)
 
 		var out bytes.Buffer
 		doneCmd := makeDoneCmd()
@@ -1422,6 +1425,9 @@ func markChangeReadyForDone(t *testing.T, root string, change *model.Change) {
 	writePassingWaveEvidence(t, root, change.Slug, 1)
 	writePassingReviewEvidencePack(t, root, change.Slug, 1)
 	writePassingGoalVerificationEvidence(t, root, change.Slug, 1)
+	if change.WorkflowPreset != model.WorkflowPresetLight {
+		writePassingFinalCloseoutEvidence(t, root, change.Slug, 1)
+	}
 }
 
 func writePassingWaveEvidence(t *testing.T, root, slug string, runSummaryVersion int) {
@@ -1470,5 +1476,16 @@ func writePassingGoalVerificationEvidence(t *testing.T, root, slug string, runSu
 		Timestamp:  time.Now().UTC(),
 		RunVersion: runSummaryVersion,
 		References: []string{"verification:pass"},
+	})
+}
+
+func writePassingFinalCloseoutEvidence(t *testing.T, root, slug string, runSummaryVersion int) {
+	t.Helper()
+	writeSkillVerification(t, root, slug, "final-closeout", model.VerificationRecord{
+		Verdict:    model.VerificationVerdictPass,
+		Blockers:   []model.ReasonCode{},
+		Timestamp:  time.Now().UTC(),
+		RunVersion: runSummaryVersion,
+		References: []string{"closeout:assurance_complete=pass"},
 	})
 }

--- a/cmd/next_skill_view.go
+++ b/cmd/next_skill_view.go
@@ -115,7 +115,7 @@ func assembleSkillViewWithOptions(
 				*governedChange,
 				view.CurrentState,
 				latestRunVersion,
-				presetPolicy.CloseoutRefreshRequired,
+				progression.FinalCloseoutEvidenceRequired(presetPolicy),
 				planningSubSteps...,
 			)
 			if evalErr != nil {
@@ -459,7 +459,7 @@ func buildRequiredSkillEvidence(
 		registry,
 		change.NeedsDiscovery,
 		workflowState,
-		presetPolicy.CloseoutRefreshRequired,
+		progression.FinalCloseoutEvidenceRequired(presetPolicy),
 		planSubSteps...,
 	)
 	required = skill.FilterRequiredSkillsForWorkflowProfile(required, change.EffectiveWorkflowProfile())

--- a/cmd/progression_next_test.go
+++ b/cmd/progression_next_test.go
@@ -519,6 +519,7 @@ func TestRunJSONFinalCloseoutDropsRetiredFreshEvidenceHint(t *testing.T) {
 		require.NoError(t, state.SaveChange(root, change))
 
 		markChangeReadyForDone(t, root, &change)
+		require.NoError(t, os.Remove(state.VerificationFilePath(root, slug, progression.SkillFinalCloseout)))
 		writeAssuranceMD(t, root, slug, validAssuranceContent())
 		// Refresh the summary after bundle mutations so full-closeout readiness
 		// uses the latest evidence window.
@@ -1481,6 +1482,7 @@ func TestNextReturnsDoneReadyWithoutNextSkillAfterGovernedShipPasses(t *testing.
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 
+	change.WorkflowPreset = model.WorkflowPresetLight
 	change.CurrentState = model.StateS4Verify
 	change.PlanSubStep = model.PlanSubStepNone
 	require.NoError(t, state.SaveChange(root, change))
@@ -1520,7 +1522,7 @@ func TestNextReturnsDoneReadyWithoutNextSkillAfterGovernedShipPasses(t *testing.
 	assert.NotContains(t, model.ReasonSpecs(handoff.Blockers), "no_skill_required:S4_VERIFY")
 }
 
-func TestNextReturnsDoneReadyWithoutFinalCloseoutRequirementForStandardRequestPath(t *testing.T) {
+func TestNextReturnsDoneReadyWithFinalCloseoutAttestationForStandardRequestPath(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
 	ensureTestGitRepo(t, root)
@@ -1545,6 +1547,7 @@ func TestNextReturnsDoneReadyWithoutFinalCloseoutRequirementForStandardRequestPa
 	writePassingWaveEvidence(t, root, slug, 1)
 	writePassingReviewEvidencePack(t, root, slug, 1)
 	writePassingGoalVerificationEvidence(t, root, slug, 1)
+	writePassingFinalCloseoutEvidence(t, root, slug, 1)
 
 	view, err := buildNextView(root, changeRef{Slug: slug}, "", false, true, false)
 	require.NoError(t, err)
@@ -1555,6 +1558,60 @@ func TestNextReturnsDoneReadyWithoutFinalCloseoutRequirementForStandardRequestPa
 	assert.Nil(t, view.NextSkill)
 	assert.Contains(t, model.ReasonSpecs(view.Blockers), "run_slipway_done_to_finalize")
 	assert.NotContains(t, model.ReasonSpecs(view.Blockers), "ship_gate_blocked:required_skill_missing:final-closeout")
+	assert.NotContains(t, model.ReasonSpecs(view.Blockers), "closeout_assurance_attestation_missing")
+}
+
+func TestNextDiagnosticsSkillEvidenceUsesStandardCloseoutRequirement(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+
+		slug := createGovernedRequest(t, root, "L2", "standard closeout diagnostics contract")
+		change, err := state.LoadChange(root, slug)
+		require.NoError(t, err)
+
+		change.WorkflowPreset = model.WorkflowPresetStandard
+		change.QualityMode = model.QualityModeStandard
+		change.CurrentState = model.StateS4Verify
+		change.PlanSubStep = model.PlanSubStepNone
+		require.NoError(t, state.SaveChange(root, change))
+		writePassingExecutionSummary(t, root, slug, 1, "t-01")
+
+		bundlePath := filepath.Join(root, "artifacts", "changes", change.Slug)
+		require.NoError(t, os.MkdirAll(bundlePath, 0o755))
+		writeShipReadyGovernedBundle(t, root, change)
+		writeAssuranceMD(t, root, change.Slug, validAssuranceContent())
+		writePassingExecutionSummary(t, root, slug, 1, "t-01")
+
+		writePassingWaveEvidence(t, root, slug, 1)
+		writePassingReviewEvidencePack(t, root, slug, 1)
+		writePassingGoalVerificationEvidence(t, root, slug, 1)
+
+		cmd := commandForRoot(t, root, makeNextCmd())
+		cmd.SetArgs([]string{"--json", "--diagnostics", "--change", slug})
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		require.NoError(t, cmd.Execute())
+
+		var view nextView
+		require.NoError(t, json.Unmarshal(out.Bytes(), &view))
+		require.NotNil(t, view.NextSkill)
+		assert.Equal(t, progression.SkillFinalCloseout, view.NextSkill.Name)
+		assert.Contains(t, model.ReasonSpecs(view.Blockers), "required_skill_missing:final-closeout")
+
+		statusBySkill := map[string]skillEvidenceEntry{}
+		for _, entry := range view.SkillEvidence {
+			statusBySkill[entry.SkillName] = entry
+		}
+		require.Contains(t, statusBySkill, progression.SkillGoalVerification)
+		require.Contains(t, statusBySkill, progression.SkillFinalCloseout)
+		assert.True(t, statusBySkill[progression.SkillGoalVerification].HasEvidence)
+		assert.Equal(t, "passing", statusBySkill[progression.SkillGoalVerification].Status)
+		assert.False(t, statusBySkill[progression.SkillFinalCloseout].HasEvidence)
+		assert.Equal(t, "missing", statusBySkill[progression.SkillFinalCloseout].Status)
+	})
 }
 
 func TestNextJSONDefaultIsHandoffOnlyAndDiagnosticsKeepsFullSurface(t *testing.T) {

--- a/internal/engine/artifact/manager.go
+++ b/internal/engine/artifact/manager.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"text/template"
 	"unicode"
 	"unicode/utf8"
@@ -986,7 +987,103 @@ func AssuranceStructureBlockers(content string) []string {
 	if err != nil {
 		return []string{"assurance_structure_invalid:" + err.Error()}
 	}
-	return nil
+
+	// Deterministic placeholder floor (issue #47): a section can be structurally
+	// non-empty yet still hold only the generated scaffold prose. Such content
+	// is semantically blank and must not satisfy closeout. This blocker is the
+	// fail-closed counterpart to the AI-driven assurance attestation; it cannot
+	// be rubber-stamped because detection derives from the embedded template.
+	var blockers []string
+	for _, heading := range headings {
+		body := strings.Join(markdownSectionLines(content, heading), "\n")
+		if assuranceSectionLooksScaffold(heading, body) {
+			blockers = append(blockers, "assurance_section_placeholder:"+heading)
+		}
+	}
+	return blockers
+}
+
+// assuranceSectionScaffold lazily derives, from the embedded assurance.md
+// template, the normalized scaffold body for each required section. The
+// template is the single source of truth for what "unedited scaffold" looks
+// like, so detection cannot drift from the template wording the way a
+// hand-maintained phrase list does. Required-section bodies in the template
+// contain no template directives, so the raw content is sufficient.
+var assuranceSectionScaffold = sync.OnceValue(func() map[string]string {
+	scaffold := map[string]string{}
+	content, err := TemplateContent("assurance.md")
+	if err != nil {
+		return scaffold
+	}
+	for _, heading := range requiredSectionsForArtifact("assurance.md") {
+		body := normalizeAssuranceBody(strings.Join(markdownSectionLines(content, heading), "\n"))
+		if body != "" {
+			scaffold[heading] = body
+		}
+	}
+	return scaffold
+})
+
+// normalizeAssuranceBody collapses whitespace so detection is insensitive to
+// reflow, indentation, and trailing space.
+func normalizeAssuranceBody(body string) string {
+	return strings.Join(strings.Fields(strings.TrimSpace(body)), " ")
+}
+
+// assuranceSectionLooksScaffold reports whether a required assurance section
+// body is still template scaffold. Hybrid detection: an exact template-derived
+// match catches the verbatim scaffold, and containment checks catch cases where
+// the author appended prose without replacing the scaffold body or one of its
+// seed sentences. Empty bodies are not flagged here — the structure check owns
+// the empty case.
+//
+// The containment checks accept a false-positive tradeoff: authored prose that
+// embeds a scaffold seed sentence verbatim is rejected. Short section seeds are
+// more collision-prone, but the floor favors catching retained scaffold over
+// admitting boilerplate-only assurance.
+func assuranceSectionLooksScaffold(heading, body string) bool {
+	scaffold := assuranceSectionScaffold()[heading]
+	if scaffold == "" {
+		return false
+	}
+	norm := normalizeAssuranceBody(body)
+	if norm == "" {
+		return false
+	}
+	if norm == scaffold || strings.Contains(norm, scaffold) {
+		return true
+	}
+	for _, seed := range assuranceScaffoldSentences(scaffold) {
+		if seed == scaffold {
+			continue
+		}
+		if norm == seed || strings.Contains(norm, seed) {
+			return true
+		}
+	}
+	return false
+}
+
+// assuranceScaffoldSentences derives sentence-level scaffold seeds from a
+// normalized template section body. This catches older one-sentence scaffold
+// sections when the template later grows extra instructions.
+func assuranceScaffoldSentences(scaffold string) []string {
+	var sentences []string
+	start := 0
+	for i, r := range scaffold {
+		switch r {
+		case '.', '!', '?':
+			sentence := strings.TrimSpace(scaffold[start : i+1])
+			if sentence != "" {
+				sentences = append(sentences, sentence)
+			}
+			start = i + 1
+		}
+	}
+	if tail := strings.TrimSpace(scaffold[start:]); tail != "" {
+		sentences = append(sentences, tail)
+	}
+	return sentences
 }
 
 // renderTemplateWithFallback resolves a template using the following priority:

--- a/internal/engine/artifact/manager_test.go
+++ b/internal/engine/artifact/manager_test.go
@@ -370,6 +370,143 @@ One`
 	assert.Contains(t, blockers[0], "assurance_structure_invalid:")
 }
 
+// TestAssuranceStructureBlockersRejectsScaffold covers issue #47: a structurally
+// valid assurance.md whose sections still hold the template scaffold prose must
+// be rejected, with one blocker naming each scaffold section.
+func TestAssuranceStructureBlockersRejectsScaffold(t *testing.T) {
+	t.Parallel()
+
+	// The embedded template is itself the canonical all-scaffold document.
+	scaffold, err := TemplateContent("assurance.md")
+	require.NoError(t, err)
+
+	blockers := AssuranceStructureBlockers(scaffold)
+	require.NotEmpty(t, blockers, "all-scaffold assurance.md must be rejected")
+	for _, heading := range requiredSectionsForArtifact("assurance.md") {
+		assert.Contains(t, blockers, "assurance_section_placeholder:"+heading,
+			"scaffold section %q must be flagged", heading)
+	}
+	// Structure itself is valid; the rejection is purely the placeholder floor.
+	for _, b := range blockers {
+		assert.NotContains(t, b, "assurance_structure_invalid")
+	}
+}
+
+// TestAssuranceStructureBlockersPartialPlaceholder covers the partial case: only
+// the still-scaffold section is named; authored sections pass.
+func TestAssuranceStructureBlockersPartialPlaceholder(t *testing.T) {
+	t.Parallel()
+
+	// Every section authored except Scope Summary, which is left as the verbatim
+	// template scaffold sentence.
+	content := `## Scope Summary
+Summarize delivered scope.
+
+## Verification Verdict
+All 42 tests pass; go build ./... is green.
+
+## Evidence Index
+- test: go test ./... (42/42)
+
+## Requirement Coverage
+REQ-001 -> t-01; REQ-002 -> t-02.
+
+## Residual Risks and Exceptions
+None; the change is behind the standard/strict gate only.
+
+## Rollback Readiness
+Single commit; git revert restores prior behavior.
+
+## Archive Decision
+Archived after a fresh validate --json freshness proof was captured before done.`
+
+	blockers := AssuranceStructureBlockers(content)
+	assert.Equal(t, []string{"assurance_section_placeholder:## Scope Summary"}, blockers)
+}
+
+// TestAssuranceStructureBlockersRejectsArchiveDecisionSeedSentence covers the
+// legacy one-sentence Archive Decision scaffold from issue #47. The current
+// template has grown additional guidance, but retaining only the original seed
+// sentence is still placeholder content.
+func TestAssuranceStructureBlockersRejectsArchiveDecisionSeedSentence(t *testing.T) {
+	t.Parallel()
+
+	content := `## Scope Summary
+Added a template-derived placeholder floor to assurance validation.
+
+## Verification Verdict
+go test ./... passes (full suite green).
+
+## Evidence Index
+- test: go test ./...
+
+## Requirement Coverage
+REQ-001..006 each mapped to t-01..t-05.
+
+## Residual Risks and Exceptions
+None beyond the documented light-preset exclusion.
+
+## Rollback Readiness
+Revert the single feature commit.
+
+## Archive Decision
+Record archive readiness decision.`
+
+	assert.Equal(t,
+		[]string{"assurance_section_placeholder:## Archive Decision"},
+		AssuranceStructureBlockers(content),
+	)
+}
+
+// TestAssuranceStructureBlockersAuthoredPasses covers the fully-authored case.
+func TestAssuranceStructureBlockersAuthoredPasses(t *testing.T) {
+	t.Parallel()
+
+	content := `## Scope Summary
+Added a template-derived placeholder floor to assurance validation.
+
+## Verification Verdict
+go test ./... passes (full suite green).
+
+## Evidence Index
+- test: go test ./...
+
+## Requirement Coverage
+REQ-001..006 each mapped to t-01..t-05.
+
+## Residual Risks and Exceptions
+None beyond the documented light-preset exclusion.
+
+## Rollback Readiness
+Revert the single feature commit.
+
+## Archive Decision
+Ready to archive; validate --json freshness proof captured before done.`
+
+	assert.Empty(t, AssuranceStructureBlockers(content))
+}
+
+// TestAssuranceSectionScaffoldDerivesFromTemplate is the template-drift safety
+// check: the detector's per-section scaffold MUST equal the embedded template's
+// section bodies, so detection follows the template instead of a hand-maintained
+// phrase list.
+func TestAssuranceSectionScaffoldDerivesFromTemplate(t *testing.T) {
+	t.Parallel()
+
+	scaffold := assuranceSectionScaffold()
+	require.NotEmpty(t, scaffold)
+
+	tmplContent, err := TemplateContent("assurance.md")
+	require.NoError(t, err)
+
+	for _, heading := range requiredSectionsForArtifact("assurance.md") {
+		body := normalizeAssuranceBody(strings.Join(markdownSectionLines(tmplContent, heading), "\n"))
+		require.NotEmpty(t, body, "template section %q must have scaffold body", heading)
+		assert.Equal(t, body, scaffold[heading],
+			"detector scaffold for %q must be derived from the template", heading)
+	}
+}
+
 func TestScaffoldGovernedBundleSeedsRequirementsDraft(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()

--- a/internal/engine/progression/advance_governed.go
+++ b/internal/engine/progression/advance_governed.go
@@ -130,7 +130,7 @@ func AdvanceGoverned(root, slug string, opts ...AdvanceOptions) (summary Advance
 
 	// 4. Skill evidence evaluation
 	nextSkillName, evidenceState := ResolveNextSkill(change)
-	closeoutRequired := presetPolicy.CloseoutRefreshRequired
+	closeoutRequired := FinalCloseoutEvidenceRequired(presetPolicy)
 
 	var passingSkills map[string]model.VerificationRecord
 	// worktree-preflight is not a governance skill; its gate is checked in

--- a/internal/engine/progression/authority.go
+++ b/internal/engine/progression/authority.go
@@ -56,6 +56,12 @@ func loadRuntimeGovernanceInputs(root string, change model.Change) (runtimeGover
 	}, nil
 }
 
+// FinalCloseoutEvidenceRequired returns whether final-closeout is required as
+// S4 governance evidence for the resolved policy.
+func FinalCloseoutEvidenceRequired(policy governance.PresetPolicy) bool {
+	return policy.CloseoutRefreshRequired || policy.EffectivePreset != model.WorkflowPresetLight
+}
+
 func EvaluateReviewAuthority(root string, change model.Change) (ReviewAuthority, error) {
 	policy, err := governance.ResolvePresetPolicy(root, change)
 	if err != nil {
@@ -133,7 +139,18 @@ func buildShipAuthorityFromReadiness(root string, change model.Change, readiness
 		}
 	}
 	verifyPassingSkills := cloneVerificationRecords(readiness.PassingSkills)
+	// Assurance attestation is required on every standard/strict effective preset,
+	// matching the Layer 2 floor (AssuranceContractBlockers
+	// and the done gate) — NOT CloseoutRefreshRequired. The latter also trips for
+	// light + quality_mode=full, where assurance.md is optional and the closeout
+	// template instructs light to omit the reference; gating on it would block a
+	// valid light/full closeout and, conversely, miss a plain standard closeout
+	// (CloseoutRefreshRequired is false there). EffectivePreset keeps both layers
+	// consistent.
+	assuranceRequired := inputs.Policy.EffectivePreset != model.WorkflowPresetLight
+	attestationBlockers := closeoutAssuranceAttestationBlockers(verifyPassingSkills, assuranceRequired)
 	verifySkillBlockers := append([]model.ReasonCode(nil), readiness.SkillBlockers...)
+	verifySkillBlockers = append(verifySkillBlockers, attestationBlockers...)
 
 	manifestOK, manifestBlockers := ValidateChangeYamlR0(
 		filepath.Join(inputs.Paths.GovernedBundleDir, "change.yaml"),
@@ -142,13 +159,19 @@ func buildShipAuthorityFromReadiness(root string, change model.Change, readiness
 	artifactReady := readiness.ArtifactReadiness.Ready
 	verificationReady := len(verifySkillBlockers) == 0 &&
 		len(reviewAuthority.Blockers) == 0 &&
-		ComputeVerificationReadiness(verifyPassingSkills, inputs.Policy.CloseoutRefreshRequired)
+		ComputeVerificationReadiness(verifyPassingSkills, FinalCloseoutEvidenceRequired(inputs.Policy))
 	requiredActions := cloneRequiredActions(readiness.RequiredActions)
 	requiredActionBlockers := model.ReasonCodesFromSpecs(governance.RequiredActionBlockers(change, requiredActions))
 	highRiskChecks := ExtractHighRiskChecks(verifyPassingSkills)
 
 	unresolved := append([]model.ReasonCode{}, readiness.Blockers...)
 	unresolved = append(unresolved, model.ReasonCodesFromSpecs(manifestBlockers)...)
+	// Surface the attestation blocker as an actionable G_ship reason — the same
+	// channel the Layer 2 placeholder blocker travels (readiness.Blockers). Left
+	// only in verifySkillBlockers it would flip verificationReady but EvaluateGShip
+	// would emit only the generic verification_evidence_missing, hiding the
+	// specific, actionable closeout_assurance_attestation_missing code.
+	unresolved = append(unresolved, attestationBlockers...)
 	unresolved = model.NormalizeReasonCodes(unresolved)
 
 	return ShipAuthority{
@@ -172,6 +195,43 @@ func buildShipAuthorityFromReadiness(root string, change model.Change, readiness
 			highRiskChecks,
 		),
 	}, nil
+}
+
+// assuranceCompleteReference is the AI-driven closeout attestation: the host's
+// structured judgment, recorded in the final-closeout verification record, that
+// every required assurance section is genuinely authored rather than scaffold.
+const assuranceCompleteReference = "closeout:assurance_complete=pass"
+
+// closeoutAssuranceAttestationBlockers enforces Layer 1 of issue #47. When
+// assurance is required for the change's effective preset (standard/strict),
+// the passing final-closeout record must carry the assurance-complete
+// attestation. The kernel does not re-read assurance prose here; it only
+// requires the AI's attestation to be present, so a closeout cannot reach ship
+// without the host explicitly vouching for the assurance content. Missing
+// standard/strict final-closeout evidence is the same attestation failure as a
+// passing-but-unattested record. Light preset (assurance optional) is
+// unaffected.
+func closeoutAssuranceAttestationBlockers(passingSkills map[string]model.VerificationRecord, assuranceRequired bool) []model.ReasonCode {
+	if !assuranceRequired {
+		return nil
+	}
+	record, ok := passingSkills[SkillFinalCloseout]
+	if !ok {
+		return []model.ReasonCode{closeoutAssuranceAttestationMissingBlocker()}
+	}
+	for _, ref := range record.References {
+		if strings.TrimSpace(ref) == assuranceCompleteReference {
+			return nil
+		}
+	}
+	return []model.ReasonCode{closeoutAssuranceAttestationMissingBlocker()}
+}
+
+func closeoutAssuranceAttestationMissingBlocker() model.ReasonCode {
+	return model.NewReasonCode(
+		"closeout_assurance_attestation_missing",
+		"final-closeout must record "+assuranceCompleteReference+" on standard/strict",
+	)
 }
 
 func EvaluateReviewLayerBlockersFromNamedEvidence(

--- a/internal/engine/progression/authority_test.go
+++ b/internal/engine/progression/authority_test.go
@@ -1,0 +1,195 @@
+package progression
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/signalridge/slipway/internal/bootstrap"
+	"github.com/signalridge/slipway/internal/engine/governance"
+	"github.com/signalridge/slipway/internal/model"
+	"github.com/signalridge/slipway/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCloseoutAssuranceAttestationBlockers covers Layer 1 of issue #47: under
+// standard/strict the passing final-closeout record must carry the
+// assurance-complete attestation, and its absence is a fail-closed blocker.
+func TestCloseoutAssuranceAttestationBlockers(t *testing.T) {
+	t.Parallel()
+
+	// Standard/strict, passing closeout record but attestation missing -> blocker.
+	missing := map[string]model.VerificationRecord{
+		SkillFinalCloseout: {
+			Verdict:    model.VerificationVerdictPass,
+			References: []string{"closeout:test_suite=pass:5/5"},
+		},
+	}
+	blockers := closeoutAssuranceAttestationBlockers(missing, true)
+	require.Len(t, blockers, 1)
+	assert.Equal(t, "closeout_assurance_attestation_missing", blockers[0].Code)
+
+	// Attestation present -> no blocker.
+	present := map[string]model.VerificationRecord{
+		SkillFinalCloseout: {
+			Verdict:    model.VerificationVerdictPass,
+			References: []string{"closeout:test_suite=pass:5/5", "closeout:assurance_complete=pass"},
+		},
+	}
+	assert.Empty(t, closeoutAssuranceAttestationBlockers(present, true))
+
+	// Assurance optional (assuranceRequired=false, i.e. light preset) never
+	// enforces the attestation.
+	assert.Empty(t, closeoutAssuranceAttestationBlockers(missing, false))
+
+	// No final-closeout record at all -> same fail-closed blocker. Plain
+	// standard does not require final-closeout through ComputeVerificationReadiness,
+	// so this Layer 1 check owns the missing-record path.
+	blockers = closeoutAssuranceAttestationBlockers(map[string]model.VerificationRecord{}, true)
+	require.Len(t, blockers, 1)
+	assert.Equal(t, "closeout_assurance_attestation_missing", blockers[0].Code)
+
+	// Surrounding whitespace on the reference is tolerated.
+	padded := map[string]model.VerificationRecord{
+		SkillFinalCloseout: {
+			Verdict:    model.VerificationVerdictPass,
+			References: []string{"  closeout:assurance_complete=pass  "},
+		},
+	}
+	assert.Empty(t, closeoutAssuranceAttestationBlockers(padded, true))
+}
+
+// TestBuildShipAuthorityAttestationPresetGating guards the two ship-authority
+// contract bugs in the Layer 1 wiring:
+//  1. The attestation must be gated on the effective preset (required on every
+//     standard/strict preset), NOT on CloseoutRefreshRequired — which also trips for
+//     light + quality_mode=full (false positive) and is false for a plain
+//     standard change (false negative).
+//  2. When the attestation is missing, the specific, actionable
+//     closeout_assurance_attestation_missing code must surface in the G_ship
+//     reasons, not collapse into the generic verification_evidence_missing.
+func TestBuildShipAuthorityAttestationPresetGating(t *testing.T) {
+	t.Parallel()
+
+	const attestationMissing = "closeout_assurance_attestation_missing"
+	hasCode := func(codes []model.ReasonCode) bool {
+		return slices.ContainsFunc(codes, func(c model.ReasonCode) bool {
+			return c.Code == attestationMissing
+		})
+	}
+	passingGoalVerificationOnly := func() map[string]model.VerificationRecord {
+		return map[string]model.VerificationRecord{
+			SkillGoalVerification: {
+				Verdict: model.VerificationVerdictPass,
+			},
+		}
+	}
+	// Passing goal-verification plus a passing final-closeout record that omits
+	// the assurance attestation.
+	passingGoalAndCloseoutNoAttestation := func() map[string]model.VerificationRecord {
+		passing := passingGoalVerificationOnly()
+		passing[SkillFinalCloseout] = model.VerificationRecord{
+			Verdict:    model.VerificationVerdictPass,
+			References: []string{"closeout:test_suite=pass:5/5"},
+		}
+		return passing
+	}
+
+	// Plain standard preset (no quality_mode=full, so CloseoutRefreshRequired is
+	// false). Final-closeout is still required for standard ship evidence, and
+	// the missing record must produce the Layer 1 blocker rather than only a
+	// generic verification failure.
+	t.Run("standard requires the attestation even without a closeout record", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		initGitWorkspaceForReadinessOptimizationTests(t, root)
+		require.NoError(t, bootstrap.InitWorkspace(root, nil, false))
+
+		change := model.NewChange("ship-standard-missing-closeout")
+		change.WorkflowPreset = model.WorkflowPresetStandard
+		change.CurrentState = model.StateS4Verify
+		require.NoError(t, state.SaveChange(root, change))
+
+		policy, err := governance.ResolvePresetPolicy(root, change)
+		require.NoError(t, err)
+		require.Equal(t, model.WorkflowPresetStandard, policy.EffectivePreset)
+		require.False(t, policy.CloseoutRefreshRequired,
+			"plain standard must NOT set CloseoutRefreshRequired — standard assurance is a separate final-closeout requirement")
+
+		ship, err := buildShipAuthorityFromReadiness(root, change, GovernanceReadiness{
+			ArtifactReadiness: ArtifactReadiness{Ready: true},
+			PassingSkills:     passingGoalVerificationOnly(),
+			ReviewSurface:     &ReviewAuthority{},
+		})
+		require.NoError(t, err)
+		assert.True(t, hasCode(ship.VerifySkillBlockers),
+			"standard missing final-closeout must block as a missing assurance attestation")
+		assert.True(t, hasCode(ship.Result.ReasonCodes),
+			"the actionable blocker must surface in the G_ship reasons")
+	})
+
+	// Plain standard preset (no quality_mode=full, so CloseoutRefreshRequired is
+	// false). Assurance is still required on every standard/strict preset, so the
+	// attestation is required and the specific blocker must reach Result.ReasonCodes.
+	t.Run("standard requires and surfaces the attestation blocker", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		initGitWorkspaceForReadinessOptimizationTests(t, root)
+		require.NoError(t, bootstrap.InitWorkspace(root, nil, false))
+
+		change := model.NewChange("ship-standard-missing-attestation")
+		change.WorkflowPreset = model.WorkflowPresetStandard
+		change.CurrentState = model.StateS4Verify
+		require.NoError(t, state.SaveChange(root, change))
+
+		policy, err := governance.ResolvePresetPolicy(root, change)
+		require.NoError(t, err)
+		require.Equal(t, model.WorkflowPresetStandard, policy.EffectivePreset)
+		require.False(t, policy.CloseoutRefreshRequired,
+			"plain standard must NOT set CloseoutRefreshRequired — the old gate would have skipped enforcement here")
+
+		ship, err := buildShipAuthorityFromReadiness(root, change, GovernanceReadiness{
+			ArtifactReadiness: ArtifactReadiness{Ready: true},
+			PassingSkills:     passingGoalAndCloseoutNoAttestation(),
+			ReviewSurface:     &ReviewAuthority{},
+		})
+		require.NoError(t, err)
+		assert.True(t, hasCode(ship.VerifySkillBlockers),
+			"standard closeout missing the attestation must block verification")
+		assert.True(t, hasCode(ship.Result.ReasonCodes),
+			"the actionable blocker must surface in the G_ship reasons, not only as a side field")
+	})
+
+	// Light preset under quality_mode=full sets CloseoutRefreshRequired=true, but
+	// assurance.md stays optional for light, so the attestation must NOT be
+	// required — gating is on the effective preset, not closeout refresh.
+	t.Run("light + quality_mode=full does not require the attestation", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		initGitWorkspaceForReadinessOptimizationTests(t, root)
+		require.NoError(t, bootstrap.InitWorkspace(root, nil, false))
+
+		change := model.NewChange("ship-light-full-no-attestation")
+		change.WorkflowPreset = model.WorkflowPresetLight
+		change.QualityMode = model.QualityModeFull
+		change.CurrentState = model.StateS4Verify
+		require.NoError(t, state.SaveChange(root, change))
+
+		policy, err := governance.ResolvePresetPolicy(root, change)
+		require.NoError(t, err)
+		require.Equal(t, model.WorkflowPresetLight, policy.EffectivePreset)
+		require.True(t, policy.CloseoutRefreshRequired,
+			"light + full must set CloseoutRefreshRequired — the exact case the old gate mis-blocked")
+
+		ship, err := buildShipAuthorityFromReadiness(root, change, GovernanceReadiness{
+			ArtifactReadiness: ArtifactReadiness{Ready: true},
+			PassingSkills:     passingGoalAndCloseoutNoAttestation(),
+			ReviewSurface:     &ReviewAuthority{},
+		})
+		require.NoError(t, err)
+		assert.False(t, hasCode(ship.VerifySkillBlockers),
+			"light keeps assurance optional; no attestation blocker")
+		assert.False(t, hasCode(ship.Result.ReasonCodes),
+			"light keeps assurance optional; no attestation reason in G_ship")
+	})
+}

--- a/internal/engine/progression/readiness.go
+++ b/internal/engine/progression/readiness.go
@@ -210,7 +210,7 @@ func evaluateGovernanceReadinessBaseWithReaders(
 		evaluationChange,
 		effectiveState,
 		execCtx.LatestRunVersion,
-		policy.CloseoutRefreshRequired,
+		FinalCloseoutEvidenceRequired(policy),
 		planningSubSteps...,
 	)
 	if err != nil {

--- a/internal/engine/progression/validation.go
+++ b/internal/engine/progression/validation.go
@@ -467,10 +467,12 @@ func GovernedBundleBlockers(root string, change model.Change) []string {
 }
 
 // AssuranceContractBlockers validates the assurance.md body-first contract:
-// all required headings present, in order, with non-empty content.
-// Returns nil when the assurance artifact has not been authored yet (file
-// missing or at template-only state during early planning).
-// Enforcement begins at S3_REVIEW and later.
+// all required headings present, in order, with non-empty content, and — via
+// the shared artifact.AssuranceStructureBlockers floor — not still template
+// scaffold (issue #47). Returns nil before enforcement begins: light effective
+// preset (assurance optional), or states earlier than S3_REVIEW. Once enforcing
+// at S3_REVIEW and later, a missing file yields assurance_contract_missing and a
+// template-only/scaffold body is rejected per-section rather than passing.
 func AssuranceContractBlockers(root string, change model.Change) []string {
 	// Light effective preset: assurance.md is optional.
 	// Uses EffectivePreset so min_preset and guardrail-domain upgrades are respected.

--- a/internal/tmpl/templates/skills/final-closeout/SKILL.md.tmpl
+++ b/internal/tmpl/templates/skills/final-closeout/SKILL.md.tmpl
@@ -65,7 +65,19 @@ On light preset, skip this section — `assurance.md` is optional.
 - archive decision with rationale, including that active `validate --json`
   proof was captured before `done`
 
-If any required section is empty or missing, closeout is blocked.
+Judge each required section semantically, not structurally. For every section,
+decide whether the body is genuine, change-specific closeout content or merely
+the generated scaffold sentence — including the case where the seeded sentence
+was lightly reworded or padded but still says nothing concrete. A section that
+is structurally non-empty but semantically blank does NOT count as authored.
+
+If any required section is empty, missing, or still scaffold/boilerplate, closeout is blocked.
+
+Record the per-section judgment as evidence in the closeout references, one line
+per section you affirm as authored, e.g.
+`closeout:assurance_section:scope_summary=authored`. These per-section lines are
+your shown work; the aggregate `closeout:assurance_complete=pass` below is the
+required attestation the ship gate enforces on standard/strict.
 
 ## Write Verification
 Closeout must be performed independently from implementation.
@@ -81,11 +93,16 @@ references:
   - "closeout:test_suite=pass:N/N"
   - "closeout:reviewer_independence=pass"
   - "closeout:guardrail_baseline=pass"
+  - "closeout:assurance_complete=pass"   # REQUIRED on standard/strict; omit on light
 notes: |
   <verification notes>
 ```
 
-On standard/strict preset, also add `closeout:assurance_complete=pass`.
+On standard/strict preset, `closeout:assurance_complete=pass` is REQUIRED: the
+ship gate blocks with `closeout_assurance_attestation_missing` if the passing
+final-closeout record omits it. Add it only after you have judged every required
+assurance section as genuinely authored (see Assurance Artifact Verification).
+On light preset, omit it — assurance is optional there.
 
 ## Present and Advance
 Show closeout summary with verification index. {{template "hard-gate"}}

--- a/internal/tmpl/templates_test.go
+++ b/internal/tmpl/templates_test.go
@@ -78,7 +78,7 @@ func TestPlanAuditTemplateDoesNotReintroduceLightPresetVerificationBlocker(t *te
 	assert.NotContains(t, content, "Every task needs explicit per-task verification fields before execution begins.")
 }
 
-func TestFinalCloseoutTemplateKeepsAssuranceReferenceConditional(t *testing.T) {
+func TestFinalCloseoutTemplateRequiresAssuranceAttestationOnStandardStrict(t *testing.T) {
 	t.Parallel()
 
 	content, err := Render("skills/final-closeout/SKILL.md.tmpl", map[string]string{
@@ -88,8 +88,13 @@ func TestFinalCloseoutTemplateKeepsAssuranceReferenceConditional(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	assert.Contains(t, content, "On standard/strict preset, also add `closeout:assurance_complete=pass`.")
-	assert.NotContains(t, content, "\n  - \"closeout:assurance_complete=pass\"\n")
+	// The attestation is now part of the closeout references list and is
+	// described as required on standard/strict — the ship gate enforces it via
+	// closeout_assurance_attestation_missing. Light preset still omits it.
+	assert.Contains(t, content, `- "closeout:assurance_complete=pass"`)
+	assert.Contains(t, content, "`closeout:assurance_complete=pass` is REQUIRED")
+	assert.Contains(t, content, "closeout_assurance_attestation_missing")
+	assert.Contains(t, content, "On light preset, omit it")
 }
 
 func TestCoreGovernanceSkillsUseWorkflowOutlineInsteadOfGraphviz(t *testing.T) {


### PR DESCRIPTION
## Summary
- reject template/scaffold assurance sections through the shared AssuranceStructureBlockers path
- require standard/strict final-closeout attestation and share the closeout-required predicate with next diagnostics skill_evidence
- update final-closeout host guidance and regression coverage

## Verification
- go build ./...
- go test ./cmd -run TestNextDiagnosticsSkillEvidenceUsesStandardCloseoutRequirement -count=1
- go test -count=1 ./...
- git diff --check origin/main...HEAD
- /tmp/slipway-issue47-pr validate --json
- /tmp/slipway-issue47-pr next --json --diagnostics
- /tmp/slipway-issue47-pr done --json

Closes #47