### PR TITLE
fix(governance): align health, confirmation, and portable scan (#59, #61, #62)

### DIFF
--- a/artifacts/changes/archived/resolve-open-github-issues-59-61-and-62-align-governance-hea/assurance.md
+++ b/artifacts/changes/archived/resolve-open-github-issues-59-61-and-62-align-governance-hea/assurance.md
@@ -1,0 +1,53 @@
+# Assurance
+
+## Scope Summary
+This change is limited to the three active GitHub issues selected at intake:
+
+- Issue #59: governance health must report current traceability/control diagnostics instead of preserving resolved stale controls or hiding gap identities; command docs must distinguish validate/run/health authority; a stale `wave-orchestration` record must not satisfy the wave gate after newer runtime task evidence (the plan-audit source-freshness half is deferred to #66 — see REQ-006); read-only gate projections must keep the planning gate approved after closeout assurance edits.
+- Issue #61: hard-stop confirmation metadata must distinguish non-resumable skill handoffs and command boundaries from resumable checkpoints.
+- Issue #62: the goal-verification placeholder scan must avoid GNU-only `grep -P` so the generated instruction works on macOS.
+
+The implementation stays within health diagnostics, next-step confirmation diagnostics, the common required-skill evidence evaluator, command contract docs/templates, the goal-verification skill template, and focused regressions for those surfaces. It does not close the GitHub issues remotely, redesign the lifecycle state model, or change existing JSON field meanings.
+
+## Verification Verdict
+Pass. The execution, review, goal-verification, and final-closeout records for run version 1 show full test/build proof, source-scope coverage, external API contract review, evidence freshness, and closeout assurance. This turn intentionally stops at the pre-`done` state so final archive remains an explicit operator action.
+
+Key proof already captured in run version 1:
+
+- `go test ./...` passed.
+- `go build ./...` passed.
+- `git diff --check` passed.
+- `go run . health --governance --json --change resolve-open-github-issues-59-61-and-62-align-governance-hea` reported healthy governance state.
+- `go run . validate --json --change resolve-open-github-issues-59-61-and-62-align-governance-hea` reported fresh evidence and scope pass before final-closeout evidence was added.
+- `go run . validate --json --change resolve-open-github-issues-59-61-and-62-align-governance-hea` is rerun after final-closeout evidence to confirm `G_ship` approval.
+
+## Evidence Index
+- Intake clarification: `verification/intake-clarification.yaml`
+- Research orchestration: `verification/research-orchestration.yaml`
+- Plan audit: `verification/plan-audit.yaml`
+- Wave orchestration and task execution: `verification/wave-orchestration.yaml`, `verification/execution-summary.yaml`
+- Spec compliance review: `verification/spec-compliance-review.yaml`
+- Code quality review: `verification/code-quality-review.yaml`
+- Goal verification: `verification/goal-verification.yaml`
+- Final closeout: `verification/final-closeout.yaml`
+
+## Requirement Coverage
+- REQ-001: Satisfied by `internal/engine/governance/health.go`, `cmd/health.go`, and `cmd/health_test.go`; health now exposes traceability gap detail and recompute no longer carries resolved stale clarification controls forward.
+- REQ-002: Satisfied by `cmd/next.go` and `cmd/progression_next_test.go`; confirmation metadata now reports `resume_response_supported` and a concrete `next_action` for skill handoffs, command boundaries, and checkpoints.
+- REQ-003: Satisfied by `internal/tmpl/templates/skills/goal-verification/SKILL.md.tmpl` and `internal/tmpl/templates_test.go`; rendered goal-verification instructions use a portable Perl empty-object scan and reject `grep -P`.
+- REQ-004: Satisfied by `scope_contract:pass` in validation and review evidence; changed files are limited to the planned issue surfaces and tests.
+- REQ-005: Satisfied by additive JSON metadata and focused compatibility checks; existing JSON fields remain present and unchanged.
+- REQ-006: Satisfied by `internal/engine/progression/wave_sync.go` and `internal/engine/progression/wave_sync_test.go`; a passing `wave-orchestration` record is rejected when runtime task evidence (`captured_at`) for the same run summary version is newer. The plan-audit source-freshness half is descoped to #66 — an mtime guard false-positives on Slipway's own `tasks.md` checkbox writeback — so `evidence.go`, `advance_governed.go`, and `readiness.go` retain their prior plan-audit semantics (missing/not-passing only) with no source-freshness check.
+- REQ-007: Satisfied by `cmd/governance_gate_consistency_test.go`, `docs/commands.md`, generated command prompt partials, and `internal/tmpl/templates_test.go`; command authority boundaries, `advanced`/`blockers` semantics, and read-only gate projection consistency are documented/tested.
+
+## Residual Risks and Exceptions
+- Existing callers that ignore new confirmation metadata remain compatible, but downstream integrations must opt in to use `resume_response_supported` and `next_action`.
+- An existing stale `wave-orchestration` record may now block where it previously passed; the intended remediation is to rerun wave orchestration against the current runtime task evidence.
+- The portable scan now depends on Perl being available in the host environment; macOS includes Perl by default, and the template only uses it for local verification guidance.
+- This change does not remotely close issues #59, #61, or #62. Closeout proves the code and governed bundle are ready for human review before those issue statuses are updated.
+
+## Rollback Readiness
+Rollback is a normal git revert of the modified command diagnostics, governance health recompute/display behavior, the wave-orchestration evidence freshness guard, command docs/templates, goal-verification template text, and associated tests. No persisted runtime state, database schema, migration, credential, network, or irreversible operation is introduced.
+
+## Archive Decision
+Ready for governed archive once the workflow reaches the pre-`done` state. The archive rationale is that all planned tasks for issues #59, #61, and #62 have passing run-version-1 evidence, both required review skills pass, goal-verification and final-closeout pass, scope validation is clean, and the remaining action is intentionally reserved for explicit `slipway done`.

--- a/artifacts/changes/archived/resolve-open-github-issues-59-61-and-62-align-governance-hea/change.yaml
+++ b/artifacts/changes/archived/resolve-open-github-issues-59-61-and-62-align-governance-hea/change.yaml
@@ -1,0 +1,58 @@
+version: 1
+slug: resolve-open-github-issues-59-61-and-62-align-governance-hea
+description: 'resolve open GitHub issues #59, #61, and #62: align governance health freshness and diagnostics, hard-stop confirmation behavior, and portable goal-verification placeholder scans'
+status: done
+current_state: DONE
+needs_discovery: true
+complexity_level: critical
+base_ref: HEAD
+created_at: 2026-06-03T14:50:47.214664Z
+guardrail_domain: external_api_contracts
+quality_mode: standard
+workflow_preset: standard
+worktree_branch: feat/resolve-open-github-issues-59-61-and-62-align-governance-hea
+artifact_schema: expanded
+project_context:
+    tech_stack: Go CLI
+    test_cmd: go test ./...
+    build_cmd: go build ./...
+    languages:
+        - Go
+    recent_work: 'Current main includes issue #53 Tier 1/Tier 2/Tier 3 governance fixes; this change targets still-open issues #59, #61, and #62.'
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: 0e753c3b6a71c9f3bc7ba31d48514cc954ff4d293db38e2280ebd00eb68e12c8
+        updated_at: 2026-06-03T18:31:44.938104446Z
+    decision:
+        id: decision
+        path: decision.md
+        state: frozen
+        content_hash: 1caae15f4b9fb20096a9eeab5afcdff7023e9102d8652f45a90d0ac4b988b7db
+        updated_at: 2026-06-03T18:30:09.297783289Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: 9190948b4f85c9f0a75e38aeeff620f930e172f4f06210db9497859937220030
+        updated_at: 2026-06-03T18:30:53.645324516Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: fe24b5496913c2ec87f12936bd7a98f089dc1497cff8e2aa7d803edf0d62620b
+        updated_at: 2026-06-03T18:29:19.255696804Z
+    research:
+        id: research
+        path: research.md
+        state: frozen
+        content_hash: ea1a05288712eb693b1e5b33bac0e8974b47eeb57aaed9c4869ce82d6f25742d
+        updated_at: 2026-06-03T15:26:35.729469582Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: 0a52fe5c26704587dce1a2af8fbd9a330a65f568dbd75ab6e975f65ece89e101
+        updated_at: 2026-06-04T03:22:58.934499111Z

--- a/artifacts/changes/archived/resolve-open-github-issues-59-61-and-62-align-governance-hea/decision.md
+++ b/artifacts/changes/archived/resolve-open-github-issues-59-61-and-62-align-governance-hea/decision.md
@@ -1,0 +1,61 @@
+# Decision
+
+## Project Context
+- Tech Stack: Go CLI
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Alternatives Considered
+
+### DEC-001: Add structured diagnostics, freshness guards, and contract documentation while keeping existing lifecycle semantics
+This approach exposes already-computed traceability gaps on the failing health check, adds explicit next-action/resume-support metadata to confirmation requirements, rejects stale `wave-orchestration` evidence when newer runtime task evidence exists for the same run version, documents the `validate`/`run`/`health` authority boundary, and replaces the GNU-only placeholder scan with a portable command. Covers REQ-001, REQ-002, REQ-003, REQ-004, REQ-005, REQ-006, and REQ-007.
+
+> **Note (descope):** an earlier revision of this approach also added an mtime-based
+> `plan-audit` source-freshness guard. It was removed before ship because Slipway
+> rewrites `tasks.md` during execution (checkbox writeback), so an mtime/timestamp
+> comparison false-positives on a normal `[ ]`→`[x]` tick. Content-addressed
+> plan-audit freshness is tracked separately in #66. REQ-006 in this change is
+> therefore satisfied by the `wave-orchestration` half only.
+
+Tradeoffs:
+- Low blast radius and backward-compatible additive JSON fields.
+- Keeps current snapshot recomputation behavior instead of redesigning the cache.
+- Keeps blocker severity semantics intact: blockers still describe the current stop condition, while docs explain how to read them after a successful `run` transition.
+
+### DEC-002: Replace governance snapshot caching with always-live health evaluation and change skill handoff boundaries
+This approach would make health always recompute from scratch and rename/reclassify skill handoff boundaries. Covers REQ-001 and REQ-002.
+
+Tradeoffs:
+- Stronger conceptual cleanup, but higher risk to performance, existing JSON consumers, and unrelated governance behavior.
+- Larger change than required because current tests already prove material-change recomputation.
+
+### DEC-003: Create active checkpoints for every skill handoff
+This approach would convert skill handoffs into resumable checkpoint state accepted by `--resume-response`. Covers REQ-002.
+
+Tradeoffs:
+- Resolves the reporter's checkpoint confusion literally.
+- Conflates workflow skill handoffs with execution checkpoints and expands state-machine semantics well beyond the issue scope.
+
+## Selected Approach
+Select DEC-001. It is the narrowest approach that satisfies all requirements: expose existing traceability gap data in health output, add explicit action metadata to confirmation output without changing the checkpoint contract, fail closed on stale wave-orchestration evidence (runtime task evidence freshness), document the command authority boundary, and make the goal-verification scan portable. This direction preserves existing JSON fields while adding tested optional metadata for external API consumers. (Plan-audit source-freshness is deliberately excluded; see the descope note above and #66.)
+
+## Interfaces and Data Flow
+- `internal/engine/governance.GovernanceHealthCheck` gains optional structured details for traceability failures. `cmd/health.go` JSON encodes those details automatically, and text output may print them for human health output.
+- `cmd.confirmationRequirement` gains optional action metadata, such as whether `--resume-response` is supported and the next command/action a caller should take.
+- `deriveConfirmationRequirement` sets non-checkpoint action metadata for skill handoffs and checkpoint action metadata only when `input_context.resume_checkpoint` is actually pending.
+- `progression.SyncGovernedWaveExecution` rejects a passing `wave-orchestration` record whose timestamp predates current runtime task evidence (`captured_at`) for the same run summary version.
+- Plan-audit source-freshness is intentionally not implemented here. `EvaluateRequiredSkillsForChange` and `EvaluatePlanGate` retain their prior semantics (missing/not-passing plan-audit evidence only); content-addressed plan-audit freshness is deferred to #66.
+- `internal/tmpl/templates/skills/goal-verification/SKILL.md.tmpl` uses a portable empty-block scan command.
+- `docs/commands.md` and generated command prompts document the distinction between `validate` as active-readiness authority, `run` as mutating transition surface, and `health --governance` as diagnostic feedback.
+
+## Rollout and Rollback
+- Rollout is a normal code change with regression tests in `cmd/health_test.go`, `cmd/governance_gate_consistency_test.go`, `cmd/progression_next_test.go`, `internal/engine/progression/evidence_test.go`, and `internal/tmpl/templates_test.go`.
+- Rollback is a standard git revert. No runtime data migration is introduced.
+- Verification: focused tests for the changed command/template surfaces, then `go test ./...`, `go build ./...`, and Slipway validation.
+
+## Risk
+- Medium external API risk: JSON surfaces gain new optional fields. Mitigation: keep existing fields stable and add tests for the added metadata.
+- Medium governance risk if stale runtime evidence is accepted. Mitigation: compare wave-orchestration timestamps with current runtime task evidence (`captured_at`) during wave sync. (An mtime-based plan-audit guard was considered and rejected — it false-positives on Slipway's own `tasks.md` checkbox writeback; the content-digest replacement is tracked in #66.)
+- Medium operator-risk if details are too terse. Mitigation: reuse `TraceabilityGap` fields so gap ID, type, issue, and blocking status are visible.
+- Low portability risk: Perl one-liner replaces GNU `grep -P`; the target macOS environment supports Perl and the issue reporter used Perl successfully.

--- a/artifacts/changes/archived/resolve-open-github-issues-59-61-and-62-align-governance-hea/intent.md
+++ b/artifacts/changes/archived/resolve-open-github-issues-59-61-and-62-align-governance-hea/intent.md
@@ -1,0 +1,66 @@
+# Intent
+
+## Project Context
+- Tech Stack: Go CLI
+- Languages: Go
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Conventions:
+
+## Summary
+INT-001: Resolve open GitHub issues #59, #61, and #62 by making governance health diagnostics actionable, making handoff confirmation output distinguish non-checkpoint actions from checkpoint resume, and making goal-verification placeholder scans portable on macOS.
+
+## Complexity Assessment
+critical
+
+## Guardrail Domains
+external_api_contracts
+
+## In Scope
+- INT-001A: Resolve GitHub issue #59:
+  - prevent `slipway health --governance` from serving stale governance-control or traceability signals after lifecycle/control/artifact changes, or otherwise provide an explicit refresh/recompute path if caching remains intentional.
+  - align `validate`, `run`, and `health --governance` diagnostics enough that operators can identify the authoritative next action when the surfaces differ.
+  - expose actionable traceability/governance gap identities in JSON diagnostics or observation output so operators do not need to infer missing refs by manual bisection.
+- INT-001B: Resolve GitHub issue #61:
+  - make hard-stop confirmation output actionable by either creating a resumable checkpoint accepted by `--resume-response` or changing diagnostics to name the correct non-checkpoint next action.
+  - cover the behavior with regression tests for the reported review-handoff case.
+- INT-001C: Resolve GitHub issue #62:
+  - remove GNU-only `grep -P` from generated goal-verification placeholder-scan instructions, or include a macOS-compatible fallback command.
+  - update tests/goldens for the generated skill/template content so this does not regress.
+- INT-001D: Keep the implementation scoped to Slipway CLI/governance-health/progression/template behavior needed by those issues.
+- INT-001E: Resolve GitHub issue #59 item 4 for the wave-execution gate by ensuring runtime task evidence freshness (`captured_at`) before a `wave-orchestration` record can satisfy the gate. The planning-gate (plan-audit) half is deferred to #66: mtime-based source-freshness false-positives on Slipway's own `tasks.md` checkbox writeback, so it is replaced by a content-digest approach there rather than shipped here.
+- INT-001F: Resolve GitHub issue #59 item 2/item 3 by documenting and testing the authority boundary between active readiness (`validate`), mutating transition result (`run`), and diagnostic health feedback (`health --governance`).
+
+## Out of Scope
+- Do not redesign the whole governance kernel, workflow state model, or evidence schema unless a minimal fix proves impossible.
+- Do not address unrelated open issues, previous issue #53 tier work, or Lattice product-code behavior.
+- Do not close/archive the governed change; stop at the Slipway close-ready/done-ready boundary before final close.
+- Do not close the GitHub issues from this change unless the user later asks for issue-management follow-through.
+
+## Constraints
+- Preserve existing JSON contracts where possible; this change is classified as `external_api_contracts`, so any changed fields must be deliberate, documented by tests, and backward-compatible when practical.
+- Favor source-backed diagnostics over cosmetic wording changes: issue #59 requires the health/validate/run surfaces to reflect current authority.
+- The default agent environment includes macOS/BSD userland, so verification instructions must not require GNU-only flags without a fallback.
+- Preserve unrelated local worktrees and ignored runtime state.
+
+## Acceptance Signals
+- Issue #59: tests prove governance-health data is invalidated or recomputed after relevant lifecycle/control/artifact changes, JSON diagnostics include actionable traceability/gap identities, stale planning/runtime evidence fails closed, and command surfaces document the validate/run/health authority boundary.
+- Issue #61: tests prove a hard-stop confirmation boundary no longer emits a non-actionable `--resume-response` path without an active checkpoint.
+- Issue #62: generated goal-verification instructions no longer require GNU `grep -P` on macOS, and template/golden tests cover the portable placeholder scan.
+- Full verification before close-ready includes `go test ./...`, `go build ./...`, and Slipway `validate --json` for this change.
+
+## Open Questions
+(none)
+
+## Resolved Ownership Notes
+- health ownership: `cmd/health.go` recomputes governance snapshots and `internal/engine/governance/health.go` renders health checks.
+- confirmation ownership: `cmd/next.go` derives `confirmation_requirement`; `cmd/next_context_build.go` handles actual checkpoint resume.
+- placeholder scan source: `internal/tmpl/templates/skills/goal-verification/SKILL.md.tmpl`.
+
+## Deferred Ideas
+- Broader governance UX consolidation across all command surfaces.
+- Large-scale health/validate/run schema redesign.
+- Closing or commenting on the GitHub issues after implementation.
+
+## Approved Summary
+Approved from the user's standing goal instruction on 2026-06-03T15:22:26Z: implement one governed change for open issues #59, #61, and #62, make best-effort autonomous decisions if blockers appear, and continue until the change is ready to close but before final close/archive. The change is limited to Slipway governance-health freshness/diagnostics, hard-stop confirmation actionability, and macOS-portable goal-verification placeholder-scan instructions. Out of scope are unrelated issues, broad governance redesign, Lattice product-code changes, and final close/archive.

--- a/artifacts/changes/archived/resolve-open-github-issues-59-61-and-62-align-governance-hea/requirements.md
+++ b/artifacts/changes/archived/resolve-open-github-issues-59-61-and-62-align-governance-hea/requirements.md
@@ -1,0 +1,93 @@
+# Requirements
+
+## Project Context
+- Tech Stack: Go CLI
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Requirements
+
+### Requirement: Governance health exposes current traceability gap identities.
+REQ-001: `slipway health --governance --json` MUST expose actionable traceability gap identities when `traceability_coherence` is WARN or FAIL. Traces to INT-001A.
+
+#### Scenario: Failing traceability health names gaps
+GIVEN a governed bundle whose traceability snapshot contains blocking gaps
+WHEN `slipway health --governance --json --change <slug>` runs
+THEN the `traceability_coherence` check identifies the offending gap IDs, types, issues, and blocking status.
+
+#### Scenario: Current recompute behavior is preserved
+GIVEN a persisted governance snapshot and a later artifact/control change
+WHEN governance health runs
+THEN current artifact/control state is recomputed or treated as the authoritative source, preserving existing material-change freshness behavior.
+
+### Requirement: Handoff confirmation diagnostics name the correct action.
+REQ-002: Skill-handoff confirmation output MUST explicitly distinguish non-checkpoint handoffs from active checkpoint resume and MUST not imply that `--resume-response` is valid unless an active checkpoint exists. Traces to INT-001B.
+
+#### Scenario: Skill handoff is not checkpoint-resumable
+GIVEN `next/run --json --diagnostics` returns a required skill handoff and no `input_context.resume_checkpoint`
+WHEN `confirmation_requirement` is rendered
+THEN it includes a non-checkpoint next action for the skill handoff and reports that `--resume-response` is not supported.
+
+#### Scenario: Active checkpoint remains checkpoint-resumable
+GIVEN a real `active_checkpoint` exists
+WHEN `next/run --json --diagnostics` renders `confirmation_requirement`
+THEN it reports that `--resume-response` is supported and keeps the checkpoint resume path intact.
+
+### Requirement: Goal-verification placeholder scan is macOS-portable.
+REQ-003: The generated `slipway-goal-verification` skill MUST NOT require GNU-only `grep -P` for the empty-block placeholder scan on macOS. Traces to INT-001C.
+
+#### Scenario: Rendered skill uses portable scan
+GIVEN the goal-verification skill template is rendered
+WHEN its stub/placeholder scan section is inspected
+THEN it does not contain `grep -P` and includes a portable empty-block scan command.
+
+### Requirement: Scope remains limited to the three open issues.
+REQ-004: The implementation MUST stay scoped to the Slipway CLI/governance-health/progression/template/docs behavior required for issues #59, #61, and #62. Traces to INT-001D.
+
+#### Scenario: No unrelated governance redesign
+GIVEN the implementation diff
+WHEN reviewed against the change intent
+THEN it modifies only the health diagnostics, confirmation diagnostics, planning evidence freshness guard, goal-verification template, command contract docs, and their tests unless a directly required helper is introduced.
+
+### Requirement: external_api_contracts guardrail compliance.
+REQ-005: Additive JSON-surface changes MUST be covered by regression tests and MUST preserve existing fields. Traces to INT-001.
+
+#### Scenario: Additive contract change
+GIVEN existing JSON consumers rely on current `confirmation_requirement` and governance health fields
+WHEN this change adds action/detail metadata
+THEN current field names and meanings remain available and tests cover the new metadata.
+
+### Requirement: Runtime task evidence must be fresh.
+REQ-006: A passing `wave-orchestration` record MUST NOT satisfy a gate when runtime task evidence for the same run summary version is newer than that record. Traces to INT-001E.
+
+#### Scenario: New task evidence invalidates prior wave orchestration
+GIVEN `verification/wave-orchestration.yaml` is passing for a run summary version
+AND runtime task evidence for that same run summary version has a newer `captured_at`
+WHEN wave execution is synchronized
+THEN the old wave orchestration record is not reused and sync reports `wave_orchestration_stale_task_evidence:<task_id>`.
+
+> **Descoped — plan-audit source-freshness moved to #66.** An earlier revision of
+> this requirement also failed `plan-audit` evidence closed when a planning source
+> artifact (`intent/requirements/research/decision/tasks.md`) had a newer
+> filesystem mtime than the verification record. That guard was removed before
+> ship: Slipway itself rewrites `tasks.md` during execution (checkbox writeback in
+> `syncCompletedTaskCheckboxes`), so an mtime/timestamp comparison false-positives
+> on a normal `[ ]`→`[x]` tick and would report `plan-audit:stale_evidence` on
+> read-only surfaces after S2. Source-fresh plan-audit evidence is re-approached in
+> #66 via a content digest (`TaskPlanSemanticHash`, checkbox-invariant) bound at
+> acceptance, not wall-clock time. Only the wave-orchestration half — which
+> compares the embedded logical `captured_at`, never mtime — remains in this change.
+
+### Requirement: Command surfaces explain their authority boundary.
+REQ-007: Command documentation and generated command prompts MUST distinguish active readiness (`validate`), mutating transition result (`run`), and diagnostic health feedback (`health --governance`) so error-severity blockers after a successful `run` advance are not misread as command failure. Traces to INT-001F.
+
+#### Scenario: Run transition and next blockers are distinct
+GIVEN `slipway run --json` advances and then stops at a required skill
+WHEN an operator reads the command contract
+THEN `advanced` is documented as the invocation's mutation result and `blockers` is documented as the current stop condition after that mutation.
+
+#### Scenario: Read-only gate projections agree after planning
+GIVEN planning evidence passed before the change reached verification
+WHEN status, validate, and next project gate status after closeout assurance edits
+THEN all three surfaces keep the planning gate approved and none downgrades it.

--- a/artifacts/changes/archived/resolve-open-github-issues-59-61-and-62-align-governance-hea/research.md
+++ b/artifacts/changes/archived/resolve-open-github-issues-59-61-and-62-align-governance-hea/research.md
@@ -1,0 +1,97 @@
+# Research
+
+## Research Findings
+
+### Architecture
+- Affected modules:
+  - `cmd/health.go` owns `slipway health --governance` command routing, snapshot load/recompute, JSON output, text rendering, and doctor action synthesis. Evidence: `cmd/health.go:21`, `cmd/health.go:128`, `cmd/health.go:145`, `cmd/health.go:186`, `cmd/health.go:193`, `cmd/health.go:641`.
+  - `internal/engine/governance/health.go` owns `GovernanceHealthCheck`, traceability health checks, snapshot preview/recompute, and active-control coherence. Evidence: `internal/engine/governance/health.go:17`, `internal/engine/governance/health.go:253`, `internal/engine/governance/health.go:397`, `internal/engine/governance/health.go:407`, `internal/engine/governance/health.go:451`.
+  - `internal/engine/governance/traceability.go` already computes structured `TraceabilityGap` records with ID/type/issue/blocking but the health check message collapses them to a count. Evidence: `internal/engine/governance/traceability.go:48`, `internal/engine/governance/traceability.go:59`, `internal/engine/governance/traceability.go:122`, `internal/engine/governance/traceability.go:177`, `internal/engine/governance/traceability.go:258`, `internal/engine/governance/traceability.go:273`.
+  - `cmd/next.go` owns `confirmation_requirement`; it currently maps any skill handoff to the same `hard_stop` constructor used for checkpoint-like boundaries. Evidence: `cmd/next.go:56`, `cmd/next.go:594`, `cmd/next.go:598`, `cmd/next.go:605`, `cmd/next.go:634`.
+  - `cmd/next_context_build.go` owns active checkpoint projection and the `no_active_checkpoint` error when `--resume-response` is supplied without an actual checkpoint. Evidence: `cmd/next_context_build.go:300`, `cmd/next_context_build.go:310`, `cmd/next_context_build.go:333`.
+  - `internal/tmpl/templates/skills/goal-verification/SKILL.md.tmpl` emits the GNU-only placeholder scan. Evidence: `internal/tmpl/templates/skills/goal-verification/SKILL.md.tmpl:56`, `internal/tmpl/templates/skills/goal-verification/SKILL.md.tmpl:63`.
+- Dependency chains:
+  - `health` command -> `governance.LoadSnapshot` -> `governance.RecomputeGovernanceSnapshot` -> `governance.CollectGovernanceHealthWithSnapshot` -> `checkTraceabilityCoherence`.
+  - `next/run` command -> `buildNextView` -> `deriveConfirmationRequirement`; checkpoint resume support is separate through `buildResumeCheckpoint`.
+  - template content -> `internal/tmpl.Render`/toolgen tests -> generated `slipway-goal-verification` skill.
+- Blast radius:
+  - CLI JSON additions for governance health checks and confirmation requirements.
+  - Text health rendering only if structured details are printed for human output.
+  - One generated skill template and its tests.
+- Constraints:
+  - Preserve existing JSON fields and meanings; add optional fields rather than renaming current fields.
+  - Keep recompute behavior from current `cmd/health_test.go` coverage; do not replace the snapshot cache design unless tests prove it stale.
+  - Keep `--resume-response` scoped to real `active_checkpoint` state.
+
+### Patterns
+- Existing conventions:
+  - Command JSON structs use optional `omitempty` fields for additive diagnostics, for example `healthView.Observations`, `healthView.Diagnostics`, and `nextView.Warnings`. Evidence: `cmd/health.go:21`, `cmd/next.go:16`.
+  - Governance details commonly use existing model structs where possible; `TraceabilityGap` is already part of `TraceabilitySummary`. Evidence: `internal/model/governance_snapshot.go:16`, `internal/model/traceability.go:33`.
+  - Tests exercise command JSON by unmarshalling into command view structs and asserting specific diagnostic fields. Evidence: `cmd/health_test.go:1032`, `cmd/progression_next_test.go:1939`.
+  - Template tests render `goal-verification` directly and assert text contracts. Evidence: `internal/tmpl/templates_test.go:512`.
+- Reusable abstractions:
+  - Use `model.TraceabilityGap` as the structured details payload for `traceability_coherence`, avoiding a duplicate schema.
+  - Extend `confirmationRequirement` with optional action metadata rather than inventing a separate checkpoint state.
+  - Replace `grep -Pzo` with a Perl one-liner; Perl is available on the target macOS environment and already matches the reporter's successful workaround.
+- Convention deviations:
+  - Adding optional fields to `confirmation_requirement` and governance checks is an external JSON surface change, but it is additive and directly tied to `external_api_contracts` acceptance.
+
+### Risks
+- Technical risks:
+  - Medium: exposing full traceability gap structs may make health JSON larger. Mitigation: only include details on non-OK traceability checks.
+  - Medium: changing confirmation semantics could break tests or callers expecting only five fields. Mitigation: additive `next_action` / `resume_response_supported` fields; keep existing fields stable.
+  - Low: replacing the placeholder scan with Perl changes copy, not runtime behavior. Mitigation: template tests assert absence of `grep -P`.
+- Guardrail domains:
+  - `external_api_contracts` is touched because machine-readable `health` and `next/run` JSON surfaces change.
+- Reversibility:
+  - All changes are local to command JSON structs, governance health formatting, tests, and templates. Rollback is a standard git revert with no data migration.
+
+### Test Strategy
+- Existing coverage:
+  - Health recomputation tests already cover stale persisted snapshots and material artifact changes. Evidence: `cmd/health_test.go:1032`, `cmd/health_test.go:1133`, `cmd/health_test.go:1234`.
+  - Confirmation requirement tests currently assert skill handoff hard stops but no actionable resume metadata. Evidence: `cmd/progression_next_test.go:1939`, `cmd/progression_next_test.go:1970`.
+  - Resume-response rejection without checkpoint is already covered. Evidence: `cmd/progression_next_test.go:1588`.
+  - Template rendering tests already cover goal-verification content. Evidence: `internal/tmpl/templates_test.go:512`.
+- Infrastructure needs:
+  - Add/extend command-level JSON tests in `cmd/health_test.go` and `cmd/progression_next_test.go`.
+  - Add/extend template tests in `internal/tmpl/templates_test.go`.
+- Verification approach:
+  - `#59`: assert `traceability_coherence` JSON includes gap IDs/types/issues for a failing bundle; preserve existing recompute tests.
+  - `#61`: assert skill handoff confirmation includes an explicit non-checkpoint next action and `resume_response_supported=false`; assert resume checkpoint remains `true`.
+  - `#62`: assert rendered goal-verification template does not contain `grep -P` and does contain the portable Perl scan.
+
+## Alternatives Considered
+
+- Approach 1: Add optional structured details/action metadata and keep existing runtime behavior.
+  - Tradeoffs: minimal blast radius, additive JSON compatibility, directly addresses operator ambiguity; does not redesign all command verdict semantics.
+- Approach 2: Replace governance snapshot caching with always-live health evaluation and change skill handoffs from `hard_stop` to a new boundary.
+  - Tradeoffs: stronger semantic cleanup, but higher risk to performance and external JSON consumers; likely overbroad for the three issues.
+- Approach 3: Implement checkpoint creation for every skill handoff and allow `--resume-response` to advance through host skills.
+  - Tradeoffs: resolves `#61` literally but conflates human/agent skill handoffs with execution checkpoints and would expand the state machine.
+- Selected: Approach 1. It fixes the observed operator problems with the smallest external-contract change: health exposes the already-computed traceability gap identities, confirmation output tells callers whether `--resume-response` is supported and what action to take, and goal-verification uses a portable scan command.
+
+
+## Unknowns
+- Resolved: health snapshot owner -> `cmd/health.go` recomputes snapshots under the change lock and feeds `CollectGovernanceHealthWithSnapshot`; current tests already cover material artifact changes.
+- Resolved: traceability gap source -> `EvaluateTraceability` already computes `TraceabilitySummary.Gaps`, so the missing behavior is surfacing, not detection.
+- Resolved: confirmation output owner -> `deriveConfirmationRequirement` owns skill-handoff hard-stop metadata, while `buildResumeCheckpoint` owns real checkpoint resume support.
+- Resolved: GNU-only scan source -> `internal/tmpl/templates/skills/goal-verification/SKILL.md.tmpl`.
+- Remaining: None for planning.
+
+
+## Assumptions
+- Adding optional JSON fields is acceptable because current consumers can ignore unknown fields and the issue explicitly asks for more actionable diagnostics. Evidence: current command view structs already use optional diagnostic fields (`cmd/health.go:21`, `cmd/next.go:16`).
+- We should not replace the health cache wholesale because current tests already assert recomputation when material state changes (`cmd/health_test.go:1032`, `cmd/health_test.go:1234`).
+- Perl is an acceptable portable fallback for macOS agents because the filed issue's successful workaround used Perl and the target environment is macOS.
+
+
+## Canonical References
+- `artifacts/changes/resolve-open-github-issues-59-61-and-62-align-governance-hea/intent.md` for the original request and intake context.
+- `requirements.md` and `decision.md` in the same bundle once planning artifacts are refined.
+- Existing code paths and tests related to the affected behavior in the repository.
+- `cmd/health.go:128` for governance health command flow.
+- `internal/engine/governance/health.go:17` for `GovernanceHealthCheck`.
+- `internal/engine/governance/traceability.go:258` for existing gap storage on `TraceabilitySummary`.
+- `cmd/next.go:56` and `cmd/next.go:594` for confirmation requirement shape and derivation.
+- `cmd/next_context_build.go:300` for checkpoint resume projection.
+- `internal/tmpl/templates/skills/goal-verification/SKILL.md.tmpl:56` for placeholder scan instructions.

--- a/artifacts/changes/archived/resolve-open-github-issues-59-61-and-62-align-governance-hea/tasks.md
+++ b/artifacts/changes/archived/resolve-open-github-issues-59-61-and-62-align-governance-hea/tasks.md
@@ -1,0 +1,105 @@
+# Tasks
+
+## Project Context
+- Tech Stack: Go CLI
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Task List
+
+- [x] `t-01` RED tests for issue #59 health traceability gap details.
+  - wave: 1
+  - depends_on: []
+  - target_files: ["cmd/health_test.go", "internal/engine/governance/health_test.go"]
+  - task_kind: code
+  - evidence: failing_test
+  - covers: [REQ-001, REQ-005]
+
+- [x] `t-02` RED tests for issue #61 confirmation action metadata.
+  - wave: 1
+  - depends_on: []
+  - target_files: ["cmd/progression_next_test.go"]
+  - task_kind: code
+  - evidence: failing_test
+  - covers: [REQ-002, REQ-005]
+
+- [x] `t-03` RED test for issue #62 portable goal-verification placeholder scan.
+  - wave: 1
+  - depends_on: []
+  - target_files: ["internal/tmpl/templates_test.go"]
+  - task_kind: code
+  - evidence: failing_test
+  - covers: [REQ-003, REQ-005]
+
+- [x] `t-04` Implement issue #59 structured traceability gap details on governance health checks.
+  - wave: 2
+  - depends_on: [t-01]
+  - target_files: ["internal/engine/governance/health.go", "cmd/health.go"]
+  - task_kind: code
+  - evidence: test_pass
+  - covers: [REQ-001, REQ-004, REQ-005]
+
+- [x] `t-05` Implement issue #61 non-checkpoint/active-checkpoint action metadata in `confirmation_requirement`.
+  - wave: 2
+  - depends_on: [t-02]
+  - target_files: ["cmd/next.go", "cmd/next_handoff.go"]
+  - task_kind: code
+  - evidence: test_pass
+  - covers: [REQ-002, REQ-004, REQ-005]
+
+- [x] `t-06` Implement issue #62 portable goal-verification placeholder scan.
+  - wave: 2
+  - depends_on: [t-03]
+  - target_files: ["internal/tmpl/templates/skills/goal-verification/SKILL.md.tmpl"]
+  - task_kind: code
+  - evidence: test_pass
+  - covers: [REQ-003, REQ-004, REQ-005]
+
+- [x] `t-07` Run focused and full verification before review/close-ready progression.
+  - wave: 3
+  - depends_on: [t-04, t-05, t-06]
+  - target_files: ["cmd/health_test.go", "cmd/progression_next_test.go", "internal/engine/governance/health_test.go", "internal/tmpl/templates_test.go"]
+  - task_kind: verification
+  - evidence: command_output
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004, REQ-005]
+
+- [x] `t-08` (DESCOPED -> #66) RED regression for plan-audit source-freshness — removed before ship; an mtime guard false-positives on Slipway's own tasks.md checkbox writeback.
+  - wave: 4
+  - depends_on: [t-07]
+  - target_files: ["internal/engine/progression/evidence_test.go"]
+  - task_kind: code
+  - evidence: failing_test
+  - covers: [REQ-006]
+
+- [x] `t-09` (DESCOPED -> #66) Plan-audit source-freshness guard — implemented then reverted before ship; content-digest replacement tracked in #66. Net code change is the revert only.
+  - wave: 5
+  - depends_on: [t-08]
+  - target_files: ["internal/engine/progression/evidence.go", "internal/engine/progression/evidence_test.go", "internal/engine/progression/advance_governed.go", "internal/engine/progression/advance_test.go", "internal/engine/progression/readiness.go"]
+  - task_kind: code
+  - evidence: test_pass
+  - covers: [REQ-006, REQ-004]
+
+- [x] `t-10` Document command authority boundaries and confirmation metadata.
+  - wave: 4
+  - depends_on: [t-05]
+  - target_files: ["cmd/governance_gate_consistency_test.go", "docs/commands.md", "internal/tmpl/templates/_partials/command-next-body.tmpl", "internal/tmpl/templates/_partials/command-run-body.tmpl", "internal/tmpl/templates_test.go"]
+  - task_kind: code
+  - evidence: test_pass
+  - covers: [REQ-002, REQ-005, REQ-007]
+
+- [x] `t-11` Refresh full verification after #59 item 2/3/4 repairs.
+  - wave: 7
+  - depends_on: [t-09, t-10, t-12]
+  - target_files: ["cmd/governance_gate_consistency_test.go", "cmd/health_test.go", "cmd/lifecycle_commands_test.go", "cmd/progression_next_test.go", "cmd/repair_test.go", "docs/commands.md", "internal/engine/governance/health_test.go", "internal/engine/progression/advance_test.go", "internal/engine/progression/evidence_test.go", "internal/engine/progression/wave_sync_test.go", "internal/tmpl/templates_test.go"]
+  - task_kind: verification
+  - evidence: command_output
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004, REQ-005, REQ-006, REQ-007]
+
+- [x] `t-12` Enforce wave-orchestration evidence freshness against current runtime task evidence.
+  - wave: 6
+  - depends_on: [t-09]
+  - target_files: ["cmd/lifecycle_commands_test.go", "cmd/progression_next_test.go", "cmd/repair_test.go", "internal/engine/progression/wave_sync.go", "internal/engine/progression/wave_sync_test.go", "internal/model/reason_code.go", "internal/model/model_test.go"]
+  - task_kind: code
+  - evidence: test_pass
+  - covers: [REQ-006, REQ-004]

--- a/cmd/governance_gate_consistency_test.go
+++ b/cmd/governance_gate_consistency_test.go
@@ -91,15 +91,24 @@ Planning evidence remains authoritative after S1.
 `)))
 	writeAssuranceMD(t, root, slug, validAssuranceContent())
 
+	sourceAt := time.Date(2026, 6, 4, 10, 0, 0, 0, time.UTC)
+	planAuditAt := sourceAt.Add(time.Hour)
+	for _, rel := range []string{"intent.md", "requirements.md", "research.md", "decision.md", "tasks.md"} {
+		path := filepath.Join(bundlePath, rel)
+		require.NoError(t, os.Chtimes(path, sourceAt, sourceAt))
+	}
+	assurancePath := filepath.Join(bundlePath, "assurance.md")
+	require.NoError(t, os.Chtimes(assurancePath, planAuditAt.Add(time.Hour), planAuditAt.Add(time.Hour)))
+
 	writeSkillVerification(t, root, slug, "plan-audit", model.VerificationRecord{
 		Verdict:   model.VerificationVerdictPass,
 		Blockers:  []model.ReasonCode{},
-		Timestamp: time.Now().UTC(),
+		Timestamp: planAuditAt,
 	})
 	writeSkillVerification(t, root, slug, "research-orchestration", model.VerificationRecord{
 		Verdict:   model.VerificationVerdictPass,
 		Blockers:  []model.ReasonCode{},
-		Timestamp: time.Now().UTC().Add(time.Second),
+		Timestamp: planAuditAt,
 	})
 
 	statusResp, validateResp, nextResp := runReadOnlyGovernanceViewsForChange(t, root, slug)

--- a/cmd/health.go
+++ b/cmd/health.go
@@ -183,7 +183,11 @@ func makeHealthCmd() *cobra.Command {
 						if err != nil {
 							return err
 						}
-						snap, err = governance.RecomputeGovernanceSnapshot(root, latest, paths.GovernedBundleDir)
+						// Governance health reports current artifact/control state. Use
+						// preview so stale resolved controls are not carried forward by
+						// the core monotonic recompute path used during lifecycle
+						// advancement.
+						snap, err = governance.PreviewGovernanceSnapshot(root, latest, paths.GovernedBundleDir)
 						if err != nil {
 							// Snapshot recompute failed: degrade gracefully with diagnostic.
 							govReport = governance.CollectGovernanceHealth(root, latest)
@@ -421,6 +425,9 @@ func writeHealthText(w io.Writer, view healthView) error {
 		writer.Writef("\nGovernance Health (active change: %s):\n", view.Governance.Slug)
 		for _, check := range view.Governance.Checks {
 			writer.Writef("  %-28s %s - %s\n", check.Name+":", check.Status, check.Message)
+			for _, gap := range check.TraceabilityGaps {
+				writer.Writef("    - %s [%s] blocking=%t: %s\n", gap.ID, gap.Type, gap.Blocking, gap.Issue)
+			}
 		}
 		if view.Governance.Healthy {
 			writer.Writef("\nOverall: HEALTHY\n")

--- a/cmd/health_test.go
+++ b/cmd/health_test.go
@@ -1124,9 +1124,107 @@ Not ready.
 				found = true
 				assert.Equal(t, "FAIL", check.Status)
 				assert.Contains(t, check.Message, "blocking traceability gaps")
+				require.NotEmpty(t, check.TraceabilityGaps)
+				foundGapDetails := false
+				for _, gap := range check.TraceabilityGaps {
+					if gap.ID == "update auth middleware" && gap.Type == "task" {
+						foundGapDetails = true
+						assert.Contains(t, gap.Issue, "task covers no requirement")
+						assert.True(t, gap.Blocking)
+					}
+				}
+				assert.True(t, foundGapDetails, "expected actionable task traceability gap details")
 			}
 		}
 		assert.True(t, found, "expected traceability_coherence check")
+	})
+}
+
+func TestHealthCommandGovernanceRecomputeDropsResolvedClarificationControl(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+
+		slug := createGovernedRequest(t, root, "L2", "health resolved clarification")
+		change, err := state.LoadChange(root, slug)
+		require.NoError(t, err)
+		change.CurrentState = model.StateS1Plan
+		change.PlanSubStep = model.PlanSubStepBundle
+		change.ArtifactSchema = model.ArtifactSchemaExpanded
+		change.NeedsDiscovery = true
+		require.NoError(t, state.SaveChange(root, change))
+
+		bundleDir := filepath.Join(root, "artifacts", "changes", slug)
+		require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "intent.md"), []byte(`# Intent
+INT-001: stabilize auth middleware
+## Open Questions
+(none)
+`), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "requirements.md"), []byte(`# Requirements
+### Requirement: auth stability
+REQ-001: Preserve auth middleware behavior. Traces to INT-001.
+`), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "tasks.md"), []byte(`# Tasks
+- [ ] update auth middleware
+  covers: [REQ-001]
+`), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "decision.md"), []byte(`# Decision
+## Alternatives Considered
+### Option A
+Patch the current middleware.
+
+## Selected Approach
+Choose Option A.
+`), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "assurance.md"), []byte(`# Assurance
+## Requirement Coverage
+REQ-001: pending
+`), 0o644))
+
+		require.NoError(t, governance.SaveSnapshot(root, slug, model.GovernanceSnapshot{
+			Version: model.GovernanceSnapshotVersion,
+			Summary: model.SignalSummary{
+				BlastRadius: model.SignalLevelLow,
+			},
+			Traceability: model.TraceabilitySummary{
+				Status: model.TraceabilityStatusFail,
+				Gaps: []model.TraceabilityGap{
+					{ID: "INT-001", Type: "intent", Issue: "blocking open questions remain unresolved", Blocking: true},
+				},
+			},
+			ActiveControls: []model.ControlActivation{
+				{
+					ControlID:    model.ControlClarification,
+					Mode:         model.ControlModeBlocking,
+					Scope:        model.ControlScopeDiscovery,
+					Active:       true,
+					TriggeredBy:  []string{"traceability: blocking open questions remain unresolved"},
+					PolicySource: model.BuiltinPolicySource,
+				},
+			},
+			ComputedAt: time.Now().UTC().Add(-time.Hour),
+		}))
+
+		var out bytes.Buffer
+		cmd := commandForRoot(t, root, makeHealthCmd())
+		cmd.SetArgs([]string{"--json", "--governance", "--change", slug})
+		cmd.SetOut(&out)
+		require.NoError(t, cmd.Execute())
+
+		var view healthView
+		require.NoError(t, json.Unmarshal(out.Bytes(), &view))
+		require.NotNil(t, view.Governance)
+
+		found := false
+		for _, check := range view.Governance.Checks {
+			if check.Name == "signal_control_coherence" {
+				found = true
+				assert.Equal(t, "OK", check.Status)
+				assert.NotContains(t, check.Message, "clarification")
+			}
+		}
+		assert.True(t, found, "expected signal_control_coherence check")
 	})
 }
 

--- a/cmd/lifecycle_commands_test.go
+++ b/cmd/lifecycle_commands_test.go
@@ -1115,6 +1115,14 @@ func TestRunStalePlanningRecoveryRequiresFreshReviewAfterExecutionRefresh(t *tes
 	require.NotNil(t, advanceView.NextSkill)
 	assert.Equal(t, progression.SkillWaveOrchestration, advanceView.NextSkill.Name)
 
+	writeSkillVerification(t, root, slug, progression.SkillWaveOrchestration, model.VerificationRecord{
+		Verdict:    model.VerificationVerdictPass,
+		Blockers:   []model.ReasonCode{},
+		Timestamp:  staleAt.Add(3 * time.Second),
+		RunVersion: 1,
+		References: []string{"wave-orchestration:refreshed"},
+	})
+
 	syncCmd := commandForRoot(t, root, makeRunCmd())
 	syncCmd.SetArgs([]string{"--json", "--diagnostics", "--change", slug})
 	var syncBuf bytes.Buffer
@@ -1124,11 +1132,18 @@ func TestRunStalePlanningRecoveryRequiresFreshReviewAfterExecutionRefresh(t *tes
 	var syncView nextView
 	require.NoError(t, json.Unmarshal(syncBuf.Bytes(), &syncView))
 	assert.Equal(t, model.StateS3Review, syncView.CurrentState)
+	require.NotNil(t, syncView.Advanced)
+	assert.Equal(t, "advanced", syncView.Advanced.Action)
+	assert.Equal(t, model.StateS2Execute, syncView.Advanced.FromState)
+	assert.Equal(t, model.StateS3Review, syncView.Advanced.ToState)
 	require.NotNil(t, syncView.NextSkill)
 	assert.Equal(t, progression.SkillSpecComplianceReview, syncView.NextSkill.Name)
 	reasons := model.ReasonSpecs(syncView.Blockers)
 	assert.Contains(t, reasons, "required_skill_missing:"+progression.SkillSpecComplianceReview)
 	assert.NotContains(t, reasons, "run_slipway_run_to_advance:"+string(model.StateS3Review))
+	assert.Equal(t, "skill_handoff:"+progression.SkillSpecComplianceReview, syncView.ConfirmationRequirement.Reason)
+	assert.False(t, syncView.ConfirmationRequirement.ResumeResponseSupported)
+	assert.Equal(t, "complete governance skill handoff: "+progression.SkillSpecComplianceReview, syncView.ConfirmationRequirement.NextAction)
 }
 
 func TestRunStalePlanningRecoveryRefreshesEvidenceInOrder(t *testing.T) {
@@ -1199,7 +1214,30 @@ func TestRunStalePlanningRecoveryRefreshesEvidenceInOrder(t *testing.T) {
 	require.NoError(t, json.Unmarshal(syncBuf.Bytes(), &syncView))
 	require.NotNil(t, syncView.Advanced)
 	assert.Equal(t, "blocked", syncView.Advanced.Action)
-	assert.Contains(t, model.ReasonSpecs(syncView.Blockers), "tasks_plan_changed_since_task_evidence:t-01")
+	assert.Contains(t, model.ReasonSpecs(syncView.Blockers), "wave_orchestration_stale_task_evidence:t-01")
+
+	_, err = state.LoadExecutionSummary(root, slug)
+	require.Error(t, err)
+
+	writeSkillVerification(t, root, slug, progression.SkillWaveOrchestration, model.VerificationRecord{
+		Verdict:    model.VerificationVerdictPass,
+		Blockers:   []model.ReasonCode{},
+		Timestamp:  time.Now().UTC().Add(4 * time.Second),
+		RunVersion: 1,
+		References: []string{"wave-orchestration:refreshed"},
+	})
+
+	resyncCmd := commandForRoot(t, root, makeRunCmd())
+	resyncCmd.SetArgs([]string{"--json", "--diagnostics", "--change", slug})
+	var resyncBuf bytes.Buffer
+	resyncCmd.SetOut(&resyncBuf)
+	require.NoError(t, resyncCmd.Execute())
+
+	var resyncView nextView
+	require.NoError(t, json.Unmarshal(resyncBuf.Bytes(), &resyncView))
+	require.NotNil(t, resyncView.Advanced)
+	assert.Equal(t, "blocked", resyncView.Advanced.Action)
+	assert.Contains(t, model.ReasonSpecs(resyncView.Blockers), "tasks_plan_changed_since_task_evidence:t-01")
 
 	summary, err := state.LoadExecutionSummary(root, slug)
 	require.NoError(t, err)

--- a/cmd/next.go
+++ b/cmd/next.go
@@ -59,6 +59,10 @@ type confirmationRequirement struct {
 	FreshConfirmationRequired    bool   `json:"fresh_confirmation_required"`
 	PriorAuthorizationSufficient bool   `json:"prior_authorization_sufficient"`
 	Reason                       string `json:"reason"`
+	ResumeResponseSupported      bool   `json:"resume_response_supported"`
+	NextAction                   string `json:"next_action,omitempty"`
+	NextActionKind               string `json:"next_action_kind,omitempty"`
+	NextCommand                  string `json:"next_command,omitempty"`
 }
 
 type skillEvidenceEntry struct {
@@ -595,6 +599,8 @@ func deriveConfirmationRequirement(view nextView) confirmationRequirement {
 	switch {
 	case view.PresetConfirmationPending || hasReasonCode(view.Blockers, "preset_confirmation_required"):
 		return confirmationHardStop("preset_confirmation_required")
+	case hasPendingRunCheckpoint(view.InputContext.ResumeCheckpoint):
+		return confirmationHardStop("resume_checkpoint")
 	case view.NextSkill != nil:
 		reason := "skill_handoff"
 		if strings.TrimSpace(view.NextSkill.BlockingName) != "" {
@@ -603,8 +609,6 @@ func deriveConfirmationRequirement(view nextView) confirmationRequirement {
 			reason = "skill_handoff:" + strings.TrimSpace(view.NextSkill.Name)
 		}
 		return confirmationHardStop(reason)
-	case hasPendingRunCheckpoint(view.InputContext.ResumeCheckpoint):
-		return confirmationHardStop("resume_checkpoint")
 	case hasReasonCode(view.Blockers, "run_slipway_done_to_finalize"):
 		return confirmationCommandRequired("run_slipway_done_to_finalize")
 	case hasReasonCode(view.Blockers, "run_slipway_run_to_advance"):
@@ -632,22 +636,34 @@ func hasReasonCode(reasons []model.ReasonCode, code string) bool {
 }
 
 func confirmationHardStop(reason string) confirmationRequirement {
+	reason = strings.TrimSpace(reason)
+	resumeResponseSupported := reason == "resume_checkpoint"
+	kind, command := hardStopNextActionKind(reason, resumeResponseSupported)
 	return confirmationRequirement{
 		Required:                     true,
 		Boundary:                     "hard_stop",
 		FreshConfirmationRequired:    true,
 		PriorAuthorizationSufficient: false,
-		Reason:                       strings.TrimSpace(reason),
+		Reason:                       reason,
+		ResumeResponseSupported:      resumeResponseSupported,
+		NextAction:                   hardStopNextAction(reason, resumeResponseSupported),
+		NextActionKind:               kind,
+		NextCommand:                  command,
 	}
 }
 
 func confirmationCommandRequired(reason string) confirmationRequirement {
+	reason = strings.TrimSpace(reason)
+	kind, command := commandBoundaryNextActionKind(reason)
 	return confirmationRequirement{
 		Required:                     false,
 		Boundary:                     "command_required",
 		FreshConfirmationRequired:    false,
 		PriorAuthorizationSufficient: true,
-		Reason:                       strings.TrimSpace(reason),
+		Reason:                       reason,
+		NextAction:                   commandBoundaryNextAction(reason),
+		NextActionKind:               kind,
+		NextCommand:                  command,
 	}
 }
 
@@ -658,6 +674,8 @@ func confirmationEvidenceContinuation(reason string) confirmationRequirement {
 		FreshConfirmationRequired:    false,
 		PriorAuthorizationSufficient: true,
 		Reason:                       strings.TrimSpace(reason),
+		NextAction:                   "continue with eligible evidence",
+		NextActionKind:               "none",
 	}
 }
 
@@ -668,6 +686,70 @@ func confirmationNoBoundary(reason string) confirmationRequirement {
 		FreshConfirmationRequired:    false,
 		PriorAuthorizationSufficient: true,
 		Reason:                       strings.TrimSpace(reason),
+		NextAction:                   "no action required",
+		NextActionKind:               "none",
+	}
+}
+
+func hardStopNextAction(reason string, resumeResponseSupported bool) string {
+	if resumeResponseSupported {
+		return "resume pending checkpoint with slipway run --resume-response"
+	}
+	if skillName, ok := strings.CutPrefix(reason, "skill_handoff:"); ok && strings.TrimSpace(skillName) != "" {
+		return "complete governance skill handoff: " + strings.TrimSpace(skillName)
+	}
+	switch reason {
+	case "preset_confirmation_required":
+		return "confirm workflow preset before continuing"
+	default:
+		return "complete required confirmation before continuing"
+	}
+}
+
+func commandBoundaryNextAction(reason string) string {
+	switch reason {
+	case "run_slipway_done_to_finalize":
+		return "run slipway done to finalize"
+	case "run_slipway_run_to_advance":
+		return "run slipway run to advance"
+	case "blocked_by_governance":
+		return "resolve governance blockers before continuing"
+	default:
+		return "run the command indicated by blockers"
+	}
+}
+
+// hardStopNextActionKind returns the machine-readable action kind and, when one
+// applies, the exact command to run for a hard-stop boundary. Callers branch on
+// next_action_kind rather than parsing the human-readable next_action prose.
+// next_command is populated only when it is runnable as-is; checkpoint resume
+// requires an operator-supplied response argument, so it leaves next_command
+// empty and is signaled by resume_response_supported instead.
+func hardStopNextActionKind(reason string, resumeResponseSupported bool) (kind, command string) {
+	switch {
+	case resumeResponseSupported:
+		return "checkpoint_resume", ""
+	case reason == "preset_confirmation_required":
+		return "preset_confirmation", ""
+	case strings.HasPrefix(reason, "skill_handoff"):
+		return "skill_handoff", ""
+	default:
+		return "confirmation", ""
+	}
+}
+
+// commandBoundaryNextActionKind mirrors commandBoundaryNextAction as a
+// machine-readable kind plus the exact command for command-boundary stops.
+func commandBoundaryNextActionKind(reason string) (kind, command string) {
+	switch reason {
+	case "run_slipway_done_to_finalize":
+		return "command", "slipway done"
+	case "run_slipway_run_to_advance":
+		return "command", "slipway run"
+	case "blocked_by_governance":
+		return "blocker_resolution", ""
+	default:
+		return "command", ""
 	}
 }
 

--- a/cmd/progression_next_test.go
+++ b/cmd/progression_next_test.go
@@ -1955,6 +1955,10 @@ func TestConfirmationRequirementDistinguishesHardStopFromCommandBoundary(t *test
 	assert.True(t, handoff.FreshConfirmationRequired)
 	assert.False(t, handoff.PriorAuthorizationSufficient)
 	assert.Equal(t, "skill_handoff:code-quality-review", handoff.Reason)
+	assert.False(t, handoff.ResumeResponseSupported)
+	assert.Equal(t, "complete governance skill handoff: code-quality-review", handoff.NextAction)
+	assert.Equal(t, "skill_handoff", handoff.NextActionKind)
+	assert.Empty(t, handoff.NextCommand)
 
 	doneReady := deriveConfirmationRequirement(nextView{
 		Blockers: []model.ReasonCode{model.NewReasonCode("run_slipway_done_to_finalize", "")},
@@ -1964,6 +1968,47 @@ func TestConfirmationRequirementDistinguishesHardStopFromCommandBoundary(t *test
 	assert.False(t, doneReady.FreshConfirmationRequired)
 	assert.True(t, doneReady.PriorAuthorizationSufficient)
 	assert.Equal(t, "run_slipway_done_to_finalize", doneReady.Reason)
+	assert.False(t, doneReady.ResumeResponseSupported)
+	assert.Equal(t, "run slipway done to finalize", doneReady.NextAction)
+	assert.Equal(t, "command", doneReady.NextActionKind)
+	assert.Equal(t, "slipway done", doneReady.NextCommand)
+
+	checkpoint := deriveConfirmationRequirement(nextView{
+		InputContext: nextContext{
+			ResumeCheckpoint: &resumeCheckpoint{
+				PausedTaskID:    "task-02",
+				PausedWaveIndex: 2,
+				CheckpointType:  string(model.CheckpointHumanVerify),
+			},
+		},
+	})
+	assert.True(t, checkpoint.Required)
+	assert.Equal(t, "hard_stop", checkpoint.Boundary)
+	assert.True(t, checkpoint.FreshConfirmationRequired)
+	assert.False(t, checkpoint.PriorAuthorizationSufficient)
+	assert.Equal(t, "resume_checkpoint", checkpoint.Reason)
+	assert.True(t, checkpoint.ResumeResponseSupported)
+	assert.Equal(t, "resume pending checkpoint with slipway run --resume-response", checkpoint.NextAction)
+	assert.Equal(t, "checkpoint_resume", checkpoint.NextActionKind)
+	// next_command stays empty: checkpoint resume needs an operator-supplied
+	// response argument, so it is signaled via resume_response_supported.
+	assert.Empty(t, checkpoint.NextCommand)
+
+	checkpointWithSkill := deriveConfirmationRequirement(nextView{
+		NextSkill: &nextSkillView{Name: progression.SkillWaveOrchestration},
+		InputContext: nextContext{
+			ResumeCheckpoint: &resumeCheckpoint{
+				PausedTaskID:    "task-02",
+				PausedWaveIndex: 2,
+				CheckpointType:  string(model.CheckpointHumanVerify),
+			},
+		},
+	})
+	assert.Equal(t, "resume_checkpoint", checkpointWithSkill.Reason)
+	assert.True(t, checkpointWithSkill.ResumeResponseSupported)
+	assert.Equal(t, "resume pending checkpoint with slipway run --resume-response", checkpointWithSkill.NextAction)
+	assert.Equal(t, "checkpoint_resume", checkpointWithSkill.NextActionKind)
+	assert.Empty(t, checkpointWithSkill.NextCommand)
 }
 
 func TestNextHandoffViewUsesStructuredConfirmationRequirement(t *testing.T) {
@@ -1992,7 +2037,11 @@ func TestNextHandoffViewUsesStructuredConfirmationRequirement(t *testing.T) {
 	require.NoError(t, json.Unmarshal(raw, &payload))
 	assert.NotContains(t, payload, "confirmation_required")
 	require.Contains(t, payload, "confirmation_requirement")
-	require.Equal(t, "hard_stop", payload["confirmation_requirement"].(map[string]any)["boundary"])
+	confirmation := payload["confirmation_requirement"].(map[string]any)
+	require.Equal(t, "hard_stop", confirmation["boundary"])
+	assert.Equal(t, false, confirmation["resume_response_supported"])
+	assert.Equal(t, "complete governance skill handoff: code-quality-review", confirmation["next_action"])
+	assert.Equal(t, "skill_handoff", confirmation["next_action_kind"])
 }
 
 func TestNextHandoffViewOutputsMinimalWarnBudget(t *testing.T) {
@@ -3131,6 +3180,11 @@ func TestNextIncludesActiveCheckpointWithoutRequiringResumeResponse(t *testing.T
 		assert.Equal(t, "task-02", view.InputContext.ResumeCheckpoint.PausedTaskID)
 		assert.Equal(t, "human_verify", view.InputContext.ResumeCheckpoint.CheckpointType)
 		assert.Empty(t, view.InputContext.ResumeCheckpoint.UserResponsePayload)
+		assert.True(t, view.ConfirmationRequirement.Required)
+		assert.Equal(t, "hard_stop", view.ConfirmationRequirement.Boundary)
+		assert.Equal(t, "resume_checkpoint", view.ConfirmationRequirement.Reason)
+		assert.True(t, view.ConfirmationRequirement.ResumeResponseSupported)
+		assert.Equal(t, "resume pending checkpoint with slipway run --resume-response", view.ConfirmationRequirement.NextAction)
 
 		after, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
@@ -3565,13 +3619,6 @@ func TestNextS6GovernedMaterializesExecutionSummaryAndRuntimeSummary(t *testing.
 	change.PlanSubStep = model.PlanSubStepNone
 	require.NoError(t, state.SaveChange(root, change))
 
-	writeSkillVerification(t, root, slug, "wave-orchestration", model.VerificationRecord{
-		Verdict:    model.VerificationVerdictPass,
-		Blockers:   []model.ReasonCode{},
-		Timestamp:  time.Now().UTC(),
-		RunVersion: 1,
-		References: []string{"task:evidence"},
-	})
 	writeTaskEvidenceFile(t, root, slug, 1, "task-a", map[string]any{
 		"task_id":             "task-a",
 		"run_summary_version": 1,
@@ -3581,6 +3628,13 @@ func TestNextS6GovernedMaterializesExecutionSummaryAndRuntimeSummary(t *testing.
 		"blockers":            []string{},
 		"evidence_ref":        "test:task-a",
 		"captured_at":         time.Now().UTC().Format(time.RFC3339Nano),
+	})
+	writeSkillVerification(t, root, slug, "wave-orchestration", model.VerificationRecord{
+		Verdict:    model.VerificationVerdictPass,
+		Blockers:   []model.ReasonCode{},
+		Timestamp:  time.Now().UTC(),
+		RunVersion: 1,
+		References: []string{"task:evidence"},
 	})
 	bundlePath := filepath.Join(root, "artifacts", "changes", slug)
 	require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks

--- a/cmd/repair_test.go
+++ b/cmd/repair_test.go
@@ -435,15 +435,15 @@ func TestRepairRebuildsUnreadableExecutionSummaryWithoutResidualDrift(t *testing
   - target_files: ["cmd/repair.go"]
   - task_kind: code
 `)))
+		writeTaskEvidenceFile(t, root, slug, 1, "t-01", map[string]any{
+			"changed_files": []string{"cmd/repair.go"},
+			"target_files":  []string{"cmd/repair.go"},
+		})
 		writeSkillVerification(t, root, slug, "wave-orchestration", model.VerificationRecord{
 			Verdict:    model.VerificationVerdictPass,
 			Blockers:   []model.ReasonCode{},
 			Timestamp:  time.Now().UTC(),
 			RunVersion: 1,
-		})
-		writeTaskEvidenceFile(t, root, slug, 1, "t-01", map[string]any{
-			"changed_files": []string{"cmd/repair.go"},
-			"target_files":  []string{"cmd/repair.go"},
 		})
 
 		summaryPath := executionSummaryPathForTest(root, slug)
@@ -847,8 +847,6 @@ func TestRepairRebuildsReadyButStaleExecutionSummaryDrift(t *testing.T) {
   - target_files: ["docs/commands.md"]
   - task_kind: code
 `)))
-		writePassingWaveEvidence(t, root, slug, 1)
-
 		runtimeCapturedAt := time.Now().UTC()
 		summaryCapturedAt := runtimeCapturedAt.Add(time.Hour)
 		writeTaskEvidenceFile(t, root, slug, 1, "t-01", map[string]any{
@@ -859,6 +857,7 @@ func TestRepairRebuildsReadyButStaleExecutionSummaryDrift(t *testing.T) {
 			"task_id":     "t-02",
 			"captured_at": runtimeCapturedAt.Format(time.RFC3339Nano),
 		})
+		writePassingWaveEvidence(t, root, slug, 1)
 		writeExecutionSummary(t, root, slug, model.ExecutionSummary{
 			Version:           model.ExecutionSummaryVersion,
 			RunSummaryVersion: 1,

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -95,10 +95,21 @@ When diagnostics are enabled, review-state handoff JSON can also include:
 
 - `next_skill.display_name`, `next_skill.blocking_name`, and `next_skill.resolution_reason` when the conceptual stage differs from the actionable missing skill.
 - `next_skill.review_context.required_artifact_layers` and `next_skill.review_context.required_implementation_layers`, which map to exact gate tokens such as `layer:R0=pass`, `layer:R3=pass`, `layer:IR1=pass`, and `layer:IR3=pass`.
-- top-level `confirmation_requirement`, which reports whether a hard stop needs fresh user confirmation, whether prior authorization is sufficient, and whether the current boundary is a command-only or evidence-continuation step.
+- top-level `confirmation_requirement`, which reports whether a hard stop needs fresh user confirmation, whether prior authorization is sufficient, whether `--resume-response` is supported at this stop (`resume_response_supported`), the next operator action as human prose (`next_action`), a machine-readable `next_action_kind` (`skill_handoff` | `checkpoint_resume` | `preset_confirmation` | `command` | `blocker_resolution` | `confirmation` | `none`), and the exact `next_command` to run when one is runnable as-is. `next_command` is empty for stops that need operator-supplied input — notably `checkpoint_resume`, which requires a `--resume-response` argument and is therefore signaled by `resume_response_supported` rather than an exact command. Branch on `next_action_kind`/`next_command`; treat `next_action` as display prose only.
 - `freshness_diagnostics`, which reports stale source/evidence pairs, field-level execution input mismatches, path authority, and the next regeneration action.
 
-`validate --json` mirrors actionable review handoff through `actionable_next_skill`, including `required_tokens` for the exact layer references the actionable skill must supply. `status --json` includes `freshness_diagnostics` when execution evidence is known stale and marks each `artifact_dag` node with `blocking` plus `blocking_reason` so draft planning artifacts are not mistaken for current review blockers.
+`validate --json` is the active-readiness authority: it answers whether the
+current governed state can advance now and mirrors actionable review handoff
+through `actionable_next_skill`, including `required_tokens` for the exact layer
+references the actionable skill must supply. `run --json` is the mutating
+transition surface: `advanced` reports what this invocation changed, while
+`blockers` reports the current stop condition after any transition. A successful
+advance can therefore be followed by error-severity blockers for the next
+required skill. `health --governance --json` is diagnostic health feedback; use
+it to inspect controls and traceability details, not as the lifecycle authority
+for whether `run` just advanced.
+
+`status --json` includes `freshness_diagnostics` when execution evidence is known stale and marks each `artifact_dag` node with `blocking` plus `blocking_reason` so draft planning artifacts are not mistaken for current review blockers.
 
 `validate --change <slug>` selects an explicit active change. If the slug names
 an archived terminal change, the command fails with

--- a/internal/engine/governance/health.go
+++ b/internal/engine/governance/health.go
@@ -16,9 +16,10 @@ import (
 
 // GovernanceHealthCheck represents one governance health diagnostic.
 type GovernanceHealthCheck struct {
-	Name    string `json:"name"`
-	Status  string `json:"status"` // OK, WARN, FAIL
-	Message string `json:"message"`
+	Name             string                  `json:"name"`
+	Status           string                  `json:"status"` // OK, WARN, FAIL
+	Message          string                  `json:"message"`
+	TraceabilityGaps []model.TraceabilityGap `json:"traceability_gaps,omitempty"`
 }
 
 // GovernanceHealthReport contains all governance health checks for a change.
@@ -268,15 +269,17 @@ func checkTraceabilityCoherence(snap model.GovernanceSnapshot) GovernanceHealthC
 		}
 	case model.TraceabilityStatusWarning:
 		return GovernanceHealthCheck{
-			Name:    "traceability_coherence",
-			Status:  "WARN",
-			Message: snap.Traceability.Message,
+			Name:             "traceability_coherence",
+			Status:           "WARN",
+			Message:          snap.Traceability.Message,
+			TraceabilityGaps: snap.Traceability.Gaps,
 		}
 	default:
 		return GovernanceHealthCheck{
-			Name:    "traceability_coherence",
-			Status:  "FAIL",
-			Message: snap.Traceability.Message,
+			Name:             "traceability_coherence",
+			Status:           "FAIL",
+			Message:          snap.Traceability.Message,
+			TraceabilityGaps: snap.Traceability.Gaps,
 		}
 	}
 }

--- a/internal/engine/governance/health_test.go
+++ b/internal/engine/governance/health_test.go
@@ -364,6 +364,51 @@ func TestRecomputeGovernanceSnapshotUsesTasksChecklistTargetFilesPreExecution(t 
 	assert.Contains(t, controlIDs, model.ControlWorktreeIsolation)
 }
 
+func TestRecomputeGovernanceSnapshotPreservesExistingControlsWithoutCurrentCandidate(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	slug := "monotonic-recompute-controls"
+
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "artifacts", "changes", slug), 0o755))
+	require.NoError(t, SaveSnapshot(root, slug, model.GovernanceSnapshot{
+		Version: model.GovernanceSnapshotVersion,
+		Summary: model.SignalSummary{
+			BlastRadius: model.SignalLevelHigh,
+		},
+		Traceability: model.TraceabilitySummary{
+			Status: model.TraceabilityStatusOK,
+		},
+		ActiveControls: []model.ControlActivation{
+			{
+				ControlID:    model.ControlIndependentReview,
+				Mode:         model.ControlModeBlocking,
+				Scope:        model.ControlScopeReview,
+				Active:       true,
+				TriggeredBy:  []string{"blast_radius=high"},
+				PolicySource: model.BuiltinPolicySource,
+			},
+		},
+		ComputedAt: time.Now().UTC().Add(-time.Hour),
+	}))
+
+	change := model.Change{
+		Slug:         slug,
+		CurrentState: model.StateS1Plan,
+		PlanSubStep:  model.PlanSubStepBundle,
+	}
+
+	snap, err := RecomputeGovernanceSnapshot(root, change, filepath.Join(root, "artifacts", "changes", slug))
+	require.NoError(t, err)
+	assert.Equal(t, model.SignalLevelLow, snap.Summary.BlastRadius)
+
+	var controlIDs []model.ControlID
+	for _, control := range snap.ActiveControls {
+		controlIDs = append(controlIDs, control.ControlID)
+	}
+	assert.Contains(t, controlIDs, model.ControlIndependentReview,
+		"core recompute must preserve existing active controls unless an explicit deactivation path clears them")
+}
+
 func TestRecomputeGovernanceSnapshotRecoversFromUnreadableExistingSnapshot(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()

--- a/internal/engine/progression/wave_sync.go
+++ b/internal/engine/progression/wave_sync.go
@@ -92,6 +92,12 @@ func SyncGovernedWaveExecution(root string, change model.Change) (WaveSyncResult
 		blockers = append(blockers, model.ReasonCodesFromSpecs(parseIssues)...)
 		return WaveSyncResult{Blockers: model.NormalizeReasonCodes(blockers)}, nil
 	}
+	if staleBlockers := waveRecordStaleTaskEvidenceBlockers(record, tasks); len(staleBlockers) > 0 {
+		// Surface parse issues alongside staleness so invalid task evidence is
+		// not masked when both conditions hold at the same time.
+		staleBlockers = append(staleBlockers, model.ReasonCodesFromSpecs(parseIssues)...)
+		return WaveSyncResult{Blockers: model.NormalizeReasonCodes(staleBlockers)}, nil
+	}
 
 	wavePlan, err := state.LoadWavePlanForChange(root, change)
 	if err != nil {
@@ -218,6 +224,23 @@ func LatestPassingWaveEvidence(root, slug string) (model.VerificationRecord, boo
 		return model.VerificationRecord{}, false, nil
 	}
 	return rec, true, nil
+}
+
+func waveRecordStaleTaskEvidenceBlockers(
+	record model.VerificationRecord,
+	tasks []model.ExecutionTaskSummary,
+) []model.ReasonCode {
+	if record.Timestamp.IsZero() || len(tasks) == 0 {
+		return nil
+	}
+	recordedAt := record.Timestamp.UTC()
+	blockers := []model.ReasonCode{}
+	for _, task := range tasks {
+		if task.CapturedAt.UTC().After(recordedAt) {
+			blockers = append(blockers, model.NewReasonCode("wave_orchestration_stale_task_evidence", task.TaskID))
+		}
+	}
+	return model.NormalizeReasonCodes(blockers)
 }
 
 // LoadExecutionTasksFromEvidence loads task execution summaries from evidence files for a specific version.

--- a/internal/engine/progression/wave_sync_test.go
+++ b/internal/engine/progression/wave_sync_test.go
@@ -341,6 +341,7 @@ func TestSyncGovernedWaveExecution_PersistsExecutionSummaryAndRuntimeSummary(t *
 	root := t.TempDir()
 
 	slug := "wave-sync"
+	recordedAt := time.Date(2026, 4, 6, 10, 0, 0, 0, time.UTC)
 	change := model.NewChange(slug)
 	change.CurrentState = model.StateS2Execute
 	change.PlanSubStep = model.PlanSubStepNone
@@ -349,7 +350,7 @@ func TestSyncGovernedWaveExecution_PersistsExecutionSummaryAndRuntimeSummary(t *
 	record := model.VerificationRecord{
 		Verdict:    model.VerificationVerdictPass,
 		Blockers:   []model.ReasonCode{},
-		Timestamp:  time.Now().UTC(),
+		Timestamp:  recordedAt,
 		RunVersion: 1,
 	}
 	writeVerificationForTest(t, root, slug, SkillWaveOrchestration, record)
@@ -369,7 +370,7 @@ func TestSyncGovernedWaveExecution_PersistsExecutionSummaryAndRuntimeSummary(t *
 		"changed_files":       []string{"cmd/next.go"},
 		"blockers":            []string{},
 		"evidence_ref":        "test:task-a",
-		"captured_at":         time.Now().UTC().Format(time.RFC3339Nano),
+		"captured_at":         recordedAt.Format(time.RFC3339Nano),
 		"freshness_inputs":    state.ExpectedExecutionTaskFreshnessInputs(change, 1, "task-a"),
 	}
 	raw, err := json.Marshal(taskEvidence)
@@ -401,6 +402,125 @@ func TestSyncGovernedWaveExecution_PersistsExecutionSummaryAndRuntimeSummary(t *
 	if len(summary.Tasks) != 1 || summary.Tasks[0].TaskID != "task-a" {
 		t.Fatalf("expected persisted execution task summary, got %+v", summary.Tasks)
 	}
+}
+
+func TestSyncGovernedWaveExecutionRejectsWaveEvidenceOlderThanTaskEvidence(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	slug := "wave-sync-stale-wave-record"
+	recordedAt := time.Date(2026, 4, 6, 10, 0, 0, 0, time.UTC)
+	change := model.NewChange(slug)
+	change.CurrentState = model.StateS2Execute
+	change.PlanSubStep = model.PlanSubStepNone
+	require.NoError(t, state.SaveChange(root, change))
+
+	record := model.VerificationRecord{
+		Verdict:    model.VerificationVerdictPass,
+		Blockers:   []model.ReasonCode{},
+		Timestamp:  recordedAt,
+		RunVersion: 1,
+	}
+	writeVerificationForTest(t, root, slug, SkillWaveOrchestration, record)
+	writeTasksAndMaterializeWavePlan(t, root, change, `# Tasks
+
+- [ ] `+"`task-a`"+` Implement task A
+  - target_files: ["cmd/next.go"]
+  - wave: 1
+  - task_kind: code
+`)
+
+	taskEvidence := map[string]any{
+		"task_id":             "task-a",
+		"run_summary_version": 1,
+		"task_kind":           "code",
+		"verdict":             "pass",
+		"changed_files":       []string{"cmd/next.go"},
+		"blockers":            []string{},
+		"evidence_ref":        "test:task-a",
+		"captured_at":         recordedAt.Add(time.Hour).Format(time.RFC3339Nano),
+		"freshness_inputs":    state.ExpectedExecutionTaskFreshnessInputs(change, 1, "task-a"),
+	}
+	raw, err := json.Marshal(taskEvidence)
+	require.NoError(t, err)
+	taskPath := filepath.Join(state.EvidenceTasksDir(root, slug), "task-a.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(taskPath), 0o755))
+	require.NoError(t, os.WriteFile(taskPath, raw, 0o644))
+
+	result, err := SyncGovernedWaveExecution(root, change)
+	require.NoError(t, err)
+	assert.False(t, result.Updated)
+	assert.True(t, hasWaveReasonCode(result.Blockers, "wave_orchestration_stale_task_evidence", "task-a"))
+	assert.Contains(t, waveReasonMessage(result.Blockers, "wave_orchestration_stale_task_evidence"),
+		"rerun wave-orchestration", "stale task-evidence blocker must carry an actionable remediation")
+
+	_, err = state.LoadExecutionSummary(root, slug)
+	require.Error(t, err)
+}
+
+func TestSyncGovernedWaveExecutionSurfacesParseIssuesAlongsideStaleEvidence(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	slug := "wave-sync-stale-and-invalid"
+	recordedAt := time.Date(2026, 4, 6, 10, 0, 0, 0, time.UTC)
+	change := model.NewChange(slug)
+	change.CurrentState = model.StateS2Execute
+	change.PlanSubStep = model.PlanSubStepNone
+	require.NoError(t, state.SaveChange(root, change))
+
+	record := model.VerificationRecord{
+		Verdict:    model.VerificationVerdictPass,
+		Blockers:   []model.ReasonCode{},
+		Timestamp:  recordedAt,
+		RunVersion: 1,
+	}
+	writeVerificationForTest(t, root, slug, SkillWaveOrchestration, record)
+	writeTasksAndMaterializeWavePlan(t, root, change, `# Tasks
+
+- [ ] `+"`task-a`"+` Implement task A
+  - target_files: ["cmd/next.go"]
+  - wave: 1
+  - task_kind: code
+`)
+
+	// Valid evidence captured after the wave record -> staleness.
+	taskEvidence := map[string]any{
+		"task_id":             "task-a",
+		"run_summary_version": 1,
+		"task_kind":           "code",
+		"verdict":             "pass",
+		"changed_files":       []string{"cmd/next.go"},
+		"blockers":            []string{},
+		"evidence_ref":        "test:task-a",
+		"captured_at":         recordedAt.Add(time.Hour).Format(time.RFC3339Nano),
+		"freshness_inputs":    state.ExpectedExecutionTaskFreshnessInputs(change, 1, "task-a"),
+	}
+	raw, err := json.Marshal(taskEvidence)
+	require.NoError(t, err)
+	tasksDir := state.EvidenceTasksDir(root, slug)
+	require.NoError(t, os.MkdirAll(tasksDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(tasksDir, "task-a.json"), raw, 0o644))
+
+	// A second evidence file that fails to parse -> parse issue that must not be
+	// masked by the staleness early return.
+	require.NoError(t, os.WriteFile(filepath.Join(tasksDir, "task-b.json"), []byte("{not valid json"), 0o644))
+
+	result, err := SyncGovernedWaveExecution(root, change)
+	require.NoError(t, err)
+	assert.True(t, hasWaveReasonCode(result.Blockers, "wave_orchestration_stale_task_evidence", "task-a"),
+		"stale blocker must still be reported")
+	assert.True(t, hasReasonCodeWithCode(result.Blockers, "task_evidence_invalid"),
+		"invalid task evidence must not be masked by the stale blocker")
+}
+
+func hasReasonCodeWithCode(reasons []model.ReasonCode, code string) bool {
+	for _, reason := range reasons {
+		if reason.Code == code {
+			return true
+		}
+	}
+	return false
 }
 
 func TestSyncGovernedWaveExecution_DoesNotRewriteMatchingExecutionSummary(t *testing.T) {
@@ -670,11 +790,11 @@ func TestSyncGovernedWaveExecution_SharedSessionProducesBlocker(t *testing.T) {
 	record := model.VerificationRecord{
 		Verdict:    model.VerificationVerdictPass,
 		Blockers:   []model.ReasonCode{},
-		Timestamp:  time.Now().UTC(),
+		Timestamp:  time.Date(2026, 4, 6, 10, 0, 0, 0, time.UTC),
 		RunVersion: 1,
 	}
 	writeVerificationForTest(t, root, slug, SkillWaveOrchestration, record)
-	writeTasksAndMaterializeWavePlan(t, root, change, `# Tasks
+	tasksPath := writeTasksAndMaterializeWavePlan(t, root, change, `# Tasks
 
 - [ ] `+"`task-a`"+` Implement task A
   - target_files: ["cmd/next.go"]
@@ -686,6 +806,8 @@ func TestSyncGovernedWaveExecution_SharedSessionProducesBlocker(t *testing.T) {
   - wave: 2
   - task_kind: code
 `)
+	tasksAt := record.Timestamp.Add(-time.Minute)
+	require.NoError(t, os.Chtimes(tasksPath, tasksAt, tasksAt))
 
 	sharedSessionID := "session-shared"
 	for _, taskID := range []string{"task-a", "task-b"} {
@@ -696,7 +818,7 @@ func TestSyncGovernedWaveExecution_SharedSessionProducesBlocker(t *testing.T) {
 			"verdict":             "pass",
 			"blockers":            []string{},
 			"evidence_ref":        "test:" + taskID,
-			"captured_at":         time.Now().UTC().Format(time.RFC3339Nano),
+			"captured_at":         record.Timestamp.Format(time.RFC3339Nano),
 			"freshness_inputs":    state.ExpectedExecutionTaskFreshnessInputs(change, 1, taskID),
 			"session_id":          sharedSessionID,
 		}
@@ -1040,4 +1162,13 @@ func hasWaveReasonCode(reasons []model.ReasonCode, code, detail string) bool {
 		}
 	}
 	return false
+}
+
+func waveReasonMessage(reasons []model.ReasonCode, code string) string {
+	for _, reason := range reasons {
+		if reason.Code == code {
+			return reason.Message
+		}
+	}
+	return ""
 }

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -256,6 +256,33 @@ func TestNormalizeReasonCodesSortsGateReasons(t *testing.T) {
 	assert.Equal(t, "verification_evidence_missing", reasonCodes[1].Code)
 }
 
+func TestWaveReasonCodesCarryRemediation(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		code            string
+		detail          string
+		messageContains string
+	}{
+		{"wave_orchestration_stale_task_evidence", "task-a", "rerun wave-orchestration to refresh the wave record"},
+		{"wave_orchestration_run_summary_version_invalid", "", "rerun wave-orchestration to produce a versioned run summary"},
+		{"missing_task_evidence_for_run_summary", "", "rerun wave-orchestration to capture task evidence"},
+		{"wave_plan_missing", "slug-a", "materialize the wave plan from tasks.md"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.code, func(t *testing.T) {
+			t.Parallel()
+			reason := NewReasonCode(tc.code, tc.detail)
+			assert.Equal(t, ReasonSeverityError, reason.Severity)
+			assert.Contains(t, reason.Message, tc.messageContains,
+				"wave reason code %q must carry an actionable remediation, not a humanized fallback", tc.code)
+			if tc.detail != "" {
+				assert.Contains(t, reason.Message, tc.detail)
+			}
+		})
+	}
+}
+
 func TestPhaseForMapsWorkflowStates(t *testing.T) {
 	t.Parallel()
 

--- a/internal/model/reason_code.go
+++ b/internal/model/reason_code.go
@@ -96,6 +96,10 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 		Severity: ReasonSeverityError,
 		Message:  "Required discovery evidence is missing",
 	},
+	"missing_task_evidence_for_run_summary": {
+		Severity: ReasonSeverityError,
+		Message:  "Task evidence is missing for the recorded run summary; rerun wave-orchestration to capture task evidence",
+	},
 	"missing_worktree_branch": {
 		Severity: ReasonSeverityError,
 		Message:  "The change is missing a bound worktree branch",
@@ -183,6 +187,18 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 	"verification_evidence_missing": {
 		Severity: ReasonSeverityError,
 		Message:  "Required verification evidence is missing",
+	},
+	"wave_orchestration_run_summary_version_invalid": {
+		Severity: ReasonSeverityError,
+		Message:  "The wave run-summary version is invalid; rerun wave-orchestration to produce a versioned run summary",
+	},
+	"wave_orchestration_stale_task_evidence": {
+		Severity: ReasonSeverityError,
+		Message:  "Task evidence was captured after the wave verification record; rerun wave-orchestration to refresh the wave record",
+	},
+	"wave_plan_missing": {
+		Severity: ReasonSeverityError,
+		Message:  "The wave plan is missing; materialize the wave plan from tasks.md before wave execution",
 	},
 }
 

--- a/internal/tmpl/templates/_partials/command-next-body.tmpl
+++ b/internal/tmpl/templates/_partials/command-next-body.tmpl
@@ -18,6 +18,8 @@ slipway next --json
 - Treat `next_skill.skill_constraints` and `next_skill.technique_hints` as action metadata for that host.
 - Use only paths returned under `input_context`.
 - Do not expect inline policy-pack prose; read policy-pack content only by path when diagnostics or local config provide one.
+- `confirmation_requirement.resume_response_supported` is true only when `--resume-response` can satisfy the current stop.
+- Branch on `confirmation_requirement.next_action_kind` (`skill_handoff` | `checkpoint_resume` | `preset_confirmation` | `command` | `blocker_resolution` | `confirmation` | `none`) and run `confirmation_requirement.next_command` when present; `next_action` is human prose, not a contract to parse.
 - `context_budget` appears only when `guard_action` is `warn` or `stop`; absence means no budget guard is active.
 - Write evidence to `next_skill.verification_dir`.
 - If `blockers` is non-empty, resolve the blockers before executing the skill.

--- a/internal/tmpl/templates/_partials/command-run-body.tmpl
+++ b/internal/tmpl/templates/_partials/command-run-body.tmpl
@@ -18,6 +18,8 @@ slipway run --resume-response "<response>" --json
 - If an active checkpoint exists, plain `run` is rejected and `--resume-response` is required.
 - If resumable non-checkpoint execution exists, plain `run` is rejected and `--resume` is required.
 - `run` reuses the same `next --json` contract for the returned next-skill / blocker surface.
+- `advanced` reports the mutation performed by this invocation; `blockers` reports the current stop condition after that mutation. A successful advance can still return error-severity blockers for the next required skill.
+- `confirmation_requirement.resume_response_supported` is true only when `--resume-response` can be used for the current stop; otherwise branch on `confirmation_requirement.next_action_kind` and run `confirmation_requirement.next_command` when present (`next_action` is human prose, not a contract to parse).
 - Treat default JSON as the action contract. Use `slipway run --json --diagnostics` only for full readiness fields.
 - If governance control details are needed, run `slipway health --governance --json --change <slug>`.
 - Do not expect inline policy-pack prose in default JSON; read policy-pack content only by path from diagnostics or config.

--- a/internal/tmpl/templates/skills/goal-verification/SKILL.md.tmpl
+++ b/internal/tmpl/templates/skills/goal-verification/SKILL.md.tmpl
@@ -60,7 +60,7 @@ Run the following scans against all claimed target files. Any real hit is a bloc
 grep -rn 'TODO\|FIXME\|HACK\|XXX\|PLACEHOLDER\|NotImplemented\|not implemented' <target_files>
 grep -rn 'panic(".*implement\|panic(".*todo\|return nil, nil' <target_files>
 grep -rn 'return ""$\|return 0$\|return false$' <target_files>
-grep -Pzo '\{\s*\n\s*\}' <target_files>
+perl -0ne 'print "$ARGV\n" if /\{\s*\n\s*\}/' <target_files>
 ```
 
 Also block:

--- a/internal/tmpl/templates_test.go
+++ b/internal/tmpl/templates_test.go
@@ -328,6 +328,8 @@ func TestRenderNextCommandEntryUsesQueryOnlyContract(t *testing.T) {
 	assert.Contains(t, content, "Query the next governed host without advancing lifecycle state.")
 	assert.Contains(t, content, "`next_skill.name` is the authoritative governed-host handoff.")
 	assert.Contains(t, content, "Treat the default JSON as an action contract")
+	assert.Contains(t, content, "confirmation_requirement.resume_response_supported")
+	assert.Contains(t, content, "confirmation_requirement.next_action")
 	assert.Contains(t, content, "`context_budget` appears only when `guard_action` is `warn` or `stop`")
 	assert.Contains(t, content, "slipway health --governance --json --change <slug>")
 	assert.Contains(t, content, "Run `slipway run --json` when evidence is ready.")
@@ -516,6 +518,17 @@ func TestVerificationDoctrineDocumentsStringOnlyReferences(t *testing.T) {
 	assert.Contains(t, content, "do not write structured maps under `references`")
 }
 
+func TestGoalVerificationPlaceholderScanIsMacOSPortable(t *testing.T) {
+	t.Parallel()
+
+	content, err := Render("skills/goal-verification/SKILL.md.tmpl", nil)
+	require.NoError(t, err)
+
+	assert.NotContains(t, content, "grep -P")
+	assert.Contains(t, content, "perl -0ne")
+	assert.Contains(t, content, `\{\s*\n\s*\}`)
+}
+
 func TestPlanAuditBlocksFutureLifecycleAcceptanceCriteria(t *testing.T) {
 	t.Parallel()
 
@@ -614,6 +627,10 @@ func TestRunCommandEntryContainsLoopBehavioralBlocks(t *testing.T) {
 		"run command missing returned-view context guard guidance")
 	assert.Contains(t, content, "Use `slipway run --json --diagnostics` only for full readiness fields",
 		"run command missing diagnostics boundary guidance")
+	assert.Contains(t, content, "`advanced` reports the mutation performed by this invocation",
+		"run command missing advanced/blockers boundary guidance")
+	assert.Contains(t, content, "confirmation_requirement.resume_response_supported",
+		"run command missing resume-response capability guidance")
 	assert.Contains(t, content, "slipway health --governance --json --change <slug>",
 		"run command missing governance health handoff")
 


### PR DESCRIPTION
## Summary

Resolves three open Lattice-feedback issues with **additive, backward-compatible** diagnostics rather than a governance-kernel redesign. JSON-surface changes add optional fields only; existing field names/meanings are preserved (this is an `external_api_contracts` guardrail change).

| Issue | Status | What changed |
|---|---|---|
| **#62** | ✅ closable | goal-verification placeholder scan uses a portable `perl -0ne` one-liner instead of GNU-only `grep -Pzo`; works on macOS/BSD. Template test asserts no `grep -P`. |
| **#61** | ✅ closable | `confirmation_requirement` gains `resume_response_supported`, `next_action`, `next_action_kind`, `next_command`. Skill handoffs are distinguished from resumable checkpoints and no longer imply `--resume-response` without an active checkpoint. |
| **#59** | ◑ partial | Covered subset resolved (see below). plan-audit source-freshness is deferred to **#66**. |

### #59 — what this PR covers
- `health --governance` derives checks from a **read-only preview snapshot** (`PreviewGovernanceSnapshot`), so resolved controls are no longer carried forward by the monotonic recompute path — health now agrees with the readiness gate (`readiness.go` already used preview).
- Traceability **gap identities** are exposed in `health --governance --json` and human output (`GovernanceHealthCheck.traceability_gaps`).
- A passing `wave-orchestration` record is **rejected when newer runtime task evidence** exists for the same run version (`wave_orchestration_stale_task_evidence`); this compares the embedded logical `captured_at`, never filesystem mtime.
- `docs/commands.md` + command prompt partials document the **authority boundary**: `validate` = active readiness, `run` = mutating transition, `health` = diagnostic feedback.

### #59 — explicitly deferred to #66
The plan-audit *source*-freshness half is **not** in this PR. An mtime-based guard false-positives on Slipway's own `tasks.md` checkbox writeback (`[ ]`→`[x]`). The correct fix is a checkbox-invariant **content digest** (`TaskPlanSemanticHash`), tracked in **#66**. Only the wave-orchestration half (logical `captured_at`, never mtime) ships here.

## Optimality note
This is the narrowest approach that satisfies all requirements (kept lifecycle/checkpoint semantics, additive JSON, health as a diagnostic surface, no mtime false-positives). Heavier alternatives were considered and rejected: always-live health recompute (larger blast radius) and converting every skill handoff into a checkpoint (conflates handoffs with execution checkpoints). The real long-term improvement is **#66 content-digest freshness**.

## Verification
- `go build ./...` ✅  ·  `go vet ./...` ✅  ·  `git diff --check` ✅ clean
- `go test ./...` ✅ all 23 packages pass
- Driven through the governed flow to done-ready (`validate --json`: `can_advance=true`, `G_ship` approved, freshness `fresh`); archived bundle included under `artifacts/changes/archived/<slug>/`.

## Issue closure
Per the change intent, this PR does **not** auto-close any issue (`Refs`, not `Closes`). On merge: #61 and #62 can be closed; #59 should stay open and be narrowed to the #66 content-digest follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)