### PR TITLE
fix(governance): harden Open Questions detection against continuations and resolution markers

### DIFF
--- a/internal/stringutil/html.go
+++ b/internal/stringutil/html.go
@@ -1,6 +1,9 @@
 package stringutil
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
 
 // StripHTMLComments removes <!-- ... --> blocks from the string.
 func StripHTMLComments(s string) string {
@@ -62,17 +65,27 @@ func LastMarkdownSectionContent(content, heading string) string {
 }
 
 // HasBlockingOpenQuestions reports whether the canonical Open Questions section
-// contains unresolved content. A resolved checklist entry, an empty/comment-only
-// section, or an explicit none marker is documentation, not an intake blocker.
+// contains unresolved content. Documentation is not an intake blocker: a resolved
+// checklist entry (`- [x]`), an indented continuation of a list item, an explicit
+// none marker, or a line carrying a RESOLVED/ANSWERED marker all read as resolved.
+// Only an explicitly unchecked checklist item (`- [ ]`) or an unmarked bare entry
+// blocks. Continuations and resolution markers keep a wrapped or prose-documented
+// answer from reading as a fresh question.
 func HasBlockingOpenQuestions(content string) bool {
 	section := LastMarkdownSectionContent(content, "## Open Questions")
 	if section == "" {
 		return false
 	}
-	lines := strings.Split(section, "\n")
-	for _, line := range lines {
+	for _, line := range strings.Split(section, "\n") {
 		trimmed := strings.TrimSpace(line)
 		if trimmed == "" {
+			continue
+		}
+		// An indented line that does not itself start a list item is a
+		// continuation of the previous entry; it inherits that entry's state and
+		// never blocks on its own. This lets a resolved `- [x]` item wrap across
+		// lines without the wrapped text reading as a new question.
+		if isOpenQuestionContinuation(line, trimmed) {
 			continue
 		}
 		lowerTrimmed := strings.ToLower(trimmed)
@@ -85,9 +98,35 @@ func HasBlockingOpenQuestions(content string) bool {
 		if isExplicitNoneMarker(trimmed) {
 			continue
 		}
+		if hasResolvedMarker(trimmed) {
+			continue
+		}
 		return true
 	}
 	return false
+}
+
+// isOpenQuestionContinuation reports whether raw is an indented continuation of
+// the previous list item rather than a new top-level entry. An indented line that
+// itself starts a list marker is treated as its own (nested) entry, so a nested
+// `- [ ]` still blocks.
+func isOpenQuestionContinuation(raw, trimmed string) bool {
+	if raw == trimmed {
+		return false // no leading indentation: a top-level line
+	}
+	if strings.HasPrefix(trimmed, "- ") || strings.HasPrefix(trimmed, "* ") {
+		return false // an indented list item is its own entry, not a continuation
+	}
+	return true
+}
+
+var resolvedMarkerPattern = regexp.MustCompile(`(?i)\b(resolved|answered)\b`)
+
+// hasResolvedMarker reports whether a line carries an explicit resolution marker
+// (RESOLVED or ANSWERED, case-insensitive, on a word boundary so "unresolved"
+// does not match). Such a line documents an answered question.
+func hasResolvedMarker(line string) bool {
+	return resolvedMarkerPattern.MatchString(line)
 }
 
 func isExplicitNoneMarker(line string) bool {

--- a/internal/stringutil/html_test.go
+++ b/internal/stringutil/html_test.go
@@ -125,6 +125,52 @@ Copied source.
 `,
 			want: false,
 		},
+		{
+			name: "resolved checklist wraps across lines",
+			content: `## Open Questions
+- [x] Part C mechanism — RESOLVED: Option A keeps the change to SKILL.md prose
+  only, anchored on the existing task_kind=test->code + depends_on model, so
+  no parser or hash change is needed.
+`,
+			want: false,
+		},
+		{
+			name: "uppercase RESOLVED prose is documentation",
+			content: `## Open Questions
+All intake questions RESOLVED during research; see research.md.
+`,
+			want: false,
+		},
+		{
+			name: "lowercase resolved prose is documentation",
+			content: `## Open Questions
+Domain classification resolved: verification.
+`,
+			want: false,
+		},
+		{
+			name: "unresolved prose still blocks",
+			content: `## Open Questions
+Adapter layout is still unresolved.
+`,
+			want: true,
+		},
+		{
+			name: "nested unchecked checklist still blocks",
+			content: `## Open Questions
+- [x] Parent question — RESOLVED.
+  - [ ] Nested follow-up still open.
+`,
+			want: true,
+		},
+		{
+			name: "resolved checklist continuation with question mark does not block",
+			content: `## Open Questions
+- [x] Which host emits the hint — RESOLVED: wave-orchestration only. Why not
+  tdd-governance? Because it is ExportOnlyExtra and never a next-skill.
+`,
+			want: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Problem

`HasBlockingOpenQuestions` (`internal/stringutil/html.go`) backs the
`traceability_coherence` health check (and intake research routing). It treated
**any** line in the `## Open Questions` section that wasn't a single-line
`- [x]` item or an explicit none marker as a blocker.

That misfires on two natural, correct ways to document resolved questions:

1. **Multi-line `- [x]` items** — an indented continuation line read as a fresh
   unresolved line.
2. **Resolved prose** — a line like `... RESOLVED: ...` read as unresolved.

Result: a false `traceability_coherence: FAIL` whenever a resolved answer
wrapped across lines or was written as prose, forcing authors to collapse
everything into single-line `- [x]` entries.

## Fix

Keep the fail-closed intent — an unchecked `- [ ]` (including nested) and an
unmarked bare entry still block — but stop misreading documentation:

- An **indented non-list line** is a continuation that inherits the current
  item's state (never independently blocking).
- A line carrying a **RESOLVED / ANSWERED** marker (case-insensitive,
  word-boundary so `unresolved` does not match) is treated as resolved.

| Open Questions content | before | after |
|---|---|---|
| `- [x]` single line | pass | pass |
| `- [x]` wrapped across lines | **FAIL** | pass |
| prose `... RESOLVED: ...` | **FAIL** | pass |
| `- [ ]` (incl. nested) | block | block |
| `... still unresolved` | block | block |

## Tests

Added 6 cases to `TestHasBlockingOpenQuestions` (continuation wrap, upper/lower
`resolved` prose, `unresolved` still blocks, nested `- [ ]` blocks, continuation
with a `?` does not block). `go test ./...` and `go build ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)