### PR TITLE
fix(workflow): issue #53 tier 1 next/done diagnostics

### DIFF
--- a/cmd/done.go
+++ b/cmd/done.go
@@ -90,8 +90,14 @@ func markChangeDone(change *model.Change) {
 	change.CurrentState = model.StateDone
 }
 
-const doneWorktreeDirtyWarning = "worktree has uncommitted source changes; commit or review these files before removing the worktree"
+const doneWorktreeDirtyWarning = "worktree has uncommitted non-bundle changes; commit them together with the archived bundle before removing the worktree"
 
+// doneWorktreeDirtyState reports uncommitted non-bundle worktree changes as a
+// non-blocking advisory. `done` proceeds and archives — premature worktree
+// deletion is already refused by `git worktree remove` on a dirty tree — but the
+// returned warning and file list tell the operator what to commit alongside the
+// archived bundle. The active governed bundle is exempt because `done` rewrites
+// it; sibling or archived bundles are reported (see WorkspaceChangedFilesForDoneArchive).
 func doneWorktreeDirtyState(root string, change model.Change) (string, []string) {
 	if strings.TrimSpace(change.WorktreePath) == "" {
 		return "", nil
@@ -100,7 +106,7 @@ func doneWorktreeDirtyState(root string, change model.Change) (string, []string)
 	if err != nil {
 		return "", nil
 	}
-	files := progression.WorkspaceChangedFiles(paths)
+	files := progression.WorkspaceChangedFilesForDoneArchive(paths)
 	if len(files) == 0 {
 		return "", nil
 	}
@@ -281,6 +287,7 @@ func makeDoneCmd() *cobra.Command {
 						nil,
 					)
 				}
+				worktreeDirtyWarning, worktreeDirtyFiles := doneWorktreeDirtyState(root, change)
 				if err := reconcileDoneFilesystemState(root, &change); err != nil {
 					return err
 				}
@@ -294,7 +301,6 @@ func makeDoneCmd() *cobra.Command {
 				if shipBlocked {
 					return shipGateBlockedError(change, shipEval)
 				}
-				worktreeDirtyWarning, worktreeDirtyFiles := doneWorktreeDirtyState(root, change)
 				beforeChange := change
 				markChangeDone(&change)
 				change.RemediationSources = mergeArchiveReferences(
@@ -449,6 +455,7 @@ func archiveSingleDoneReady(root, slug string, change model.Change) doneBulkItem
 	if !action.CanFinalizeDone(change.CurrentState) {
 		return newDoneBulkSkipped(slug, string(change.CurrentState), "not_done_ready")
 	}
+	worktreeDirtyWarning, worktreeDirtyFiles := doneWorktreeDirtyState(root, change)
 	if err := reconcileDoneFilesystemState(root, &change); err != nil {
 		return newDoneBulkFailed(slug, "artifact_reconcile_failed", err.Error())
 	}
@@ -467,7 +474,6 @@ func archiveSingleDoneReady(root, slug string, change model.Change) doneBulkItem
 			append([]model.ReasonCode(nil), shipEval.ReasonCodes...),
 		)
 	}
-	worktreeDirtyWarning, worktreeDirtyFiles := doneWorktreeDirtyState(root, change)
 	beforeChange := change
 	markChangeDone(&change)
 

--- a/cmd/lifecycle_commands_test.go
+++ b/cmd/lifecycle_commands_test.go
@@ -99,6 +99,7 @@ func TestDoneJSONReportsWorktreeArchivePathWhenRunFromWorktree(t *testing.T) {
 		writePassingReviewEvidencePack(t, root, slug, 1)
 		writePassingGoalVerificationEvidence(t, root, slug, 1)
 		writePassingFinalCloseoutEvidence(t, root, slug, 1)
+		gitCommitAll(t, normalizedWT, "ship-ready bundle")
 
 		previousWD, err := os.Getwd()
 		require.NoError(t, err)
@@ -123,7 +124,7 @@ func TestDoneJSONReportsWorktreeArchivePathWhenRunFromWorktree(t *testing.T) {
 	})
 }
 
-func TestDoneJSONWarnsWhenWorktreeSourceChangesAreUncommitted(t *testing.T) {
+func TestDoneJSONWarnsButArchivesWhenWorktreeChangesAreUncommitted(t *testing.T) {
 	root := t.TempDir()
 	initGitRepoForWorktreeTests(t, root)
 	withWorkspace(t, root, func() {
@@ -167,10 +168,166 @@ func TestDoneJSONWarnsWhenWorktreeSourceChangesAreUncommitted(t *testing.T) {
 		doneCmd.SetArgs([]string{"--json"})
 		require.NoError(t, doneCmd.Execute())
 
+		// Dirty source no longer blocks: `done` archives and surfaces a
+		// non-blocking advisory listing what to commit with the archived bundle.
 		var view doneView
 		require.NoError(t, json.Unmarshal(out.Bytes(), &view))
-		assert.Contains(t, view.WorktreeDirtyWarning, "uncommitted source changes")
+		assert.True(t, view.Archived)
+		assert.NotEmpty(t, view.WorktreeDirtyWarning)
 		assert.Contains(t, view.WorktreeDirtyFiles, "cmd/done.go")
+		assert.NotContains(t, view.WorktreeDirtyFiles, filepath.ToSlash(filepath.Join("artifacts", "changes", slug, "intent.md")))
+		require.FileExists(t, filepath.Join(normalizedWT, "artifacts", "changes", "archived", slug, "change.yaml"))
+	})
+}
+
+func TestDoneJSONAllowsUncommittedGovernedBundleArchive(t *testing.T) {
+	root := t.TempDir()
+	initGitRepoForWorktreeTests(t, root)
+	withWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+
+		slug := "done-worktree-bundle-dirty"
+		branch := "feat/" + slug
+		worktreeRoot := filepath.Join(t.TempDir(), slug)
+		runGit(t, root, "worktree", "add", worktreeRoot, "-b", branch)
+		normalizedWT, err := state.NormalizePath(worktreeRoot)
+		require.NoError(t, err)
+
+		change := model.NewChange(slug)
+		change.WorktreePath = normalizedWT
+		change.WorktreeBranch = branch
+		change.CurrentState = model.StateS4Verify
+		change.PlanSubStep = model.PlanSubStepNone
+		require.NoError(t, state.SaveChange(root, change))
+
+		writeShipReadyGovernedBundle(t, normalizedWT, change)
+		writeAssuranceMD(t, normalizedWT, slug, validAssuranceContent())
+		writePassingExecutionSummary(t, root, slug, 1, "t-01")
+		writePassingWaveEvidence(t, root, slug, 1)
+		writePassingReviewEvidencePack(t, root, slug, 1)
+		writePassingGoalVerificationEvidence(t, root, slug, 1)
+		writePassingFinalCloseoutEvidence(t, root, slug, 1)
+
+		previousWD, err := os.Getwd()
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(normalizedWT))
+		defer func() {
+			_ = os.Chdir(previousWD)
+		}()
+
+		var out bytes.Buffer
+		doneCmd := makeDoneCmd()
+		doneCmd.SetOut(&out)
+		doneCmd.SetArgs([]string{"--json"})
+		require.NoError(t, doneCmd.Execute())
+
+		var view doneView
+		require.NoError(t, json.Unmarshal(out.Bytes(), &view))
+		assert.True(t, view.Archived)
+		require.FileExists(t, filepath.Join(normalizedWT, "artifacts", "changes", "archived", slug, "change.yaml"))
+		require.NoDirExists(t, filepath.Join(normalizedWT, "artifacts", "changes", slug))
+	})
+}
+
+func TestDoneJSONWarnsDirtyNonActiveChangeArtifact(t *testing.T) {
+	root := t.TempDir()
+	initGitRepoForWorktreeTests(t, root)
+	withWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+
+		slug := "done-nonactive-artifact-dirty"
+		branch := "feat/" + slug
+		worktreeRoot := filepath.Join(t.TempDir(), slug)
+		runGit(t, root, "worktree", "add", worktreeRoot, "-b", branch)
+		normalizedWT, err := state.NormalizePath(worktreeRoot)
+		require.NoError(t, err)
+
+		change := model.NewChange(slug)
+		change.WorktreePath = normalizedWT
+		change.WorktreeBranch = branch
+		change.CurrentState = model.StateS4Verify
+		change.PlanSubStep = model.PlanSubStepNone
+		require.NoError(t, state.SaveChange(root, change))
+
+		writeShipReadyGovernedBundle(t, normalizedWT, change)
+		writeAssuranceMD(t, normalizedWT, slug, validAssuranceContent())
+		writePassingExecutionSummary(t, root, slug, 1, "t-01")
+		writePassingWaveEvidence(t, root, slug, 1)
+		writePassingReviewEvidencePack(t, root, slug, 1)
+		writePassingGoalVerificationEvidence(t, root, slug, 1)
+		writePassingFinalCloseoutEvidence(t, root, slug, 1)
+
+		// A sibling/archived change bundle left uncommitted is reported in the
+		// dirty advisory because only the active artifacts/changes/<slug>/ bundle
+		// is exempt — but it no longer blocks `done`.
+		siblingRel := filepath.ToSlash(filepath.Join("artifacts", "changes", "archived", "other-change", "change.yaml"))
+		siblingPath := filepath.Join(normalizedWT, filepath.FromSlash(siblingRel))
+		require.NoError(t, os.MkdirAll(filepath.Dir(siblingPath), 0o755))
+		require.NoError(t, os.WriteFile(siblingPath, []byte("slug: other-change\n"), 0o644))
+
+		previousWD, err := os.Getwd()
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(normalizedWT))
+		defer func() {
+			_ = os.Chdir(previousWD)
+		}()
+
+		var out bytes.Buffer
+		doneCmd := makeDoneCmd()
+		doneCmd.SetOut(&out)
+		doneCmd.SetArgs([]string{"--json"})
+		require.NoError(t, doneCmd.Execute())
+
+		var view doneView
+		require.NoError(t, json.Unmarshal(out.Bytes(), &view))
+		assert.True(t, view.Archived)
+		assert.Contains(t, view.WorktreeDirtyFiles, siblingRel)
+		assert.NotContains(t, view.WorktreeDirtyFiles, filepath.ToSlash(filepath.Join("artifacts", "changes", slug, "intent.md")))
+	})
+}
+
+func TestDoneAllReadyWarnsDirtyBoundWorktree(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	initGitRepoForWorktreeTests(t, root)
+	withWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+
+		slug := "bulk-dirty-worktree"
+		branch := "feat/" + slug
+		worktreeRoot := filepath.Join(t.TempDir(), slug)
+		runGit(t, root, "worktree", "add", worktreeRoot, "-b", branch)
+		normalizedWT, err := state.NormalizePath(worktreeRoot)
+		require.NoError(t, err)
+
+		change := model.NewChange(slug)
+		change.WorktreePath = normalizedWT
+		change.WorktreeBranch = branch
+		change.CurrentState = model.StateS4Verify
+		change.PlanSubStep = model.PlanSubStepNone
+		require.NoError(t, state.SaveChange(root, change))
+
+		writeShipReadyGovernedBundle(t, normalizedWT, change)
+		writeAssuranceMD(t, normalizedWT, slug, validAssuranceContent())
+		writePassingExecutionSummary(t, root, slug, 1, "t-01")
+		writePassingWaveEvidence(t, root, slug, 1)
+		writePassingReviewEvidencePack(t, root, slug, 1)
+		writePassingGoalVerificationEvidence(t, root, slug, 1)
+		writePassingFinalCloseoutEvidence(t, root, slug, 1)
+		gitCommitAll(t, normalizedWT, "ship-ready bundle")
+
+		require.NoError(t, os.MkdirAll(filepath.Join(normalizedWT, "cmd"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(normalizedWT, "cmd", "done.go"), []byte("package cmd\n"), 0o644))
+
+		view := archiveAllDoneReady(root)
+		assert.Empty(t, view.Failed)
+		require.Len(t, view.Archived, 1)
+		assert.Equal(t, slug, view.Archived[0].Slug)
+		assert.Equal(t, string(model.ChangeStatusDone), view.Archived[0].Status)
+		assert.NotEmpty(t, view.Archived[0].WorktreeDirtyWarning)
+		assert.Contains(t, view.Archived[0].WorktreeDirtyFiles, "cmd/done.go")
+		require.FileExists(t, filepath.Join(normalizedWT, "artifacts", "changes", "archived", slug, "change.yaml"))
 	})
 }
 
@@ -1263,6 +1420,12 @@ func runGit(t *testing.T, dir string, args ...string) {
 	cmd.Dir = dir
 	out, err := cmd.CombinedOutput()
 	require.NoErrorf(t, err, "git %v failed: %s", args, string(out))
+}
+
+func gitCommitAll(t *testing.T, dir, message string) {
+	t.Helper()
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", message)
 }
 
 func writeSkillVerification(t *testing.T, root, slug, skillName string, rec model.VerificationRecord) {

--- a/cmd/next.go
+++ b/cmd/next.go
@@ -607,6 +607,8 @@ func deriveConfirmationRequirement(view nextView) confirmationRequirement {
 		return confirmationHardStop("resume_checkpoint")
 	case hasReasonCode(view.Blockers, "run_slipway_done_to_finalize"):
 		return confirmationCommandRequired("run_slipway_done_to_finalize")
+	case hasReasonCode(view.Blockers, "run_slipway_run_to_advance"):
+		return confirmationCommandRequired("run_slipway_run_to_advance")
 	case len(view.Blockers) > 0:
 		return confirmationCommandRequired("blocked_by_governance")
 	case len(view.AutoPassEligible) > 0:

--- a/cmd/next_skill_view.go
+++ b/cmd/next_skill_view.go
@@ -197,6 +197,14 @@ func assembleSkillViewWithOptions(
 			blockers = append(blockers, advanced.Blockers...)
 		}
 		if len(blockers) == 0 {
+			if governedChange != nil {
+				canAdvance, advanceBlockers := noSkillStateAdvanceReadiness(root, *governedChange)
+				if len(advanceBlockers) > 0 {
+					blockers = append(blockers, advanceBlockers...)
+				} else if canAdvance {
+					blockers = append(blockers, model.NewReasonCode("run_slipway_run_to_advance", string(view.CurrentState)))
+				}
+			}
 			blockers = append(blockers, model.NewReasonCode("no_skill_required", string(view.CurrentState)))
 		}
 		view.Blockers = model.NormalizeReasonCodes(blockers)
@@ -549,6 +557,22 @@ func appendCatalogHints(
 		})
 	}
 	return existing
+}
+
+func noSkillStateAdvanceReadiness(root string, change model.Change) (bool, []model.ReasonCode) {
+	switch change.CurrentState {
+	case model.StateS0Intake:
+		blockers := progression.IntakeAdvanceBlockers(root, change)
+		return len(blockers) == 0, blockers
+	case model.StateS1Plan:
+		// S1 research reaches the no-skill branch only after its evidence passed
+		// and the display skill was cleared.
+		return change.PlanSubStep == model.PlanSubStepResearch || change.PlanSubStep == model.PlanSubStepValidate, nil
+	case model.StateS3Review:
+		return true, nil
+	default:
+		return false, nil
+	}
 }
 
 func supportHintName(skillID string) string {

--- a/cmd/progression_next_test.go
+++ b/cmd/progression_next_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/signalridge/slipway/internal/engine/artifact"
+	"github.com/signalridge/slipway/internal/engine/gate"
 	"github.com/signalridge/slipway/internal/engine/progression"
 	"github.com/signalridge/slipway/internal/model"
 	"github.com/signalridge/slipway/internal/state"
@@ -78,7 +79,7 @@ func TestNextReturnsNextSkillForGovernedState(t *testing.T) {
 	})
 }
 
-func TestNextS0ResearchActionDoesNotRequestResearchMarkdown(t *testing.T) {
+func TestNextS0ResearchActionReportsRunGuidanceWithoutPrematureScopeGate(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
@@ -89,6 +90,12 @@ func TestNextS0ResearchActionDoesNotRequestResearchMarkdown(t *testing.T) {
 		require.NoError(t, err)
 		change.IntakeSubStep = model.IntakeSubStepResearch
 		require.NoError(t, state.SaveChange(root, change))
+		writeSkillVerification(t, root, slug, progression.SkillIntakeClarification, model.VerificationRecord{
+			Verdict:    model.VerificationVerdictPass,
+			Blockers:   []model.ReasonCode{},
+			Timestamp:  time.Now().UTC(),
+			RunVersion: 0,
+		})
 
 		cmd := commandForRoot(t, root, makeNextCmd())
 		cmd.SetArgs([]string{"--json", "--diagnostics"})
@@ -98,8 +105,11 @@ func TestNextS0ResearchActionDoesNotRequestResearchMarkdown(t *testing.T) {
 
 		var view nextView
 		require.NoError(t, json.Unmarshal(buf.Bytes(), &view))
-		require.NotNil(t, view.NextSkill)
-		assert.Equal(t, progression.SkillIntakeClarification, view.NextSkill.Name)
+		assert.Nil(t, view.NextSkill)
+		assert.NotContains(t, view.InputContext.GateStatus, string(gate.GateScope))
+		assert.Contains(t, model.ReasonSpecs(view.Blockers), "run_slipway_run_to_advance:S0_INTAKE")
+		assert.Contains(t, model.ReasonSpecs(view.Blockers), "no_skill_required:S0_INTAKE")
+		assert.Equal(t, "run_slipway_run_to_advance", view.ConfirmationRequirement.Reason)
 		require.NotEmpty(t, view.RequiredActions)
 		for _, action := range view.RequiredActions {
 			if action.ControlID == string(model.ControlResearch) {
@@ -107,6 +117,86 @@ func TestNextS0ResearchActionDoesNotRequestResearchMarkdown(t *testing.T) {
 				assert.Contains(t, action.Description, "S0 intake research questions")
 			}
 		}
+	})
+}
+
+func TestNextS3ReviewWithPassingEvidenceReportsRunGuidance(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	ensureTestGitRepo(t, root)
+	initTestWorkspace(t, root)
+
+	slug := createGovernedRequest(t, root, "L2", "s3 run guidance")
+	change, err := state.LoadChange(root, slug)
+	require.NoError(t, err)
+	change.CurrentState = model.StateS3Review
+	change.PlanSubStep = model.PlanSubStepNone
+	require.NoError(t, state.SaveChange(root, change))
+	writeShipReadyGovernedBundle(t, root, change)
+	writePassingExecutionSummary(t, root, slug, 1, "t-01")
+	writePassingWaveEvidence(t, root, slug, 1)
+	writePassingReviewEvidencePack(t, root, slug, 1)
+
+	view, err := buildNextView(root, changeRef{Slug: slug}, "", true, false, false)
+	require.NoError(t, err)
+	assert.Nil(t, view.NextSkill)
+	assert.Contains(t, model.ReasonSpecs(view.Blockers), "run_slipway_run_to_advance:S3_REVIEW")
+	assert.Equal(t, "run_slipway_run_to_advance", view.ConfirmationRequirement.Reason)
+	for _, blocker := range view.Blockers {
+		if blocker.Code == "no_skill_required" {
+			assert.NotEqual(t, model.ReasonSeverityError, blocker.Severity)
+		}
+	}
+}
+
+func TestNextS0ConfirmWithoutApprovedSummaryDoesNotReportRunGuidance(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		slug := createIntakeChangeFixture(t, root, "confirm requires approved summary")
+		change, err := state.LoadChange(root, slug)
+		require.NoError(t, err)
+		change.IntakeSubStep = model.IntakeSubStepConfirm
+		change.ComplexityLevel = "simple"
+		require.NoError(t, state.SaveChange(root, change))
+
+		bundlePath := filepath.Join(root, "artifacts", "changes", change.Slug)
+		require.NoError(t, writeBundleArtifactFile(bundlePath, change.Slug, "intent.md", []byte(`# Intent
+
+## Summary
+Clarified workflow diagnostic fix.
+
+## In Scope
+- Keep S0 confirm blocked until the user approves the summary.
+
+## Out of Scope
+- Do not advance planning before confirmation.
+
+## Acceptance Signals
+- next --json does not advertise slipway run before approval.
+
+## Open Questions
+<!-- none -->
+
+## Approved Summary
+<!-- pending user confirmation -->
+`)))
+		writeSkillVerification(t, root, slug, progression.SkillIntakeClarification, model.VerificationRecord{
+			Verdict:    model.VerificationVerdictPass,
+			Blockers:   []model.ReasonCode{},
+			Timestamp:  time.Now().UTC(),
+			RunVersion: 0,
+		})
+
+		view, err := buildNextView(root, changeRef{Slug: slug}, "", true, false, false)
+		require.NoError(t, err)
+		assert.Nil(t, view.NextSkill)
+		assert.Contains(t, model.ReasonSpecs(view.Blockers), "intake_confirmation_incomplete:intent.md requires non-empty 'Approved Summary'")
+		assert.Contains(t, model.ReasonSpecs(view.Blockers), "no_skill_required:S0_INTAKE")
+		assert.NotContains(t, model.ReasonSpecs(view.Blockers), "run_slipway_run_to_advance:S0_INTAKE")
+		assert.NotEqual(t, "run_slipway_run_to_advance", view.ConfirmationRequirement.Reason)
 	})
 }
 
@@ -958,7 +1048,9 @@ func TestDiagnosticCommandsExposePathAuthorityWhenFreshnessUnknown(t *testing.T)
 		require.NotNil(t, nextDiag.FreshnessDiagnostics)
 		assert.Equal(t, "unknown", nextDiag.FreshnessDiagnostics.Status)
 		require.NotNil(t, nextDiag.FreshnessDiagnostics.PathAuthority)
-		assert.Contains(t, nextDiag.FreshnessDiagnostics.PathAuthority.RuntimeEvidencePath, ".git/slipway/runtime/changes/"+slug)
+		runtimePath := nextDiag.FreshnessDiagnostics.PathAuthority.RuntimeEvidencePath
+		assert.True(t, filepath.IsAbs(runtimePath))
+		assert.True(t, strings.HasSuffix(runtimePath, "/.git/slipway/runtime/changes/"+slug), runtimePath)
 
 		validateCmd := commandForRoot(t, root, makeValidateCmd())
 		validateCmd.SetArgs([]string{"--json", "--change", slug})

--- a/cmd/repair_test.go
+++ b/cmd/repair_test.go
@@ -896,7 +896,9 @@ func TestRepairRebuildsReadyButStaleExecutionSummaryDrift(t *testing.T) {
 			assert.False(t, strings.Contains(drift.Target, slug), "rebuilt stale summary must not remain unrepaired: %+v", drift)
 		}
 		require.Contains(t, summary.PathAuthority, slug)
-		assert.Contains(t, summary.PathAuthority[slug].TaskEvidencePath, ".git/slipway/runtime/changes/"+slug+"/evidence/tasks")
+		taskEvidencePath := summary.PathAuthority[slug].TaskEvidencePath
+		assert.True(t, filepath.IsAbs(taskEvidencePath))
+		assert.True(t, strings.HasSuffix(taskEvidencePath, "/.git/slipway/runtime/changes/"+slug+"/evidence/tasks"), taskEvidencePath)
 
 		rebuilt, err := state.LoadExecutionSummary(root, slug)
 		require.NoError(t, err)

--- a/cmd/status_view_build_test.go
+++ b/cmd/status_view_build_test.go
@@ -171,7 +171,9 @@ func TestBuildGovernedStatusViewIncludesStaleExecutionEvidenceBlocker(t *testing
 	assert.Contains(t, view.FreshnessDiagnostics.FirstStaleCause.EvidenceArtifact, "execution-summary.yaml")
 	assert.Contains(t, view.FreshnessDiagnostics.FirstStaleCause.NextAction, "rerun")
 	require.NotNil(t, view.FreshnessDiagnostics.PathAuthority)
-	assert.Contains(t, view.FreshnessDiagnostics.PathAuthority.RuntimeEvidencePath, ".git/slipway/runtime/changes/stale-execution-summary")
+	runtimePath := view.FreshnessDiagnostics.PathAuthority.RuntimeEvidencePath
+	assert.True(t, filepath.IsAbs(runtimePath))
+	assert.True(t, strings.HasSuffix(runtimePath, "/.git/slipway/runtime/changes/stale-execution-summary"), runtimePath)
 	assert.Contains(t, view.FreshnessDiagnostics.PathAuthority.GovernedBundlePath, "artifacts/changes/stale-execution-summary")
 }
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -102,9 +102,13 @@ before `done`; it is not a post-archive audit surface for frozen bundles.
 `repair --json` separates `applied_repairs` from `unrepaired_drift`. Applied repairs are bounded local fixes that were actually performed; unrepaired drift includes a target, reason, and `next_action` for evidence or artifact work that Slipway did not mutate automatically. Ready execution summaries that are stale only because runtime task evidence is newer can be rebuilt from current wave-backed task evidence; stale planning-source drift remains unrepaired. Empty orphan active-bundle directories left behind after archive cleanup are removed as `empty_orphan_bundle` applied repairs; non-empty orphan bundles remain operator-reviewed integrity findings. Missing task-evidence blockers include the runtime task evidence path and the required flat JSON fields: `task_id,run_summary_version,task_kind,verdict,evidence_ref,captured_at,freshness_inputs`. `health --json` findings include `active_change_blocking` and `active_change_impact`; advisory codebase-map warnings are marked non-blocking for the active change.
 
 `done --json` archives done-ready worktree-bound changes even when source files
-are still uncommitted, but returns `worktree_dirty_warning` and
-`worktree_dirty_files` so operators do not delete a worktree while implementation
-changes are still only local.
+or non-active governance artifacts are still uncommitted, returning a
+non-blocking `worktree_dirty_warning` with `worktree_dirty_files` so operators
+commit those files together with the archived bundle. `done` never removes the
+worktree, and `git worktree remove` already refuses to drop a dirty worktree, so
+the advisory replaces a hard block. The active `artifacts/changes/<slug>/` bundle
+is excluded from the advisory because `done` rewrites it into
+`artifacts/changes/archived/<slug>/`; sibling or archived bundles are listed.
 
 ## Resume And Checkpoints
 

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -29,10 +29,15 @@ go run . status --json
 
 Avoid deciding readiness from `main...HEAD` alone. Pair branch comparisons with direct worktree status and diff checks.
 After `slipway done`, Git-safe archived records remain in the owning worktree; commit or merge them before removing that worktree.
-When a worktree-bound change still has uncommitted source changes, `done --json`
-archives the governed bundle but returns `worktree_dirty_warning` and
-`worktree_dirty_files` so the operator can commit or inspect the source diff
-before deleting the worktree.
+When a worktree-bound change still has uncommitted source or non-active
+governance changes, `done --json` archives anyway and returns a non-blocking
+`worktree_dirty_warning` with `worktree_dirty_files` so the operator commits
+those files together with the archived bundle. `done` does not remove the
+worktree, and `git worktree remove` refuses to drop a dirty worktree, so the
+advisory is sufficient. The active `artifacts/changes/<slug>/` bundle is excluded
+from the advisory because `done` rewrites it into
+`artifacts/changes/archived/<slug>/`; a dirty sibling or archived bundle is
+listed in the advisory.
 
 ## Health And Repair
 
@@ -130,9 +135,11 @@ Before `done`:
 3. Confirm `git diff --check`.
 4. Stage intended files only.
 5. Confirm `git diff --cached --check`.
-6. Run `slipway done --json` when the change is done-ready.
-7. If `worktree_dirty_warning` is present, inspect or commit the listed source
-   files before removing the worktree.
+6. Run `slipway done --json` when the change is done-ready. The active change
+   bundle does not need a pre-`done` commit.
+7. If `worktree_dirty_warning` is returned, the change is already archived;
+   commit the listed `worktree_dirty_files` together with the archived bundle
+   before removing the worktree.
 
 After `done`, use the archived `change.yaml` and bundle contents as frozen
 project records. `validate --change <slug>` intentionally rejects archived

--- a/internal/engine/progression/advance_intake.go
+++ b/internal/engine/progression/advance_intake.go
@@ -1,6 +1,7 @@
 package progression
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -59,29 +60,8 @@ func advanceIntakeClarify(root string, change *model.Change, fromState model.Wor
 		}
 	}
 
-	// Check required intent.md sections — complexity-proportional.
-	// trivial: In Scope + Acceptance Signals only
-	// simple+: In Scope + Out of Scope + Acceptance Signals
-	hasScope := sectionNonEmpty(intentContent, "## In Scope")
-	hasAcceptance := sectionNonEmpty(intentContent, "## Acceptance Signals")
-
-	var missing []string
-	if !hasScope {
-		missing = append(missing, "In Scope")
-	}
-	if !hasAcceptance {
-		missing = append(missing, "Acceptance Signals")
-	}
-	// Out of Scope only required for simple and above
-	if change.ComplexityLevel != "trivial" {
-		if !sectionNonEmpty(intentContent, "## Out of Scope") {
-			missing = append(missing, "Out of Scope")
-		}
-	}
-	if len(missing) > 0 {
-		return blockedAdvanceSummary(fromState, []model.ReasonCode{
-			model.NewReasonCode("intake_clarification_incomplete", "intent.md requires non-empty sections: "+strings.Join(missing, ", ")),
-		}), nil
+	if blockers := intakeClarificationBlockers(*change, intentContent); len(blockers) > 0 {
+		return blockedAdvanceSummary(fromState, blockers), nil
 	}
 
 	// If open questions have critical unknowns, route to research
@@ -130,33 +110,44 @@ func advanceIntakeResearch(root string, change *model.Change, fromState model.Wo
 		return AdvanceSummary{}, err
 	}
 
-	// Check skill evidence
-	nextSkillName, evidenceState := ResolveNextSkill(*change)
-	var passingSkills map[string]model.VerificationRecord
-	if nextSkillName != "" {
-		executionSummaryCtx, err := state.LoadRelevantExecutionSummaryContext(root, *change)
-		if err != nil {
-			return AdvanceSummary{}, err
-		}
-		var skillBlockers []string
-		passingSkills, skillBlockers, err = EvaluateRequiredSkillsForChange(
-			root,
-			*change,
-			model.WorkflowState(evidenceState),
-			executionSummaryCtx.LatestRunVersion,
-			false,
-		)
-		if err != nil {
-			return AdvanceSummary{}, err
-		}
-		if len(skillBlockers) > 0 {
-			return blockedAdvanceSummary(fromState, model.ReasonCodesFromSpecs(skillBlockers)), nil
-		}
+	// The research substep surfaces no host skill (machine-only), but the
+	// intake-clarification evidence gate must still hold before advancing into
+	// planning. Evaluate it independently of ResolveNextSkill so the mutating
+	// run path stays fail-closed even though no skill handoff is shown here.
+	evidenceBlockers, passingSkills, err := intakeClarificationEvidenceBlockers(root, *change)
+	if err != nil {
+		return AdvanceSummary{}, err
+	}
+	if len(evidenceBlockers) > 0 {
+		return blockedAdvanceSummary(fromState, evidenceBlockers), nil
 	}
 
-	// If still has open questions, go back to clarify
 	fromSub := string(change.IntakeSubStep)
 	if hasOpenQuestions(intentContent) {
+		if change.NeedsDiscovery {
+			sideEffects, cleared, err := enterPlanningFromIntake(root, change, true)
+			if err != nil {
+				return AdvanceSummary{}, err
+			}
+			if err := state.SaveChange(root, *change); err != nil {
+				return AdvanceSummary{}, err
+			}
+			return AdvanceSummary{
+				Action:        "advanced",
+				FromState:     fromState,
+				ToState:       model.StateS1Plan,
+				FromSubStep:   fromSub,
+				ToSubStep:     string(change.PlanSubStep),
+				Reason:        "open_questions_require_discovery",
+				Signals:       map[string]bool{"open_questions_detected": true},
+				SideEffects:   sideEffects,
+				ClearedFields: cleared,
+				Message:       fmt.Sprintf("Advanced to S1_PLAN/%s for structured discovery research.", change.PlanSubStep),
+			}, nil
+		}
+
+		// Non-discovery intake research stays in S0 clarification until the open
+		// questions are resolved.
 		change.AdvanceIntakeSubStep(model.IntakeSubStepClarify)
 		if err := state.SaveChange(root, *change); err != nil {
 			return AdvanceSummary{}, err
@@ -199,27 +190,15 @@ func advanceIntakeConfirm(root string, change *model.Change, fromState model.Wor
 		return AdvanceSummary{}, err
 	}
 
-	if !sectionNonEmpty(intentContent, "## Approved Summary") {
-		return blockedAdvanceSummary(fromState, []model.ReasonCode{
-			model.NewReasonCode("intake_confirmation_incomplete", "intent.md requires non-empty 'Approved Summary'"),
-		}), nil
+	if blockers := intakeConfirmationBlockers(intentContent); len(blockers) > 0 {
+		return blockedAdvanceSummary(fromState, blockers), nil
 	}
 
 	// Transition to S1_PLAN
 	fromSub := string(change.IntakeSubStep)
-	cleared := change.EnterPlanning(change.NeedsDiscovery)
-	if change.ClearAutoPassHistory() {
-		cleared = append(cleared, "last_auto_passed_states")
-	}
-	sideEffects := []SideEffect{}
-	if change.NeedsDiscovery && change.PlanSubStep == model.PlanSubStepResearch {
-		if err := artifact.EnsureResearchArtifactForChange(root, *change); err != nil {
-			return AdvanceSummary{}, err
-		}
-		sideEffects = append(sideEffects, SideEffect{
-			Kind:   "scaffolded_research",
-			Detail: "research.md created or verified for S1_PLAN/research",
-		})
+	sideEffects, cleared, err := enterPlanningFromIntake(root, change, change.NeedsDiscovery)
+	if err != nil {
+		return AdvanceSummary{}, err
 	}
 	if err := state.SaveChange(root, *change); err != nil {
 		return AdvanceSummary{}, err
@@ -235,6 +214,54 @@ func advanceIntakeConfirm(root string, change *model.Change, fromState model.Wor
 		ClearedFields: cleared,
 		Message:       fmt.Sprintf("Advanced to S1_PLAN/%s.", change.PlanSubStep),
 	}, nil
+}
+
+func enterPlanningFromIntake(root string, change *model.Change, clearResearchEvidence bool) ([]SideEffect, []string, error) {
+	sideEffects := []SideEffect{}
+	if clearResearchEvidence {
+		cleared, err := clearSkillVerification(root, *change, SkillResearchOrchestration)
+		if err != nil {
+			return nil, nil, err
+		}
+		sideEffects = append(sideEffects, cleared...)
+	}
+
+	cleared := change.EnterPlanning(change.NeedsDiscovery)
+	if change.ClearAutoPassHistory() {
+		cleared = append(cleared, "last_auto_passed_states")
+	}
+	if change.NeedsDiscovery && change.PlanSubStep == model.PlanSubStepResearch {
+		if err := artifact.EnsureResearchArtifactForChange(root, *change); err != nil {
+			return nil, nil, err
+		}
+		sideEffects = append(sideEffects, SideEffect{
+			Kind:   "scaffolded_research",
+			Detail: "research.md created or verified for S1_PLAN/research",
+		})
+	}
+	return sideEffects, cleared, nil
+}
+
+func clearSkillVerification(root string, change model.Change, skillName string) ([]SideEffect, error) {
+	skillName = strings.TrimSpace(skillName)
+	if skillName == "" {
+		return nil, nil
+	}
+	paths, err := state.ResolveChangePaths(root, change)
+	if err != nil {
+		return nil, err
+	}
+	path := filepath.Join(paths.GovernedBundleDir, "verification", skillName+".yaml")
+	if err := os.Remove(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("clear stale %s verification: %w", skillName, err)
+	}
+	return []SideEffect{{
+		Kind:   "cleared_verification",
+		Detail: state.DisplayPath(root, path),
+	}}, nil
 }
 
 // readIntentContent reads the intent.md file for a change.
@@ -254,6 +281,88 @@ func readIntentContent(root string, change model.Change) (string, error) {
 		return "", err
 	}
 	return string(data), nil
+}
+
+// IntakeAdvanceBlockers returns S0 machine-step blockers that AdvanceGoverned
+// would enforce after skill evidence has passed.
+func IntakeAdvanceBlockers(root string, change model.Change) []model.ReasonCode {
+	if change.CurrentState != model.StateS0Intake {
+		return nil
+	}
+	intentContent, err := readIntentContent(root, change)
+	if err != nil {
+		return []model.ReasonCode{model.NewReasonCode("artifact_not_ready", err.Error())}
+	}
+	switch change.IntakeSubStep {
+	case model.IntakeSubStepClarify:
+		return intakeClarificationBlockers(change, intentContent)
+	case model.IntakeSubStepResearch:
+		// Machine-only advance: no artifact gate beyond the clarify baseline, but
+		// the intake-clarification evidence must still pass so the next view's
+		// advanceability matches the fail-closed run path in advanceIntakeResearch.
+		evidenceBlockers, _, err := intakeClarificationEvidenceBlockers(root, change)
+		if err != nil {
+			return []model.ReasonCode{model.NewReasonCode("artifact_not_ready", err.Error())}
+		}
+		return evidenceBlockers
+	case model.IntakeSubStepConfirm:
+		return intakeConfirmationBlockers(intentContent)
+	default:
+		return []model.ReasonCode{model.NewReasonCode("intake_substep_invalid", string(change.IntakeSubStep))}
+	}
+}
+
+// intakeClarificationEvidenceBlockers re-evaluates the S0 intake-clarification
+// skill evidence. The machine-only research advance surfaces no host skill via
+// ResolveNextSkill, so this check runs independently to keep the intake gate
+// fail-closed on both the next-view advanceability and the mutating run path.
+func intakeClarificationEvidenceBlockers(root string, change model.Change) ([]model.ReasonCode, map[string]model.VerificationRecord, error) {
+	summaryCtx, err := state.LoadRelevantExecutionSummaryContext(root, change)
+	if err != nil {
+		return nil, nil, err
+	}
+	passing, skillBlockers, err := EvaluateRequiredSkillsForChange(
+		root,
+		change,
+		model.StateS0Intake,
+		summaryCtx.LatestRunVersion,
+		false,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	return model.ReasonCodesFromSpecs(skillBlockers), passing, nil
+}
+
+func intakeClarificationBlockers(change model.Change, intentContent string) []model.ReasonCode {
+	// Required sections are complexity-proportional:
+	// trivial: In Scope + Acceptance Signals
+	// simple+: In Scope + Out of Scope + Acceptance Signals
+	var missing []string
+	if !sectionNonEmpty(intentContent, "## In Scope") {
+		missing = append(missing, "In Scope")
+	}
+	if !sectionNonEmpty(intentContent, "## Acceptance Signals") {
+		missing = append(missing, "Acceptance Signals")
+	}
+	if change.ComplexityLevel != "trivial" && !sectionNonEmpty(intentContent, "## Out of Scope") {
+		missing = append(missing, "Out of Scope")
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	return []model.ReasonCode{
+		model.NewReasonCode("intake_clarification_incomplete", "intent.md requires non-empty sections: "+strings.Join(missing, ", ")),
+	}
+}
+
+func intakeConfirmationBlockers(intentContent string) []model.ReasonCode {
+	if sectionNonEmpty(intentContent, "## Approved Summary") {
+		return nil
+	}
+	return []model.ReasonCode{
+		model.NewReasonCode("intake_confirmation_incomplete", "intent.md requires non-empty 'Approved Summary'"),
+	}
 }
 
 // sectionNonEmpty checks if a markdown section contains non-placeholder content.

--- a/internal/engine/progression/advance_test.go
+++ b/internal/engine/progression/advance_test.go
@@ -675,6 +675,181 @@ Docs build
 	}
 }
 
+func TestAdvanceIntakeResearchDiscoveryEntersS1ResearchAndClearsStaleEvidence(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	if err := model.SaveConfig(state.ConfigPath(root), model.DefaultConfig()); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	change := model.NewChange("s0-research-enters-s1")
+	change.CurrentState = model.StateS0Intake
+	change.IntakeSubStep = model.IntakeSubStepResearch
+	change.PlanSubStep = model.PlanSubStepNone
+	change.NeedsDiscovery = true
+	change.ComplexityLevel = "complex"
+	change.WorkflowPreset = model.WorkflowPresetStandard
+	change.ArtifactSchema = model.ArtifactSchemaExpanded
+	if err := state.SaveChange(root, change); err != nil {
+		t.Fatalf("save change: %v", err)
+	}
+
+	bundleDir := filepath.Join(root, "artifacts", "changes", change.Slug)
+	if err := os.MkdirAll(bundleDir, 0o755); err != nil {
+		t.Fatalf("mkdir bundle: %v", err)
+	}
+	intent := `# Intent
+
+## Summary
+Test S0 research handoff.
+
+## In Scope
+Clarify discovery before planning.
+
+## Out of Scope
+Skip direct execution.
+
+## Acceptance Signals
+S1 research must require fresh research evidence.
+
+## Open Questions
+- Which implementation path should be selected?
+`
+	if err := os.WriteFile(filepath.Join(bundleDir, "intent.md"), []byte(intent), 0o644); err != nil {
+		t.Fatalf("write intent.md: %v", err)
+	}
+	// Reaching S0_INTAKE/research implies intake clarification already passed;
+	// the machine-only research advance stays fail-closed on that evidence.
+	writeVerificationForTest(t, root, change.Slug, SkillIntakeClarification, model.VerificationRecord{
+		Verdict:    model.VerificationVerdictPass,
+		Timestamp:  change.CreatedAt,
+		RunVersion: 0,
+		References: []string{"s0:clarify"},
+	})
+	writeVerificationForTest(t, root, change.Slug, SkillResearchOrchestration, model.VerificationRecord{
+		Verdict:    model.VerificationVerdictPass,
+		Timestamp:  change.CreatedAt,
+		RunVersion: 0,
+		References: []string{"s0:stale"},
+	})
+
+	summary, err := AdvanceGoverned(root, change.Slug)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if summary.Action != "advanced" {
+		t.Fatalf("expected advanced, got %+v", summary)
+	}
+	if summary.ToState != model.StateS1Plan || summary.ToSubStep != string(model.PlanSubStepResearch) {
+		t.Fatalf("expected S1_PLAN/research, got state=%s substep=%s", summary.ToState, summary.ToSubStep)
+	}
+	if summary.Reason != "open_questions_require_discovery" {
+		t.Fatalf("expected open_questions_require_discovery, got %s", summary.Reason)
+	}
+	if !hasSideEffect(summary.SideEffects, "cleared_verification") {
+		t.Fatalf("expected stale research verification to be cleared, got %+v", summary.SideEffects)
+	}
+	if !hasSideEffect(summary.SideEffects, "scaffolded_research") {
+		t.Fatalf("expected research artifact to be scaffolded, got %+v", summary.SideEffects)
+	}
+	if _, err := os.Stat(filepath.Join(bundleDir, "research.md")); err != nil {
+		t.Fatalf("expected research.md to exist after S1 research handoff: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(bundleDir, "verification", SkillResearchOrchestration+".yaml")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected stale research verification to be removed, err=%v", err)
+	}
+
+	reloaded, err := state.LoadChange(root, change.Slug)
+	if err != nil {
+		t.Fatalf("reload change: %v", err)
+	}
+	if reloaded.CurrentState != model.StateS1Plan || reloaded.PlanSubStep != model.PlanSubStepResearch {
+		t.Fatalf("expected reloaded S1_PLAN/research, got state=%s substep=%s", reloaded.CurrentState, reloaded.PlanSubStep)
+	}
+	if reloaded.IntakeSubStep != model.IntakeSubStepNone {
+		t.Fatalf("expected intake substep cleared, got %s", reloaded.IntakeSubStep)
+	}
+
+	blocked, err := AdvanceGoverned(root, change.Slug)
+	if err != nil {
+		t.Fatalf("unexpected second advance error: %v", err)
+	}
+	if blocked.Action != "blocked" {
+		t.Fatalf("expected missing S1 research evidence to block, got %+v", blocked)
+	}
+	if !hasAdvanceReasonDetail(blocked.Blockers, "required_skill_missing", SkillResearchOrchestration) {
+		t.Fatalf("expected missing research-orchestration blocker, got %+v", blocked.Blockers)
+	}
+}
+
+func TestAdvanceIntakeResearchBlocksWhenIntakeClarificationEvidenceMissing(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	if err := model.SaveConfig(state.ConfigPath(root), model.DefaultConfig()); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	change := model.NewChange("s0-research-missing-intake-evidence")
+	change.CurrentState = model.StateS0Intake
+	change.IntakeSubStep = model.IntakeSubStepResearch
+	change.PlanSubStep = model.PlanSubStepNone
+	change.NeedsDiscovery = true
+	change.ComplexityLevel = "complex"
+	change.WorkflowPreset = model.WorkflowPresetStandard
+	change.ArtifactSchema = model.ArtifactSchemaExpanded
+	if err := state.SaveChange(root, change); err != nil {
+		t.Fatalf("save change: %v", err)
+	}
+
+	bundleDir := filepath.Join(root, "artifacts", "changes", change.Slug)
+	if err := os.MkdirAll(bundleDir, 0o755); err != nil {
+		t.Fatalf("mkdir bundle: %v", err)
+	}
+	intent := `# Intent
+
+## Summary
+Test S0 research fail-closed on missing intake evidence.
+
+## In Scope
+Clarify discovery before planning.
+
+## Out of Scope
+Skip direct execution.
+
+## Acceptance Signals
+Advance must block without intake-clarification evidence.
+
+## Open Questions
+- Which implementation path should be selected?
+`
+	if err := os.WriteFile(filepath.Join(bundleDir, "intent.md"), []byte(intent), 0o644); err != nil {
+		t.Fatalf("write intent.md: %v", err)
+	}
+	// Intentionally omit intake-clarification evidence: the machine-only research
+	// advance must not bypass the intake gate even though no skill is surfaced.
+
+	summary, err := AdvanceGoverned(root, change.Slug)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if summary.Action != "blocked" {
+		t.Fatalf("expected missing intake-clarification evidence to block, got %+v", summary)
+	}
+	if !hasAdvanceReasonDetail(summary.Blockers, "required_skill_missing", SkillIntakeClarification) {
+		t.Fatalf("expected missing intake-clarification blocker, got %+v", summary.Blockers)
+	}
+
+	reloaded, err := state.LoadChange(root, change.Slug)
+	if err != nil {
+		t.Fatalf("reload change: %v", err)
+	}
+	if reloaded.CurrentState != model.StateS0Intake || reloaded.IntakeSubStep != model.IntakeSubStepResearch {
+		t.Fatalf("expected change to remain at S0_INTAKE/research, got state=%s substep=%s", reloaded.CurrentState, reloaded.IntakeSubStep)
+	}
+}
+
 func TestSectionNonEmptyPrefersCanonicalIntentSectionOverSummarySourceDocument(t *testing.T) {
 	t.Parallel()
 
@@ -1037,6 +1212,12 @@ func TestAdvanceIntake_ConfirmToS1PlanResearchMaterializesResearchArtifact(t *te
 	if err := os.WriteFile(filepath.Join(bundleDir, "intent.md"), []byte(intent), 0o644); err != nil {
 		t.Fatalf("write intent.md: %v", err)
 	}
+	writeVerificationForTest(t, root, change.Slug, SkillResearchOrchestration, model.VerificationRecord{
+		Verdict:    model.VerificationVerdictPass,
+		Timestamp:  change.CreatedAt,
+		RunVersion: 0,
+		References: []string{"s0-confirm:stale"},
+	})
 
 	summary, err := AdvanceGoverned(root, change.Slug)
 	if err != nil {
@@ -1051,8 +1232,25 @@ func TestAdvanceIntake_ConfirmToS1PlanResearchMaterializesResearchArtifact(t *te
 	if !hasSideEffect(summary.SideEffects, "scaffolded_research") {
 		t.Fatalf("expected scaffolded_research side effect, got %+v", summary.SideEffects)
 	}
+	if !hasSideEffect(summary.SideEffects, "cleared_verification") {
+		t.Fatalf("expected stale research verification to be cleared, got %+v", summary.SideEffects)
+	}
 	if _, err := os.Stat(filepath.Join(bundleDir, "research.md")); err != nil {
 		t.Fatalf("expected research.md to exist after intake confirmation: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(bundleDir, "verification", SkillResearchOrchestration+".yaml")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected stale research verification to be removed, err=%v", err)
+	}
+
+	blocked, err := AdvanceGoverned(root, change.Slug)
+	if err != nil {
+		t.Fatalf("unexpected second advance error: %v", err)
+	}
+	if blocked.Action != "blocked" {
+		t.Fatalf("expected missing S1 research evidence to block, got %+v", blocked)
+	}
+	if !hasAdvanceReasonDetail(blocked.Blockers, "required_skill_missing", SkillResearchOrchestration) {
+		t.Fatalf("expected missing research-orchestration blocker, got %+v", blocked.Blockers)
 	}
 }
 

--- a/internal/engine/progression/readiness.go
+++ b/internal/engine/progression/readiness.go
@@ -1,6 +1,7 @@
 package progression
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -328,6 +329,10 @@ func evaluateGateReadiness(
 ) (map[gate.GateID]gate.GateEvaluation, *ShipAuthority, error) {
 	var result map[gate.GateID]gate.GateEvaluation
 	var err error
+	effectiveState := change.CurrentState
+	if opts.WorkflowStateOverride != nil && *opts.WorkflowStateOverride != "" {
+		effectiveState = *opts.WorkflowStateOverride
+	}
 	if opts.IncludeGateEvaluations {
 		planSkills, err := gatePlanningSkillRecords(root, change, model.PlanSubStepAudit)
 		if err != nil {
@@ -336,7 +341,7 @@ func evaluateGateReadiness(
 		result = map[gate.GateID]gate.GateEvaluation{
 			gate.GatePlan: EvaluatePlanGate(root, change, planSkills),
 		}
-		if change.NeedsDiscovery {
+		if change.NeedsDiscovery && effectiveState != model.StateS0Intake {
 			scopeSkills, err := gatePlanningSkillRecords(root, change, model.PlanSubStepResearch)
 			if err != nil {
 				return nil, nil, err
@@ -349,10 +354,6 @@ func evaluateGateReadiness(
 		}
 	}
 	shipReadiness := currentReadiness
-	effectiveState := change.CurrentState
-	if opts.WorkflowStateOverride != nil && *opts.WorkflowStateOverride != "" {
-		effectiveState = *opts.WorkflowStateOverride
-	}
 	needsVerifyRefresh := effectiveState != model.StateS4Verify
 	if !needsVerifyRefresh {
 		_, needsVerifyRefresh = currentReadiness.cachedReviewAuthority()
@@ -609,13 +610,42 @@ func resolveArtifactEvaluationContext(root string, change model.Change, required
 }
 
 func scopeContractWorkspaceChangedFiles(paths state.ResolvedChangePaths) []string {
+	return workspaceChangedFiles(paths, workspaceChangedFilesOptions{})
+}
+
+type workspaceChangedFilesOptions struct {
+	includeGovernedBundle bool
+	includeLocalState     bool
+	// exemptActiveBundleOnly narrows the governed-bundle dirty exemption to the
+	// active change's bundle. When false, every artifacts/changes/ path is
+	// exempted (scope-contract behavior). `done` archive sets this true so a
+	// dirty sibling or archived bundle is still reported in the non-blocking
+	// dirty advisory — only the active artifacts/changes/<slug>/ bundle is
+	// suppressed because `done` rewrites it into the archived record (REQ-004).
+	exemptActiveBundleOnly bool
+}
+
+// WorkspaceChangedFilesForDoneArchive returns Git-visible changed files that
+// `done` reports in its non-blocking dirty-worktree advisory (REQ-004). Archive
+// still completes; only the active governed bundle is exempted, because `done`
+// rewrites it into the archived bundle. Any other dirty governance artifact is
+// surfaced so the operator can commit it alongside the archived record.
+func WorkspaceChangedFilesForDoneArchive(paths state.ResolvedChangePaths) []string {
+	return workspaceChangedFiles(paths, workspaceChangedFilesOptions{
+		includeGovernedBundle:  false,
+		includeLocalState:      true,
+		exemptActiveBundleOnly: true,
+	})
+}
+
+func workspaceChangedFiles(paths state.ResolvedChangePaths, opts workspaceChangedFilesOptions) []string {
 	workspaceRoot := strings.TrimSpace(paths.WorkspaceRoot)
 	if workspaceRoot == "" {
 		return nil
 	}
 	files := gitNameOnly(workspaceRoot, "diff", "--name-only", "HEAD", "--")
 	for _, file := range gitNameOnly(workspaceRoot, "ls-files", "--others", "--exclude-standard") {
-		if scopeContractUntrackedChangedFile(workspaceRoot, file) {
+		if opts.includeLocalState || scopeContractUntrackedChangedFile(workspaceRoot, file) {
 			files = append(files, file)
 		}
 	}
@@ -634,11 +664,16 @@ func scopeContractWorkspaceChangedFiles(paths state.ResolvedChangePaths) []strin
 		if file == "" {
 			continue
 		}
-		if file == "artifacts" || strings.HasPrefix(file, "artifacts/changes/") {
+		if opts.includeLocalState && generatedOnlyLocalStateChangedFile(workspaceRoot, file) {
 			continue
 		}
-		if bundleRel != "" && bundleRel != "." && (file == bundleRel || strings.HasPrefix(file, bundleRel+"/")) {
-			continue
+		if !opts.includeGovernedBundle {
+			if !opts.exemptActiveBundleOnly && (file == "artifacts" || strings.HasPrefix(file, "artifacts/changes/")) {
+				continue
+			}
+			if bundleRel != "" && bundleRel != "." && (file == bundleRel || strings.HasPrefix(file, bundleRel+"/")) {
+				continue
+			}
 		}
 		filtered = append(filtered, file)
 	}
@@ -646,12 +681,6 @@ func scopeContractWorkspaceChangedFiles(paths state.ResolvedChangePaths) []strin
 		return nil
 	}
 	return stringutil.UniqueSorted(filtered)
-}
-
-// WorkspaceChangedFiles returns implementation-side changed files for the
-// resolved workspace, excluding governed bundle files.
-func WorkspaceChangedFiles(paths state.ResolvedChangePaths) []string {
-	return scopeContractWorkspaceChangedFiles(paths)
 }
 
 func scopeContractUntrackedChangedFile(workspaceRoot, file string) bool {
@@ -672,13 +701,77 @@ func scopeContractUntrackedChangedFile(workspaceRoot, file string) bool {
 	return true
 }
 
+func generatedOnlyLocalStateChangedFile(workspaceRoot, file string) bool {
+	switch file {
+	case ".gitignore":
+		return generatedOnlyGitIgnoreChange(workspaceRoot)
+	case fsutil.ProjectConfigFileName:
+		return generatedOnlyProjectConfigChange(workspaceRoot)
+	default:
+		return false
+	}
+}
+
+func generatedOnlyGitIgnoreChange(workspaceRoot string) bool {
+	raw, err := os.ReadFile(filepath.Join(workspaceRoot, ".gitignore"))
+	if err != nil {
+		return false
+	}
+	content := normalizeLineEndings(string(raw))
+	headContent, ok := gitHeadFileContent(workspaceRoot, ".gitignore")
+	if !ok {
+		return strings.TrimSpace(content) == strings.TrimSpace(state.LocalStateGitIgnoreBlock())
+	}
+	expected, err := state.NormalizeLocalStateGitIgnoreContent(headContent)
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(content) == strings.TrimSpace(normalizeLineEndings(expected))
+}
+
+func generatedOnlyProjectConfigChange(workspaceRoot string) bool {
+	if _, ok := gitHeadFileContent(workspaceRoot, fsutil.ProjectConfigFileName); ok {
+		return false
+	}
+	raw, err := os.ReadFile(filepath.Join(workspaceRoot, fsutil.ProjectConfigFileName))
+	if err != nil {
+		return false
+	}
+	cfg, err := model.ParseConfigYAML(raw)
+	if err != nil {
+		return false
+	}
+	current, err := cfg.ToYAML()
+	if err != nil {
+		return false
+	}
+	defaultConfig, err := model.DefaultConfig().ToYAML()
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(bytes.TrimSpace(current), bytes.TrimSpace(defaultConfig))
+}
+
 func scopeContractGeneratedOnlyGitIgnore(workspaceRoot string) bool {
 	raw, err := os.ReadFile(filepath.Join(workspaceRoot, ".gitignore"))
 	if err != nil {
 		return false
 	}
-	content := strings.ReplaceAll(string(raw), "\r\n", "\n")
+	content := normalizeLineEndings(string(raw))
 	return strings.TrimSpace(content) == strings.TrimSpace(state.LocalStateGitIgnoreBlock())
+}
+
+func normalizeLineEndings(content string) string {
+	return strings.ReplaceAll(content, "\r\n", "\n")
+}
+
+func gitHeadFileContent(workspaceRoot, file string) (string, bool) {
+	cmd := exec.Command("git", "-C", workspaceRoot, "show", "HEAD:"+filepath.ToSlash(file))
+	out, err := cmd.Output()
+	if err != nil {
+		return "", false
+	}
+	return string(out), true
 }
 
 func gitNameOnly(workspaceRoot string, args ...string) []string {

--- a/internal/engine/progression/readiness_optimization_test.go
+++ b/internal/engine/progression/readiness_optimization_test.go
@@ -437,6 +437,83 @@ func TestScopeContractWorkspaceChangedFilesIncludesWorktreeDiffAndExcludesBundle
 	assert.NotContains(t, files, "artifacts/changes/scope-drift/tasks.md")
 }
 
+func TestWorkspaceChangedFilesForDoneArchiveExcludesBundleAndGeneratedLocalState(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	initGitWorkspaceForReadinessOptimizationTests(t, root)
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "cmd"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "README.md"), []byte("before\n"), 0o644))
+	gitForReadinessOptimizationTests(t, root, "add", "README.md")
+	gitForReadinessOptimizationTests(t, root, "commit", "-m", "init")
+
+	bundleDir := filepath.Join(root, "artifacts", "changes", "done-dirty")
+	require.NoError(t, os.MkdirAll(bundleDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "README.md"), []byte("after\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "cmd", "untracked.go"), []byte("package cmd\n"), 0o644))
+	require.NoError(t, model.SaveConfig(state.ConfigPath(root), model.DefaultConfig()))
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".gitignore"), []byte(state.LocalStateGitIgnoreBlock()), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "tasks.md"), []byte("# Tasks\n"), 0o644))
+
+	files := WorkspaceChangedFilesForDoneArchive(state.ResolvedChangePaths{
+		WorkspaceRoot:     root,
+		GovernedBundleDir: bundleDir,
+	})
+
+	assert.Contains(t, files, "README.md")
+	assert.Contains(t, files, "cmd/untracked.go")
+	assert.NotContains(t, files, "artifacts/changes/done-dirty/tasks.md")
+	assert.NotContains(t, files, ".gitignore")
+	assert.NotContains(t, files, ".slipway.yaml")
+}
+
+func TestWorkspaceChangedFilesForDoneArchiveKeepsRealLocalGovernanceFiles(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	initGitWorkspaceForReadinessOptimizationTests(t, root)
+	require.NoError(t, os.WriteFile(filepath.Join(root, "README.md"), []byte("before\n"), 0o644))
+	gitForReadinessOptimizationTests(t, root, "add", "README.md")
+	gitForReadinessOptimizationTests(t, root, "commit", "-m", "init")
+
+	bundleDir := filepath.Join(root, "artifacts", "changes", "done-dirty")
+	require.NoError(t, os.MkdirAll(bundleDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".gitignore"), []byte("node_modules/\n\n"+state.LocalStateGitIgnoreBlock()), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".slipway.yaml"), []byte("context:\n  tech_stack: Go\n"), 0o644))
+
+	files := WorkspaceChangedFilesForDoneArchive(state.ResolvedChangePaths{
+		WorkspaceRoot:     root,
+		GovernedBundleDir: bundleDir,
+	})
+
+	assert.Contains(t, files, ".gitignore")
+	assert.Contains(t, files, ".slipway.yaml")
+}
+
+func TestWorkspaceChangedFilesForDoneArchiveSkipsManagedGitIgnoreMigration(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	initGitWorkspaceForReadinessOptimizationTests(t, root)
+	legacyGitIgnore := "build/\n\n" +
+		"# Slipway local state (managed)\n" +
+		"/old-slipway-local-state/\n" +
+		"# End Slipway local state\n\n" +
+		"dist/\n"
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".gitignore"), []byte(legacyGitIgnore), 0o644))
+	gitForReadinessOptimizationTests(t, root, "add", ".gitignore")
+	gitForReadinessOptimizationTests(t, root, "commit", "-m", "init")
+	_, err := state.EnsureLocalStateGitIgnore(root)
+	require.NoError(t, err)
+
+	files := WorkspaceChangedFilesForDoneArchive(state.ResolvedChangePaths{
+		WorkspaceRoot:     root,
+		GovernedBundleDir: filepath.Join(root, "artifacts", "changes", "done-dirty"),
+	})
+
+	assert.NotContains(t, files, ".gitignore")
+}
+
 func TestScopeContractUntrackedChangedFileKeepsRealRootDotfiles(t *testing.T) {
 	t.Parallel()
 

--- a/internal/engine/progression/skill_resolution.go
+++ b/internal/engine/progression/skill_resolution.go
@@ -35,7 +35,8 @@ func resolveS0Intake(change model.Change) (string, string) {
 	case model.IntakeSubStepClarify:
 		return SkillIntakeClarification, string(model.StateS0Intake)
 	case model.IntakeSubStepResearch:
-		return SkillIntakeClarification, string(model.StateS0Intake)
+		// Machine-only step: advances discovery-scoped intake into S1_PLAN/research.
+		return "", ""
 	case model.IntakeSubStepConfirm:
 		// Machine-only step: confirms approved summary presence.
 		return "", ""

--- a/internal/engine/progression/skill_resolution_test.go
+++ b/internal/engine/progression/skill_resolution_test.go
@@ -13,7 +13,7 @@ func TestResolveNextSkill_S0Intake_SubSteps(t *testing.T) {
 		skill   string
 	}{
 		{model.IntakeSubStepClarify, SkillIntakeClarification},
-		{model.IntakeSubStepResearch, SkillIntakeClarification},
+		{model.IntakeSubStepResearch, ""},
 		{model.IntakeSubStepConfirm, ""},
 	}
 	for _, tt := range tests {

--- a/internal/model/reason_code.go
+++ b/internal/model/reason_code.go
@@ -76,6 +76,18 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 		Severity: ReasonSeverityError,
 		Message:  "The requested pivot kind is invalid",
 	},
+	"intake_clarification_incomplete": {
+		Severity: ReasonSeverityError,
+		Message:  "Intake clarification is incomplete",
+	},
+	"intake_confirmation_incomplete": {
+		Severity: ReasonSeverityError,
+		Message:  "Intake confirmation is incomplete",
+	},
+	"intake_substep_invalid": {
+		Severity: ReasonSeverityError,
+		Message:  "The intake substep is invalid",
+	},
 	"manifest_r0_invalid": {
 		Severity: ReasonSeverityError,
 		Message:  "The governed change manifest failed R0 validation",
@@ -91,6 +103,10 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 	"missing_worktree_path": {
 		Severity: ReasonSeverityError,
 		Message:  "The change is missing a bound worktree path",
+	},
+	"no_skill_required": {
+		Severity: ReasonSeverityInfo,
+		Message:  "No skill is required for the current workflow state",
 	},
 	"pivot_not_approved": {
 		Severity: ReasonSeverityError,
@@ -119,6 +135,10 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 	"required_skill_not_ready": {
 		Severity: ReasonSeverityError,
 		Message:  "A required governance skill is present but not ready",
+	},
+	"run_slipway_run_to_advance": {
+		Severity: ReasonSeverityWarning,
+		Message:  "Run `slipway run` to advance the workflow",
 	},
 	"scope_contract_changed_files_missing": {
 		Severity: ReasonSeverityError,

--- a/internal/state/execution_summary.go
+++ b/internal/state/execution_summary.go
@@ -435,10 +435,10 @@ func ExecutionPathAuthorityDiagnostics(root string, change model.Change, runSumm
 	}
 	out := &ExecutionPathAuthority{
 		InvocationWorkspacePath: DisplayPath(root, root),
-		GitCommonDirPath:        DisplayPath(root, GitCommonDir(root)),
-		RuntimeEvidencePath:     DisplayPath(root, ChangeDir(root, slug)),
+		GitCommonDirPath:        absolutePathForDiagnostics(GitCommonDir(root)),
+		RuntimeEvidencePath:     absolutePathForDiagnostics(ChangeDir(root, slug)),
 	}
-	out.TaskEvidencePath = DisplayPath(root, EvidenceTasksDir(root, slug))
+	out.TaskEvidencePath = absolutePathForDiagnostics(EvidenceTasksDir(root, slug))
 	if paths, err := ResolveChangePaths(root, change); err == nil {
 		out.BoundWorkspacePath = DisplayPath(root, paths.WorkspaceRoot)
 		out.GovernedBundlePath = DisplayPath(root, paths.GovernedBundleDir)
@@ -446,6 +446,13 @@ func ExecutionPathAuthorityDiagnostics(root string, change model.Change, runSumm
 		out.ChangeAuthorityPath = DisplayPath(root, filepath.Join(paths.GovernedBundleDir, "change.yaml"))
 	}
 	return out
+}
+
+func absolutePathForDiagnostics(path string) string {
+	if normalized, err := NormalizePath(path); err == nil {
+		return filepath.ToSlash(normalized)
+	}
+	return filepath.ToSlash(filepath.Clean(path))
 }
 
 func taskFreshnessInputDiffs(root string, change model.Change, summary *model.ExecutionSummary) []ExecutionTaskInputDifference {

--- a/internal/state/execution_summary_test.go
+++ b/internal/state/execution_summary_test.go
@@ -187,7 +187,9 @@ tasks:
 	assert.Equal(t, "change_id", ctx.Diagnostics.TaskInputDiffs[0].Field)
 	assert.Contains(t, ctx.Diagnostics.TaskInputDiffs[0].Current, "legacy evidence_input_hash=wrong-content-hash")
 	require.NotNil(t, ctx.Diagnostics.PathAuthority)
-	assert.Contains(t, ctx.Diagnostics.PathAuthority.RuntimeEvidencePath, ".git/slipway/runtime/changes/"+change.Slug)
+	runtimePath := ctx.Diagnostics.PathAuthority.RuntimeEvidencePath
+	assert.True(t, filepath.IsAbs(runtimePath))
+	assert.True(t, strings.HasSuffix(runtimePath, "/.git/slipway/runtime/changes/"+change.Slug), runtimePath)
 	assert.Contains(t, ctx.Diagnostics.NextAction, "regenerate")
 }
 

--- a/internal/state/local_ignore.go
+++ b/internal/state/local_ignore.go
@@ -46,6 +46,12 @@ func LocalStateGitIgnoreBlock() string {
 	return b.String()
 }
 
+// NormalizeLocalStateGitIgnoreContent returns content with the Slipway-managed
+// local-state block present and current, without writing it to disk.
+func NormalizeLocalStateGitIgnoreContent(current string) (string, error) {
+	return ensureLocalStateGitIgnoreBlock(current)
+}
+
 func EnsureLocalStateGitIgnore(root string) (GitIgnoreUpdate, error) {
 	workspaceRoot, err := NormalizePath(root)
 	if err != nil {


### PR DESCRIPTION
## Summary

Tier 1 of issue #53 — the low-risk workflow and diagnostic repairs grouped under root causes **C, D, E, G** in the [repair plan](https://github.com/signalridge/slipway/issues/53#issuecomment-4604547893). Tier 2 (A/F evidence contract + closeout reuse) and Tier 3 (B1/B2 stale-planning recovery) are intentionally deferred to separate PRs.

| RC | Fix |
|----|-----|
| **C** | Register `no_skill_required` as **info** severity (was defaulting to error). At `S3_REVIEW` with passing review evidence, `next` now projects the advanceable machine step and emits `run_slipway_run_to_advance` guidance instead of presenting a spurious error blocker. |
| **D** | `S0_INTAKE/research` becomes a **machine-only** step that advances into `S1_PLAN/research`, where the established `research-orchestration` registry/gate owns research evidence. Stale `research-orchestration` evidence is cleared on the transition so S0-era evidence cannot satisfy the S1 discovery gate. G_scope is no longer projected during S0 intake (no more premature "failed S1 research" reporting). |
| **E** | Git-internal runtime evidence paths (`git_common_dir_path`, `runtime_evidence_path`, `task_evidence_path`) render as **absolute** paths in linked-worktree diagnostics, where `.git` is a gitdir file and relative `.git/...` paths do not resolve. |
| **G** | Dirty **non-bundle** bound-worktree state is reported as a **non-blocking** `done` advisory (`worktree_dirty_warning` + `worktree_dirty_files`); `done` still archives. The active governed bundle is exempt because `done` rewrites it into the archived record. `git worktree remove` already refuses to drop a dirty tree, so the advisory replaces a hard block. |

## Design notes

- Extracted `IntakeAdvanceBlockers` / `intakeClarificationEvidenceBlockers` so the `next`-view advanceability projection and the mutating `run` path share the **same fail-closed evidence checks** — the next view cannot claim "advanceable" where `run` would block.
- `enterPlanningFromIntake` dedupes the two S0→S1 entry paths and centralizes stale-evidence clearing.
- The dirty-`done` repair lands as an **advisory, not a hard block** (per REQ-004), matching the established direction that git already guards premature worktree removal.

## Testing

- `go build ./...` ✅  `go vet ./...` ✅
- `go test ./...` ✅ (full suite, fresh)
- Focused regression coverage: S3 run guidance, S0→S1 research routing + stale-evidence clearing, S1 bundle plan-audit handoff, linked-worktree path diagnostics, non-bundle dirty-`done` advisory, active-bundle-only archiving.

Addresses #53 — **Tier 1 only**; the tracker stays open for Tier 2 and Tier 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
