### PR TITLE
fix(governance): align S2 task evidence diagnostics

### DIFF
--- a/artifacts/changes/archived/fix-issue-72-align-read-only-s2-task-evidence-diagnostics-wi/assurance.md
+++ b/artifacts/changes/archived/fix-issue-72-align-read-only-s2-task-evidence-diagnostics-wi/assurance.md
@@ -1,0 +1,52 @@
+# Assurance
+
+## Project Context
+- Tech Stack: Go CLI
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Scope Summary
+Issue #72 is scoped to S2 read-only diagnostics for present but stale,
+invalid, non-passing, or task-plan-mismatched runtime task evidence. The
+change does not address release lag, does not mutate Lattice artifacts, does
+not reopen issue #71, and does not redesign unrelated readiness behavior.
+
+## Verification Verdict
+Implementation and governance proof passes. Focused command and progression
+tests pass, full workspace tests pass, build succeeds, diff whitespace check
+passes, S3 reviews pass, execution evidence is fresh, and active validation is
+ready to be refreshed again after goal-verification and final-closeout evidence.
+
+## Evidence Index
+- Passed: `go test ./cmd -run 'TestReadOnlyS2DiagnosticsUseTaskEvidenceDriftInsteadOfRunSummaryMissing|TestNextS6GovernedBlocksWithoutTaskEvidenceForWaveRunSummary|TestNextS6GovernedMaterializesExecutionSummaryAndRuntimeSummary'`
+- Passed: `go test ./internal/engine/progression -run 'TestSyncGovernedWaveExecution|TestEvaluateGovernanceReadiness'`
+- Passed: `go test -count=1 ./cmd -run 'TestReadOnlyS2DiagnosticsUseTaskEvidenceDriftInsteadOfRunSummaryMissing|TestNextS6GovernedBlocksWithoutTaskEvidenceForWaveRunSummary|TestNextS6GovernedMaterializesExecutionSummaryAndRuntimeSummary'`
+- Passed: `go test -count=1 ./internal/engine/progression -run 'TestSyncGovernedWaveExecution|TestEvaluateGovernanceReadiness'`
+- Passed: `go test -count=1 ./...`
+- Passed: `go build ./...`
+- Passed: `git diff --check`
+- Passed: `go run . validate --json --change fix-issue-72-align-read-only-s2-task-evidence-diagnostics-wi` through S3 review and S4 entry; final active validation will be refreshed after S4 evidence records.
+
+## Requirement Coverage
+- REQ-001: covered by `t-01`, `t-02`, and `t-03`; focused command regression asserts specific task-plan drift blockers.
+- REQ-002: covered by `t-02` and `t-03`; existing missing task-evidence regression remains in the focused command suite.
+- REQ-003: covered by `t-01` and `t-02`; regression asserts read-only commands do not create `execution-summary.yaml`.
+- REQ-004: covered by `t-02` and existing progression sync tests.
+- REQ-005: covered by `t-04`; final closeout refreshes full proof.
+- REQ-006: covered by domain review and the command-surface regression.
+
+## Residual Risks and Exceptions
+No accepted exceptions. Residual risk is limited to external JSON consumers
+that matched the old misleading blocker for present task evidence; the new
+blocker is more specific and remains fail-closed.
+
+## Rollback Readiness
+Rollback is source-only: revert the changes to `wave_sync.go`, `readiness.go`,
+and `progression_next_test.go`. No schema migration or runtime cleanup is
+required.
+
+## Archive Decision
+Not ready to archive until wave execution evidence, domain review,
+goal-verification, final-closeout, and final active `validate --json` proof are
+recorded. Active validation must be captured before any `done` archive step.

--- a/artifacts/changes/archived/fix-issue-72-align-read-only-s2-task-evidence-diagnostics-wi/assurance.md
+++ b/artifacts/changes/archived/fix-issue-72-align-read-only-s2-task-evidence-diagnostics-wi/assurance.md
@@ -13,24 +13,25 @@ change does not address release lag, does not mutate Lattice artifacts, does
 not reopen issue #71, and does not redesign unrelated readiness behavior.
 
 ## Verification Verdict
-Implementation and governance proof passes. Focused command and progression
-tests pass, full workspace tests pass, build succeeds, diff whitespace check
-passes, S3 reviews pass, execution evidence is fresh, and active validation is
-ready to be refreshed again after goal-verification and final-closeout evidence.
+Implementation verification passes. Focused command and progression tests cover
+the plan-drift path, the true-missing task-evidence path, and the read-only
+non-materialization contract; full workspace tests, vet, build, and diff
+whitespace checks are clean. This bundle is archived with `status=done`, so
+active `validate --change` commands intentionally reject it as archived; future
+inspection should use this archived evidence record or validate a new active
+change.
 
 ## Evidence Index
-- Passed: `go test ./cmd -run 'TestReadOnlyS2DiagnosticsUseTaskEvidenceDriftInsteadOfRunSummaryMissing|TestNextS6GovernedBlocksWithoutTaskEvidenceForWaveRunSummary|TestNextS6GovernedMaterializesExecutionSummaryAndRuntimeSummary'`
-- Passed: `go test ./internal/engine/progression -run 'TestSyncGovernedWaveExecution|TestEvaluateGovernanceReadiness'`
-- Passed: `go test -count=1 ./cmd -run 'TestReadOnlyS2DiagnosticsUseTaskEvidenceDriftInsteadOfRunSummaryMissing|TestNextS6GovernedBlocksWithoutTaskEvidenceForWaveRunSummary|TestNextS6GovernedMaterializesExecutionSummaryAndRuntimeSummary'`
+- Passed: `go test -count=1 ./cmd -run 'TestNextS6GovernedBlocksWithoutTaskEvidenceForWaveRunSummary|TestReadOnlyS2DiagnosticsKeepSingleRunSummaryMissingForAbsentTaskEvidence|TestReadOnlyS2DiagnosticsUseTaskEvidenceDriftInsteadOfRunSummaryMissing|TestNextS6GovernedMaterializesExecutionSummaryAndRuntimeSummary'`
 - Passed: `go test -count=1 ./internal/engine/progression -run 'TestSyncGovernedWaveExecution|TestEvaluateGovernanceReadiness'`
 - Passed: `go test -count=1 ./...`
+- Passed: `go vet ./internal/engine/progression/... ./cmd/...`
 - Passed: `go build ./...`
-- Passed: `git diff --check`
-- Passed: `go run . validate --json --change fix-issue-72-align-read-only-s2-task-evidence-diagnostics-wi` through S3 review and S4 entry; final active validation will be refreshed after S4 evidence records.
+- Passed: `git diff --check origin/main`
 
 ## Requirement Coverage
 - REQ-001: covered by `t-01`, `t-02`, and `t-03`; focused command regression asserts specific task-plan drift blockers.
-- REQ-002: covered by `t-02` and `t-03`; existing missing task-evidence regression remains in the focused command suite.
+- REQ-002: covered by `t-02` and `t-03`; the true-missing task-evidence regression keeps one compatible `run_summary_missing` blocker and enriches it with the concrete run summary version and task evidence path.
 - REQ-003: covered by `t-01` and `t-02`; regression asserts read-only commands do not create `execution-summary.yaml`.
 - REQ-004: covered by `t-02` and existing progression sync tests.
 - REQ-005: covered by `t-04`; final closeout refreshes full proof.
@@ -47,6 +48,6 @@ and `progression_next_test.go`. No schema migration or runtime cleanup is
 required.
 
 ## Archive Decision
-Not ready to archive until wave execution evidence, domain review,
-goal-verification, final-closeout, and final active `validate --json` proof are
-recorded. Active validation must be captured before any `done` archive step.
+Archived as done. Active governance commands no longer validate this slug
+because it has moved under `artifacts/changes/archived/`; the durable closeout
+record is this archived bundle plus the branch-level verification listed above.

--- a/artifacts/changes/archived/fix-issue-72-align-read-only-s2-task-evidence-diagnostics-wi/change.yaml
+++ b/artifacts/changes/archived/fix-issue-72-align-read-only-s2-task-evidence-diagnostics-wi/change.yaml
@@ -1,0 +1,58 @@
+version: 1
+slug: fix-issue-72-align-read-only-s2-task-evidence-diagnostics-wi
+description: 'Fix issue #72: align read-only S2 task-evidence diagnostics with run diagnostics so present-but-stale or plan-mismatched task evidence is not reported as run_summary_missing'
+status: done
+current_state: DONE
+needs_discovery: true
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-06-04T19:16:00.620427Z
+guardrail_domain: external_api_contracts
+quality_mode: standard
+workflow_preset: standard
+worktree_branch: feat/fix-issue-72-align-read-only-s2-task-evidence-diagnostics-wi
+artifact_schema: expanded
+project_context:
+    tech_stack: Go
+    test_cmd: go test ./...
+    build_cmd: go build ./...
+    languages:
+        - Go
+    recent_work: 'Current main 4483e74; issue #72 reproduced on read-only validate/status with wave-orchestration:run_summary_missing while run --diagnostics reports task evidence drift.'
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: 69d3c26aea5b6c32afaa527c83ab22738a3a4097902f88bd961bf9a61c1b1035
+        updated_at: 2026-06-05T02:03:29.737757045Z
+    decision:
+        id: decision
+        path: decision.md
+        state: frozen
+        content_hash: 91c5a43ee26cd0d51e704174909b696bc2b6a94ab72c479532e39141cb1559c8
+        updated_at: 2026-06-05T01:56:11.994788662Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: cfb951260f4cda3a756f05bbb14d880142b92227c472bb268a81f6db232e77ba
+        updated_at: 2026-06-05T01:57:27.350806853Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: e171bc97e7777e2d2d68e0bdbfa24248716ba8133f01940abd2d5d498e412720
+        updated_at: 2026-06-05T01:56:11.994641954Z
+    research:
+        id: research
+        path: research.md
+        state: frozen
+        content_hash: 02203d1293efc3e63f8be37ec89af78a5ba9f18a45bb3c63ed0a93c03854cf83
+        updated_at: 2026-06-05T01:56:11.994435162Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: 64ad4a96634bec544bbd05d3012cc3e9cfdaba88dcfde022448a4dac83386895
+        updated_at: 2026-06-05T01:59:34.217610356Z

--- a/artifacts/changes/archived/fix-issue-72-align-read-only-s2-task-evidence-diagnostics-wi/change.yaml
+++ b/artifacts/changes/archived/fix-issue-72-align-read-only-s2-task-evidence-diagnostics-wi/change.yaml
@@ -24,8 +24,8 @@ artifacts:
         id: assurance
         path: assurance.md
         state: frozen
-        content_hash: 69d3c26aea5b6c32afaa527c83ab22738a3a4097902f88bd961bf9a61c1b1035
-        updated_at: 2026-06-05T02:03:29.737757045Z
+        content_hash: d808c694f3f7b8e2cb7ccefc8f6398d507595a6ab6aec8f54d96554dae4094dc
+        updated_at: 2026-06-05T02:41:22Z
     decision:
         id: decision
         path: decision.md
@@ -36,8 +36,8 @@ artifacts:
         id: intent
         path: intent.md
         state: frozen
-        content_hash: cfb951260f4cda3a756f05bbb14d880142b92227c472bb268a81f6db232e77ba
-        updated_at: 2026-06-05T01:57:27.350806853Z
+        content_hash: f4baaab1a3e3e6f7ba2320cab62c5a76874ce5f7da63eb047675e506984d6797
+        updated_at: 2026-06-05T02:40:17Z
     requirements:
         id: requirements
         path: requirements.md

--- a/artifacts/changes/archived/fix-issue-72-align-read-only-s2-task-evidence-diagnostics-wi/decision.md
+++ b/artifacts/changes/archived/fix-issue-72-align-read-only-s2-task-evidence-diagnostics-wi/decision.md
@@ -1,0 +1,72 @@
+# Decision
+
+## Project Context
+- Tech Stack: Go CLI
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Alternatives Considered
+
+### Option A: Keep read-only `run_summary_missing`
+This avoids code changes, but it leaves #72 unresolved. The operator can only
+see the real task-evidence drift after running a mutating path, so the
+read-only diagnosis remains misleading.
+
+### Option B: Run wave sync from read-only surfaces
+This reuses exact execution-path logic, but it would write derived runtime
+state from `next`, `validate`, and `status`. That violates REQ-003 and the
+documented query-only command contract.
+
+### Option C: Add a non-mutating wave execution preview
+Extract the common wave/task evidence diagnosis into a helper that can run
+with or without writes. The mutating path keeps writing `wave-runs`,
+`execution-summary.yaml`, and checklist changes. The read-only path only uses
+the preview blockers to refine S2 readiness.
+
+### Option D: Patch each command renderer
+Each command could post-process `wave-orchestration:run_summary_missing`, but
+that duplicates diagnosis logic across renderers and risks divergence from
+`run`.
+
+## Selected Approach
+DEC-001: Use Option C. Add `PreviewGovernedWaveExecution` on top of the same
+core evaluator as `SyncGovernedWaveExecution`. In S2 readiness, when the
+execution summary is absent and the required-skill blocker is specifically
+`wave-orchestration:run_summary_missing`, run the preview. If preview blockers
+show present but stale/invalid/plan-drifted task evidence, remove the
+misleading run-summary-missing blocker and append the specific blockers. If
+task evidence is absent, preserve the existing missing-evidence path.
+
+## Interfaces and Data Flow
+- `internal/engine/progression/wave_sync.go` exposes
+  `PreviewGovernedWaveExecution(root, change)` and keeps
+  `SyncGovernedWaveExecution(root, change)` as the mutating surface.
+- Both functions share one evaluator. The preview returns blockers after
+  parsing evidence, stale checks, wave-plan loading, plan-drift checks, and
+  non-pass task collection, but skips `state.SaveWaveRuns`,
+  `state.SaveExecutionSummary`, and `syncCompletedTaskCheckboxes`.
+- `internal/engine/progression/readiness.go` refines only S2
+  run-summary-missing skill blockers for `wave-orchestration`, and only when
+  no ready execution summary already exists.
+- `cmd/progression_next_test.go` covers the JSON surfaces by exercising
+  `next --json --diagnostics`, `validate --json`, and `status --json` on the
+  same S2 fixture.
+
+## Rollout and Rollback
+Roll forward by adding the command-surface regression, extracting the preview
+helper, and wiring readiness refinement. Roll back by reverting the touched
+source/test files. No migration, persisted schema change, or runtime cleanup
+is required.
+
+## Risk
+- Medium: read-only evaluation might accidentally write derived execution
+  state. Mitigation: preview skips all write calls and regression asserts no
+  `execution-summary.yaml` is created by read-only commands.
+- Medium: absent task evidence could be reclassified incorrectly. Mitigation:
+  refinement removes `run_summary_missing` only when preview blockers are more
+  specific than `missing_task_evidence_for_run_summary`; existing missing
+  evidence regression remains in place.
+- Medium: JSON consumers may depend on the old blocker. Mitigation: the old
+  blocker was misleading for present stale evidence; the replacement is more
+  actionable and remains fail-closed.

--- a/artifacts/changes/archived/fix-issue-72-align-read-only-s2-task-evidence-diagnostics-wi/intent.md
+++ b/artifacts/changes/archived/fix-issue-72-align-read-only-s2-task-evidence-diagnostics-wi/intent.md
@@ -1,0 +1,82 @@
+# Intent
+
+## Project Context
+<!-- Auto-filled by InferProjectContext(); .slipway.yaml overrides -->
+- Tech Stack: Go
+- Languages: Go
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Conventions: 
+
+## Summary
+Fix issue #72: align read-only S2 task-evidence diagnostics with run diagnostics so present-but-stale or plan-mismatched task evidence is not reported as run_summary_missing
+## Complexity Assessment
+complex
+The change touches Slipway lifecycle diagnostics for a governed S2 execution
+state. The implementation is expected to be localized, but the surface is an
+externally consumed CLI contract (`validate/status/next --json`) and must keep
+read-only behavior non-mutating while matching execution-path diagnosis.
+
+## Guardrail Domains
+external_api_contracts
+
+## In Scope
+- Align read-only S2 task-evidence diagnostics on `validate --json`,
+  `status --json`, and `next --json` with the diagnosis already available from
+  `run --json --diagnostics`.
+- Distinguish absent task evidence from task evidence that exists but is stale,
+  plan-hash mismatched, or otherwise not acceptable for the current `tasks.md`.
+- Keep the diagnostic actionable for issue #72's reproduced case: present
+  task evidence should not collapse to `wave-orchestration:run_summary_missing`
+  when the more specific task-evidence drift reason is available.
+- Add focused Go regression coverage for the read-only surface behavior.
+
+## Out of Scope
+- Do not change the mutating `run` advancement semantics except where shared
+  diagnostic helpers require a narrow consistency adjustment.
+- Do not implement release-channel or installed-version skew remediation for
+  `slipway 0.5.0`.
+- Do not reopen issue #71 or broaden this change into unrelated governance
+  readiness redesign.
+- Do not alter Lattice Change 16 artifacts or completed governance state.
+
+## Constraints
+- Read-only commands must remain read-only and must not restamp or rewrite
+  runtime evidence.
+- JSON output contracts should remain backward compatible except for clearer
+  blocker/detail diagnostics.
+- The fix must preserve the existing external API contract guardrail posture
+  for CLI consumers.
+
+## Acceptance Signals
+- A fixture with task evidence present but mismatched to current `tasks.md`
+  causes read-only diagnostics to report task-evidence drift rather than only
+  `wave-orchestration:run_summary_missing`.
+- Existing no-task-evidence cases still report missing run summary/task evidence
+  as appropriate.
+- Targeted Go tests covering the affected read-only surfaces pass.
+- `go test ./...` and `go build ./...` pass before closeout.
+
+## Resolved Questions
+- `SyncGovernedWaveExecution` in `internal/engine/progression/wave_sync.go`
+  owns the more specific task-evidence diagnosis. The selected approach
+  extracts a non-mutating preview from the same evaluator so
+  `validate/status/next` can reuse the diagnosis without writing
+  execution-summary or checklist state.
+
+## Deferred Ideas
+- Add release-version skew diagnostics for installed binaries versus current
+  source once the current diagnostic inconsistency is fixed.
+
+## Approved Summary
+Approved 2026-06-05T01:44:46Z. Complete issue #72 by aligning read-only
+S2 task-evidence diagnostics (`validate --json`, `status --json`, and
+`next --json --diagnostics`) with the existing mutating execution-path
+diagnosis. When runtime task evidence exists but is stale, plan-hash
+mismatched, or otherwise unacceptable for the current `tasks.md`, read-only
+surfaces must report the specific task-evidence drift/blocker instead of
+collapsing to `wave-orchestration:run_summary_missing`. Keep absent-task
+evidence cases on the existing missing-evidence path. Do not implement release
+version skew remediation, do not change Lattice Change 16 artifacts, and do not
+broaden into unrelated governance readiness redesign. Acceptance is focused Go
+regressions plus full `go test ./...` and `go build ./...`.

--- a/artifacts/changes/archived/fix-issue-72-align-read-only-s2-task-evidence-diagnostics-wi/intent.md
+++ b/artifacts/changes/archived/fix-issue-72-align-read-only-s2-task-evidence-diagnostics-wi/intent.md
@@ -6,7 +6,7 @@
 - Languages: Go
 - Test Command: go test ./...
 - Build Command: go build ./...
-- Conventions: 
+- Conventions:
 
 ## Summary
 Fix issue #72: align read-only S2 task-evidence diagnostics with run diagnostics so present-but-stale or plan-mismatched task evidence is not reported as run_summary_missing

--- a/artifacts/changes/archived/fix-issue-72-align-read-only-s2-task-evidence-diagnostics-wi/requirements.md
+++ b/artifacts/changes/archived/fix-issue-72-align-read-only-s2-task-evidence-diagnostics-wi/requirements.md
@@ -1,0 +1,84 @@
+# Requirements
+
+## Project Context
+- Tech Stack: Go CLI
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Requirements
+
+### Requirement: ReadOnlyS2SpecificTaskEvidenceDiagnostics
+REQ-001: When S2 has passing `wave-orchestration` evidence and present task
+evidence that is stale, invalid, non-passing, or mismatched against the current
+task plan, read-only surfaces MUST report the specific task-evidence blocker
+instead of collapsing the state to `wave-orchestration:run_summary_missing`.
+Traces to issue #72.
+
+#### Scenario: Plan-drifted task evidence is specific
+GIVEN a governed change is in `S2_EXECUTE` with passing wave evidence, task
+evidence for run summary version 1, no `execution-summary.yaml`, and a
+semantically changed `tasks.md`
+WHEN `slipway next --json --diagnostics`, `slipway validate --json`, or
+`slipway status --json` is run
+THEN blockers include `tasks_plan_changed_since_task_evidence:<task-id>` and
+do not include `wave-orchestration:run_summary_missing`.
+
+### Requirement: MissingEvidencePathPreserved
+REQ-002: When S2 has passing `wave-orchestration` evidence but no task evidence
+for the run summary version, read-only and mutating surfaces MUST keep the
+missing task-evidence guidance path, including the task evidence directory and
+required fields. Traces to issue #72 non-goal.
+
+#### Scenario: Absent task evidence stays actionable
+GIVEN a governed change is in `S2_EXECUTE` with passing wave evidence and no
+matching task evidence
+WHEN readiness is rendered
+THEN the blocker remains actionable as missing task evidence rather than being
+reclassified as task-plan drift.
+
+### Requirement: ReadOnlySurfacesRemainQueryOnly
+REQ-003: `next`, `validate`, and `status` readiness evaluation MUST NOT write
+`execution-summary.yaml`, wave-run files, or task checklist completion state
+while refining S2 diagnostics. Traces to the command contract.
+
+#### Scenario: Diagnostic preview does not materialize summary
+GIVEN the S2 plan-drift fixture has no `execution-summary.yaml`
+WHEN read-only command surfaces are executed
+THEN no `execution-summary.yaml` is created as a side effect.
+
+### Requirement: SharedDiagnosisNoCommandDuplication
+REQ-004: The implementation SHOULD reuse the execution-path wave/task evidence
+diagnosis so future blocker behavior remains aligned between `run` and
+read-only surfaces. It MUST NOT duplicate divergent diagnosis logic in each
+command renderer.
+
+#### Scenario: Mutating sync behavior is unchanged
+GIVEN existing wave-sync tests for stale task evidence, parse issues, plan
+drift, and successful summary materialization
+WHEN the implementation is complete
+THEN those tests continue to pass.
+
+### Requirement: RegressionAndGovernanceProof
+REQ-005: The change MUST include focused regressions for the affected command
+surfaces and focused progression tests, plus fresh full build/test/diff and
+governance proof before closeout. Traces to issue #72.
+
+#### Scenario: Verification commands pass
+GIVEN implementation is complete
+WHEN verification runs
+THEN focused command tests, focused progression tests, `go test ./...`,
+`go build ./...`, `git diff --check`, and `slipway validate --json` provide
+fresh passing evidence.
+
+### Requirement: ExternalAPIContractsGuardrail
+REQ-006: Because JSON blockers are externally consumed command output, the
+intentional contract change MUST be reviewed as `external_api_contracts` and
+must remain backward-compatible for absent task evidence.
+
+#### Scenario: Domain review covers JSON blocker change
+GIVEN `validate`, `status`, and `next` JSON blockers change for present
+stale task evidence
+WHEN review evidence is recorded
+THEN the review states that the changed blocker is intentional, actionable,
+and fail-closed.

--- a/artifacts/changes/archived/fix-issue-72-align-read-only-s2-task-evidence-diagnostics-wi/research.md
+++ b/artifacts/changes/archived/fix-issue-72-align-read-only-s2-task-evidence-diagnostics-wi/research.md
@@ -1,0 +1,48 @@
+# Research
+
+## Research Findings
+
+### Architecture
+- Affected modules: `internal/engine/progression/wave_sync.go` owns wave/task evidence loading, plan-drift diagnosis, execution-summary materialization, wave-run writes, and task checklist sync. `internal/engine/progression/readiness.go` owns read-only governance readiness blockers consumed by `validate`, `status`, and `next --diagnostics`. `cmd/progression_next_test.go` provides command-surface regressions for `next`, `validate`, and `status`.
+- Dependency chains: command surfaces call `progression.EvaluateGovernanceReadiness`; readiness uses `EvaluateRequiredSkillsForChange` with `execCtx.LatestRunVersion`; run-summary-bound `wave-orchestration` currently reports `run_summary_missing` when no execution summary exists. The mutating execution path already calls `SyncGovernedWaveExecution`, which can diagnose task-evidence staleness, parse issues, and `tasks_plan_changed_since_task_evidence`.
+- Blast radius: limited to S2 read-only blocker rendering and wave-sync diagnostic reuse. The mutating sync path must keep existing writes: `wave-runs`, `execution-summary.yaml`, and task checklist completion.
+- Constraints: `next`, `validate`, and `status` are query/readiness surfaces and must not materialize execution summaries or mutate task checkboxes. Absent task evidence must remain actionable as missing task evidence; only present but invalid/stale/drifted evidence should replace `wave-orchestration:run_summary_missing`.
+
+### Patterns
+- Existing conventions: reason-code blockers are normalized with `model.NormalizeReasonCodes`; command tests assert stable `model.ReasonSpecs`; read-only surfaces share `EvaluateGovernanceReadiness`; wave sync reports specific blockers before writing derived summaries.
+- Reusable abstractions: `SyncGovernedWaveExecution` already computes the correct execution-path diagnosis, so a read-only preview can share the same core calculation without duplicating command-specific logic.
+- Convention deviations: none required. The change should add a small preview wrapper and readiness refinement, not a new command surface or readiness subsystem.
+- Codebase-map advisory: `artifacts/codebase` is `partial`; populated docs describe general CLI/state/test layout, but some entries still reference an older create-guard change. They are treated as weak layout context only, not as #72 authority.
+
+### Risks
+- Technical risks: medium risk of accidentally turning read-only diagnostics into a write path; medium risk of hiding the legitimate missing-evidence path; low risk of duplicate blockers on mixed parse/drift scenarios.
+- Guardrail domains: `external_api_contracts`, because JSON blocker content changes on `validate --json`, `status --json`, and `next --json --diagnostics`.
+- Reversibility: source-only rollback. No schema migration or persistent runtime migration is introduced.
+
+### Test Strategy
+- Existing coverage: `internal/engine/progression/wave_sync_test.go` already covers mutating sync blockers for stale task evidence, parse issues, and task-plan drift. Existing command tests cover missing task evidence.
+- Infrastructure needs: a command-layer fixture with S2 state, passing wave-orchestration evidence, task evidence captured against an old wave plan, then a semantically changed `tasks.md` with no execution summary.
+- Verification approach: assert `next --json --diagnostics`, `validate --json`, and `status --json` surface `tasks_plan_changed_since_task_evidence:<task>` and do not include `wave-orchestration:run_summary_missing`; assert read-only commands do not create `execution-summary.yaml`; rerun focused command tests, focused progression tests, then full Go verification.
+
+## Alternatives Considered
+- Option A: Leave read-only readiness as `wave-orchestration:run_summary_missing` until `run` materializes execution diagnostics. This preserves current behavior but keeps #72 unresolved because users cannot see that task evidence exists and is specifically stale or plan-mismatched.
+- Option B: Call the mutating `SyncGovernedWaveExecution` from read-only command surfaces. This would reuse exact execution logic but violates the read-only contract by writing `execution-summary.yaml`, `wave-runs`, or task checkboxes from `next`, `validate`, or `status`.
+- Option C: Extract a non-mutating wave execution preview and let S2 readiness replace only the misleading `wave-orchestration:run_summary_missing` blocker when preview blockers prove task evidence exists but is invalid, stale, or plan-drifted.
+- Selected: Option C. It reuses the execution-path diagnosis, keeps command surfaces read-only, and preserves the absent-evidence path.
+
+## Unknowns
+- Resolved: Does current source reproduce #72? Yes, issue evidence and local code inspection show read-only readiness uses `execCtx.LatestRunVersion` and reports run-summary-bound missing before applying wave-sync task-evidence diagnosis.
+- Resolved: Is #71 in scope? No. The operator explicitly closed #71 as not a problem.
+- Remaining: None.
+
+## Assumptions
+- The issue fixture's plan-drift case is representative of the failing user experience because it has passing wave evidence, present task evidence, no derived execution summary, and a changed task plan. Evidence: issue #72 comment and `internal/engine/progression/wave_sync.go`.
+- The read-only contract matters for all three surfaces. Evidence: `next` command comment says state advancement is owned by `run`, and `validate` says it inspects readiness without advancing state.
+
+## Canonical References
+- `artifacts/changes/fix-issue-72-align-read-only-s2-task-evidence-diagnostics-wi/intent.md` for the original request and intake context.
+- `internal/engine/progression/wave_sync.go` for execution-path task-evidence diagnosis and sync writes.
+- `internal/engine/progression/readiness.go` for shared read-only readiness blockers.
+- `internal/engine/progression/evidence.go` for run-summary-bound required-skill blocker behavior.
+- `cmd/next.go`, `cmd/validate.go`, and `cmd/status_view_build.go` for the affected JSON command surfaces.
+- `cmd/progression_next_test.go` and `internal/engine/progression/wave_sync_test.go` for regression patterns.

--- a/artifacts/changes/archived/fix-issue-72-align-read-only-s2-task-evidence-diagnostics-wi/tasks.md
+++ b/artifacts/changes/archived/fix-issue-72-align-read-only-s2-task-evidence-diagnostics-wi/tasks.md
@@ -1,0 +1,41 @@
+# Tasks
+
+## Project Context
+- Tech Stack: Go CLI
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Task List
+
+- [x] `t-01` Add command-surface regression for S2 plan-drifted task evidence.
+  - wave: 1
+  - depends_on: []
+  - target_files: ["cmd/progression_next_test.go"]
+  - task_kind: test
+  - acceptance: next, validate, and status JSON include task-plan drift, omit wave-orchestration run-summary-missing, and do not create execution-summary.yaml.
+  - covers: [REQ-001, REQ-003, REQ-005, REQ-006]
+
+- [x] `t-02` Extract non-mutating wave execution preview from sync diagnosis.
+  - wave: 2
+  - depends_on: [t-01]
+  - target_files: ["internal/engine/progression/wave_sync.go"]
+  - task_kind: code
+  - acceptance: mutating sync behavior remains covered by existing wave-sync tests while preview returns the same task-evidence blockers without writes.
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004]
+
+- [x] `t-03` Refine S2 read-only readiness blockers with preview diagnostics.
+  - wave: 3
+  - depends_on: [t-02]
+  - target_files: ["internal/engine/progression/readiness.go"]
+  - task_kind: code
+  - acceptance: readiness replaces only misleading wave-orchestration run-summary-missing blockers when preview has specific task-evidence blockers.
+  - covers: [REQ-001, REQ-002, REQ-004, REQ-006]
+
+- [x] `t-04` Run focused and full verification gates.
+  - wave: 4
+  - depends_on: [t-01, t-02, t-03]
+  - target_files: ["cmd/progression_next_test.go", "internal/engine/progression/readiness.go", "internal/engine/progression/wave_sync.go"]
+  - task_kind: verification
+  - acceptance: focused command tests, focused progression tests, full Go tests, build, diff check, and Slipway validate evidence pass.
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004, REQ-005, REQ-006]

--- a/cmd/progression_next_test.go
+++ b/cmd/progression_next_test.go
@@ -3692,6 +3692,88 @@ func TestNextS6GovernedBlocksWithoutTaskEvidenceForWaveRunSummary(t *testing.T) 
 	assert.Equal(t, model.StateS2Execute, view.CurrentState)
 }
 
+func TestReadOnlyS2DiagnosticsUseTaskEvidenceDriftInsteadOfRunSummaryMissing(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	ensureTestGitRepo(t, root)
+	initTestWorkspace(t, root)
+	slug := createGovernedRequest(t, root, "L2", "surface stale task evidence diagnostics")
+	change, err := state.LoadChange(root, slug)
+	require.NoError(t, err)
+	change.CurrentState = model.StateS2Execute
+	change.PlanSubStep = model.PlanSubStepNone
+	require.NoError(t, state.SaveChange(root, change))
+
+	bundlePath := filepath.Join(root, "artifacts", "changes", slug)
+	require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
+
+- [ ] `+"`task-a`"+` Initial objective
+  - wave: 1
+  - target_files: ["cmd/next.go"]
+  - task_kind: code
+`)))
+	_, err = state.MaterializeWavePlan(root, change)
+	require.NoError(t, err)
+
+	taskCapturedAt := time.Now().UTC().Add(-2 * time.Minute)
+	writeTaskEvidenceFile(t, root, slug, 1, "task-a", map[string]any{
+		"changed_files": []string{"cmd/next.go"},
+		"captured_at":   taskCapturedAt.Format(time.RFC3339Nano),
+	})
+	writeSkillVerification(t, root, slug, "wave-orchestration", model.VerificationRecord{
+		Verdict:    model.VerificationVerdictPass,
+		Blockers:   []model.ReasonCode{},
+		Timestamp:  taskCapturedAt.Add(time.Minute),
+		RunVersion: 1,
+	})
+	require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
+
+- [ ] `+"`task-a`"+` Updated objective
+  - wave: 1
+  - target_files: ["cmd/status.go"]
+  - task_kind: code
+`)))
+
+	nextCmd := commandForRoot(t, root, makeNextCmd())
+	nextCmd.SetArgs([]string{"--json", "--diagnostics", "--change", slug})
+	var nextOut bytes.Buffer
+	nextCmd.SetOut(&nextOut)
+	require.NoError(t, nextCmd.Execute())
+	var nextDiag nextView
+	require.NoError(t, json.Unmarshal(nextOut.Bytes(), &nextDiag))
+	assertReadOnlyS2TaskEvidenceDriftBlockers(t, "next", nextDiag.Blockers)
+
+	validateCmd := commandForRoot(t, root, makeValidateCmd())
+	validateCmd.SetArgs([]string{"--json", "--change", slug})
+	var validateOut bytes.Buffer
+	validateCmd.SetOut(&validateOut)
+	require.NoError(t, validateCmd.Execute())
+	var validate validateView
+	require.NoError(t, json.Unmarshal(validateOut.Bytes(), &validate))
+	assertReadOnlyS2TaskEvidenceDriftBlockers(t, "validate", validate.Blockers)
+
+	statusCmd := commandForRoot(t, root, makeStatusCmd())
+	statusCmd.SetArgs([]string{"--json", "--change", slug})
+	var statusOut bytes.Buffer
+	statusCmd.SetOut(&statusOut)
+	require.NoError(t, statusCmd.Execute())
+	var status statusView
+	require.NoError(t, json.Unmarshal(statusOut.Bytes(), &status))
+	assertReadOnlyS2TaskEvidenceDriftBlockers(t, "status", status.Blockers)
+
+	_, err = os.Stat(state.ExecutionSummaryPathForRead(root, slug))
+	assert.True(t, os.IsNotExist(err), "read-only surfaces must not materialize execution-summary.yaml")
+}
+
+func assertReadOnlyS2TaskEvidenceDriftBlockers(t *testing.T, surface string, blockers []model.ReasonCode) {
+	t.Helper()
+	specs := model.ReasonSpecs(blockers)
+	assert.Contains(t, specs, "tasks_plan_changed_since_task_evidence:task-a", surface)
+	for _, spec := range specs {
+		assert.NotContains(t, spec, "wave-orchestration:run_summary_missing", surface)
+	}
+}
+
 func prepareStalePlanningRecoveryFixture(t *testing.T, root string, currentState model.WorkflowState) (string, model.Change) {
 	t.Helper()
 	slug, change := prepareStalePlanningRecoveryBaseFixture(t, root, currentState)

--- a/cmd/progression_next_test.go
+++ b/cmd/progression_next_test.go
@@ -3658,22 +3658,7 @@ func TestNextS6GovernedMaterializesExecutionSummaryAndRuntimeSummary(t *testing.
 
 func TestNextS6GovernedBlocksWithoutTaskEvidenceForWaveRunSummary(t *testing.T) {
 	t.Parallel()
-	root := t.TempDir()
-	ensureTestGitRepo(t, root)
-	initTestWorkspace(t, root)
-	slug := createGovernedRequest(t, root, "L2", "missing task evidence should block")
-	change, err := state.LoadChange(root, slug)
-	require.NoError(t, err)
-	change.CurrentState = model.StateS2Execute
-	change.PlanSubStep = model.PlanSubStepNone
-	require.NoError(t, state.SaveChange(root, change))
-
-	writeSkillVerification(t, root, slug, "wave-orchestration", model.VerificationRecord{
-		Verdict:    model.VerificationVerdictPass,
-		Blockers:   []model.ReasonCode{},
-		Timestamp:  time.Now().UTC(),
-		RunVersion: 1,
-	})
+	root, slug := prepareMissingTaskEvidenceForWaveRunSummaryFixture(t)
 
 	view, err := buildNextView(root, changeRef{Slug: slug}, "", false, true, false)
 	require.NoError(t, err)
@@ -3690,6 +3675,38 @@ func TestNextS6GovernedBlocksWithoutTaskEvidenceForWaveRunSummary(t *testing.T) 
 	assert.Contains(t, missingEvidenceBlocker, "record_command=slipway evidence task")
 	assert.Contains(t, missingEvidenceBlocker, "required_fields=task_id,run_summary_version,task_kind,verdict,evidence_ref,captured_at,freshness_inputs")
 	assert.Equal(t, model.StateS2Execute, view.CurrentState)
+}
+
+func TestReadOnlyS2DiagnosticsKeepSingleRunSummaryMissingForAbsentTaskEvidence(t *testing.T) {
+	t.Parallel()
+	root, slug := prepareMissingTaskEvidenceForWaveRunSummaryFixture(t)
+
+	nextCmd := commandForRoot(t, root, makeNextCmd())
+	nextCmd.SetArgs([]string{"--json", "--diagnostics", "--change", slug})
+	var nextOut bytes.Buffer
+	nextCmd.SetOut(&nextOut)
+	require.NoError(t, nextCmd.Execute())
+	var nextDiag nextView
+	require.NoError(t, json.Unmarshal(nextOut.Bytes(), &nextDiag))
+	assertSingleRunSummaryMissingTaskEvidenceBlocker(t, "next", nextDiag.Blockers, slug)
+
+	validateCmd := commandForRoot(t, root, makeValidateCmd())
+	validateCmd.SetArgs([]string{"--json", "--change", slug})
+	var validateOut bytes.Buffer
+	validateCmd.SetOut(&validateOut)
+	require.NoError(t, validateCmd.Execute())
+	var validate validateView
+	require.NoError(t, json.Unmarshal(validateOut.Bytes(), &validate))
+	assertSingleRunSummaryMissingTaskEvidenceBlocker(t, "validate", validate.Blockers, slug)
+
+	statusCmd := commandForRoot(t, root, makeStatusCmd())
+	statusCmd.SetArgs([]string{"--json", "--change", slug})
+	var statusOut bytes.Buffer
+	statusCmd.SetOut(&statusOut)
+	require.NoError(t, statusCmd.Execute())
+	var status statusView
+	require.NoError(t, json.Unmarshal(statusOut.Bytes(), &status))
+	assertSingleRunSummaryMissingTaskEvidenceBlocker(t, "status", status.Blockers, slug)
 }
 
 func TestReadOnlyS2DiagnosticsUseTaskEvidenceDriftInsteadOfRunSummaryMissing(t *testing.T) {
@@ -3772,6 +3789,45 @@ func assertReadOnlyS2TaskEvidenceDriftBlockers(t *testing.T, surface string, blo
 	for _, spec := range specs {
 		assert.NotContains(t, spec, "wave-orchestration:run_summary_missing", surface)
 	}
+}
+
+func assertSingleRunSummaryMissingTaskEvidenceBlocker(t *testing.T, surface string, blockers []model.ReasonCode, slug string) {
+	t.Helper()
+	specs := model.ReasonSpecs(blockers)
+	matches := []string{}
+	for _, spec := range specs {
+		assert.NotContains(t, spec, "missing_task_evidence_for_run_summary", surface)
+		if strings.HasPrefix(spec, "required_skill_not_ready:wave-orchestration:run_summary_missing") {
+			matches = append(matches, spec)
+		}
+	}
+	require.Len(t, matches, 1, surface)
+	missingEvidenceBlocker := matches[0]
+	assert.Contains(t, missingEvidenceBlocker, "run_summary_version=1", surface)
+	assert.Contains(t, missingEvidenceBlocker, ".git/slipway/runtime/changes/"+slug+"/evidence/tasks", surface)
+	assert.Contains(t, missingEvidenceBlocker, "record_command=slipway evidence task", surface)
+	assert.Contains(t, missingEvidenceBlocker, "required_fields=task_id,run_summary_version,task_kind,verdict,evidence_ref,captured_at,freshness_inputs", surface)
+}
+
+func prepareMissingTaskEvidenceForWaveRunSummaryFixture(t *testing.T) (string, string) {
+	t.Helper()
+	root := t.TempDir()
+	ensureTestGitRepo(t, root)
+	initTestWorkspace(t, root)
+	slug := createGovernedRequest(t, root, "L2", "missing task evidence should block")
+	change, err := state.LoadChange(root, slug)
+	require.NoError(t, err)
+	change.CurrentState = model.StateS2Execute
+	change.PlanSubStep = model.PlanSubStepNone
+	require.NoError(t, state.SaveChange(root, change))
+
+	writeSkillVerification(t, root, slug, "wave-orchestration", model.VerificationRecord{
+		Verdict:    model.VerificationVerdictPass,
+		Blockers:   []model.ReasonCode{},
+		Timestamp:  time.Now().UTC(),
+		RunVersion: 1,
+	})
+	return root, slug
 }
 
 func prepareStalePlanningRecoveryFixture(t *testing.T, root string, currentState model.WorkflowState) (string, model.Change) {

--- a/internal/engine/progression/readiness.go
+++ b/internal/engine/progression/readiness.go
@@ -221,7 +221,19 @@ func evaluateGovernanceReadinessBaseWithReaders(
 	}
 	readiness.PassingSkills = cloneVerificationRecords(passingSkills)
 	readiness.SkillBlockers = model.ReasonCodesFromSpecs(skillBlockers)
+	var wavePreviewBlockers []model.ReasonCode
+	readiness.SkillBlockers, wavePreviewBlockers, err = refineS2WaveExecutionSkillBlockers(
+		root,
+		evaluationChange,
+		effectiveState,
+		execCtx.Summary,
+		readiness.SkillBlockers,
+	)
+	if err != nil {
+		return GovernanceReadiness{}, err
+	}
 	readiness.Blockers = append(readiness.Blockers, readiness.SkillBlockers...)
+	readiness.Blockers = append(readiness.Blockers, wavePreviewBlockers...)
 	if effectiveState == model.StateS2Execute && evaluationChange.NeedsDiscovery && strings.TrimSpace(evaluationChange.WorktreePath) == "" {
 		derivation, err := DeriveWorktreeBlockers(root, evaluationChange, passingSkills)
 		if err != nil {
@@ -306,6 +318,69 @@ func evaluateGovernanceReadinessBaseWithReaders(
 	readiness.Blockers = model.NormalizeReasonCodes(readiness.Blockers)
 	readiness.Diagnostics = stringutil.UniqueSorted(readiness.Diagnostics)
 	return readiness, nil
+}
+
+func refineS2WaveExecutionSkillBlockers(
+	root string,
+	change model.Change,
+	effectiveState model.WorkflowState,
+	summary *model.ExecutionSummary,
+	skillBlockers []model.ReasonCode,
+) ([]model.ReasonCode, []model.ReasonCode, error) {
+	if effectiveState != model.StateS2Execute ||
+		state.ExecutionSummaryReady(summary) ||
+		!hasWaveRunSummaryMissingSkillBlocker(skillBlockers) {
+		return skillBlockers, nil, nil
+	}
+
+	preview, err := PreviewGovernedWaveExecution(root, change)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(preview.Blockers) == 0 {
+		return skillBlockers, nil, nil
+	}
+
+	previewBlockers := model.NormalizeReasonCodes(preview.Blockers)
+	if wavePreviewHasSpecificTaskEvidenceBlockers(previewBlockers) {
+		return filterWaveRunSummaryMissingSkillBlockers(skillBlockers), previewBlockers, nil
+	}
+	return skillBlockers, previewBlockers, nil
+}
+
+func hasWaveRunSummaryMissingSkillBlocker(blockers []model.ReasonCode) bool {
+	for _, blocker := range blockers {
+		if isWaveRunSummaryMissingSkillBlocker(blocker) {
+			return true
+		}
+	}
+	return false
+}
+
+func filterWaveRunSummaryMissingSkillBlockers(blockers []model.ReasonCode) []model.ReasonCode {
+	filtered := make([]model.ReasonCode, 0, len(blockers))
+	for _, blocker := range blockers {
+		if isWaveRunSummaryMissingSkillBlocker(blocker) {
+			continue
+		}
+		filtered = append(filtered, blocker)
+	}
+	return filtered
+}
+
+func isWaveRunSummaryMissingSkillBlocker(blocker model.ReasonCode) bool {
+	return blocker.Code == "required_skill_not_ready" &&
+		strings.HasPrefix(strings.TrimSpace(blocker.Detail), SkillWaveOrchestration+":run_summary_missing")
+}
+
+func wavePreviewHasSpecificTaskEvidenceBlockers(blockers []model.ReasonCode) bool {
+	for _, blocker := range blockers {
+		if blocker.Code == "missing_task_evidence_for_run_summary" {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 func scopeContractNeedsRecoveryGuidance(state model.WorkflowState, report scopecontract.Report) bool {

--- a/internal/engine/progression/readiness.go
+++ b/internal/engine/progression/readiness.go
@@ -342,10 +342,13 @@ func refineS2WaveExecutionSkillBlockers(
 	}
 
 	previewBlockers := model.NormalizeReasonCodes(preview.Blockers)
-	if wavePreviewHasSpecificTaskEvidenceBlockers(previewBlockers) {
+	if wavePreviewHasReplacementBlockers(previewBlockers) {
 		return filterWaveRunSummaryMissingSkillBlockers(skillBlockers), previewBlockers, nil
 	}
-	return skillBlockers, previewBlockers, nil
+	if missingDetail, ok := missingTaskEvidencePreviewDetail(previewBlockers); ok {
+		return enrichWaveRunSummaryMissingSkillBlockers(skillBlockers, missingDetail), nil, nil
+	}
+	return skillBlockers, nil, nil
 }
 
 func hasWaveRunSummaryMissingSkillBlocker(blockers []model.ReasonCode) bool {
@@ -368,12 +371,45 @@ func filterWaveRunSummaryMissingSkillBlockers(blockers []model.ReasonCode) []mod
 	return filtered
 }
 
+func enrichWaveRunSummaryMissingSkillBlockers(blockers []model.ReasonCode, detail string) []model.ReasonCode {
+	detail = strings.TrimSpace(detail)
+	if detail == "" {
+		return blockers
+	}
+	enriched := make([]model.ReasonCode, 0, len(blockers))
+	for _, blocker := range blockers {
+		if isWaveRunSummaryMissingSkillBlocker(blocker) {
+			enriched = append(enriched, model.NewReasonCode(
+				blocker.Code,
+				SkillWaveOrchestration+":run_summary_missing; "+detail,
+			))
+			continue
+		}
+		enriched = append(enriched, blocker)
+	}
+	return enriched
+}
+
 func isWaveRunSummaryMissingSkillBlocker(blocker model.ReasonCode) bool {
 	return blocker.Code == "required_skill_not_ready" &&
 		strings.HasPrefix(strings.TrimSpace(blocker.Detail), SkillWaveOrchestration+":run_summary_missing")
 }
 
-func wavePreviewHasSpecificTaskEvidenceBlockers(blockers []model.ReasonCode) bool {
+func missingTaskEvidencePreviewDetail(blockers []model.ReasonCode) (string, bool) {
+	for _, blocker := range blockers {
+		if blocker.Code != "missing_task_evidence_for_run_summary" {
+			continue
+		}
+		detail := strings.TrimSpace(blocker.Detail)
+		if detail == "" {
+			continue
+		}
+		return detail, true
+	}
+	return "", false
+}
+
+func wavePreviewHasReplacementBlockers(blockers []model.ReasonCode) bool {
 	for _, blocker := range blockers {
 		if blocker.Code == "missing_task_evidence_for_run_summary" {
 			continue

--- a/internal/engine/progression/wave_sync.go
+++ b/internal/engine/progression/wave_sync.go
@@ -66,8 +66,18 @@ func (e TaskEvidenceRunVersionMismatchError) Error() string {
 	return fmt.Sprintf("run_summary_version mismatch: expected=%d got=%d", e.Expected, e.Got)
 }
 
+// PreviewGovernedWaveExecution reports the same blockers as wave execution sync
+// without materializing execution summaries or mutating task checkboxes.
+func PreviewGovernedWaveExecution(root string, change model.Change) (WaveSyncResult, error) {
+	return evaluateGovernedWaveExecution(root, change, false)
+}
+
 // SyncGovernedWaveExecution synchronizes wave execution state for a governed change.
 func SyncGovernedWaveExecution(root string, change model.Change) (WaveSyncResult, error) {
+	return evaluateGovernedWaveExecution(root, change, true)
+}
+
+func evaluateGovernedWaveExecution(root string, change model.Change, mutate bool) (WaveSyncResult, error) {
 	record, found, err := LatestPassingWaveEvidence(root, change.Slug)
 	if err != nil {
 		return WaveSyncResult{}, err
@@ -118,10 +128,6 @@ func SyncGovernedWaveExecution(root string, change model.Change) (WaveSyncResult
 		return WaveSyncResult{}, err
 	}
 	previousTasksPlanHash := strings.TrimSpace(wavePlan.TasksPlanHash)
-	existingSummary, err := state.LoadOptionalExecutionSummary(root, change.Slug)
-	if err != nil {
-		return WaveSyncResult{}, err
-	}
 	planDriftBlockers := tasksPlanChangedSinceTaskEvidenceBlockers(previousTasksPlanHash, tasks, tasksPlanHash)
 	planDriftBlockers = append(planDriftBlockers, taskEvidencePlanHashBlockers(previousTasksPlanHash, tasks)...)
 	executionSummary := BuildExecutionSummary(record.RunVersion, tasks, record.Timestamp, &record)
@@ -133,6 +139,18 @@ func SyncGovernedWaveExecution(root string, change model.Change) (WaveSyncResult
 	if len(parseIssues) > 0 || len(planDriftBlockers) > 0 {
 		executionSummary.OpenBlockers = model.NormalizeReasonCodes(append(executionSummary.OpenBlockers, model.ReasonCodesFromSpecs(append(parseIssues, planDriftBlockers...))...))
 		executionSummary.SyncDerivedFields()
+	}
+	if !mutate {
+		runs := executionSummary.TaskRunMap()
+		blockers := model.ReasonCodesFromSpecs(parseIssues)
+		blockers = append(blockers, model.ReasonCodesFromSpecs(planDriftBlockers)...)
+		blockers = append(blockers, CollectNonPassTaskBlockers(runs)...)
+		return WaveSyncResult{Blockers: model.NormalizeReasonCodes(blockers)}, nil
+	}
+
+	existingSummary, err := state.LoadOptionalExecutionSummary(root, change.Slug)
+	if err != nil {
+		return WaveSyncResult{}, err
 	}
 	existingWaveRuns, err := state.LoadOptionalWaveRuns(root, change.Slug, record.RunVersion)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Add a non-mutating wave execution preview so read-only S2 readiness can reuse execution-path task evidence blockers.
- Replace misleading `wave-orchestration:run_summary_missing` only when present task evidence has a more specific stale/plan-drift/non-pass blocker.
- Add command-surface regression coverage for `next --json --diagnostics`, `validate --json`, and `status --json`, including the absent task-evidence compatibility path.
- Archive the governed change artifacts for #72 after closeout.

## Review follow-up
- Renamed the internal preview helper to `wavePreviewHasReplacementBlockers` so the name matches the actual "replace run_summary_missing" predicate.
- Kept the empty-detail fallback in the missing-evidence enrichment path as defensive handling; current production evidence details are always populated.

## Verification
- `go test -count=1 ./cmd -run TestNextS6GovernedBlocksWithoutTaskEvidenceForWaveRunSummary|TestReadOnlyS2DiagnosticsKeepSingleRunSummaryMissingForAbsentTaskEvidence|TestReadOnlyS2DiagnosticsUseTaskEvidenceDriftInsteadOfRunSummaryMissing|TestNextS6GovernedMaterializesExecutionSummaryAndRuntimeSummary`
- `go test -count=1 ./internal/engine/progression -run TestSyncGovernedWaveExecution|TestEvaluateGovernanceReadiness`
- `go test -count=1 ./...`
- `go vet ./internal/engine/progression/... ./cmd/...`
- `go build ./...`
- `git diff --check origin/main`
- After closeout, `go run . validate --json --change fix-issue-72-align-read-only-s2-task-evidence-diagnostics-wi` correctly returns `archived_change_not_validatable`; archived evidence records the pre-closeout active validation and current branch-level proof.

Closes #72