### PR TITLE
fix(governance): add stale planning recovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ All routed commands support `--json` for structured output:
 - `slipway next --json` — query next step as a handoff-only JSON surface (read-only, does not advance state)
 - `slipway next --json --no-auto-pass` — query next step, reporting `auto_pass_eligible` instead of auto-passing
 - `slipway next --json --diagnostics` — include governance/readiness diagnostics in the next-step view
-- `slipway run --json` — advance to next step and return the handoff-only JSON surface (the only state-mutating execution surface)
+- `slipway run --json` — advance to next step and return the handoff-only JSON surface (the only state-mutating execution surface); when S3/S4 planning evidence is stale, `run` can reopen S1 plan-audit, clear stale planning/downstream verification evidence, and preserve runtime execution evidence for ordered refresh
 - `slipway run --json --diagnostics` — include transition traces and governance/readiness diagnostics in the returned run view
 - `slipway status --json` — check current state
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ flowchart LR
 ```
 
 The primary lifecycle commands are `slipway new`, `slipway next`, `slipway run`, `slipway status`, and `slipway done`.
+If planning evidence drifts after execution or review, `slipway next` reports
+the recovery path without mutating state, while `slipway run` can reopen
+planning, clear stale planning/downstream verification evidence, and preserve
+runtime execution evidence for ordered refresh.
 
 ## Install
 

--- a/artifacts/changes/complete-issue-53-tier-3-stale-planning-recovery-state-machi/assurance.md
+++ b/artifacts/changes/complete-issue-53-tier-3-stale-planning-recovery-state-machi/assurance.md
@@ -1,0 +1,48 @@
+# Assurance
+
+## Scope Summary
+Tier 3 implements issue #53 B1/B2 only: non-destructive S3/S4 stale-planning
+recovery, actionable `next`/`run` guidance, selective evidence invalidation,
+S3/S4 scope-contract recovery guidance, and pivot precondition parity. Tier 1,
+Tier 2, backup handling, and final `slipway done` closeout remain out of scope.
+
+## Verification Verdict
+Implementation proof passes. Focused recovery/pivot/scope-contract regressions
+pass, touched packages pass, full workspace tests pass, and build/vet/diff
+checks pass. Governance validation is refreshed after this assurance update.
+
+## Evidence Index
+- Passed: `go test ./cmd -run 'TestRunStalePlanning(EvidenceReopensPlanAuditAndPreservesRuntimeEvidence|RecoveryRequiresFreshReviewAfterExecutionRefresh|RecoveryRefreshesEvidenceInOrder)|TestNextStalePlanningEvidenceReportsRecoveryRunGuidance|TestValidateAndNextGuideS3ScopeContractDriftToRecoveryPath|TestPivotRescopeRejectedOutsideS2|TestValidatePivotPreconditions' -count=1 -v`
+- Passed: `go test ./internal/engine/gate ./internal/engine/progression -run 'TestEvaluateGPivot|Test.*StalePlanning|TestScopeContract' -count=1 -v`
+- Passed: `go test -count=1 ./cmd ./internal/engine/gate ./internal/engine/progression`
+- Passed: `go test -count=1 ./...`
+- Passed: `go build ./...`
+- Passed: `go vet ./...`
+- Passed: `git diff --check`
+- Passed: legacy rescope token/name search returned no source or artifact matches.
+
+## Requirement Coverage
+- REQ-001 -> t-01, t-03, t-06
+- REQ-002 -> t-01, t-04, t-06, t-07
+- REQ-003 -> t-01, t-03, t-06
+- REQ-004 -> t-01, t-03, t-06
+- REQ-005 -> t-02, t-05, t-07
+- REQ-006 -> t-06, t-07
+- REQ-007 -> t-04, t-05, domain-review evidence
+
+## Residual Risks and Exceptions
+No accepted exceptions. Runtime task evidence preservation, stale downstream
+review/verify invalidation, fail-closed rebuild ordering, S3/S4 recovery
+guidance, and pivot precondition parity are covered by focused regressions.
+
+## Rollback Readiness
+Rollback is source-only: revert the lifecycle, next-view, pivot-gate, and test
+changes. No migration is introduced. Recovery side effects are limited to
+active bundle verification files and downstream review/verify records; rollback
+does not require migration.
+
+## Archive Decision
+Ready for PR after final-closeout and active `validate --json` proof. The
+branch should be reviewed before any local `slipway done` archive step; active
+validation is captured before done-ready, and the archive step remains a
+post-review/merge workflow decision.

--- a/artifacts/changes/complete-issue-53-tier-3-stale-planning-recovery-state-machi/change.yaml
+++ b/artifacts/changes/complete-issue-53-tier-3-stale-planning-recovery-state-machi/change.yaml
@@ -1,0 +1,21 @@
+version: 1
+slug: complete-issue-53-tier-3-stale-planning-recovery-state-machi
+description: 'complete issue #53 Tier 3 stale-planning recovery state-machine fixes'
+status: active
+current_state: S4_VERIFY
+needs_discovery: true
+complexity_level: critical
+base_ref: HEAD
+created_at: 2026-06-03T04:46:46.186362Z
+guardrail_domain: external_api_contracts
+quality_mode: standard
+workflow_preset: standard
+worktree_branch: feat/complete-issue-53-tier-3-stale-planning-recovery-state-machi
+artifact_schema: expanded
+project_context:
+    tech_stack: Go CLI
+    test_cmd: go test -count=1 ./...
+    build_cmd: go build ./...
+    languages:
+        - Go
+    recent_work: 'Issue #53 Tier 1 (#60) and Tier 2 (#63) are merged into main; Tier 3 targets B1/B2 stale-planning recovery state-machine behavior.'

--- a/artifacts/changes/complete-issue-53-tier-3-stale-planning-recovery-state-machi/decision.md
+++ b/artifacts/changes/complete-issue-53-tier-3-stale-planning-recovery-state-machi/decision.md
@@ -1,0 +1,93 @@
+# Decision
+
+## Project Context
+- Tech Stack: Go CLI
+- Test Command: go test -count=1 ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Alternatives Considered
+
+### Option A: Use `pivot --rescope` for S3/S4 recovery
+Reuses an existing command, but the current pivot implementation clears
+runtime execution residue and returns rescope to S0 intake. That is too
+destructive for benign stale-planning drift and would violate REQ-003.
+
+### Option B: Add a new plan-audit refresh command
+Creates an explicit callable surface for plan refresh, but it adds another
+external API and still needs lifecycle state mutation, evidence invalidation,
+and `next` guidance. The extra command is unnecessary for the Tier 3 scope.
+
+### Option C: Reopen `S1_PLAN/audit` from `slipway run`
+When S3/S4 readiness reports `stale_planning_evidence`, `slipway run` reopens
+`S1_PLAN/audit`, clears only stale derived verification artifacts, preserves
+runtime task evidence, and lets the existing plan-audit -> wave-plan ->
+execution-summary pipeline rebuild the chain.
+
+### Option D: Allow `pivot --rescope` from S3/S4
+This would make review/verify recovery feel direct, but it overloads a
+destructive execution-scope pivot with a planning-freshness repair. It would
+also make it easier to mutate the object under review after review/verify
+started, blurring evidence ownership and invalidation semantics.
+
+## Selected Approach
+DEC-001: Use Option C. Implement stale-planning recovery as a governed
+`slipway run` transition from S3/S4 back to `S1_PLAN/audit`, with read-only
+`next` guidance that tells the operator to run the recovery transition.
+Keep pivot separate: align `EvaluateGPivot` to the CLI boundary where rescope
+is S2-only because pivot remains destructive, and use `rescope_state_invalid`
+as the shared rescope state failure code.
+
+## Interfaces and Data Flow
+- `state.LoadRelevantExecutionSummaryContext` continues to classify stale
+  planning drift as `stale_planning_evidence`.
+- `progression.AdvanceGoverned` handles recoverable S3/S4
+  `stale_planning_evidence` before the generic execution-summary blocker
+  return, mutating the change to `S1_PLAN/audit`.
+- Recovery removes `verification/plan-audit.yaml`,
+  `verification/wave-plan.yaml`, `verification/execution-summary.yaml`, and
+  downstream run-summary-bound records:
+  `verification/spec-compliance-review.yaml`,
+  `verification/code-quality-review.yaml`,
+  `verification/goal-verification.yaml`, and
+  `verification/final-closeout.yaml`. It does not remove
+  `.git/slipway/runtime/changes/<slug>` or
+  `verification/wave-orchestration.yaml`.
+- `cmd/next_skill_view.go` recognizes recoverable stale planning blockers and
+  projects `run_slipway_run_to_advance` plus a recovery warning on read-only
+  handoff surfaces.
+- `internal/engine/gate.EvaluateGPivot` mirrors
+  `cmd.validatePivotPreconditions`: reroute allowed from S1/S2/S3/S4, rescope
+  allowed from S2 only.
+- `internal/engine/progression.EvaluateGovernanceReadiness` adds S3/S4
+  `scope_contract` guidance that tells operators to fix `tasks.md`
+  `target_files` or execution scope first, then use stale-planning recovery
+  when planning artifacts change. It does not point S3/S4 users toward
+  `pivot --rescope`.
+
+## Rollout and Rollback
+Roll forward by adding focused tests first, implementing the recovery helper,
+then updating JSON handoff and pivot gate parity. Roll back by reverting those
+code/test changes; no persistent migration is introduced. Runtime recovery
+side effects are limited to the active change's governed verification files
+and are auditable through lifecycle events.
+
+## Risk
+- High: accidentally deleting runtime task evidence would make recovery
+  destructive. Mitigation: tests assert task evidence and wave-orchestration
+  verification survive recovery.
+- High: stale plan-audit or wave-plan evidence could be reused. Mitigation:
+  recovery removes those files before presenting `plan-audit`.
+- High: old review/verify evidence could be reused after the execution summary
+  is rebuilt with the same run summary version. Mitigation: recovery also
+  removes downstream spec/code review, goal-verification, and final-closeout
+  records and clears the corresponding evidence refs.
+- Medium: preserved task evidence can be incompatible with changed `tasks.md`.
+  Mitigation: existing wave sync task-plan drift blockers remain in the
+  acceptance path.
+- Medium: read-only `next` could advertise the wrong host. Mitigation: tests
+  assert `run_slipway_run_to_advance` is present and recovery is the actionable
+  route when stale planning blocks S3/S4.
+- Medium: S3/S4 `scope_contract` failures could look like a `rescope` problem.
+  Mitigation: readiness diagnostics explicitly explain the recovery path and
+  that `pivot --rescope` remains S2-only.

--- a/artifacts/changes/complete-issue-53-tier-3-stale-planning-recovery-state-machi/intent.md
+++ b/artifacts/changes/complete-issue-53-tier-3-stale-planning-recovery-state-machi/intent.md
@@ -1,0 +1,84 @@
+# Intent
+
+## Project Context
+<!-- Auto-filled by InferProjectContext(); .slipway.yaml overrides -->
+- Tech Stack: Go CLI
+- Languages: Go
+- Test Command: go test -count=1 ./...
+- Build Command: go build ./...
+- Conventions: 
+
+## Summary
+INT-001: Complete issue #53 Tier 3 stale-planning recovery state-machine fixes.
+
+Complete issue #53 Tier 3 stale-planning recovery state-machine fixes for
+B1/B2: non-destructive S3/S4 recovery when planning evidence becomes stale.
+## Complexity Assessment
+critical
+Rationale: changes lifecycle state-machine behavior and machine-readable CLI
+surfaces for governed recovery paths in an external API contract domain.
+
+## Guardrail Domains
+external_api_contracts
+
+## In Scope
+- Design and implement a non-destructive S3/S4 recovery path for benign
+  planning drift caused by edits to `tasks.md` or planning evidence.
+- Make the recovery route actionable from CLI/AI surfaces instead of emitting a
+  dead-end instruction to rerun plan-audit from states that cannot call it.
+- Align `EvaluateGPivot` and `slipway pivot --rescope` preconditions so allowed
+  rescope states are consistent across gate evaluation and command enforcement.
+- Preserve useful execution evidence during rescope/recovery while invalidating
+  only downstream evidence that depends on stale planning artifacts.
+- Add focused regression tests for S3/S4 stale-planning recovery routing,
+  recovery ordering, fail-closed stale evidence, and pivot precondition
+  consistency.
+
+## Out of Scope
+- Tier 1 diagnostics/workflow fixes already merged in PR #60.
+- Tier 2 task-ledger and closeout reuse fixes already merged in PR #63.
+- Reopening the `execution-summary.broken.*.yaml` backup concern unless a new
+  Tier 3-specific repro appears.
+- Archiving/closeout via `slipway done`; this change must stop before closeout.
+
+## Constraints
+- Keep recovery non-destructive: do not require `cancel` or manual runtime
+  surgery for benign S3/S4 planning drift.
+- Keep stale planning and scope-contract drift fail-closed until refreshed
+  plan-audit, wave-plan, and execution-summary evidence are complete.
+- Respect existing Slipway lifecycle gates and preserve unrelated local dirt.
+- Treat JSON/CLI behavior changes as external API contract changes requiring
+  domain-aware review evidence.
+
+## Acceptance Signals
+- Editing `tasks.md` or planning evidence in S3/S4 exposes an actionable
+  recovery route rather than a dead-end plan-audit instruction.
+- Recovery refreshes plan-audit, wave-plan, and execution-summary evidence in
+  the correct dependency order.
+- Scope contract drift and stale planning evidence remain blockers until the
+  refreshed evidence chain is complete.
+- `EvaluateGPivot` and `slipway pivot --rescope` agree on allowed states.
+- Fresh proof includes focused regressions plus `go test -count=1 ./...`,
+  `go build ./...`, `git diff --check`, and `slipway validate --json`.
+
+## Open Questions
+None.
+
+## Resolved Clarifications
+Code research selected a non-destructive S3/S4 `slipway run` recovery
+transition back to `S1_PLAN/audit`, with pivot rescope kept S2-only.
+
+## Deferred Ideas
+- Broader lifecycle ergonomics beyond B1/B2.
+- Additional recovery surfaces for non-benign or destructive scope changes.
+
+## Approved Summary
+Confirmed from the user objective and GitHub issue #53 comment
+`4604547893` on 2026-06-03T05:20:34Z: implement Tier 3 only. The change will
+add a non-destructive S3/S4 stale-planning recovery path for B1/B2, align
+`EvaluateGPivot` and CLI `pivot --rescope` state preconditions, and preserve
+useful execution evidence while invalidating only evidence downstream of stale
+planning artifacts. Tier 1, Tier 2, backup handling, and `slipway done`
+closeout are out of scope. Acceptance is proven by focused regressions plus
+full build/test/diff/governance validation, stopping at close-ready before
+final closeout.

--- a/artifacts/changes/complete-issue-53-tier-3-stale-planning-recovery-state-machi/requirements.md
+++ b/artifacts/changes/complete-issue-53-tier-3-stale-planning-recovery-state-machi/requirements.md
@@ -1,0 +1,133 @@
+# Requirements
+
+## Project Context
+- Tech Stack: Go CLI
+- Test Command: go test -count=1 ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Requirements
+
+### Requirement: S3S4PlanningRecoveryRoute
+REQ-001: When a governed change in `S3_REVIEW` or `S4_VERIFY` has execution
+freshness blocked by `stale_planning_evidence`, `slipway run` MUST provide a
+non-destructive recovery transition back to a planning audit state instead of
+leaving the operator at a dead-end instruction. Traces to INT-001.
+
+#### Scenario: Review-state planning drift recovery
+GIVEN a change is in `S3_REVIEW` with an existing execution summary
+WHEN a planning artifact changes after the summary was captured
+THEN `slipway run --json --diagnostics` transitions to `S1_PLAN/audit` with a
+recovery reason and presents `plan-audit` as the next actionable host.
+
+#### Scenario: Verify-state planning drift recovery
+GIVEN a change is in `S4_VERIFY` with an existing execution summary
+WHEN `tasks.md` or another planning artifact changes after execution evidence
+THEN `slipway run --json --diagnostics` reopens planning audit without
+finalizing or archiving the change.
+
+### Requirement: ReadOnlyRecoveryGuidance
+REQ-002: `slipway next --json` and diagnostic handoffs MUST expose an
+actionable recovery route for recoverable S3/S4 stale planning evidence,
+including `run_slipway_run_to_advance`, rather than surfacing only a stale
+plan-audit instruction from a state that cannot call plan-audit. S3/S4
+`scope_contract` failures MUST also guide the operator toward updating
+`tasks.md` `target_files` or execution scope and then using stale-planning
+recovery when planning artifacts change, not `pivot --rescope`. Traces to
+INT-001.
+
+#### Scenario: Query surface shows recovery action
+GIVEN a change is blocked in S3/S4 by `stale_planning_evidence`
+WHEN the operator runs `slipway next --json --diagnostics`
+THEN the JSON output includes stale freshness diagnostics and a warning or
+reason code directing the operator to run `slipway run` for recovery.
+
+#### Scenario: Scope-contract drift points to recovery path
+GIVEN a change is in S3/S4 and `scope_contract` fails because changed files do
+not match the task target contract
+WHEN `slipway validate --json` or `slipway next --json --diagnostics` renders
+the blocked state
+THEN diagnostics explain that the operator should fix `tasks.md` `target_files`
+or execution scope first, and that planning changes recover through
+`stale_planning_evidence` by running `slipway run` back to `S1_PLAN/audit`.
+
+### Requirement: SelectiveEvidenceInvalidation
+REQ-003: Stale-planning recovery MUST clear derived planning/execution
+verification artifacts and downstream review/verify records that depend on the
+stale planning inputs while preserving useful runtime execution evidence for
+later rebuilds. Traces to INT-001.
+
+#### Scenario: Recovery invalidates derived artifacts only
+GIVEN stale planning recovery starts from S3/S4
+WHEN the lifecycle reopens `S1_PLAN/audit`
+THEN `verification/plan-audit.yaml`, `verification/wave-plan.yaml`, and
+`verification/execution-summary.yaml` are removed if present. Downstream
+run-summary-bound records `verification/spec-compliance-review.yaml`,
+`verification/code-quality-review.yaml`, `verification/goal-verification.yaml`,
+and `verification/final-closeout.yaml` are also removed if present, while
+runtime task evidence under `.git/slipway/runtime/changes/<slug>/evidence/tasks`
+and the existing `wave-orchestration.yaml` evidence are preserved.
+
+#### Scenario: Old review evidence is not reused after rebuild
+GIVEN stale-planning recovery started from S4 with passing review and
+verification records for run summary version 1
+WHEN task evidence is refreshed and `execution-summary.yaml` is rebuilt with
+the same run summary version
+THEN old spec/code review, goal-verification, and final-closeout records cannot
+be reused; S3 requires fresh `spec-compliance-review` evidence.
+
+### Requirement: RefreshOrderingAndFailClosedEvidence
+REQ-004: Recovery MUST force the refreshed evidence chain through
+plan-audit, wave-plan materialization, and execution-summary rebuild in that
+order, and MUST remain fail-closed until the chain is complete. Traces to
+INT-001.
+
+#### Scenario: Refreshed chain order
+GIVEN recovery has reopened `S1_PLAN/audit`
+WHEN passing plan-audit evidence is recorded and `slipway run` advances
+THEN Slipway materializes a fresh `wave-plan.yaml` before entering S2, and S2
+wave synchronization rebuilds `execution-summary.yaml` from current wave/task
+evidence.
+
+#### Scenario: Incompatible task plan remains blocked
+GIVEN recovered planning changed `tasks.md` semantically after task evidence
+was captured
+WHEN S2 wave synchronization runs
+THEN the change remains blocked by task-plan drift instead of treating the
+preserved execution evidence as fresh.
+
+### Requirement: PivotPreconditionParity
+REQ-005: `EvaluateGPivot` and CLI pivot preconditions MUST agree on allowed
+pivot states: reroute is allowed from `S1_PLAN` and governed pivot states, and
+rescope remains limited to `S2_EXECUTE` because the pivot path is destructive.
+The CLI and gate surfaces SHOULD use `rescope_state_invalid` for the shared
+rescope state failure. Traces to INT-001.
+
+#### Scenario: Gate and CLI agree on rescope states
+GIVEN candidate states S1, S2, S3, and S4
+WHEN gate evaluation and CLI precondition checks are compared
+THEN both allow `--rescope` only from S2 and reject S1/S3/S4 consistently.
+
+### Requirement: RegressionAndGovernanceProof
+REQ-006: The implementation MUST include focused regression tests for recovery
+routing, recovery ordering, stale-evidence fail-closed behavior, downstream
+review/verify invalidation, scope-contract recovery guidance, and pivot
+precondition parity, plus full build/test/diff/governance proof before closeout.
+Traces to INT-001.
+
+#### Scenario: Verification commands pass
+GIVEN implementation and test work is complete
+WHEN verification is run
+THEN focused tests, `go test -count=1 ./...`, `go build ./...`,
+`git diff --check`, and `slipway validate --json` provide fresh passing proof.
+
+### Requirement: ExternalAPIContractsGuardrail
+REQ-007: JSON/CLI behavior changes MUST remain explicit, backward-compatible
+where possible, and covered by domain-aware review evidence because this change
+touches external API contracts. Traces to INT-001.
+
+#### Scenario: Guardrail compliance
+GIVEN `next`, `run`, `validate`, or `pivot` JSON output changes
+WHEN the change is reviewed
+THEN the domain review records the intentional contract changes and verifies
+that failures remain actionable and fail-closed.

--- a/artifacts/changes/complete-issue-53-tier-3-stale-planning-recovery-state-machi/research.md
+++ b/artifacts/changes/complete-issue-53-tier-3-stale-planning-recovery-state-machi/research.md
@@ -1,0 +1,143 @@
+# Research
+
+## Research Findings
+
+### Architecture
+- Affected modules: `internal/engine/progression/advance_governed.go` owns
+  mutating lifecycle advancement and currently returns blocked immediately when
+  `LoadRelevantExecutionSummaryContext` reports execution-summary issues
+  (`advance_governed.go:95-100`). This is the point that turns S3/S4 stale
+  planning drift into a dead end instead of a recovery transition.
+- Affected modules: `internal/state/execution_summary.go` classifies planning
+  drift separately from execution drift. `collectExecutionSummaryIssuesFromDiagnostics`
+  emits `stale_planning_evidence` when stale pairs contain planning evidence
+  (`execution_summary.go:288-309`), while `stalePlanningPairs` builds the
+  plan-audit -> wave-plan -> execution-summary evidence chain
+  (`execution_summary.go:553-686`).
+- Affected modules: `cmd/next_skill_view.go` resolves the user/agent handoff.
+  Its no-skill branch only adds `run_slipway_run_to_advance` when no blockers
+  exist (`next_skill_view.go:193-210`), so a stale-planning blocker currently
+  lacks a machine-actionable recovery hint.
+- Affected modules: `cmd/pivot_validation.go` and
+  `internal/engine/gate/gate.go` disagree on rescope boundaries. The CLI
+  restricts `--rescope` to `S2_EXECUTE` (`pivot_validation.go:24-33`), while
+  `EvaluateGPivot` allows rescope from S1/S2/S3/S4 (`gate.go:93-99`).
+- Dependency chains:
+  `next/run` -> `progression.AdvanceGoverned` -> `state.LoadRelevantExecutionSummaryContext`
+  -> `state.ExecutionSummaryFreshnessDiagnostics`; and
+  `S1_PLAN/audit` -> `state.MaterializeWavePlan` -> `S2_EXECUTE`
+  -> `SyncGovernedWaveExecution` -> `state.SaveExecutionSummary`.
+- Blast radius: lifecycle transition semantics, JSON reason codes, and
+  recovery diagnostics for governed changes in S3/S4. This is an external API
+  contract domain because `next/run/validate/pivot --json` surfaces change.
+- Constraints: stale planning and scope drift must stay fail-closed; recovery
+  must not delete runtime task evidence under `.git/slipway/runtime/changes`.
+
+### Patterns
+- Existing conventions: recovery-only planning already uses
+  `S1_PLAN/validate` with `RecoveryOnly` summaries for post-audit machine
+  validation failures (`advance_governed.go:302-320`), so reopening an S1
+  substep is an established lifecycle pattern.
+- Existing conventions: mutating advancement emits side effects and lifecycle
+  events from `AdvanceSummary` (`advance_governed.go:518-632`). New recovery
+  should use the same summary path instead of a command-specific side channel.
+- Existing conventions: planning evidence is stored in the governed bundle
+  verification directory (`verification/plan-audit.yaml`, `wave-plan.yaml`,
+  `execution-summary.yaml`); runtime task evidence is stored separately under
+  the git-common-dir runtime path. That separation lets recovery clear derived
+  bundle verification while preserving task ledgers.
+- Reusable abstractions: `state.RemoveExecutionSummary`, `state.WavePlanFileName`,
+  `state.ExecutionSummaryFileName`, `model.NewReasonCode`, and
+  `model.Change` substep helpers cover the needed changes without a new
+  persistent state field.
+- Convention deviations: none required. A new public command would be a larger
+  API addition and is not needed for Tier 3.
+
+### Risks
+- High: deleting too much execution state would violate the Tier 3
+  non-destructive recovery requirement. Recovery must not call
+  `ResetPivotExecutionResidue`, `ResetWaveExecution`, or remove the runtime
+  change directory.
+- High: reusing stale `plan-audit.yaml` or `wave-plan.yaml` after reopening
+  planning would falsely pass. Recovery must clear those derived files before
+  presenting `plan-audit`.
+- Medium: preserving old wave-orchestration evidence can be unsafe if
+  `tasks.md` changed semantically after task evidence capture. Existing
+  `SyncGovernedWaveExecution` checks task evidence timestamps against the
+  current tasks plan and emits `tasks_plan_changed_since_task_evidence` blockers
+  (`wave_sync.go:530-558`), so preservation remains fail-closed.
+- Medium: allowing `pivot --rescope` from S3/S4 would offer a destructive path
+  for benign drift. Aligning `EvaluateGPivot` down to the CLI's S2 rescope
+  boundary avoids advertising that as the recovery mechanism.
+- Reversibility: code changes are normal CLI/state-machine changes and can be
+  rolled back. Runtime recovery effects are explicit file removals from the
+  active governed bundle verification directory only.
+
+### Test Strategy
+- Existing coverage: `cmd/validate_artifact_gate_test.go` and
+  `cmd/review_test.go` already assert stale planning evidence remains a
+  blocker; `internal/state/execution_summary_test.go` asserts planning drift is
+  classified separately from stale execution evidence.
+- Add coverage: `next --json --diagnostics` from S3/S4 with stale planning
+  evidence should show an actionable `run_slipway_run_to_advance` recovery
+  route and should not point to a stale host skill as the only action.
+- Add coverage: `run --json --diagnostics` from S3/S4 with stale planning
+  evidence should transition to `S1_PLAN/audit`, clear only
+  `plan-audit.yaml`, `wave-plan.yaml`, and `execution-summary.yaml`, preserve
+  runtime task evidence and wave-orchestration evidence, and expose
+  `plan-audit` next.
+- Add coverage: after refreshed plan-audit, `run` should regenerate
+  `wave-plan.yaml`, then S2 wave sync should rebuild `execution-summary.yaml`
+  or fail closed on `tasks_plan_changed_since_task_evidence`.
+- Add coverage: `EvaluateGPivot` and CLI pivot preconditions agree on reroute
+  and rescope states.
+
+## Alternatives Considered
+
+- Approach 1: use `pivot --rescope` for S3/S4 stale planning recovery.
+  Tradeoff: reuses an existing command but calls the destructive pivot path,
+  which clears runtime evidence and returns to S0 intake. Rejected because Tier
+  3 requires non-destructive recovery for benign drift.
+- Approach 2: add a new callable `plan-audit refresh` command surface.
+  Tradeoff: explicit and targeted, but adds a new public API surface and still
+  needs lifecycle mutations, evidence invalidation, and `next` guidance.
+  Deferred because the existing `run` lifecycle surface can own this recovery.
+- Approach 3: make `run` reopen `S1_PLAN/audit` when S3/S4 readiness reports
+  `stale_planning_evidence`, clear only stale derived planning/execution
+  verification files, preserve runtime task evidence, and let the normal
+  plan-audit -> wave-plan -> execution-summary path refresh the chain.
+  Selected: it is the smallest state-machine change that provides an
+  actionable route, preserves useful runtime evidence, and keeps stale inputs
+  fail-closed through existing wave-sync guards.
+
+
+## Unknowns
+- Resolved: whether pivot should be the recovery surface -> no; it is
+  intentionally destructive and should stay separate from benign stale-planning
+  recovery.
+- Resolved: whether preserving wave-orchestration evidence is safe -> yes when
+  paired with existing task-plan drift blockers in `SyncGovernedWaveExecution`.
+- Remaining: None.
+
+
+## Assumptions
+- The recovery route should cover S3 and S4 only, matching the issue comment's
+  B1/B2 scope. Evidence: issue #53 comment `4604547893`.
+- Existing stale-planning classification is trusted. Evidence:
+  `internal/state/execution_summary.go:288-309` and
+  `internal/state/execution_summary_test.go:952-985`.
+- Runtime task evidence must be preserved. Evidence: issue #53 Tier 3 says to
+  preserve useful execution evidence while invalidating only downstream stale
+  planning artifacts.
+
+
+## Canonical References
+- `artifacts/changes/complete-issue-53-tier-3-stale-planning-recovery-state-machi/intent.md` for the original request and intake context.
+- `https://github.com/signalridge/slipway/issues/53#issuecomment-4604547893`
+  for Tier 3 scope and expected tests.
+- `internal/engine/progression/advance_governed.go`
+- `internal/state/execution_summary.go`
+- `cmd/next_skill_view.go`
+- `cmd/pivot_validation.go`
+- `internal/engine/gate/gate.go`
+- `internal/engine/progression/wave_sync.go`

--- a/artifacts/changes/complete-issue-53-tier-3-stale-planning-recovery-state-machi/tasks.md
+++ b/artifacts/changes/complete-issue-53-tier-3-stale-planning-recovery-state-machi/tasks.md
@@ -1,0 +1,58 @@
+# Tasks
+
+## Project Context
+- Tech Stack: Go CLI
+- Test Command: go test -count=1 ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Task List
+
+- [x] `t-01` Add failing recovery-route and S3/S4 recovery-guidance regressions.
+  - wave: 1
+  - depends_on: []
+  - target_files: ["cmd/progression_next_test.go", "cmd/lifecycle_commands_test.go", "cmd/scope_contract_test.go"]
+  - task_kind: test
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004, REQ-006]
+
+- [x] `t-02` Add pivot gate/precondition parity regressions.
+  - wave: 1
+  - depends_on: []
+  - target_files: ["internal/engine/gate/gate_test.go", "cmd/pivot_validation_test.go"]
+  - task_kind: test
+  - covers: [REQ-005]
+
+- [x] `t-03` Implement non-destructive stale-planning recovery in lifecycle advancement.
+  - wave: 2
+  - depends_on: [t-01]
+  - target_files: ["internal/engine/progression/advance_governed.go", "internal/engine/progression/stale_planning_recovery.go"]
+  - task_kind: code
+  - covers: [REQ-001, REQ-003, REQ-004]
+
+- [x] `t-04` Surface actionable read-only recovery guidance in `next` JSON/handoff output.
+  - wave: 2
+  - depends_on: [t-01]
+  - target_files: ["cmd/next_skill_view.go", "internal/engine/progression/readiness.go"]
+  - task_kind: code
+  - covers: [REQ-002, REQ-007]
+
+- [x] `t-05` Align `EvaluateGPivot` with CLI pivot preconditions.
+  - wave: 2
+  - depends_on: [t-02]
+  - target_files: ["internal/engine/gate/gate.go", "internal/model/reason_code.go", "cmd/pivot_validation.go"]
+  - task_kind: code
+  - covers: [REQ-005, REQ-007]
+
+- [x] `t-06` Verify recovered evidence ordering, downstream invalidation, and fail-closed task evidence.
+  - wave: 3
+  - depends_on: [t-03, t-04, t-05]
+  - target_files: ["cmd/progression_next_test.go", "cmd/lifecycle_commands_test.go", "cmd/scope_contract_test.go", "internal/engine/progression/readiness.go"]
+  - task_kind: verification
+  - covers: [REQ-001, REQ-003, REQ-004, REQ-006]
+
+- [x] `t-07` Run focused and full verification gates.
+  - wave: 4
+  - depends_on: [t-03, t-04, t-05, t-06]
+  - target_files: ["cmd/progression_next_test.go", "cmd/lifecycle_commands_test.go", "cmd/scope_contract_test.go", "internal/engine/gate/gate_test.go", "cmd/pivot_validation_test.go"]
+  - task_kind: verification
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004, REQ-005, REQ-006, REQ-007]

--- a/artifacts/changes/complete-issue-53-tier-3-stale-planning-recovery-state-machi/tasks.md
+++ b/artifacts/changes/complete-issue-53-tier-3-stale-planning-recovery-state-machi/tasks.md
@@ -18,7 +18,7 @@
 - [x] `t-02` Add pivot gate/precondition parity regressions.
   - wave: 1
   - depends_on: []
-  - target_files: ["internal/engine/gate/gate_test.go", "cmd/pivot_validation_test.go"]
+  - target_files: ["internal/engine/gate/gate_test.go", "cmd/pivot_validation_test.go", "cmd/cli_e2e_test.go"]
   - task_kind: test
   - covers: [REQ-005]
 
@@ -32,7 +32,7 @@
 - [x] `t-04` Surface actionable read-only recovery guidance in `next` JSON/handoff output.
   - wave: 2
   - depends_on: [t-01]
-  - target_files: ["cmd/next_skill_view.go", "internal/engine/progression/readiness.go"]
+  - target_files: ["cmd/next_skill_view.go", "cmd/next.go", "internal/engine/progression/readiness.go", "README.md", "CLAUDE.md", "docs/commands.md"]
   - task_kind: code
   - covers: [REQ-002, REQ-007]
 

--- a/cmd/cli_e2e_test.go
+++ b/cmd/cli_e2e_test.go
@@ -125,7 +125,7 @@ func TestCLIEndToEndGovernedLifecycleBlockersAndCancel(t *testing.T) {
 		require.Error(t, err)
 		assert.Empty(t, stdout)
 		pivotPayload := decodeJSONMap(t, stderr)
-		assert.Equal(t, "pivot_state_invalid", pivotPayload["error_code"])
+		assert.Equal(t, "rescope_state_invalid", pivotPayload["error_code"])
 
 		stdout, stderr, err = runRootCommandIn(root, []string{"review", "--json"})
 		require.Error(t, err)

--- a/cmd/lifecycle_commands_test.go
+++ b/cmd/lifecycle_commands_test.go
@@ -951,7 +951,7 @@ func TestPivotStateBoundaryRejected(t *testing.T) {
 		require.Error(t, err)
 		cliErr := asCLIError(err)
 		require.NotNil(t, cliErr)
-		assert.Equal(t, "pivot_state_invalid", cliErr.ErrorCode)
+		assert.Equal(t, "rescope_state_invalid", cliErr.ErrorCode)
 		assert.Equal(t, categoryGovernanceBlocked, cliErr.Category)
 		assert.Equal(t, exitCodeGovernanceBlocked, cliErr.ExitCode)
 	})
@@ -1031,6 +1031,28 @@ func TestRunStalePlanningEvidenceReopensPlanAuditAndPreservesRuntimeEvidence(t *
 			require.FileExists(t, taskEvidencePath)
 		})
 	}
+}
+
+func TestRunStalePlanningRecoveryHumanOutputListsSideEffects(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	slug, _ := prepareStalePlanningRecoveryFixture(t, root, model.StateS3Review)
+
+	runCmd := commandForRoot(t, root, makeRunCmd())
+	runCmd.SetArgs([]string{"--change", slug})
+	var buf bytes.Buffer
+	runCmd.SetOut(&buf)
+	require.NoError(t, runCmd.Execute())
+
+	stdout := buf.String()
+	assert.Contains(t, stdout, "Advanced: S3_REVIEW -> S1_PLAN")
+	assert.Contains(t, stdout, "Recovery Side Effects:")
+	assert.Contains(t, stdout, "cleared_stale_planning_evidence")
+	assert.Contains(t, stdout, "cleared_stale_downstream_verification")
+	assert.Contains(t, stdout, "preserved_runtime_execution_evidence")
+	assert.Contains(t, stdout, "artifacts/changes/"+slug+"/verification/plan-audit.yaml")
+	assert.Contains(t, stdout, "artifacts/changes/"+slug+"/verification/spec-compliance-review.yaml")
 }
 
 func TestRunStalePlanningRecoveryRequiresFreshReviewAfterExecutionRefresh(t *testing.T) {
@@ -1226,7 +1248,7 @@ func TestPivotRescopeRejectedAtIntakeState(t *testing.T) {
 		require.Error(t, err)
 		cliErr := asCLIError(err)
 		require.NotNil(t, cliErr)
-		assert.Equal(t, "pivot_state_invalid", cliErr.ErrorCode)
+		assert.Equal(t, "rescope_state_invalid", cliErr.ErrorCode)
 		assert.Equal(t, categoryGovernanceBlocked, cliErr.Category)
 		assert.Equal(t, exitCodeGovernanceBlocked, cliErr.ExitCode)
 	})

--- a/cmd/lifecycle_commands_test.go
+++ b/cmd/lifecycle_commands_test.go
@@ -957,7 +957,234 @@ func TestPivotStateBoundaryRejected(t *testing.T) {
 	})
 }
 
-func TestPivotRescopeRejectedOutsideS6(t *testing.T) {
+func TestRunStalePlanningEvidenceReopensPlanAuditAndPreservesRuntimeEvidence(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name  string
+		state model.WorkflowState
+	}{
+		{name: "review", state: model.StateS3Review},
+		{name: "verify", state: model.StateS4Verify},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			slug, _ := prepareStalePlanningRecoveryFixture(t, root, tt.state)
+
+			verificationDir := state.VerificationDir(root, slug)
+			planAuditPath := filepath.Join(verificationDir, progression.SkillPlanAudit+".yaml")
+			wavePlanPath := filepath.Join(verificationDir, state.WavePlanFileName)
+			executionSummaryPath := state.ExecutionSummaryPathForRead(root, slug)
+			waveOrchestrationPath := filepath.Join(verificationDir, progression.SkillWaveOrchestration+".yaml")
+			specReviewPath := filepath.Join(verificationDir, progression.SkillSpecComplianceReview+".yaml")
+			codeReviewPath := filepath.Join(verificationDir, progression.SkillCodeQualityReview+".yaml")
+			goalVerificationPath := filepath.Join(verificationDir, progression.SkillGoalVerification+".yaml")
+			finalCloseoutPath := filepath.Join(verificationDir, progression.SkillFinalCloseout+".yaml")
+			waveRunPath := filepath.Join(state.WaveEvidenceDir(root, slug), "wave-01.yaml")
+			taskEvidencePath := filepath.Join(state.EvidenceTasksDir(root, slug), "t-01.json")
+
+			require.FileExists(t, planAuditPath)
+			require.FileExists(t, wavePlanPath)
+			require.FileExists(t, executionSummaryPath)
+			require.FileExists(t, waveOrchestrationPath)
+			require.FileExists(t, specReviewPath)
+			require.FileExists(t, codeReviewPath)
+			require.FileExists(t, goalVerificationPath)
+			require.FileExists(t, finalCloseoutPath)
+			require.FileExists(t, waveRunPath)
+			require.FileExists(t, taskEvidencePath)
+
+			runCmd := commandForRoot(t, root, makeRunCmd())
+			runCmd.SetArgs([]string{"--json", "--diagnostics", "--change", slug})
+			var buf bytes.Buffer
+			runCmd.SetOut(&buf)
+			require.NoError(t, runCmd.Execute())
+
+			var view nextView
+			require.NoError(t, json.Unmarshal(buf.Bytes(), &view))
+			require.NotNil(t, view.Advanced)
+			assert.Equal(t, "advanced", view.Advanced.Action)
+			assert.Equal(t, tt.state, view.Advanced.FromState)
+			assert.Equal(t, model.StateS1Plan, view.Advanced.ToState)
+			assert.Equal(t, string(model.PlanSubStepAudit), view.Advanced.ToSubStep)
+			assert.True(t, view.Advanced.RecoveryOnly)
+			assert.Equal(t, "stale_planning_recovery_started", view.Advanced.Reason)
+			require.NotNil(t, view.NextSkill)
+			assert.Equal(t, progression.SkillPlanAudit, view.NextSkill.Name)
+
+			recovered, err := state.LoadChange(root, slug)
+			require.NoError(t, err)
+			assert.Equal(t, model.StateS1Plan, recovered.CurrentState)
+			assert.Equal(t, model.PlanSubStepAudit, recovered.PlanSubStep)
+
+			require.NoFileExists(t, planAuditPath)
+			require.NoFileExists(t, wavePlanPath)
+			require.NoFileExists(t, executionSummaryPath)
+			require.FileExists(t, waveOrchestrationPath)
+			require.NoFileExists(t, specReviewPath)
+			require.NoFileExists(t, codeReviewPath)
+			require.NoFileExists(t, goalVerificationPath)
+			require.NoFileExists(t, finalCloseoutPath)
+			require.FileExists(t, waveRunPath)
+			require.FileExists(t, taskEvidencePath)
+		})
+	}
+}
+
+func TestRunStalePlanningRecoveryRequiresFreshReviewAfterExecutionRefresh(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	slug, _ := prepareStalePlanningRecoveryBaseFixture(t, root, model.StateS4Verify)
+
+	bundlePath := filepath.Join(root, "artifacts", "changes", slug)
+	requirementsPath := artifact.ResolveArtifactPath(bundlePath, slug, "requirements.md")
+	rawRequirements, err := os.ReadFile(requirementsPath)
+	require.NoError(t, err)
+	require.NoError(t, writeBundleArtifactFile(
+		bundlePath,
+		slug,
+		"requirements.md",
+		append(rawRequirements, []byte("\nAdditional context changed after review.\n")...),
+	))
+	staleAt := time.Now().UTC().Add(2 * time.Second)
+	require.NoError(t, os.Chtimes(requirementsPath, staleAt, staleAt))
+
+	// Simulate the operator refreshing task evidence after recovery while keeping
+	// the same run_version. Old review/verify evidence must not become reusable
+	// just because the rebuilt execution summary has the same run_version.
+	writeTaskEvidenceFile(t, root, slug, 1, "t-01", map[string]any{
+		"changed_files": []string{"cmd/done.go"},
+		"captured_at":   staleAt.Add(time.Second).Format(time.RFC3339Nano),
+	})
+
+	recoveryCmd := commandForRoot(t, root, makeRunCmd())
+	recoveryCmd.SetArgs([]string{"--json", "--diagnostics", "--change", slug})
+	var recoveryBuf bytes.Buffer
+	recoveryCmd.SetOut(&recoveryBuf)
+	require.NoError(t, recoveryCmd.Execute())
+
+	var recoveryView nextView
+	require.NoError(t, json.Unmarshal(recoveryBuf.Bytes(), &recoveryView))
+	require.NotNil(t, recoveryView.Advanced)
+	assert.Equal(t, "stale_planning_recovery_started", recoveryView.Advanced.Reason)
+	require.NotNil(t, recoveryView.NextSkill)
+	assert.Equal(t, progression.SkillPlanAudit, recoveryView.NextSkill.Name)
+
+	writeSkillVerification(t, root, slug, progression.SkillPlanAudit, model.VerificationRecord{
+		Verdict:    model.VerificationVerdictPass,
+		Blockers:   []model.ReasonCode{},
+		Timestamp:  staleAt.Add(2 * time.Second),
+		RunVersion: 0,
+		References: []string{"plan-audit:refreshed"},
+	})
+
+	advanceCmd := commandForRoot(t, root, makeRunCmd())
+	advanceCmd.SetArgs([]string{"--json", "--diagnostics", "--change", slug})
+	var advanceBuf bytes.Buffer
+	advanceCmd.SetOut(&advanceBuf)
+	require.NoError(t, advanceCmd.Execute())
+
+	var advanceView nextView
+	require.NoError(t, json.Unmarshal(advanceBuf.Bytes(), &advanceView))
+	assert.Equal(t, model.StateS2Execute, advanceView.CurrentState)
+	require.NotNil(t, advanceView.NextSkill)
+	assert.Equal(t, progression.SkillWaveOrchestration, advanceView.NextSkill.Name)
+
+	syncCmd := commandForRoot(t, root, makeRunCmd())
+	syncCmd.SetArgs([]string{"--json", "--diagnostics", "--change", slug})
+	var syncBuf bytes.Buffer
+	syncCmd.SetOut(&syncBuf)
+	require.NoError(t, syncCmd.Execute())
+
+	var syncView nextView
+	require.NoError(t, json.Unmarshal(syncBuf.Bytes(), &syncView))
+	assert.Equal(t, model.StateS3Review, syncView.CurrentState)
+	require.NotNil(t, syncView.NextSkill)
+	assert.Equal(t, progression.SkillSpecComplianceReview, syncView.NextSkill.Name)
+	reasons := model.ReasonSpecs(syncView.Blockers)
+	assert.Contains(t, reasons, "required_skill_missing:"+progression.SkillSpecComplianceReview)
+	assert.NotContains(t, reasons, "run_slipway_run_to_advance:"+string(model.StateS3Review))
+}
+
+func TestRunStalePlanningRecoveryRefreshesEvidenceInOrder(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	slug, _ := prepareStalePlanningRecoveryFixture(t, root, model.StateS3Review)
+
+	runCmd := commandForRoot(t, root, makeRunCmd())
+	runCmd.SetArgs([]string{"--json", "--diagnostics", "--change", slug})
+	var recoveryBuf bytes.Buffer
+	runCmd.SetOut(&recoveryBuf)
+	require.NoError(t, runCmd.Execute())
+
+	recovered, err := state.LoadChange(root, slug)
+	require.NoError(t, err)
+	assert.Equal(t, model.StateS1Plan, recovered.CurrentState)
+	assert.Equal(t, model.PlanSubStepAudit, recovered.PlanSubStep)
+	require.NoFileExists(t, filepath.Join(state.VerificationDir(root, slug), progression.SkillPlanAudit+".yaml"))
+	require.NoFileExists(t, filepath.Join(state.VerificationDir(root, slug), state.WavePlanFileName))
+	require.NoFileExists(t, state.ExecutionSummaryPathForRead(root, slug))
+
+	blockedCmd := commandForRoot(t, root, makeRunCmd())
+	blockedCmd.SetArgs([]string{"--json", "--diagnostics", "--change", slug})
+	var blockedBuf bytes.Buffer
+	blockedCmd.SetOut(&blockedBuf)
+	require.NoError(t, blockedCmd.Execute())
+
+	var blockedView nextView
+	require.NoError(t, json.Unmarshal(blockedBuf.Bytes(), &blockedView))
+	require.NotNil(t, blockedView.Advanced)
+	assert.Equal(t, "blocked", blockedView.Advanced.Action)
+	assert.Contains(t, model.ReasonSpecs(blockedView.Blockers), "required_skill_missing:plan-audit")
+	require.NoFileExists(t, filepath.Join(state.VerificationDir(root, slug), state.WavePlanFileName))
+	require.NoFileExists(t, state.ExecutionSummaryPathForRead(root, slug))
+
+	writeSkillVerification(t, root, slug, progression.SkillPlanAudit, model.VerificationRecord{
+		Verdict:    model.VerificationVerdictPass,
+		Blockers:   []model.ReasonCode{},
+		Timestamp:  time.Now().UTC().Add(3 * time.Second),
+		RunVersion: 0,
+		References: []string{"plan-audit:refreshed"},
+	})
+
+	advanceCmd := commandForRoot(t, root, makeRunCmd())
+	advanceCmd.SetArgs([]string{"--json", "--diagnostics", "--change", slug})
+	var advanceBuf bytes.Buffer
+	advanceCmd.SetOut(&advanceBuf)
+	require.NoError(t, advanceCmd.Execute())
+
+	var advanceView nextView
+	require.NoError(t, json.Unmarshal(advanceBuf.Bytes(), &advanceView))
+	require.NotNil(t, advanceView.Advanced)
+	assert.Equal(t, "advanced", advanceView.Advanced.Action)
+	assert.Equal(t, model.StateS2Execute, advanceView.CurrentState)
+	require.NotNil(t, advanceView.NextSkill)
+	assert.Equal(t, progression.SkillWaveOrchestration, advanceView.NextSkill.Name)
+	require.FileExists(t, filepath.Join(state.VerificationDir(root, slug), state.WavePlanFileName))
+	require.NoFileExists(t, state.ExecutionSummaryPathForRead(root, slug))
+
+	syncCmd := commandForRoot(t, root, makeRunCmd())
+	syncCmd.SetArgs([]string{"--json", "--diagnostics", "--change", slug})
+	var syncBuf bytes.Buffer
+	syncCmd.SetOut(&syncBuf)
+	require.NoError(t, syncCmd.Execute())
+
+	var syncView nextView
+	require.NoError(t, json.Unmarshal(syncBuf.Bytes(), &syncView))
+	require.NotNil(t, syncView.Advanced)
+	assert.Equal(t, "blocked", syncView.Advanced.Action)
+	assert.Contains(t, model.ReasonSpecs(syncView.Blockers), "tasks_plan_changed_since_task_evidence:t-01")
+
+	summary, err := state.LoadExecutionSummary(root, slug)
+	require.NoError(t, err)
+	assert.Contains(t, model.ReasonSpecs(summary.OpenBlockers), "tasks_plan_changed_since_task_evidence:t-01")
+}
+
+func TestPivotRescopeRejectedOutsideS2(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()

--- a/cmd/next.go
+++ b/cmd/next.go
@@ -709,6 +709,20 @@ func writeNextHuman(w io.Writer, view nextView) error {
 		if view.Advanced.Action == "advanced" || view.Advanced.Action == "done_ready" {
 			writeLine("\nAdvanced: %s -> %s (%s)\n", view.Advanced.FromState, view.Advanced.ToState, view.Advanced.Message)
 		}
+		if len(view.Advanced.SideEffects) > 0 {
+			heading := "Side Effects:"
+			if view.Advanced.RecoveryOnly {
+				heading = "Recovery Side Effects:"
+			}
+			writeLine("%s\n", heading)
+			for _, effect := range view.Advanced.SideEffects {
+				if effect.Detail != "" {
+					writeLine("  - %s: %s\n", effect.Kind, effect.Detail)
+				} else {
+					writeLine("  - %s\n", effect.Kind)
+				}
+			}
+		}
 		if len(view.Advanced.AutoPassedStates) > 0 {
 			writeLine("Auto-Passed:\n")
 			for _, state := range view.Advanced.AutoPassedStates {

--- a/cmd/next_skill_view.go
+++ b/cmd/next_skill_view.go
@@ -165,6 +165,22 @@ func assembleSkillViewWithOptions(
 	if advanced.Action == "blocked" {
 		blockersForResolution = append(blockersForResolution, advanced.Blockers...)
 	}
+	if governedChange != nil && progression.StalePlanningRecoveryAvailable(*governedChange, blockersForResolution) {
+		nextSkillName = ""
+		nextState = string(model.StateS1Plan)
+		view.Blockers = appendReasonCodes(
+			view.Blockers,
+			[]model.ReasonCode{
+				model.NewReasonCode("stale_planning_recovery_available", progression.StalePlanningRecoveryTarget),
+				model.NewReasonCode("run_slipway_run_to_advance", string(governedChange.CurrentState)),
+			},
+		)
+		view.Warnings = append(view.Warnings, "stale_planning_recovery_available: run `slipway run` to reopen S1_PLAN/audit, then refresh plan-audit, wave-plan, and execution-summary evidence in order.")
+		blockersForResolution = append([]model.ReasonCode(nil), view.Blockers...)
+		if advanced.Action == "blocked" {
+			blockersForResolution = append(blockersForResolution, advanced.Blockers...)
+		}
+	}
 	if actionableSkill, reason := resolveActionableBlockingSkill(nextSkillName, evidenceMap, blockersForResolution); actionableSkill != "" {
 		nextSkillName = actionableSkill
 		blockingResolution = true

--- a/cmd/pivot_validation.go
+++ b/cmd/pivot_validation.go
@@ -10,23 +10,23 @@ func validatePivotPreconditions(kind string, currentState model.WorkflowState) e
 		return nil
 	}
 
-	if !isPivotState(currentState) {
-		remediation := "Advance change to S2_EXECUTE or later before pivoting, or use governed reroute from S1_PLAN."
-		return newGovernanceBlockedError(
-			"pivot_state_invalid",
-			"pivot is allowed only in S1_PLAN reroute or S2/S3/S4",
-			remediation,
-			"",
-			nil,
-		)
-	}
-
 	if kind == string(gate.PivotKindRescope) &&
 		currentState != model.StateS2Execute {
 		return newGovernanceBlockedError(
 			"rescope_state_invalid",
 			"rescope requires governed S2_EXECUTE",
 			"Rescope is only available during wave execution (S2_EXECUTE).",
+			"",
+			nil,
+		)
+	}
+
+	if !isPivotState(currentState) {
+		remediation := "Advance change to S2_EXECUTE or later before pivoting, or use governed reroute from S1_PLAN."
+		return newGovernanceBlockedError(
+			"pivot_state_invalid",
+			"pivot is allowed only in S1_PLAN reroute or S2/S3/S4",
+			remediation,
 			"",
 			nil,
 		)

--- a/cmd/pivot_validation_test.go
+++ b/cmd/pivot_validation_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestValidatePivotPreconditionsRejectsAdmissionRescope(t *testing.T) {
+func TestValidatePivotPreconditionsAllowsRescopeOnlyAtExecute(t *testing.T) {
 	t.Parallel()
 
 	err := validatePivotPreconditions(
@@ -22,7 +22,6 @@ func TestValidatePivotPreconditionsRejectsAdmissionRescope(t *testing.T) {
 func TestValidatePivotPreconditionsRejectsNonPivotState(t *testing.T) {
 	t.Parallel()
 
-	// S1_PLAN rescope is rejected because S1_PLAN is not a pivot state for rescope
 	err := validatePivotPreconditions(
 		string(gate.PivotKindRescope),
 		model.StateS1Plan,
@@ -31,22 +30,32 @@ func TestValidatePivotPreconditionsRejectsNonPivotState(t *testing.T) {
 	assert.Contains(t, err.Error(), "pivot is allowed only in S1_PLAN reroute or S2/S3/S4")
 }
 
-func TestValidatePivotPreconditionsAllowsGovernedRescopeInS5(t *testing.T) {
+func TestValidatePivotPreconditionsRejectsRescopeOutsideExecute(t *testing.T) {
 	t.Parallel()
 
-	err := validatePivotPreconditions(
-		string(gate.PivotKindRescope),
-		model.StateS2Execute,
-	)
-	require.NoError(t, err)
+	for _, state := range []model.WorkflowState{model.StateS3Review, model.StateS4Verify} {
+		err := validatePivotPreconditions(
+			string(gate.PivotKindRescope),
+			state,
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "rescope requires governed S2_EXECUTE")
+	}
 }
 
-func TestValidatePivotPreconditionsAllowsGovernedRerouteInS4(t *testing.T) {
+func TestValidatePivotPreconditionsAllowsGovernedRerouteInS1ThroughS4(t *testing.T) {
 	t.Parallel()
 
-	err := validatePivotPreconditions(
-		string(gate.PivotKindReroute),
+	for _, state := range []model.WorkflowState{
 		model.StateS1Plan,
-	)
-	require.NoError(t, err)
+		model.StateS2Execute,
+		model.StateS3Review,
+		model.StateS4Verify,
+	} {
+		err := validatePivotPreconditions(
+			string(gate.PivotKindReroute),
+			state,
+		)
+		require.NoError(t, err, "state %s", state)
+	}
 }

--- a/cmd/pivot_validation_test.go
+++ b/cmd/pivot_validation_test.go
@@ -27,7 +27,10 @@ func TestValidatePivotPreconditionsRejectsNonPivotState(t *testing.T) {
 		model.StateS1Plan,
 	)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "pivot is allowed only in S1_PLAN reroute or S2/S3/S4")
+	cliErr := asCLIError(err)
+	require.NotNil(t, cliErr)
+	assert.Equal(t, "rescope_state_invalid", cliErr.ErrorCode)
+	assert.Contains(t, err.Error(), "rescope requires governed S2_EXECUTE")
 }
 
 func TestValidatePivotPreconditionsRejectsRescopeOutsideExecute(t *testing.T) {

--- a/cmd/progression_next_test.go
+++ b/cmd/progression_next_test.go
@@ -149,6 +149,41 @@ func TestNextS3ReviewWithPassingEvidenceReportsRunGuidance(t *testing.T) {
 	}
 }
 
+func TestNextStalePlanningEvidenceReportsRecoveryRunGuidance(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name  string
+		state model.WorkflowState
+	}{
+		{name: "review", state: model.StateS3Review},
+		{name: "verify", state: model.StateS4Verify},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			slug, _ := prepareStalePlanningRecoveryFixture(t, root, tt.state)
+
+			view, err := buildNextView(root, changeRef{Slug: slug}, "", true, false, false)
+			require.NoError(t, err)
+
+			assert.Nil(t, view.NextSkill)
+			assert.Equal(t, tt.state, view.CurrentState)
+			reasons := model.ReasonSpecs(view.Blockers)
+			assert.Contains(t, reasons, "stale_planning_evidence")
+			assert.Contains(t, reasons, "run_slipway_run_to_advance:"+string(tt.state))
+			assert.Contains(t, reasons, "stale_planning_recovery_available:S1_PLAN/audit")
+			assert.Equal(t, "run_slipway_run_to_advance", view.ConfirmationRequirement.Reason)
+
+			loaded, err := state.LoadChange(root, slug)
+			require.NoError(t, err)
+			assert.Equal(t, tt.state, loaded.CurrentState, "next must remain read-only")
+			assert.Equal(t, model.PlanSubStepNone, loaded.PlanSubStep)
+		})
+	}
+}
+
 func TestNextS0ConfirmWithoutApprovedSummaryDoesNotReportRunGuidance(t *testing.T) {
 	t.Parallel()
 
@@ -3603,6 +3638,59 @@ func TestNextS6GovernedBlocksWithoutTaskEvidenceForWaveRunSummary(t *testing.T) 
 	assert.Contains(t, missingEvidenceBlocker, "record_command=slipway evidence task")
 	assert.Contains(t, missingEvidenceBlocker, "required_fields=task_id,run_summary_version,task_kind,verdict,evidence_ref,captured_at,freshness_inputs")
 	assert.Equal(t, model.StateS2Execute, view.CurrentState)
+}
+
+func prepareStalePlanningRecoveryFixture(t *testing.T, root string, currentState model.WorkflowState) (string, model.Change) {
+	t.Helper()
+	slug, change := prepareStalePlanningRecoveryBaseFixture(t, root, currentState)
+
+	bundlePath := filepath.Join(root, "artifacts", "changes", slug)
+	staleTasksPath := filepath.Join(bundlePath, "tasks.md")
+	require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
+
+- [ ] `+"`t-01`"+` verify recovered planning chain
+  - wave: 1
+  - depends_on: []
+  - target_files: ["cmd/next.go", "cmd/run.go"]
+  - task_kind: verification
+  - covers: [REQ-001]
+`)))
+	staleAt := time.Now().UTC().Add(2 * time.Second)
+	require.NoError(t, os.Chtimes(staleTasksPath, staleAt, staleAt))
+
+	return slug, change
+}
+
+func prepareStalePlanningRecoveryBaseFixture(t *testing.T, root string, currentState model.WorkflowState) (string, model.Change) {
+	t.Helper()
+	ensureTestGitRepo(t, root)
+	initTestWorkspace(t, root)
+
+	slug := createGovernedRequest(t, root, "L2", "stale planning recovery")
+	change, err := state.LoadChange(root, slug)
+	require.NoError(t, err)
+	change.CurrentState = currentState
+	change.PlanSubStep = model.PlanSubStepNone
+	require.NoError(t, state.SaveChange(root, change))
+
+	writeShipReadyGovernedBundle(t, root, change)
+	writeSkillVerification(t, root, slug, progression.SkillPlanAudit, model.VerificationRecord{
+		Verdict:    model.VerificationVerdictPass,
+		Blockers:   []model.ReasonCode{},
+		Timestamp:  time.Now().UTC().Add(-2 * time.Second),
+		RunVersion: 0,
+		References: []string{"plan-audit:fixture"},
+	})
+	writePassingExecutionSummary(t, root, slug, 1, "t-01")
+	writePassingWaveEvidence(t, root, slug, 1)
+	writeTaskEvidenceFile(t, root, slug, 1, "t-01", map[string]any{
+		"changed_files": []string{"cmd/done.go"},
+	})
+	writePassingReviewEvidencePack(t, root, slug, 1)
+	writePassingGoalVerificationEvidence(t, root, slug, 1)
+	writePassingFinalCloseoutEvidence(t, root, slug, 1)
+
+	return slug, change
 }
 
 func writeTaskEvidenceFile(t *testing.T, root, slug string, runSummaryVersion int, taskID string, payload map[string]any) {

--- a/cmd/scope_contract_test.go
+++ b/cmd/scope_contract_test.go
@@ -26,6 +26,30 @@ func TestValidateIncludesScopeContractDriftReport(t *testing.T) {
 	assert.Contains(t, model.ReasonSpecs(view.Blockers), "scope_contract_drift:cmd/review.go")
 }
 
+func TestValidateAndNextGuideS3ScopeContractDriftToRecoveryPath(t *testing.T) {
+	t.Parallel()
+
+	root, slug := writeScopeContractDriftFixtureInState(t, model.StateS3Review)
+
+	validateView, err := buildValidateViewForSlug(root, slug)
+	require.NoError(t, err)
+	assert.Contains(t, model.ReasonSpecs(validateView.Blockers), "scope_contract_drift:cmd/review.go")
+	diagnostics := strings.Join(validateView.Diagnostics, "\n")
+	assert.Contains(t, diagnostics, "scope_contract_recovery_guidance")
+	assert.Contains(t, diagnostics, "tasks.md target_files")
+	assert.Contains(t, diagnostics, "stale_planning_evidence")
+	assert.Contains(t, diagnostics, "rescope remains S2_EXECUTE-only")
+
+	nextView, err := buildNextView(root, changeRef{Slug: slug}, "", true, false, false)
+	require.NoError(t, err)
+	assert.Contains(t, model.ReasonSpecs(nextView.Blockers), "scope_contract_drift:cmd/review.go")
+	warnings := strings.Join(nextView.Warnings, "\n")
+	assert.Contains(t, warnings, "scope_contract_recovery_guidance")
+	assert.Contains(t, warnings, "tasks.md target_files")
+	assert.Contains(t, warnings, "stale_planning_evidence")
+	assert.Contains(t, warnings, "rescope remains S2_EXECUTE-only")
+}
+
 func TestStatusSurfacesScopeContractDriftBlocker(t *testing.T) {
 	t.Parallel()
 
@@ -57,6 +81,12 @@ func TestReviewFailsOnScopeContractDrift(t *testing.T) {
 func writeScopeContractDriftFixture(t *testing.T) (string, string) {
 	t.Helper()
 
+	return writeScopeContractDriftFixtureInState(t, model.StateS2Execute)
+}
+
+func writeScopeContractDriftFixtureInState(t *testing.T, workflowState model.WorkflowState) (string, string) {
+	t.Helper()
+
 	root := t.TempDir()
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
@@ -64,7 +94,7 @@ func writeScopeContractDriftFixture(t *testing.T) (string, string) {
 	slug := createGovernedRequest(t, root, "L2", "scope contract drift fixture")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
-	change.CurrentState = model.StateS2Execute
+	change.CurrentState = workflowState
 	change.PlanSubStep = model.PlanSubStepNone
 	require.NoError(t, state.SaveChange(root, change))
 
@@ -78,24 +108,33 @@ func writeScopeContractDriftFixture(t *testing.T) (string, string) {
   - task_kind: code
   - covers: [REQ-001]
 `), 0o644))
+	plan, err := state.MaterializeWavePlan(root, change)
+	require.NoError(t, err)
 
 	now := time.Now().UTC()
+	summaryTasks := []model.ExecutionTaskSummary{
+		{
+			TaskID:       "t-01",
+			Verdict:      model.TaskVerdictPass,
+			TaskKind:     model.TaskKindCode,
+			ChangedFiles: []string{"cmd/review.go"},
+			TargetFiles:  []string{"cmd/validate.go"},
+			CapturedAt:   now,
+		},
+	}
 	writeExecutionSummary(t, root, slug, model.ExecutionSummary{
 		Version:           model.ExecutionSummaryVersion,
 		RunSummaryVersion: 1,
 		CapturedAt:        now,
 		OverallVerdict:    model.ExecutionVerdictPass,
 		CompletedTasks:    []string{"t-01"},
-		Tasks: []model.ExecutionTaskSummary{
-			{
-				TaskID:       "t-01",
-				Verdict:      model.TaskVerdictPass,
-				TaskKind:     model.TaskKindCode,
-				ChangedFiles: []string{"cmd/review.go"},
-				TargetFiles:  []string{"cmd/validate.go"},
-				CapturedAt:   now,
-			},
-		},
+		Tasks:             summaryTasks,
+	})
+	runs, err := state.BuildWaveRuns(plan, 1, summaryTasks)
+	require.NoError(t, err)
+	require.NoError(t, state.SaveWaveRuns(root, slug, 1, runs))
+	writeTaskEvidenceFile(t, root, slug, 1, "t-01", map[string]any{
+		"changed_files": []string{"cmd/review.go"},
 	})
 
 	return root, slug

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -12,6 +12,12 @@ All routed commands support `--json` when structured output is useful.
 | `slipway status` | query | Show lifecycle state, blockers, progress, and next actions. |
 | `slipway done` | mutation | Finalize a done-ready change and archive it. |
 
+When an S3/S4 change has stale planning evidence, `slipway next` remains
+read-only and reports recovery guidance. `slipway run` is the mutating recovery
+path: it reopens `S1_PLAN/audit`, clears stale planning and downstream review /
+verification files, preserves runtime execution evidence, and returns the
+side effects in JSON and human-readable output.
+
 ## Creation Options
 
 ```bash

--- a/internal/engine/gate/gate.go
+++ b/internal/engine/gate/gate.go
@@ -90,12 +90,17 @@ func EvaluateGPivot(kind PivotKind, approved bool, state model.WorkflowState) Ga
 	if !approved {
 		reasonCodes = append(reasonCodes, model.NewReasonCode("pivot_not_approved", ""))
 	}
-	if kind == PivotKindRescope {
+	switch kind {
+	case PivotKindReroute:
 		switch state {
 		case model.StateS1Plan, model.StateS2Execute, model.StateS3Review, model.StateS4Verify:
-			// OK: rescope valid from S1_PLAN or later
+			// OK: reroute is available from planning through verification.
 		default:
-			reasonCodes = append(reasonCodes, model.NewReasonCode("rescope_requires_s1_or_later", string(state)))
+			reasonCodes = append(reasonCodes, model.NewReasonCode("pivot_state_invalid", string(state)))
+		}
+	case PivotKindRescope:
+		if state != model.StateS2Execute {
+			reasonCodes = append(reasonCodes, model.NewReasonCode("rescope_state_invalid", string(state)))
 		}
 	}
 

--- a/internal/engine/gate/gate_test.go
+++ b/internal/engine/gate/gate_test.go
@@ -88,21 +88,42 @@ func TestGuardrailHighRiskChecks(t *testing.T) {
 
 func TestEvaluateGPivot(t *testing.T) {
 	t.Parallel()
-	eval := EvaluateGPivot(PivotKindReroute, true, model.StateS3Review)
-	assert.Equal(t, model.GateStatusApproved, eval.Status)
 
-	eval = EvaluateGPivot(PivotKindRescope, false, model.StateS2Execute)
+	eval := EvaluateGPivot(PivotKindRescope, false, model.StateS2Execute)
 	assert.Equal(t, model.GateStatusBlocked, eval.Status)
 	assert.True(t, hasGateReasonCode(eval.ReasonCodes, "pivot_not_approved"))
 
-	// Rescope from S3_REVIEW is now valid (rescope valid from S1_PLAN or later)
-	eval = EvaluateGPivot(PivotKindRescope, true, model.StateS3Review)
+	for _, state := range []model.WorkflowState{
+		model.StateS1Plan,
+		model.StateS2Execute,
+		model.StateS3Review,
+		model.StateS4Verify,
+	} {
+		eval := EvaluateGPivot(PivotKindReroute, true, state)
+		assert.Equal(t, model.GateStatusApproved, eval.Status, "reroute state %s", state)
+		assert.Empty(t, eval.ReasonCodes, "reroute state %s", state)
+	}
+
+	for _, state := range []model.WorkflowState{
+		model.StateS0Intake,
+		model.StateDone,
+	} {
+		eval := EvaluateGPivot(PivotKindReroute, true, state)
+		assert.Equal(t, model.GateStatusBlocked, eval.Status, "reroute state %s", state)
+		assert.True(t, hasGateReasonCode(eval.ReasonCodes, "pivot_state_invalid"), "reroute state %s", state)
+	}
+
+	eval = EvaluateGPivot(PivotKindRescope, true, model.StateS2Execute)
 	assert.Equal(t, model.GateStatusApproved, eval.Status)
 	assert.Empty(t, eval.ReasonCodes)
 
-	// Rescope from S0_INTAKE is blocked (requires S1_PLAN or later)
-	eval = EvaluateGPivot(PivotKindRescope, true, model.StateS0Intake)
-	assert.Equal(t, model.GateStatusBlocked, eval.Status)
-	require.NotEmpty(t, eval.ReasonCodes)
-	assert.Equal(t, "rescope_requires_s1_or_later", eval.ReasonCodes[0].Code)
+	for _, state := range []model.WorkflowState{
+		model.StateS1Plan,
+		model.StateS3Review,
+		model.StateS4Verify,
+	} {
+		eval := EvaluateGPivot(PivotKindRescope, true, state)
+		assert.Equal(t, model.GateStatusBlocked, eval.Status, "rescope state %s", state)
+		assert.True(t, hasGateReasonCode(eval.ReasonCodes, "rescope_state_invalid"), "rescope state %s", state)
+	}
 }

--- a/internal/engine/progression/advance_governed.go
+++ b/internal/engine/progression/advance_governed.go
@@ -96,6 +96,9 @@ func AdvanceGoverned(root, slug string, opts ...AdvanceOptions) (summary Advance
 	if err != nil {
 		return AdvanceSummary{}, err
 	}
+	if stalePlanningRecoveryIssueAvailable(change, executionSummaryCtx.Issues) {
+		return beginStalePlanningRecovery(root, &change, fromState)
+	}
 	if len(executionSummaryCtx.Issues) > 0 {
 		return blockedAdvanceSummary(fromState, model.ReasonCodesFromSpecs(executionSummaryCtx.Issues)), nil
 	}
@@ -414,6 +417,115 @@ func computeNextPlanSubStep(current model.PlanSubStep) model.PlanSubStep {
 		return model.PlanSubStepNone
 	}
 	return planSubStepOrder[idx+1]
+}
+
+func beginStalePlanningRecovery(root string, change *model.Change, fromState model.WorkflowState) (AdvanceSummary, error) {
+	if change == nil {
+		return AdvanceSummary{}, fmt.Errorf("change is required for stale planning recovery")
+	}
+	paths, err := state.ResolveChangePaths(root, *change)
+	if err != nil {
+		return AdvanceSummary{}, err
+	}
+
+	verificationDir := filepath.Join(paths.GovernedBundleDir, "verification")
+	planningEvidenceFiles := []string{
+		filepath.Join(verificationDir, SkillPlanAudit+".yaml"),
+		filepath.Join(verificationDir, state.WavePlanFileName),
+		filepath.Join(verificationDir, state.ExecutionSummaryFileName),
+	}
+	downstreamVerificationFiles := []string{
+		filepath.Join(verificationDir, SkillSpecComplianceReview+".yaml"),
+		filepath.Join(verificationDir, SkillCodeQualityReview+".yaml"),
+		filepath.Join(verificationDir, SkillGoalVerification+".yaml"),
+		filepath.Join(verificationDir, SkillFinalCloseout+".yaml"),
+	}
+	sideEffects := make([]SideEffect, 0, len(planningEvidenceFiles)+len(downstreamVerificationFiles)+1)
+	for _, path := range planningEvidenceFiles {
+		removed, err := removeFileIfExists(path)
+		if err != nil {
+			return AdvanceSummary{}, err
+		}
+		if removed {
+			sideEffects = append(sideEffects, SideEffect{
+				Kind:   "cleared_stale_planning_evidence",
+				Detail: state.DisplayPath(root, path),
+			})
+		}
+	}
+	for _, path := range downstreamVerificationFiles {
+		removed, err := removeFileIfExists(path)
+		if err != nil {
+			return AdvanceSummary{}, err
+		}
+		if removed {
+			sideEffects = append(sideEffects, SideEffect{
+				Kind:   "cleared_stale_downstream_verification",
+				Detail: state.DisplayPath(root, path),
+			})
+		}
+	}
+	sideEffects = append(sideEffects, SideEffect{
+		Kind:   "preserved_runtime_execution_evidence",
+		Detail: state.DisplayPath(root, state.ChangeDir(root, change.Slug)),
+	})
+
+	cleared := change.TransitionTo(model.StateS1Plan)
+	if change.PlanSubStep != model.PlanSubStepAudit {
+		change.AdvancePlanSubStep(model.PlanSubStepAudit)
+		cleared = append(cleared, "plan_substep")
+	}
+	if change.ClearAutoPassHistory() {
+		cleared = append(cleared, "last_auto_passed_states")
+	}
+	if change.ClearActiveCheckpoint() {
+		cleared = append(cleared, "active_checkpoint")
+	}
+	if change.ResetPlanAuditIterations() {
+		cleared = append(cleared, "plan_audit_iterations")
+	}
+	if change.ClearEvidenceRef(SkillPlanAudit) {
+		cleared = append(cleared, "evidence_refs."+SkillPlanAudit)
+	}
+	if change.ClearEvidenceRef(planAuditLastCheckerFeedbackKey) {
+		cleared = append(cleared, "evidence_refs."+planAuditLastCheckerFeedbackKey)
+	}
+	for _, skillName := range []string{
+		SkillSpecComplianceReview,
+		SkillCodeQualityReview,
+		SkillGoalVerification,
+		SkillFinalCloseout,
+	} {
+		if change.ClearEvidenceRef(skillName) {
+			cleared = append(cleared, "evidence_refs."+skillName)
+		}
+	}
+
+	if err := state.SaveChange(root, *change); err != nil {
+		return AdvanceSummary{}, err
+	}
+
+	return AdvanceSummary{
+		Action:        "advanced",
+		FromState:     fromState,
+		ToState:       model.StateS1Plan,
+		ToSubStep:     string(model.PlanSubStepAudit),
+		Reason:        "stale_planning_recovery_started",
+		SideEffects:   sideEffects,
+		RecoveryOnly:  true,
+		ClearedFields: stringutil.UniqueSorted(cleared),
+		Message:       "Reopened S1_PLAN/audit for stale planning evidence recovery.",
+	}, nil
+}
+
+func removeFileIfExists(path string) (bool, error) {
+	if err := os.Remove(path); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 func ensureGovernedBundleScaffolded(root string, change *model.Change) error {

--- a/internal/engine/progression/readiness.go
+++ b/internal/engine/progression/readiness.go
@@ -82,6 +82,8 @@ type GovernanceReadinessOptions struct {
 	IncludeShipSurface        bool
 }
 
+const scopeContractRecoveryGuidanceDiagnostic = "scope_contract_recovery_guidance: in S3/S4, fix tasks.md target_files or execution scope first; if the planning artifact changes, stale_planning_evidence recovery reopens S1_PLAN/audit via `slipway run`; pivot --rescope remains S2_EXECUTE-only."
+
 type ArtifactReadinessReader interface {
 	Evaluate(root string, change model.Change) (ArtifactReadiness, error)
 }
@@ -271,6 +273,9 @@ func evaluateGovernanceReadinessBaseWithReaders(
 			readiness.ScopeContract = &cloned
 			readiness.Blockers = append(readiness.Blockers, scopeReport.Blockers...)
 			readiness.Diagnostics = append(readiness.Diagnostics, scopeReport.Diagnostics...)
+			if scopeContractNeedsRecoveryGuidance(effectiveState, scopeReport) {
+				readiness.Diagnostics = append(readiness.Diagnostics, scopeContractRecoveryGuidanceDiagnostic)
+			}
 		}
 	}
 
@@ -301,6 +306,13 @@ func evaluateGovernanceReadinessBaseWithReaders(
 	readiness.Blockers = model.NormalizeReasonCodes(readiness.Blockers)
 	readiness.Diagnostics = stringutil.UniqueSorted(readiness.Diagnostics)
 	return readiness, nil
+}
+
+func scopeContractNeedsRecoveryGuidance(state model.WorkflowState, report scopecontract.Report) bool {
+	if state != model.StateS3Review && state != model.StateS4Verify {
+		return false
+	}
+	return len(report.Blockers) > 0
 }
 
 func (r GovernanceReadiness) cachedReviewAuthority() (ReviewAuthority, bool) {

--- a/internal/engine/progression/stale_planning_recovery.go
+++ b/internal/engine/progression/stale_planning_recovery.go
@@ -1,0 +1,39 @@
+package progression
+
+import (
+	"strings"
+
+	"github.com/signalridge/slipway/internal/model"
+	"github.com/signalridge/slipway/internal/state"
+)
+
+const StalePlanningRecoveryTarget = "S1_PLAN/audit"
+
+func StalePlanningRecoveryAvailable(change model.Change, blockers []model.ReasonCode) bool {
+	if !stalePlanningRecoveryState(change.CurrentState) {
+		return false
+	}
+	for _, blocker := range blockers {
+		if blocker.Code == state.StalePlanningEvidenceBlockerToken {
+			return true
+		}
+	}
+	return false
+}
+
+func stalePlanningRecoveryIssueAvailable(change model.Change, issues []string) bool {
+	if !stalePlanningRecoveryState(change.CurrentState) {
+		return false
+	}
+	for _, issue := range issues {
+		code, _, _ := strings.Cut(strings.TrimSpace(issue), ":")
+		if code == state.StalePlanningEvidenceBlockerToken {
+			return true
+		}
+	}
+	return false
+}
+
+func stalePlanningRecoveryState(workflowState model.WorkflowState) bool {
+	return workflowState == model.StateS3Review || workflowState == model.StateS4Verify
+}

--- a/internal/model/reason_code.go
+++ b/internal/model/reason_code.go
@@ -140,6 +140,14 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 		Severity: ReasonSeverityWarning,
 		Message:  "Run `slipway run` to advance the workflow",
 	},
+	"pivot_state_invalid": {
+		Severity: ReasonSeverityError,
+		Message:  "Pivot is not allowed from the current workflow state",
+	},
+	"rescope_state_invalid": {
+		Severity: ReasonSeverityError,
+		Message:  "Rescope pivots are only allowed from S2_EXECUTE",
+	},
 	"scope_contract_changed_files_missing": {
 		Severity: ReasonSeverityError,
 		Message:  "Scope Contract changed-files evidence is missing",
@@ -156,10 +164,6 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 		Severity: ReasonSeverityError,
 		Message:  "Scope Contract is missing required target files",
 	},
-	"rescope_requires_s2_state": {
-		Severity: ReasonSeverityError,
-		Message:  "Rescope pivots are only allowed from S2_EXECUTE",
-	},
 	"stale_execution_evidence": {
 		Severity: ReasonSeverityError,
 		Message:  "Execution evidence is stale; rerun wave-orchestration for affected tasks",
@@ -167,6 +171,10 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 	"stale_planning_evidence": {
 		Severity: ReasonSeverityError,
 		Message:  "Planning artifacts changed after execution evidence; rerun affected planning gates before refreshing execution evidence",
+	},
+	"stale_planning_recovery_available": {
+		Severity: ReasonSeverityWarning,
+		Message:  "Stale planning evidence can be recovered by reopening planning audit",
 	},
 	"tasks_checklist_invalid_format": {
 		Severity: ReasonSeverityError,


### PR DESCRIPTION
## Summary
- add a non-destructive S3/S4 stale-planning recovery path back to S1_PLAN/audit
- clear stale derived planning, execution, review, and verify evidence while preserving runtime task evidence
- surface read-only recovery guidance in next output and align pivot rescope parity with the CLI contract
- add governed Tier 3 artifacts for issue #53

## Verification
- go test ./cmd -run "TestRunStalePlanning(EvidenceReopensPlanAuditAndPreservesRuntimeEvidence|RecoveryRequiresFreshReviewAfterExecutionRefresh|RecoveryRefreshesEvidenceInOrder)|TestNextStalePlanningEvidenceReportsRecoveryRunGuidance|TestValidateAndNextGuideS3ScopeContractDriftToRecoveryPath|TestPivotRescopeRejectedOutsideS2|TestValidatePivotPreconditions" -count=1 -v
- go test ./internal/engine/gate ./internal/engine/progression -run "TestEvaluateGPivot|Test.*StalePlanning|TestScopeContract" -count=1 -v
- go test -count=1 ./...
- go build ./...
- go vet ./...
- git diff --check
- go run . validate --json --change complete-issue-53-tier-3-stale-planning-recovery-state-machi
- go run . run --json --diagnostics --change complete-issue-53-tier-3-stale-planning-recovery-state-machi returned done_ready

## Governance
- G_plan approved
- G_scope approved
- G_ship approved
- final-closeout pass, goal-verification pass
- scope_contract pass

Refs #53