### PR TITLE
chore(go): update toolchain to 1.26.4

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,10 +17,18 @@
       let
         pkgs = nixpkgs.legacyPackages.${system};
         version = if (self ? shortRev) then self.shortRev else "dev";
+        go_1_26_4 = pkgs.go_1_26.overrideAttrs (finalAttrs: previousAttrs: {
+          version = "1.26.4";
+          src = pkgs.fetchurl {
+            url = "https://go.dev/dl/go${finalAttrs.version}.src.tar.gz";
+            hash = "sha256-T2aKMvv8ETLmqIH7lowvHa2mMUkqM5IRc1+7JVpCYC0=";
+          };
+        });
+        buildGoModule = pkgs.buildGoModule.override { go = go_1_26_4; };
       in
       {
         packages = {
-          slipway = pkgs.buildGoModule {
+          slipway = buildGoModule {
             pname = "slipway";
             inherit version;
             src = ./.;
@@ -57,7 +65,7 @@
 
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
-            go
+            go_1_26_4
             gopls
             golangci-lint
             goreleaser

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalridge/slipway
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/gofrs/flock v0.13.0


### PR DESCRIPTION
## Summary
- update the Go toolchain directive from 1.26.3 to 1.26.4
- picks up the patched standard library for govulncheck alerts GO-2026-5037, GO-2026-5038, and GO-2026-5039
- keeps the change limited to go.mod so CI setup-go continues to use the go-version-file contract

## Verification
- go version -> go1.26.4 darwin/arm64
- go test -count=1 ./...
- go build ./...
- go run golang.org/x/vuln/cmd/govulncheck@latest ./... -> No vulnerabilities found.
- git diff --check

## Alerts
- https://github.com/signalridge/slipway/security/code-scanning/43
- https://github.com/signalridge/slipway/security/code-scanning/44
- https://github.com/signalridge/slipway/security/code-scanning/45