### PR TITLE
fix(new): scope active change create guard

### DIFF
--- a/artifacts/changes/archived/fix-slipway-new-create-guard-scoping-for-issues-48-and-50/assurance.md
+++ b/artifacts/changes/archived/fix-slipway-new-create-guard-scoping-for-issues-48-and-50/assurance.md
@@ -1,0 +1,118 @@
+# Assurance
+
+## Project Context
+- Tech Stack: Go CLI
+- Conventions: command-level behavior in `cmd/`; state/worktree authority in
+  `internal/state`; governed verification artifacts under this change bundle
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Scope Summary
+GitHub issue #48 and issue #50 were both confirmed against the live code and
+fixed in the `slipway new` create guard. The guard no longer serializes every
+active change repo-wide; it rejects only when an existing active change owns the
+current invocation scope workspace or the prospective target workspace for the
+new change.
+
+The implementation is intentionally narrow:
+- `cmd/new.go` now constructs the prospective `model.Change` before the create
+  guard runs, so the guard can inspect the resolved slug and `NeedsDiscovery`.
+- `cmd/common.go` computes invocation-scope and prospective-target workspace
+  authority before rejecting.
+- `cmd/new_test.go` covers #48, #50, preserved unbound same-workspace rejection,
+  preserved bound-current-worktree rejection, and slug namespace corruption
+  diagnostics after the guard reorder.
+
+No storage migration, new command surface, external API change, dependency
+change, or #46-style bind/park workflow was added.
+
+## Verification Verdict
+Pass. Fresh verification after the final implementation change produced:
+- `go test ./cmd -run 'TestNewCommand(RejectsWhenActiveChangeAlreadyExists|AllowsDiscoveryChangeWhenUnboundIntakeChangeOwnsRoot|AllowsBoundSiblingWorktreeActiveChange|RejectsWhenActiveChangeIsBoundToCurrentWorktree|FailsClosedWhenSlugNamespaceIsCorrupt)' -count=1`: pass.
+- `go test -count=1 ./cmd`: pass.
+- `go test -count=1 ./...`: pass for all packages.
+- `go build ./...`: pass.
+- `git diff --check`: pass.
+- `go test -count=1 -coverprofile=/tmp/slipway-issue48-50-cmd.cover ./cmd`: pass, 80.2% statement coverage for `cmd`.
+- `go run . validate --json`: active-change evidence freshness `fresh`,
+  `skills_ready.goal-verification=pass`, `scope_contract.status=pass`, and only
+  final-closeout/attestation blockers remaining before this final closeout.
+
+The stub/placeholder scan found only ordinary helper returns in existing code
+paths, not TODOs, placeholder bodies, empty implementation blocks, or hardcoded
+production responses.
+
+## Evidence Index
+- `requirements.md`: five requirements covering #48, #50, collision semantics,
+  prospective workspace targeting, and lifecycle evidence.
+- `decision.md`: selected scoped workspace-collision guard approach.
+- `tasks.md`: five completed execution tasks.
+- `verification/execution-summary.yaml`: run version 1 with all five tasks
+  passing and fresh runtime task evidence.
+- `verification/wave-orchestration.yaml`: wave execution evidence.
+- `verification/spec-compliance-review.yaml`: spec-to-code and code-to-spec
+  trace.
+- `verification/code-quality-review.yaml`: review evidence for localized
+  implementation, safety, and test quality.
+- `verification/goal-verification.yaml`: AC-level Exists/Substantive/Wired
+  proof for both issues and preserved negative paths.
+- `cmd/common.go`, `cmd/new.go`, `cmd/new_test.go`: implementation and
+  regression coverage.
+- `artifacts/codebase/`: refreshed source-backed repository context used during
+  planning and review.
+
+## Requirement Coverage
+- REQ-001: Covered by
+  `TestNewCommandAllowsDiscoveryChangeWhenUnboundIntakeChangeOwnsRoot`; an
+  unbound intake-stage root-owned change no longer blocks a discovery follow-up
+  that targets a default worktree.
+- REQ-002: Covered by `TestNewCommandRejectsWhenActiveChangeAlreadyExists`; a
+  root-owned unbound follow-up collision still fails closed with
+  `active_change_exists` and does not suggest `slipway next`.
+- REQ-003: Covered by `TestNewCommandAllowsBoundSiblingWorktreeActiveChange`;
+  a hidden active sibling worktree authority does not block a root-scoped new
+  discovery change with a different target workspace.
+- REQ-004: Covered by `cmd/new.go` guard reorder,
+  `createGuardInvocationWorkspaceRoot`, `newChangeTargetWorkspaceRoot`, and
+  `TestNewCommandRejectsWhenActiveChangeIsBoundToCurrentWorktree`; current and
+  prospective workspace authority are the collision boundaries.
+- REQ-005: Covered by fresh targeted tests, full suite, build, diff check,
+  command coverage, scope validation, and this governed closeout bundle.
+
+## Residual Risks and Exceptions
+- `targetWorkspaceCreateConflict` remains a defensive branch for an already
+  owned prospective target workspace. The normal slug generation path makes
+  that collision uncommon; the branch is retained so future custom target or
+  slug-collision behavior fails closed instead of allowing double ownership.
+- An unbound active change still resolves to the invocation root supplied to
+  `WorkspaceRootForChange`. A non-discovery `slipway new` from another
+  worktree can therefore still fail closed against an unbound root-owned
+  change, with wording that may describe the current workspace imprecisely. This
+  preserves the old blocking behavior and is outside the #48/#50 scope because
+  the fixed paths are root-owned unbound intake plus discovery follow-up and
+  bound sibling worktree isolation.
+- `go run . repair --json` was tried while refreshing evidence and failed on an
+  unrelated legacy `worktree_path` YAML field encountered by broad repair
+  scanning. The governed change did not require repair after
+  `execution-summary.yaml` was refreshed from runtime task evidence; subsequent
+  `status --json` and `validate --json` reported evidence freshness as `fresh`.
+
+No guardrail domain is active for this change, and no sensitive data,
+credentials, destructive operations, schema migrations, or external contracts
+were modified.
+
+## Rollback Readiness
+Rollback is local and low-risk: revert `cmd/common.go`, `cmd/new.go`, and
+`cmd/new_test.go`, then rerun the targeted command regression set plus
+`go test -count=1 ./...` and `go build ./...`. There is no data migration or
+persisted user-state migration to unwind. Governed artifacts can be archived or
+dropped with the branch if the code rollback is selected.
+
+## Archive Decision
+Archive-ready after final-closeout evidence is recorded and the active
+`validate --json` gate is rerun before `slipway done`. The current pre-closeout
+active validation already proves fresh execution evidence, passing
+goal-verification, valid requirements, and a passing scope contract; the only
+remaining blockers are the expected standard-preset final-closeout attestation
+requirements.

--- a/artifacts/changes/archived/fix-slipway-new-create-guard-scoping-for-issues-48-and-50/change.yaml
+++ b/artifacts/changes/archived/fix-slipway-new-create-guard-scoping-for-issues-48-and-50/change.yaml
@@ -1,0 +1,56 @@
+version: 1
+slug: fix-slipway-new-create-guard-scoping-for-issues-48-and-50
+description: 'Fix slipway new create guard scoping for issues #48 and #50'
+status: done
+current_state: DONE
+needs_discovery: true
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-06-01T15:05:41.412933Z
+quality_mode: standard
+workflow_preset: standard
+worktree_branch: feat/fix-slipway-new-create-guard-scoping-for-issues-48-and-50
+artifact_schema: expanded
+project_context:
+    test_cmd: go test ./...
+    build_cmd: go build ./...
+    languages:
+        - Go
+    recent_work: 'Address GitHub issues #48 and #50 about slipway new active-change guard and worktree scoping.'
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: 16933b9d9bcecd96b5176b13beac020653a254caf9c47d9ba702e16a9eee24a8
+        updated_at: 2026-06-01T15:53:55.776833586Z
+    decision:
+        id: decision
+        path: decision.md
+        state: frozen
+        content_hash: 31983de4524727c25283e3e1fda9880be43317d0e7eab0f374150ab96e16fdec
+        updated_at: 2026-06-01T15:17:39.888057081Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: 025d7d7e9112e12605b0c8e9ef2db9acf936063c91946a61990debf69cc7199a
+        updated_at: 2026-06-01T15:08:08.316104028Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: 26ee12b3792ad2ca90c1ec034cf949c2fa0d44cb8d87612418f221a56bf66048
+        updated_at: 2026-06-01T15:17:08.244352085Z
+    research:
+        id: research
+        path: research.md
+        state: frozen
+        content_hash: 29665e5afa3ff51ffdf36ebd4bd31afc5a4cb2674926a19032a1b1f20020ab39
+        updated_at: 2026-06-01T15:15:29.942697363Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: 1ffe7d2ed453836ad4732fb88e50e72e5a2feafca366870c944cd0de19ea5242
+        updated_at: 2026-06-01T15:23:19.996612706Z

--- a/artifacts/changes/archived/fix-slipway-new-create-guard-scoping-for-issues-48-and-50/decision.md
+++ b/artifacts/changes/archived/fix-slipway-new-create-guard-scoping-for-issues-48-and-50/decision.md
@@ -1,0 +1,78 @@
+# Decision
+
+## Project Context
+- Tech Stack: Go CLI
+- Conventions: minimal command-layer changes, source-backed worktree authority,
+  and command-level regression tests for user-visible behavior
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Alternatives Considered
+
+### Alternative 1: Only correct the unbound remediation text
+- Tradeoff: Low implementation risk and fixes the most misleading #48 message.
+- Rejected because it leaves #48's non-destructive unblock problem and #50's
+  bound sibling-worktree block intact.
+
+### Alternative 2: Add an explicit bind/park command for intake-stage changes
+- Tradeoff: Gives operators a direct escape hatch for unbound intake changes.
+- Rejected for this change because it adds a new public command surface and does
+  not address #50's bound-worktree global guard without additional guard work.
+
+### Alternative 3: Scope create-guard rejection to workspace collisions
+- Tradeoff: Requires moving the guard after slug/change construction so the
+  prospective target workspace can be known before `EnsureDefaultWorktreeForChange`.
+- Selected because it fixes both confirmed issue scenarios, preserves hidden
+  active-change discovery for fail-closed diagnostics, and keeps the code change
+  local to `cmd/new.go` and `cmd/common.go`.
+
+## Selected Approach
+
+Use Alternative 3. `slipway new` will construct the prospective change first,
+then call `rejectIfConflictingChange(root, change)`. The guard will still load
+active changes through `state.ListChangesForCreateGuard`, but it will reject
+only when an active change owns the current bound worktree or the new change's
+prospective target workspace.
+
+For a discovery change with a valid git `HEAD`, the prospective target is
+`state.DefaultWorktreePath(repoRoot, slug)`, matching the early-bind path. For a
+non-discovery, non-git, or unborn-HEAD change, the target remains the current
+workspace. Same-workspace unbound conflicts continue to return
+`active_change_exists`, with remediation that tells the operator to finish or
+cancel rather than running `slipway next`.
+
+## Interfaces and Data Flow
+
+- `cmd/new.go`: reorder create flow so slug/change construction happens before
+  conflict checking; no persisted state is written before the guard passes.
+- `cmd/common.go`: change `rejectIfConflictingChange` to accept the prospective
+  `model.Change`, compute the new target workspace, compare it with active
+  changes, and produce scoped error messages.
+- `internal/state/*`: no storage or discovery API changes. The guard continues
+  to consume `ListChangesForCreateGuard`, `WorkspaceRootForChange`,
+  `ResolveGitWorkspaceRoot`, and `DefaultWorktreePath`.
+- Tests: add command-level regressions for #48 and #50, and update the existing
+  active-change rejection test to preserve same-workspace fail-closed behavior.
+
+## Rollout and Rollback
+
+Rollout is a normal code change through the governed Slipway lifecycle. Verify
+with the targeted command test, then `go test -count=1 ./...`, `go build ./...`,
+and Slipway validation/closeout.
+
+Rollback is straightforward: revert the changes in `cmd/common.go`,
+`cmd/new.go`, and `cmd/new_test.go`, then rerun the same targeted and full test
+commands. No data migration or runtime state rewrite is required.
+
+## Risk
+
+- Medium: target workspace calculation could drift from
+  `EnsureDefaultWorktreeForChange`. Mitigation: the guard mirrors the same
+  discovery/HEAD/default-worktree conditions and tests assert the created change
+  binds to a separate worktree.
+- Low: permitting parallel governed changes could weaken true collision
+  protection. Mitigation: same-workspace unbound rejection remains covered, and
+  bound current-worktree rejection remains fail-closed.
+- Low: remediation text could regress. Mitigation: command test asserts the
+  unbound same-workspace conflict no longer references `slipway next`.

--- a/artifacts/changes/archived/fix-slipway-new-create-guard-scoping-for-issues-48-and-50/intent.md
+++ b/artifacts/changes/archived/fix-slipway-new-create-guard-scoping-for-issues-48-and-50/intent.md
@@ -1,0 +1,84 @@
+# Intent
+
+## Project Context
+<!-- Auto-filled by InferProjectContext(); .slipway.yaml overrides -->
+- Tech Stack:
+- Languages: Go
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Conventions:
+
+## Summary
+Fix `slipway new` create-guard behavior for GitHub issues #48 and #50 after
+confirming each reported problem against the live code and targeted
+reproductions.
+## Complexity Assessment
+complex
+Rationale: the change touches governed lifecycle creation, worktree authority,
+and cross-worktree active-change discovery. Regressions could block normal
+governed work or accidentally allow true same-workspace collisions, so the fix
+needs issue-specific reproduction coverage plus full workflow verification.
+
+## Guardrail Domains
+<!-- none detected -->
+
+## In Scope
+- Confirm #48: an unbound intake-stage active change can make `slipway new`
+  fail globally and the current remediation can point to a non-unblocking path.
+- Confirm #50: a bound active change in a sibling dedicated worktree can make
+  `slipway new` fail from the repo root or another worktree even when normal
+  reads are worktree-scoped.
+- Fix the create guard and related user-facing diagnostics/remediation so
+  unrelated worktree-scoped governed changes can be started while preserving
+  same-workspace collision protection.
+- Add regression tests covering the confirmed #48 and #50 scenarios and any
+  changed diagnostic/remediation contract.
+- Update governed artifacts and verification evidence required by the Slipway
+  lifecycle for this change.
+
+## Out of Scope
+- Reworking the full runtime active-change storage model proposed by #46 unless
+  live code inspection proves it is strictly required for #48/#50.
+- Implementing a new long-lived `worktree bind`, `park`, or global scheduler
+  command unless the existing guard cannot be corrected safely without it.
+- Changing non-governed `wt-*` worktree behavior or unrelated issue scopes such
+  as #44/#46/#47 except as reproduction context.
+- Weakening protections that prevent two active governed changes from sharing
+  the same workspace authority.
+
+## Constraints
+- Follow the Slipway governed lifecycle in the generated worktree.
+- Treat GitHub issue bodies and current worktree code as authoritative; do not
+  rely on stale memory for the bug classification.
+- Keep edits minimal and aligned with existing lifecycle/state-store patterns.
+- Prefer repo-native Go tests and fresh `go test -count=1 ./...` verification
+  before closeout.
+
+## Acceptance Signals
+- A targeted test reproduces and then passes for #48's unbound intake-stage
+  create-guard behavior.
+- A targeted test reproduces and then passes for #50's bound sibling-worktree
+  create-guard behavior.
+- Existing same-workspace active-change collision tests still pass or are
+  updated to the intended contract.
+- `go test -count=1 ./...` and Slipway validation/closeout gates pass from the
+  governed worktree.
+
+## Open Questions
+<!-- No unresolved intake clarification questions. -->
+
+## Deferred Ideas
+- A dedicated `slipway worktree bind` / `park` UX for operators who explicitly
+  want to isolate an intake-stage change without advancing it.
+- A configurable repo-wide serialization policy if future governance decides
+  one active governed change across all worktrees is the desired default.
+
+## Approved Summary
+Confirmed from the user objective: solve GitHub issues #48 and #50 through the
+Slipway lifecycle, confirm each report against current evidence, and fully fix
+only problems that truly exist. The implementation will focus on create-guard
+scoping/remediation for unbound and bound active changes, preserve real
+same-workspace collision protection, exclude broader #46 storage migration and
+new command surfaces unless required, and verify with targeted regressions plus
+fresh full Go and Slipway closeout checks. Confirmation timestamp:
+2026-06-01T15:06:41Z.

--- a/artifacts/changes/archived/fix-slipway-new-create-guard-scoping-for-issues-48-and-50/requirements.md
+++ b/artifacts/changes/archived/fix-slipway-new-create-guard-scoping-for-issues-48-and-50/requirements.md
@@ -1,0 +1,71 @@
+# Requirements
+
+## Project Context
+- Tech Stack: Go CLI
+- Conventions: command behavior under `cmd/`, state/worktree authority under
+  `internal/state/`, command regressions in `cmd/*_test.go`
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Requirements
+
+### Requirement: Unbound intake change must not globally block unrelated discovery work
+REQ-001: When an existing active change is unbound because it is still an
+intake-stage/non-discovery root-owned change, `slipway new` MUST allow a new
+discovery-scoped change that will be isolated into its own default worktree.
+
+#### Scenario: root-owned unbound intake plus discovery follow-up
+GIVEN an active governed change with empty `WorktreePath` owns the current root
+AND the follow-up `slipway new` classification has `needs_discovery=true`
+WHEN the follow-up change is created
+THEN the create guard MUST not fail on the existing root-owned unbound change
+AND the follow-up change MUST bind to a separate default worktree.
+
+### Requirement: Same-workspace unbound collision remains fail-closed
+REQ-002: When an existing active unbound change and a requested new change would
+both own the same workspace, `slipway new` MUST fail with
+`error_code=active_change_exists`.
+
+#### Scenario: root-owned unbound intake plus root-owned follow-up
+GIVEN an active unbound governed change owns the current workspace
+AND the follow-up `slipway new` classification has `needs_discovery=false`
+WHEN the follow-up change is created
+THEN the command MUST fail before creating state
+AND remediation MUST NOT say `slipway next` will bind the existing change.
+
+### Requirement: Bound sibling worktree must not globally block unrelated new work
+REQ-003: When an existing active change is already bound to a different sibling
+worktree, `slipway new` from the repo root or another non-colliding workspace
+MUST allow a new change whose target workspace is different.
+
+#### Scenario: hidden sibling bound authority plus root discovery follow-up
+GIVEN an active governed change is bound to a sibling worktree
+AND normal workspace markers may make that sibling hidden from root-scoped reads
+WHEN a root-scoped discovery follow-up is created
+THEN hidden-authority discovery MAY still see the sibling
+BUT the create guard MUST not reject unless the new target workspace collides.
+
+### Requirement: Create guard must compare current/prospective workspace authority
+REQ-004: The `slipway new` create guard MUST evaluate active-change conflicts
+against the current invocation workspace and the prospective target workspace
+for the new change, not against every active change repo-wide.
+
+#### Scenario: prospective target is known before worktree creation
+GIVEN `slipway new` has resolved classification and generated a slug
+WHEN it checks active-change conflicts
+THEN it MUST compute whether the new change would bind to the default worktree
+or remain in the current workspace
+AND reject only active changes that own the current bound worktree or the
+prospective target workspace.
+
+### Requirement: Regression and lifecycle evidence must prove the issue fixes
+REQ-005: The change MUST include automated regression coverage for #48, #50,
+same-workspace collision preservation, and governed lifecycle artifacts/evidence
+through Slipway closeout.
+
+#### Scenario: verification
+GIVEN the implementation is complete
+WHEN targeted and full verification commands are run
+THEN the #48/#50 regressions, existing same-workspace protection, and Slipway
+validation/closeout gates MUST pass with fresh evidence.

--- a/artifacts/changes/archived/fix-slipway-new-create-guard-scoping-for-issues-48-and-50/research.md
+++ b/artifacts/changes/archived/fix-slipway-new-create-guard-scoping-for-issues-48-and-50/research.md
@@ -1,0 +1,129 @@
+# Research
+
+## Research Findings
+
+### Architecture
+- Affected modules: `cmd/new.go` owns `slipway new` setup, slug allocation,
+  create-guard invocation, and default worktree binding (`cmd/new.go:391-476`).
+- Affected modules: `cmd/common.go` owns the shared create-guard error contract
+  and current invocation worktree resolution (`cmd/common.go:851-985`).
+- Affected modules: `internal/state/store.go` discovers active changes across
+  workspace roots for normal reads and for the create guard
+  (`internal/state/store.go:127-180`, `internal/state/store.go:244-256`,
+  `internal/state/store.go:471-484`).
+- Dependency chains: `new` resolves classification and constructs a
+  prospective `model.Change` before calling `rejectIfConflictingChange`; the
+  guard uses `state.ListChangesForCreateGuard`, `state.WorkspaceRootForChange`,
+  and `state.DefaultWorktreePath` to compare workspace authority before
+  `state.EnsureDefaultWorktreeForChange` materializes the target worktree.
+- Blast radius: create-time lifecycle gating only. Runtime progression,
+  artifact validation, and done/cancel semantics are not changed.
+- Constraints: same-workspace active change protection must remain fail-closed;
+  sibling worktree active changes must remain discoverable for diagnostics but
+  should not block unrelated `new` calls when the new workspace authority does
+  not collide.
+
+### Patterns
+- Existing conventions: CLI precondition failures use `newPreconditionError`
+  with `error_code=active_change_exists` and actionable remediation
+  (`cmd/common.go:942-985`).
+- Existing conventions: path comparisons normalize through `state.NormalizePath`
+  or fall back to cleaned paths, matching nearby command/path handling
+  (`cmd/common.go:927-940`).
+- Existing conventions: tests use `withWorkspace`, `initTestWorkspace`,
+  `recordingIntentClassifier`, and real temporary git worktrees for lifecycle
+  behavior (`cmd/new_test.go:1174-1284`).
+- Reusable abstractions: `state.ResolveGitWorkspaceRoot`,
+  `state.DefaultWorktreePath`, and `state.WorkspaceRootForChange` provide enough
+  authority information for a local create-guard fix without adding a new
+  command or storage model.
+- Convention deviations: the create guard still calls
+  `ListChangesForCreateGuard` so hidden sibling authorities are known, but the
+  rejection decision is now scoped to the current or prospective workspace
+  collision instead of any active change anywhere.
+
+### Risks
+- Technical risks: medium - allowing parallel governed changes could accidentally
+  permit same-workspace collisions if the target workspace calculation diverges
+  from `EnsureDefaultWorktreeForChange`.
+- Technical risks: low - the unbound remediation could become less specific;
+  targeted assertion ensures it no longer points to `slipway next`.
+- Technical risks: low - `git rev-parse --verify HEAD` is duplicated in the cmd
+  layer only to mirror whether a discovery change can be early-bound; unborn or
+  non-git repositories fall back to root-scoped collision checks.
+- Guardrail domains: none. This changes local CLI lifecycle behavior, not auth,
+  secrets, PII, financial flows, schema migration, irreversible operations, or
+  externally consumed web/API contracts.
+- Reversibility: high. The change is localized to `cmd/common.go`,
+  `cmd/new.go`, and command tests; rollback restores the prior global guard.
+
+### Test Strategy
+- Existing coverage: `TestNewCommandRejectsWhenActiveChangeAlreadyExists`
+  protects same-workspace active-change rejection and now verifies the unbound
+  remediation does not mention `slipway next` (`cmd/new_test.go:1174-1201`).
+- New coverage for #48: `TestNewCommandAllowsDiscoveryChangeWhenUnboundIntakeChangeOwnsRoot`
+  failed before the fix with `active_change_exists` and now verifies a discovery
+  follow-up can bind a separate worktree while the original unbound intake
+  remains active (`cmd/new_test.go:1204-1237`).
+- New coverage for #50: `TestNewCommandAllowsBoundSiblingWorktreeActiveChange`
+  failed before the fix with `active_change_exists` and now verifies a hidden
+  sibling bound worktree does not block a separate discovery follow-up
+  (`cmd/new_test.go:1239-1284`).
+- Infrastructure needs: no new external fixtures. Existing temporary git repos
+  and worktree helpers cover the behavior.
+- Verification approach: run the targeted `go test ./cmd -run ... -count=1`,
+  then broaden to package/full-suite testing and Slipway validation before
+  closeout.
+
+## Alternatives Considered
+
+- Approach 1: Keep global serialization and only fix remediation. Tradeoff:
+  small change, but #50 remains a real behavior bug and #48 still requires
+  destructive cancellation for unrelated work.
+- Approach 2: Add a new `bind` / `park` command. Tradeoff: explicit operator
+  control, but larger UX/API surface and unnecessary because the existing new
+  command can compute whether its own target workspace collides.
+- Approach 3: Scope `slipway new` rejection to current/prospective workspace
+  collisions while preserving all active-change discovery. Tradeoff: requires
+  moving the guard until after prospective change construction, but keeps hidden
+  authority visibility and fixes both reported cases with a narrow local change.
+- Selected: Approach 3. It directly matches the #48/#50 failure modes, preserves
+  same-workspace fail-closed behavior, avoids a new command surface, and stays
+  localized to the create path.
+
+## Unknowns
+
+- Resolved: Are #48 and #50 real? -> Yes. The added targeted tests failed under
+  the prior implementation with `active_change_exists` for both issue scenarios
+  and pass after the guard change.
+- Resolved: Does the fix require the broader #46 storage migration? -> No. The
+  current state APIs expose enough workspace authority to compare the existing
+  active change with the new change's prospective workspace.
+- Remaining: None for planning. Broader policy questions about configurable
+  repo-wide serialization remain deferred.
+
+## Assumptions
+
+- A discovery change with a valid git HEAD will early-bind to
+  `state.DefaultWorktreePath(repoRoot, slug)` before its bundle is persisted.
+  Evidence: `cmd/new.go:471-476` calls the create guard before
+  `state.EnsureDefaultWorktreeForChange`, and `cmd/common.go:899-911` mirrors
+  the same target calculation.
+- An active change with no `WorktreePath` owns the current workspace root until
+  it is bound. Evidence: `state.WorkspaceRootForChange` falls back to the
+  project root for unbound changes, consumed by `cmd/common.go:914-920`.
+- Hidden sibling worktree authorities should remain discoverable but should not
+  create a block unless their workspace authority collides. Evidence:
+  `internal/state/store.go:471-484` still feeds the guard with hidden
+  authorities, while `cmd/common.go:880-893` now filters by workspace collision.
+
+## Canonical References
+
+- `https://github.com/signalridge/slipway/issues/48`
+- `https://github.com/signalridge/slipway/issues/50`
+- `cmd/new.go:391-476`
+- `cmd/common.go:851-985`
+- `internal/state/store.go:127-180`
+- `internal/state/store.go:244-256`
+- `internal/state/store.go:471-484`
+- `cmd/new_test.go:1174-1284`

--- a/artifacts/changes/archived/fix-slipway-new-create-guard-scoping-for-issues-48-and-50/tasks.md
+++ b/artifacts/changes/archived/fix-slipway-new-create-guard-scoping-for-issues-48-and-50/tasks.md
@@ -1,0 +1,46 @@
+# Tasks
+
+## Project Context
+- Tech Stack: Go CLI
+- Conventions: command behavior under `cmd/`, state/worktree authority under
+  `internal/state/`, command regressions in `cmd/*_test.go`
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Task List
+
+- [x] `t-01` Add RED regressions for issue #48, issue #50, and same-workspace collision preservation.
+  - wave: 1
+  - depends_on: []
+  - target_files: ["cmd/new_test.go"]
+  - task_kind: test
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-005]
+
+- [x] `t-02` Re-scope `slipway new` create-guard conflict checks to current/prospective workspace authority.
+  - wave: 2
+  - depends_on: [t-01]
+  - target_files: ["cmd/new.go", "cmd/common.go"]
+  - task_kind: code
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004]
+
+- [x] `t-03` Verify targeted create-guard behavior after implementation.
+  - wave: 3
+  - depends_on: [t-02]
+  - target_files: ["cmd/new_test.go", "cmd/new.go", "cmd/common.go"]
+  - task_kind: verification
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004, REQ-005]
+
+- [x] `t-04` Refresh governed artifacts and codebase-map context for the confirmed design.
+  - wave: 3
+  - depends_on: [t-02]
+  - target_files: ["artifacts/changes/fix-slipway-new-create-guard-scoping-for-issues-48-and-50/", "artifacts/codebase/"]
+  - task_kind: verification
+  - covers: [REQ-005]
+
+- [x] `t-05` Run full fresh verification and Slipway closeout gates.
+  - wave: 4
+  - depends_on: [t-03, t-04]
+  - target_files: ["cmd/new_test.go", "cmd/new.go", "cmd/common.go", "artifacts/changes/fix-slipway-new-create-guard-scoping-for-issues-48-and-50/"]
+  - task_kind: verification
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004, REQ-005]

--- a/artifacts/codebase/ARCHITECTURE.md
+++ b/artifacts/codebase/ARCHITECTURE.md
@@ -1,7 +1,26 @@
 # Architecture
 
 - Module responsibilities:
+  - `cmd/new.go` owns `slipway new` classification, slug allocation, guarded
+    creation, default worktree binding, and JSON/human response rendering.
+  - `cmd/common.go` owns shared command helpers, active-change resolution, and
+    create-time precondition errors used by lifecycle commands.
+  - `internal/state/store.go` owns active bundle discovery across the current
+    workspace and sibling git worktrees.
 - Dependency flow:
+  - `cmd/new.go` builds a prospective `model.Change`, calls
+    `rejectIfConflictingChange`, then calls `state.EnsureDefaultWorktreeForChange`
+    and `state.SaveChange`.
+  - The create guard consumes `state.ListChangesForCreateGuard` and compares
+    existing active changes with the current/prospective workspace authority.
 - Coupling hotspots:
+  - `ListChangesForCreateGuard` intentionally sees hidden sibling worktree
+    authorities; callers must decide whether visibility should become a block.
+  - `state.WorkspaceRootForChange` is the authority for unbound vs bound change
+    workspace ownership.
 - Current change blast radius:
+  - Create-time lifecycle gating for `slipway new`; no runtime execution,
+    validation, archive, or template surface changes.
 - Notes:
+  - Source references: `cmd/new.go`, `cmd/common.go`,
+    `internal/state/store.go`, `internal/state/paths.go`.

--- a/artifacts/codebase/CONCERNS.md
+++ b/artifacts/codebase/CONCERNS.md
@@ -1,7 +1,23 @@
 # Concerns
 
 - Architectural pressure points:
+  - `slipway new` must distinguish "known active authority" from "blocking
+    workspace collision"; state discovery intentionally exposes hidden sibling
+    authorities to the guard.
+  - The prospective target workspace for a discovery change must stay aligned
+    with `state.EnsureDefaultWorktreeForChange`.
 - Brittle areas:
+  - Unbound active changes have no persisted `WorktreePath`; the fallback
+    workspace root is the local project root until a binding exists.
+  - Worktree visibility markers affect normal reads but should not be confused
+    with workspace collision semantics.
 - Migration traps:
+  - A broad storage migration for per-scope active-change authority is not
+    required for the #48/#50 fix; changing it here would expand the blast
+    radius beyond create-guard behavior.
 - Recheck routing:
+  - Re-run targeted `cmd` tests for unbound and bound active-change create
+    scenarios, then full `go test -count=1 ./...` before closeout.
 - Notes:
+  - Source references: `cmd/common.go`, `cmd/new.go`,
+    `internal/state/store.go`, `internal/state/paths.go`.

--- a/artifacts/codebase/STRUCTURE.md
+++ b/artifacts/codebase/STRUCTURE.md
@@ -3,5 +3,13 @@
 - Directory layout: cmd/, docs/, internal/
 - Entry points: README.md, go.mod, main.go
 - Generated versus handwritten boundaries:
+  - `cmd/*.go`, `internal/state/*.go`, and their tests are handwritten source.
+  - `artifacts/changes/*` and `artifacts/codebase/*` are governed context and
+    evidence artifacts, not runtime code.
 - Ownership hints:
+  - CLI command behavior and user-facing errors live in `cmd/`.
+  - Worktree, bundle, local runtime, and active-change authority helpers live in
+    `internal/state/`.
 - Notes:
+  - This change is scoped to `slipway new` create-time behavior and command
+    tests; it does not touch generated skill/template surfaces.

--- a/artifacts/codebase/TESTING.md
+++ b/artifacts/codebase/TESTING.md
@@ -2,7 +2,20 @@
 
 - Test layout: Go *_test.go files
 - Coverage hotspots:
+  - `cmd/new_test.go` covers `slipway new` intake setup, JSON/classifier
+    behavior, worktree binding, active-change create-guard behavior, and
+    user-facing precondition errors.
+  - `internal/state/store_test.go` covers workspace/worktree discovery,
+    visibility, and hidden authority behavior for active bundles.
 - Coverage gaps:
+  - Cross-worktree create-guard behavior must be asserted at the command layer
+    because state discovery intentionally reports more authorities than should
+    necessarily block `new`.
 - Verification commands: go build ./...; go test ./...
 - Fixture patterns:
+  - Command tests use `withWorkspace`, `initTestWorkspace`, temporary git repos,
+    `recordingIntentClassifier`, and real `git worktree add` calls.
+  - State tests use temporary repositories plus helper worktrees to exercise
+    visibility and fallback paths.
 - Notes:
+  - Source references: `cmd/new_test.go`, `internal/state/store_test.go`.

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -848,9 +848,9 @@ func errorsIsNotExist(err error) bool {
 	return err != nil && os.IsNotExist(err)
 }
 
-// rejectIfConflictingChange enforces the single-active-change contract before
-// creating a new change.
-func rejectIfConflictingChange(root string) error {
+// rejectIfConflictingChange enforces one active governed change per workspace
+// authority before creating a new change.
+func rejectIfConflictingChange(root string, nextChange model.Change) error {
 	allChanges, err := state.ListChangesForCreateGuard(root)
 	if err != nil {
 		return err
@@ -866,52 +866,149 @@ func rejectIfConflictingChange(root string) error {
 		return nil
 	}
 
-	currentWT, wtErr := currentWorktreeRoot()
-	if wtErr != nil {
-		return fmt.Errorf("cannot determine worktree for conflict check: %w", wtErr)
+	invocationWorkspace, err := createGuardInvocationWorkspaceRoot(root)
+	if err != nil {
+		return err
+	}
+	targetWorkspace, err := newChangeTargetWorkspaceRoot(root, nextChange)
+	if err != nil {
+		return err
 	}
 
-	ch := activeChanges[0]
-	if strings.TrimSpace(ch.WorktreePath) == "" {
-		remediation := "Run `slipway next` to bind the existing change to a dedicated worktree, or close it before creating a new change."
-		return newPreconditionError(
-			"active_change_exists",
-			fmt.Sprintf("active governed change %s is not yet bound to a worktree; finish, cancel, or bind it before creating a new one", ch.Slug),
-			remediation,
-			ch.Slug,
-			nil,
-		)
-	}
-
-	if currentWT != "" && ch.WorktreePath != "" {
-		normalizedCurrent, err1 := state.NormalizePath(currentWT)
-		normalizedExisting, err2 := state.NormalizePath(ch.WorktreePath)
-		if err1 == nil && err2 == nil && normalizedCurrent == normalizedExisting {
-			return newPreconditionError(
-				"active_change_exists",
-				fmt.Sprintf("active governed change %s is bound to this worktree; finish or cancel it before creating a new one", ch.Slug),
-				"Run `slipway done` or `slipway cancel` before creating a new change.",
-				ch.Slug,
-				nil,
-			)
+	for _, ch := range activeChanges {
+		existingWorkspace, err := existingChangeWorkspaceRoot(root, ch)
+		if err != nil {
+			return err
+		}
+		if strings.TrimSpace(ch.WorktreePath) != "" && pathsEqualForCreateGuard(existingWorkspace, invocationWorkspace) {
+			return boundWorktreeCreateConflict(root, ch)
+		}
+		if pathsEqualForCreateGuard(existingWorkspace, targetWorkspace) {
+			if strings.TrimSpace(ch.WorktreePath) == "" {
+				return unboundWorkspaceCreateConflict(ch)
+			}
+			return targetWorkspaceCreateConflict(root, ch, targetWorkspace)
 		}
 	}
 
+	return nil
+}
+
+func createGuardInvocationWorkspaceRoot(root string) (string, error) {
+	normalizedRoot := normalizePathForCompare(root)
+	currentWorktree, err := currentWorktreeRoot()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine worktree for conflict check: %w", err)
+	}
+	currentWorktree = normalizePathForCompare(currentWorktree)
+
+	projectWorktree, err := state.ResolveGitWorkspaceRoot(normalizedRoot)
+	if err != nil {
+		if strings.Contains(err.Error(), "not a git repository") {
+			return normalizedRoot, nil
+		}
+		return "", fmt.Errorf("resolve project worktree for create guard: %w", err)
+	}
+	projectWorktree = normalizePathForCompare(projectWorktree)
+
+	// Preserve nested Slipway scopes when the command runs from a sibling git worktree.
+	scopeRel, err := filepath.Rel(projectWorktree, normalizedRoot)
+	if err != nil {
+		return currentWorktree, nil
+	}
+	scopeRel = filepath.Clean(scopeRel)
+	if scopeRel == "." || scopeRel == "" {
+		return currentWorktree, nil
+	}
+	if scopeRel == ".." || strings.HasPrefix(scopeRel, ".."+string(filepath.Separator)) {
+		return currentWorktree, nil
+	}
+	return normalizePathForCompare(filepath.Join(currentWorktree, scopeRel)), nil
+}
+
+func newChangeTargetWorkspaceRoot(root string, change model.Change) (string, error) {
+	target := root
+	if change.NeedsDiscovery {
+		repoRoot, err := state.ResolveGitWorkspaceRoot(root)
+		if err != nil {
+			if !strings.Contains(err.Error(), "not a git repository") {
+				return "", fmt.Errorf("resolve git worktree for create guard: %w", err)
+			}
+		} else if gitWorkspaceHasHead(repoRoot) {
+			target = state.DefaultWorktreePath(repoRoot, change.Slug)
+		}
+	}
+	return normalizePathForCompare(target), nil
+}
+
+func existingChangeWorkspaceRoot(root string, ch model.Change) (string, error) {
+	workspaceRoot, err := state.WorkspaceRootForChange(root, ch)
+	if err != nil {
+		return "", fmt.Errorf("resolve active change workspace for create guard: %w", err)
+	}
+	return normalizePathForCompare(workspaceRoot), nil
+}
+
+func gitWorkspaceHasHead(repoRoot string) bool {
+	cmd := exec.Command("git", "-C", repoRoot, "rev-parse", "--verify", "--quiet", "HEAD")
+	return cmd.Run() == nil
+}
+
+func normalizePathForCompare(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	if normalized, err := state.NormalizePath(path); err == nil {
+		return normalized
+	}
+	return filepath.Clean(path)
+}
+
+func pathsEqualForCreateGuard(left, right string) bool {
+	return normalizePathForCompare(left) == normalizePathForCompare(right)
+}
+
+func unboundWorkspaceCreateConflict(ch model.Change) error {
+	return newPreconditionError(
+		"active_change_exists",
+		fmt.Sprintf("active governed change %s is already active in this workspace; finish or cancel it before creating another change here", ch.Slug),
+		"Run `slipway done` or `slipway cancel` for the existing change before creating a new change in this workspace.",
+		ch.Slug,
+		nil,
+	)
+}
+
+func boundWorktreeCreateConflict(root string, ch model.Change) error {
 	worktreeHint := strings.TrimSpace(state.DisplayPath(root, ch.WorktreePath))
 	if worktreeHint == "" {
 		worktreeHint = ch.WorktreePath
 	}
-	remediation := "Resume, finish, or cancel the existing change before creating a new change."
+	remediation := "Run `slipway done` or `slipway cancel` before creating a new change in this worktree."
 	if worktreeHint != "" {
 		remediation = fmt.Sprintf(
-			"Switch to %s to continue that change, or run `slipway done` / `slipway cancel` there before creating a new change.",
+			"Continue, finish, or cancel the active change in %s before creating a new change from that worktree.",
 			worktreeHint,
 		)
 	}
 	return newPreconditionError(
 		"active_change_exists",
-		fmt.Sprintf("active governed change %s already exists; finish or cancel it before creating a new one", ch.Slug),
+		fmt.Sprintf("active governed change %s is bound to this worktree; finish or cancel it before creating a new one", ch.Slug),
 		remediation,
+		ch.Slug,
+		nil,
+	)
+}
+
+func targetWorkspaceCreateConflict(root string, ch model.Change, targetWorkspace string) error {
+	targetHint := strings.TrimSpace(state.DisplayPath(root, targetWorkspace))
+	if targetHint == "" {
+		targetHint = targetWorkspace
+	}
+	return newPreconditionError(
+		"active_change_exists",
+		fmt.Sprintf("active governed change %s already owns target workspace %s; finish or cancel it before creating a new one there", ch.Slug, targetHint),
+		"Use a different workspace, or run `slipway done` / `slipway cancel` for the existing change before creating a new change there.",
 		ch.Slug,
 		nil,
 	)

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -392,9 +392,6 @@ func createDirectGovernedChange(
 		if _, err := state.EnsureLocalStateGitIgnore(root); err != nil {
 			return err
 		}
-		if err := rejectIfConflictingChange(root); err != nil {
-			return err
-		}
 
 		slug, err := generateUniqueChangeSlug(description, func(s string) (bool, error) {
 			return state.ChangeSlugExists(root, s)
@@ -469,6 +466,10 @@ func createDirectGovernedChange(
 			} else {
 				change.SuggestedWorkflowPreset = suggested
 			}
+		}
+
+		if err := rejectIfConflictingChange(root, change); err != nil {
+			return err
 		}
 
 		worktreeBinding, err := state.EnsureDefaultWorktreeForChange(root, &change)
@@ -600,7 +601,7 @@ func generateUniqueChangeSlug(description string, slugExists func(string) (bool,
 
 	exists, err := slugExists(baseSlug)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("check change slug %q: %w", baseSlug, err)
 	}
 	if !exists {
 		return baseSlug, nil
@@ -618,7 +619,7 @@ func generateUniqueChangeSlug(description string, slugExists func(string) (bool,
 		candidate := candidateBase + suffix
 		exists, err := slugExists(candidate)
 		if err != nil {
-			return "", err
+			return "", fmt.Errorf("check change slug %q: %w", candidate, err)
 		}
 		if !exists {
 			return candidate, nil

--- a/cmd/new_test.go
+++ b/cmd/new_test.go
@@ -1177,9 +1177,18 @@ func TestNewCommandRejectsWhenActiveChangeAlreadyExists(t *testing.T) {
 		initTestWorkspace(t, root)
 
 		existing := model.NewChange("existing-change")
+		existing.NeedsDiscovery = false
 		require.NoError(t, state.SaveChange(root, existing))
 
+		classifier := &recordingIntentClassifier{
+			classification: progression.IntentClassification{
+				NeedsDiscovery: false,
+				Complexity:     "simple",
+			},
+		}
+
 		cmd := makeNewCmd()
+		cmd.SetContext(withIntentClassifierContext(cmd.Context(), classifier))
 		cmd.SetArgs([]string{"follow-up change"})
 		err := cmd.Execute()
 		require.Error(t, err)
@@ -1188,10 +1197,46 @@ func TestNewCommandRejectsWhenActiveChangeAlreadyExists(t *testing.T) {
 		require.NotNil(t, cliErr)
 		assert.Equal(t, "active_change_exists", cliErr.ErrorCode)
 		assert.Contains(t, cliErr.Remediation, "creating a new change")
+		assert.NotContains(t, cliErr.Remediation, "slipway next")
 	})
 }
 
-func TestNewCommandRejectsWhenHiddenBoundWorktreeActiveChangeExists(t *testing.T) {
+func TestNewCommandAllowsDiscoveryChangeWhenUnboundIntakeChangeOwnsRoot(t *testing.T) {
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		runGit(t, root, "config", "user.email", "test@example.com")
+		runGit(t, root, "config", "user.name", "Test User")
+		runGit(t, root, "add", ".")
+		runGit(t, root, "commit", "-m", "init")
+
+		existing := model.NewChange("existing-unbound-intake")
+		existing.CurrentState = model.StateS0Intake
+		existing.IntakeSubStep = model.IntakeSubStepClarify
+		existing.NeedsDiscovery = false
+		existing.ComplexityLevel = "simple"
+		require.NoError(t, state.SaveChange(root, existing))
+
+		classifier := &recordingIntentClassifier{
+			classification: progression.IntentClassification{
+				NeedsDiscovery: true,
+				Complexity:     "complex",
+			},
+		}
+
+		cmd := makeNewCmd()
+		cmd.SetContext(withIntentClassifierContext(cmd.Context(), classifier))
+		cmd.SetArgs([]string{"follow-up discovery change"})
+		require.NoError(t, cmd.Execute())
+
+		change, err := state.LoadChange(root, "follow-up-discovery-change")
+		require.NoError(t, err)
+		assert.NotEmpty(t, change.WorktreePath)
+		assert.NotEqual(t, root, change.WorktreePath)
+	})
+}
+
+func TestNewCommandAllowsBoundSiblingWorktreeActiveChange(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
@@ -1219,7 +1264,64 @@ func TestNewCommandRejectsWhenHiddenBoundWorktreeActiveChangeExists(t *testing.T
 		require.NoError(t, os.Remove(state.ConfigPath(worktreeRoot)))
 		require.NoError(t, os.Remove(state.WorkspaceScopeMarkerPath(worktreeRoot)))
 
+		classifier := &recordingIntentClassifier{
+			classification: progression.IntentClassification{
+				NeedsDiscovery: true,
+				Complexity:     "complex",
+			},
+		}
+
 		cmd := makeNewCmd()
+		cmd.SetContext(withIntentClassifierContext(cmd.Context(), classifier))
+		cmd.SetArgs([]string{"follow-up change"})
+		require.NoError(t, cmd.Execute())
+
+		created, err := state.LoadChange(root, "follow-up-change")
+		require.NoError(t, err)
+		assert.NotEmpty(t, created.WorktreePath)
+		assert.NotEqual(t, bound.WorktreePath, created.WorktreePath)
+	})
+}
+
+func TestNewCommandRejectsWhenActiveChangeIsBoundToCurrentWorktree(t *testing.T) {
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		runGit(t, root, "config", "user.email", "test@example.com")
+		runGit(t, root, "config", "user.name", "Test User")
+		runGit(t, root, "add", ".")
+		runGit(t, root, "commit", "-m", "init")
+
+		slug := createGovernedRequest(t, root, "L3", "existing current bound worktree change")
+		change, err := state.LoadChange(root, slug)
+		require.NoError(t, err)
+		change.CurrentState = model.StateS2Execute
+		change.PlanSubStep = model.PlanSubStepNone
+		require.NoError(t, state.SaveChange(root, change))
+
+		worktreeRoot := filepath.Join(t.TempDir(), slug)
+		branch := "feat/" + slug
+		runGit(t, root, "worktree", "add", worktreeRoot, "-b", branch, "HEAD")
+
+		bound := change
+		require.NoError(t, state.PersistScopeWorktreeMetadata(&bound, worktreeRoot, branch))
+		require.NoError(t, state.RelocateGovernedBundle(root, change, bound))
+		require.NoError(t, state.SaveChange(root, bound))
+
+		require.NoError(t, os.Chdir(worktreeRoot))
+		defer func() {
+			require.NoError(t, os.Chdir(root))
+		}()
+
+		classifier := &recordingIntentClassifier{
+			classification: progression.IntentClassification{
+				NeedsDiscovery: true,
+				Complexity:     "complex",
+			},
+		}
+
+		cmd := makeNewCmd()
+		cmd.SetContext(withIntentClassifierContext(cmd.Context(), classifier))
 		cmd.SetArgs([]string{"follow-up change"})
 		err = cmd.Execute()
 		require.Error(t, err)
@@ -1227,7 +1329,8 @@ func TestNewCommandRejectsWhenHiddenBoundWorktreeActiveChangeExists(t *testing.T
 		cliErr := asCLIError(err)
 		require.NotNil(t, cliErr)
 		assert.Equal(t, "active_change_exists", cliErr.ErrorCode)
-		assert.Contains(t, cliErr.Remediation, "creating a new change")
+		assert.Contains(t, cliErr.Message, "bound to this worktree")
+		assert.Contains(t, cliErr.Remediation, "before creating a new change from that worktree")
 	})
 }
 


### PR DESCRIPTION
## Summary
- scope `slipway new` active-change guard to current/prospective workspace collisions
- keep hidden active-change discovery while allowing non-colliding governed worktrees
- archive the governed change evidence for issues #48 and #50

Closes #48
Closes #50

## Verification
- go test -count=1 ./cmd -run 'TestNewCommand(RejectsWhenActiveChangeAlreadyExists|AllowsDiscoveryChangeWhenUnboundIntakeChangeOwnsRoot|AllowsBoundSiblingWorktreeActiveChange|RejectsWhenActiveChangeIsBoundToCurrentWorktree|FailsClosedWhenSlugNamespaceIsCorrupt)$'
- go test -count=1 ./...
- go build ./...
- git diff --check
- /tmp/slipway-issue48-50-latest validate --json
- /tmp/slipway-issue48-50-latest done --json