### PR TITLE
fix(governance): add recovery UX tier-0 restamp

### DIFF
--- a/artifacts/changes/archived/recovery-ux-p0-issue-83-break-the-input-digest-missing-deadl/assurance.md
+++ b/artifacts/changes/archived/recovery-ux-p0-issue-83-break-the-input-digest-missing-deadl/assurance.md
@@ -1,0 +1,98 @@
+# Assurance
+## Project Context
+- Tech Stack: Go
+- Conventions: cmd/* CLI over internal/engine/* kernel; table-driven tests
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Scope Summary
+Recovery UX P0 (issue #83) delivered as one governed change across seven tasks:
+the `input_digest_missing` deadlock is healed by a Tier-0 digest backfill;
+`assurance.md` is decoupled from the plan-audit digest; stale-planning recovery
+prunes the digest entries of the records it deletes; `required_skill_stale` is an
+actionable blocker and the skill-evidence view reports a `stale` status for
+digest drift on both paths; a minimal `slipway evidence restamp --skill X
+[--dry-run]` exposes a Tier-0 restamp and refuses unavailable digest inputs even
+in dry-run mode; and `repair` routes governance-skill digest drift at
+`slipway evidence restamp`. Changes are confined to
+`internal/engine/progression/{evidence_digests,advance_governed}.go` and
+`cmd/{next_skill_view,evidence,repair}.go` plus their tests. Tier-2 attested
+restamp, the view-level recovery object, the `slipway recover` planner, and the
+blocker-parser vocabulary remain out of scope (deferred to #84/#85/#86).
+
+## Verification Verdict
+`go build ./...` and `go test ./...` both pass (exit 0). Test-first (RED→GREEN)
+was applied to the assurance decouple and the deadlock heal: the tests that
+locked the old/destructive contract were converted to the new contract and
+failed against the unchanged engine before the fix, then passed after. New
+characterization tests cover the late-`assurance.md`-edit non-staleness, the
+recovery digest-prune, the `stale` evidence status, the repair routing, and the
+`evidence restamp` eligible/refused/unavailable paths.
+
+## Evidence Index
+- `verification/intake-clarification.yaml` (pass)
+- `verification/research-orchestration.yaml` (pass)
+- `verification/plan-audit.yaml` (pass)
+- `verification/wave-orchestration.yaml` (pass, run_version=1)
+- `evidence/tasks/t-01.json … t-05.json` (run_version=1, verdict=pass)
+- `go build ./...` exit 0; `go test ./...` exit 0
+- Source: `internal/engine/progression/evidence_digests.go`,
+  `internal/engine/progression/advance_governed.go`,
+  `cmd/next_skill_view.go`, `cmd/repair.go`, `cmd/evidence.go`
+
+## Requirement Coverage
+- REQ-001 (Tier-0 backfill heals deadlock) — t-01;
+  `evidence_digests.go` (both paths) + `evidence_digests_test.go`
+  (`TestFeatureActiveMissingDigestEntryBackfillsWhenInputsUnchanged`,
+  `TestStampPassingSkillDigestsBackfillsFeatureActiveMissingResearchDigestWhenUnchanged`).
+- REQ-002 (assurance.md decoupled) — t-01;
+  `addPlanningArtifactInputs` + `TestPlanAuditInputDigestExcludesAssuranceAndIncludesSemanticTasks`,
+  `TestLateAssuranceEditDoesNotStalePlanAuditAtS1`.
+- REQ-003 (recovery prunes digests) — t-02;
+  `beginStalePlanningRecovery` + recovery integration test digest-prune assertions.
+- REQ-004 (required_skill_stale actionable) — t-03;
+  `isRequiredSkillBlocker` + `TestRequiredSkillStaleIsActionableAndSetExtractsSkillNames`.
+- REQ-005 (stale evidence status both paths) — t-03;
+  `buildRequiredSkillEvidence` + `TestBuildRequiredSkillEvidenceMarksDigestDriftedSkillStale`.
+- REQ-006 (evidence restamp Tier-0) — t-01 engine + t-05 cmd;
+  `RestampEvidenceDigestTier0` + `TestEvidenceRestampTier0EligibleDryRunThenApply`,
+  `TestEvidenceRestampTier0RefusesInputsChangedAfterVerdict`,
+  `TestEvidenceRestampTier0DryRunRefusesUnavailableInputs`,
+  `TestEvidenceRestampRequiresSkill`.
+- REQ-007 (repair routes digest drift) — t-04;
+  `buildGovernanceDigestDriftFindings`/`repairDriftNextAction` +
+  `TestRepairRoutesStaleGovernanceDigestToEvidenceRestamp`.
+
+## Residual Risks and Exceptions
+- Tier-0 over-trust is bounded: backfill/restamp occur only when the verdict is
+  passing and the certified inputs did not change after the verdict (the existing
+  conservative `digestInputsChangedAfterVerdict` predicate); judgment-affecting
+  drift still reports stale with the specific changed inputs.
+- No compatibility shim is provided for prior plan-audit digest input sets. If an
+  existing stored digest still contains the old `assurance.md` key, it follows
+  the normal stale/re-certification path.
+- `evidence restamp` uses mtime-based input-change detection, so an input whose
+  mtime moved with identical content is conservatively refused (re-run the skill).
+- `evidence restamp --dry-run` now preflights digest-input availability, so it
+  refuses with `input_digest_unavailable` instead of promising eligibility when
+  the eventual stamp could not compute inputs.
+- No guardrail-domain surface is touched; the fail-closed
+  `domain_review`/`rollback_required` policy is unchanged. No Tier-2 surface.
+
+## Rollback Readiness
+Reverting the change restores prior behavior cleanly: all edits are additive or
+localized, with no durable artifact-shape change (`change.yaml`,
+`verification/*.yaml`, `evidence-digests.yaml` are unchanged in shape) and no data
+migration. After a revert, an in-flight plan-audit digest stamped without
+`assurance.md` simply re-includes it on the next run. Rollback unit: revert the
+single PR that closes #83.
+
+## Archive Decision
+Approve for finalization at done-ready. Active `slipway validate --json` at
+S4_VERIFY reports `G_plan`, `G_scope`, and `G_ship` approved with no blockers and
+`evidence_freshness: fresh`; `slipway run --json --diagnostics` then advanced
+with `action=done_ready`. Fresh ship-gate proof was captured before any finalize,
+not reconstructed from an archived bundle. `slipway done` is intentionally
+deferred to the operator: this bundle reaches done-ready and is NOT yet archived.
+Archive only via an explicit `slipway done` after operator review.

--- a/artifacts/changes/archived/recovery-ux-p0-issue-83-break-the-input-digest-missing-deadl/change.yaml
+++ b/artifacts/changes/archived/recovery-ux-p0-issue-83-break-the-input-digest-missing-deadl/change.yaml
@@ -1,0 +1,57 @@
+version: 1
+slug: recovery-ux-p0-issue-83-break-the-input-digest-missing-deadl
+description: 'Recovery UX P0 (issue #83): break the input_digest_missing deadlock via Tier-0 digest backfill, prune digest entries on stale-planning recovery, decouple assurance.md from the plan-audit digest, surface required_skill_stale as an actionable blocker with a stale evidence status, add a minimal Tier-0 evidence restamp --dry-run, and route repair at the recovery path'
+status: done
+current_state: DONE
+needs_discovery: true
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-06-05T09:14:22.413654Z
+quality_mode: standard
+workflow_preset: standard
+worktree_branch: feat/recovery-ux-p0-issue-83-break-the-input-digest-missing-deadl
+artifact_schema: expanded
+project_context:
+    tech_stack: Go
+    test_cmd: go test ./...
+    build_cmd: go build ./...
+    languages:
+        - Go
+    recent_work: '71f3521 feat(skills): generalized test-design + language-aware capability routing; 31e9bda fix(governance): harden Open Questions detection'
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: 42bbc8a6681acab71c1d462ad8f6e007771c6be571ded3479386c9282e407cdc
+        updated_at: 2026-06-05T12:06:56.111630375Z
+    decision:
+        id: decision
+        path: decision.md
+        state: frozen
+        content_hash: 8225c95b07497539efbe388936fc382ac016be81dfd5b179814a1d826888edf2
+        updated_at: 2026-06-05T11:58:48.544187211Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: 4c28f02dbdf66599a87f190b67db2c099d85f6b3eee9bbf02ee005bbeaa7a0ab
+        updated_at: 2026-06-05T11:58:58.898119107Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: 0652b6e4ca902f3d38187d9fa7d8f085569f921d4be80f848c7280bea40cc670
+        updated_at: 2026-06-05T11:58:31.226620364Z
+    research:
+        id: research
+        path: research.md
+        state: frozen
+        content_hash: 1bb25ca8b5812727cd5c56adcbf08f5553b8e0f5a8a7d9985f0403257b15b9d3
+        updated_at: 2026-06-05T11:59:09.316759192Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: 9a2de9fc7281ab397a4dabb11a713c039adac209d9da30f78abb9d85e7053be4
+        updated_at: 2026-06-05T11:58:39.422165868Z

--- a/artifacts/changes/archived/recovery-ux-p0-issue-83-break-the-input-digest-missing-deadl/decision.md
+++ b/artifacts/changes/archived/recovery-ux-p0-issue-83-break-the-input-digest-missing-deadl/decision.md
@@ -1,0 +1,104 @@
+# Decision
+
+## Project Context
+- Tech Stack: Go
+- Conventions: cmd/* CLI layer (cobra) over internal/engine/* kernel; typed CLI errors; table-driven tests
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Alternatives Considered
+Three approaches were evaluated in `research.md`:
+- **A. RFC-faithful** — Tier-0 logic lives in the engine (reuses the canonical
+  `digestInputsChangedAfterVerdict`); `evidence restamp` wraps a new exported
+  engine Tier-0 function; the `stale` view status is derived from `view.Blockers`;
+  digest prune via one helper that removes a verification record and its digest
+  entry together; repair routing kept minimal.
+- **B. cmd-inline Tier-0** — re-implements the Tier-0 safety check in
+  `cmd/evidence.go`. Rejected: duplicates digest semantics outside the engine and
+  can drift from the canonical check (violates single-source-of-truth).
+- **C. A + full repair detector** — adds a complete governance-skill
+  digest-staleness scanner to `repair`. Deferred: overlaps P1's recovery surface
+  (#84) and pulls phase scope forward.
+
+## Selected Approach
+**A — RFC-faithful.** Confirmed by the user at research handoff (2026-06-05).
+
+Engine (`internal/engine/progression`):
+1. Unify the `digestInputsChangedAfterVerdict` safety check across **both**
+   deadlock paths — `skillDigestFreshnessBlockersWithSummary` (read) and
+   `stampPassingSkillDigests` (stamp) — so a recorded orphan with inputs unchanged
+   after the verdict is backfilled, and a genuinely drifted one reports the
+   specific `required_skill_stale:<skill>:<input>` instead of the generic
+   `input_digest_missing` token.
+2. Remove `assurance.md` from `addPlanningArtifactInputs` (plan-audit digest);
+   it remains a `final-closeout` digest input. No compatibility shim is added for
+   stored digests from the previous input set; if such a stored digest is present,
+   the normal stale/re-certification path applies.
+3. Add a single helper that deletes a verification record **and** its
+   `evidence-digests.yaml` entry together, used by `beginStalePlanningRecovery`
+   for the five skills it clears (plan-audit + spec/code reviews +
+   goal-verification + final-closeout); wave-orchestration's record and digest are
+   preserved.
+4. Add an exported `RestampEvidenceDigestTier0(root, change, skill, dryRun)` that
+   stamps only when the verdict is passing, the certified input set is
+   computable, and inputs are unchanged after the verdict; otherwise it refuses
+   and names the skill to re-run. Reuses `digestInputsChangedAfterVerdict` +
+   `stampEvidenceDigestForSkill`, with an explicit input-availability preflight
+   so `--dry-run` cannot over-report eligibility.
+
+CLI (`cmd`):
+5. Add `required_skill_stale` to `isRequiredSkillBlocker` so a stale skill routes
+   as the actionable next skill.
+6. Report the `stale` evidence status on both `buildRequiredSkillEvidence` paths,
+   derived from the `required_skill_stale` entries already in `view.Blockers`.
+7. Add `slipway evidence restamp --skill X [--dry-run]` over
+   `RestampEvidenceDigestTier0`.
+8. Route `repair` planning/digest drift at `slipway evidence restamp --dry-run`
+   (digest-aware next action; state that repair does not mutate engine-owned
+   digests), keeping the breadth for P1.
+
+## Interfaces and Data Flow
+- New engine API: `progression.RestampEvidenceDigestTier0(root string, change
+  model.Change, skillName string, dryRun bool) (EvidenceRestampOutcome, error)`;
+  `EvidenceRestampOutcome{Skill, Eligible, Stamped, DryRun, Reason, ChangedInputs,
+  RerunSkill}`. Pure over `digestInputsChangedAfterVerdict` +
+  `stampEvidenceDigestForSkill`; no new hashing.
+- New prune helper (unexported) within `progression`:
+  removes `verification/<skill>.yaml` and the matching `evidence-digests.yaml`
+  entry atomically; invoked by `beginStalePlanningRecovery`.
+- Data flow unchanged at the boundaries: `cmd/next.go` →
+  `EvaluateGovernanceReadiness` → `evaluateRequiredSkills` →
+  `skillDigestFreshnessBlockers`. The view reads `view.Blockers` (already
+  populated) to derive `stale`. `cmd/evidence restamp` → engine wrapper →
+  `evidence-digests.yaml`.
+- Durable artifact shapes (`change.yaml`, `verification/*.yaml`,
+  `evidence-digests.yaml`) are unchanged; the `stale` status value and
+  `evidence restamp` subcommand are additive.
+
+## Rollout and Rollback
+- Rollout: single PR closing #83; test-first for the decouple and the deadlock
+  heal (red → green), then the remaining tasks. `go build ./...` + `go test ./...`
+  green before finalize. Governed via Slipway (dogfood).
+- Rollback: revert the PR. No data migration; no persisted-state shape change, so
+  reverting restores prior behavior cleanly. In-flight changes that restamped a
+  plan-audit digest without `assurance.md` simply re-include it on the next run
+  after a revert.
+
+## Risk
+- **Tier-0 over-trust** (high impact if wrong): strictly gated on
+  `digestInputsChangedAfterVerdict` empty + verdict passing; never fabricates a
+  pass. Covered by deadlock heal/drift tests.
+- **Decouple audit gap** (low): verified none — assurance is enforced by
+  `AssuranceContractBlockers` at S3/S4, independent of the plan-audit digest.
+- **No compatibility shim for prior plan-audit input sets** (accepted): stored
+  digests that still contain the old `assurance.md` key are not specially
+  interpreted. Operators re-run or restamp the affected governance skill through
+  the standard stale-evidence path.
+- **Dry-run over-eligibility** (medium): `evidence restamp --dry-run` must not
+  claim Tier-0 eligibility when digest inputs are unavailable. The engine now
+  checks input availability before the mtime/verdict comparison.
+- **Prune over-reach** (medium): prune only the records recovery deletes;
+  wave-orchestration preserved. Covered by the recovery prune test.
+- **Phase creep** (low): repair routing kept minimal; the full recovery surface
+  stays in P1/#84.

--- a/artifacts/changes/archived/recovery-ux-p0-issue-83-break-the-input-digest-missing-deadl/intent.md
+++ b/artifacts/changes/archived/recovery-ux-p0-issue-83-break-the-input-digest-missing-deadl/intent.md
@@ -1,0 +1,145 @@
+# Intent
+
+## Project Context
+<!-- Auto-filled by InferProjectContext(); .slipway.yaml overrides -->
+- Tech Stack: Go
+- Languages: Go
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Conventions: standard Go; table-driven tests; cmd/* CLI layer over internal/engine/* kernel
+
+## Summary
+Recovery UX P0 (issue #83): break the input_digest_missing deadlock via Tier-0 digest backfill, prune digest entries on stale-planning recovery, decouple assurance.md from the plan-audit digest, surface required_skill_stale as an actionable blocker with a stale evidence status, add a minimal Tier-0 evidence restamp --dry-run, and route repair at the recovery path
+
+## Complexity Assessment
+complex
+<!-- Rationale: -->
+Multi-step, coordination-heavy across 6+ source files (engine progression +
+cmd layer) plus test contract rewrites. Touches governance trust semantics
+(digest staleness), so each change must preserve invariants. Not `critical`
+because P0 is deliberately scoped to provably-safe changes (no new trust
+surface; Tier-2 attested bypass is excluded).
+
+## Guardrail Domains
+<!-- none detected -->
+None (`""`). Confirmed at intake: the durable on-disk artifacts (`change.yaml`,
+`verification/*.yaml`, `evidence-digests.yaml`) do not change shape, so this is
+not an external-contract break. The new `stale` evidence-status value and the
+`evidence restamp` subcommand are clean additions. No durable artifact schema
+changes and no compatibility shim for prior digest input sets.
+
+## In Scope
+Implements the seven P0 tasks from issue #83 (Recovery UX phase P0):
+
+1. **Tier-0 backfill** — `internal/engine/progression/evidence_digests.go`,
+   `stampPassingSkillDigests`: replace the unconditional skip in the
+   `existingDigests != nil` branch (~:262-266) with the same
+   `changedAfterVerdict` safety check used in the `== nil` branch; auto-backfill
+   a digest when the verdict is still passing and inputs did not change after the
+   verdict; report stale only when they genuinely did.
+2. **Decouple assurance.md ↔ plan-audit digest** — same file, remove
+   `assurance.md` from `addPlanningArtifactInputs` (~:458); it remains a
+   legitimate final-closeout digest input (~:668). Existing stored digests from
+   the previous input set are handled by the normal stale/re-certification path,
+   not by compatibility filtering. Test-first.
+3. **Prune digests on stale-planning recovery** —
+   `internal/engine/progression/advance_governed.go`,
+   `beginStalePlanningRecovery` (~:459-556): when it deletes
+   `verification/<skill>.yaml`, prune the matching `evidence-digests.yaml`
+   entries via a single helper that removes a verification record and its digest
+   entry together (invariant: a digest entry never outlives its record).
+4. **`required_skill_stale` actionable** — `cmd/next_skill_view.go`,
+   `isRequiredSkillBlocker` (~:443): include `required_skill_stale` so the stale
+   skill is surfaced/routed as the actionable next skill.
+5. **`stale` evidence status** — `cmd/next_skill_view.go`: report `stale` for
+   digest drift on both the precomputed path (~:504-510, currently only
+   `missing`/`passing`) and the non-precomputed path (~:534-537, currently
+   `stale` only for run-version mismatch).
+6. **Minimal `slipway evidence restamp --skill X [--dry-run]`** — new subcommand
+   in `cmd/evidence.go` wrapping `progression.StampEvidenceDigestForSkill`
+   (~:89), Tier-0 only: stamp when verdict passing + inputs unchanged after
+   verdict; otherwise refuse and state why and which skill to re-run, including
+   dry-run refusal when the certified input set is unavailable.
+7. **`repair` routes to recovery** — `cmd/repair.go` (~:587-599): on
+   planning/digest drift, point at `slipway evidence restamp --dry-run` and
+   state the non-repairable root cause + why repair does not auto-handle it.
+
+Test work: convert `internal/engine/progression/evidence_digests_test.go`
+(~:540-619), `cmd/repair_test.go` (~:1051), and `cmd/lifecycle_commands_test.go`
+(~:965) from locking the old/destructive semantics to asserting the new
+contract; add a new characterization test proving a late `assurance.md` edit
+does not stale the plan-audit digest or produce plan-audit blockers at S1.
+
+## Out of Scope
+- Tier-2 operator-attested restamp (`recover --restamp --attest`) → P2 (#85).
+- View-level `recovery` object and compact-handoff recovery plan → P1 (#84).
+- `internal/engine/recovery` planner, `slipway recover`, `--from-artifact`
+  dependency index → P2 (#85).
+- Blocker parser + remediation vocabulary table → P1 (#84).
+- P3 narrow lifecycle gaps (worktree rebind, dual-active naming, abort→repair,
+  S2 scope guidance, full docs refresh) → #86.
+
+## Constraints
+- Preserve governance invariants: never silently forge a pass (Tier-0 only when
+  the verdict provably still holds); digests still detect judgment-affecting
+  drift; a digest entry never outlives its verification record; recovery is
+  idempotent.
+- Test-first (red → green) for the assurance.md decoupling and the deadlock fix.
+- Go; `go build ./...` and `go test ./...` must stay green.
+- Reuse existing engine machinery (`StampEvidenceDigestForSkill`, the existing
+  `changedAfterVerdict`/refresh-after-stored predicate); do not re-implement
+  digest hashing.
+
+## Acceptance Signals
+- A late `assurance.md` edit at S4 no longer triggers a plan-audit reopen; only
+  final-closeout goes stale (recoverable by re-running that one skill). [test]
+- An `input_digest_missing` orphan with a passing verdict and unchanged inputs
+  is auto-backfilled by `slipway run` — no internal Go helper required. [test]
+- `stale planning recovery` leaves no zombie digest entries (digest pruned
+  alongside the deleted verification record). [test]
+- `next`/`validate` route a `required_skill_stale` blocker to the actual skill
+  and show `stale` (not `missing`/`passing`). [test]
+- `slipway evidence restamp --skill X --dry-run` explains a Tier-0 refusal with
+  the next skill to re-run, including unavailable digest inputs. [test]
+- `go build ./...` and `go test ./...` pass.
+
+## Open Questions
+- [x] RFC line references and digest behavior verified at main during research (see research.md Unknowns).
+- [x] AssuranceContractBlockers returns nil before S3_REVIEW, so decoupling assurance.md from the plan-audit digest opens no audit gap.
+- [x] Digest-semantics callers and tests enumerated: two input_digest_missing emit sites, plus the assurance-coupling and deadlock tests.
+- [x] Existing fail-closed guardrail policy is untouched; no Tier-2 surface introduced.
+
+## Deferred Ideas
+<!-- Identified but postponed ideas -->
+- P1/P2/P3 follow-ups tracked in #84/#85/#86.
+
+## Approved Summary
+<!-- User-confirmed final summary + confirmation timestamp -->
+Deliver all seven P0 tasks from issue #83 as one governed change (test-first):
+(1) Tier-0 digest backfill to break the `input_digest_missing` deadlock when the
+verdict is still passing and inputs are unchanged after the verdict; (2) decouple
+`assurance.md` from the plan-audit digest so a late closeout edit no longer
+retroactively reopens S1; (3) prune `evidence-digests.yaml` entries whenever
+stale-planning recovery deletes a verification record (digest never outlives its
+record); (4) make `required_skill_stale` an actionable blocker; (5) report a
+`stale` evidence status for digest drift on both view paths; (6) add a minimal
+Tier-0 `slipway evidence restamp --skill X [--dry-run]` that stamps only when
+provably safe and otherwise refuses with the next skill to re-run; (7) route
+`repair` at the recovery surface for planning/digest drift.
+
+Scope boundaries: **in** — the seven tasks above plus their test-contract
+rewrites, in `internal/engine/progression/*` and `cmd/*`. **Out** — Tier-2
+attested restamp, the view-level `recovery` object, the `slipway recover`
+planner/`--from-artifact`, and the blocker-parser/remediation vocabulary (all
+deferred to #84/#85/#86).
+
+Guardrail domain: none (durable artifacts unchanged; clean additive surface; no
+compatibility shim for prior digest input sets).
+
+Primary acceptance signal: a late `assurance.md` edit at S4 no longer triggers a
+plan-audit reopen (only final-closeout goes stale), and an `input_digest_missing`
+orphan with a passing verdict + unchanged inputs is auto-backfilled by
+`slipway run` with no internal Go helper — both proven by tests, with
+`go build ./...` and `go test ./...` green.
+
+Confirmed by user: 2026-06-05T09:19:47Z

--- a/artifacts/changes/archived/recovery-ux-p0-issue-83-break-the-input-digest-missing-deadl/requirements.md
+++ b/artifacts/changes/archived/recovery-ux-p0-issue-83-break-the-input-digest-missing-deadl/requirements.md
@@ -1,0 +1,110 @@
+# Requirements
+## Project Context
+- Tech Stack: Go
+- Conventions: cmd/* CLI over internal/engine/* kernel; table-driven tests
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Requirements
+
+### Requirement: Tier-0 backfill heals the input_digest_missing deadlock
+REQ-001: When a governance skill has a recorded passing verdict but no
+`evidence-digests.yaml` entry, mutating advancement MUST backfill the digest when
+the certified inputs did not change after the verdict, and MUST report the
+specific `required_skill_stale:<skill>:<input>` only when an input genuinely
+changed after the verdict — never the generic `input_digest_missing` deadlock
+token. This MUST hold whether or not a digest file already exists for other
+skills.
+
+#### Scenario: Orphan with unchanged inputs is backfilled
+GIVEN a passing skill verdict, a `skill.evidence_recorded` event, no digest entry
+for that skill, and inputs whose mtime is at or before the verdict timestamp
+WHEN `slipway run` performs mutating advancement
+THEN the skill's digest is stamped (backfilled) and no `required_skill_stale`
+blocker is produced for it.
+
+#### Scenario: Orphan with drifted inputs reports the specific stale input
+GIVEN the same orphan but an input whose mtime is after the verdict timestamp
+WHEN required-skill evidence is evaluated
+THEN a `required_skill_stale:<skill>:<changed-input>` blocker is produced and the
+generic `input_digest_missing` token is not.
+
+### Requirement: assurance.md is decoupled from the plan-audit digest
+REQ-002: The plan-audit input digest MUST NOT include `assurance.md`, so a late
+edit to `assurance.md` does not retroactively stale plan-audit or trigger a
+stale-planning reopen. `assurance.md` MUST remain an input to the final-closeout
+digest.
+
+#### Scenario: Late assurance.md edit does not stale plan-audit
+GIVEN a change with a passing plan-audit verdict at S1
+WHEN `assurance.md` is created or edited
+THEN the plan-audit input digest is unchanged and no
+`required_skill_stale:plan-audit:assurance.md` blocker is produced.
+
+### Requirement: Stale-planning recovery prunes digest entries
+REQ-003: When stale-planning recovery deletes a skill's `verification/<skill>.yaml`
+record, it MUST also remove that skill's `evidence-digests.yaml` entry, so a
+digest entry never outlives its verification record. Records that recovery
+preserves (e.g. wave-orchestration) MUST keep their digest entries.
+
+#### Scenario: Cleared skills leave no zombie digests
+GIVEN a change at S3/S4 with digests stamped for plan-audit, the reviews,
+goal-verification, final-closeout, and wave-orchestration
+WHEN stale-planning recovery reopens S1_PLAN/audit
+THEN the digest entries for the five cleared skills are removed while the
+wave-orchestration digest entry remains.
+
+### Requirement: required_skill_stale is an actionable blocker
+REQ-004: A `required_skill_stale` blocker MUST be treated as a required-skill
+blocker so the stale skill is routed/surfaced as the actionable next skill.
+
+#### Scenario: next routes a stale skill
+GIVEN a `required_skill_stale:<skill>:<input>` blocker for a non-display skill
+WHEN the next-skill view resolves the actionable skill
+THEN it routes to `<skill>`.
+
+### Requirement: Evidence view reports a stale status for digest drift
+REQ-005: The required-skill evidence view MUST report `stale` (not `missing` or
+`passing`) for a skill with a `required_skill_stale` digest blocker, on both the
+precomputed and non-precomputed evidence paths.
+
+#### Scenario: Digest drift shows stale on both paths
+GIVEN a required skill with a `required_skill_stale` blocker in `view.Blockers`
+WHEN the skill-evidence entries are built (precomputed or non-precomputed)
+THEN that skill's status is `stale`.
+
+### Requirement: Minimal Tier-0 evidence restamp command
+REQ-006: `slipway evidence restamp --skill X [--dry-run]` MUST stamp the skill's
+engine-owned digest only when the verdict is passing and inputs did not change
+after the verdict; otherwise it MUST refuse and state why and which skill to
+re-run. `--dry-run` MUST report the eligibility decision without mutating state.
+
+#### Scenario: Eligible restamp
+GIVEN a passing verdict with inputs unchanged after the verdict and a missing
+digest entry
+WHEN `slipway evidence restamp --skill X` runs
+THEN the digest is stamped; with `--dry-run` it reports it would stamp without
+writing.
+
+#### Scenario: Refused restamp names the skill to re-run
+GIVEN inputs changed after the verdict (or a non-passing/absent verdict)
+WHEN `slipway evidence restamp --skill X` runs
+THEN it refuses, states the reason, and names the host skill to re-run.
+
+#### Scenario: Dry-run refuses unavailable digest inputs
+GIVEN a passing verdict whose certified input set cannot be computed
+WHEN `slipway evidence restamp --skill X --dry-run` runs
+THEN it reports `eligible=false`, reason `input_digest_unavailable`, and names
+the host skill to re-run without mutating state.
+
+### Requirement: repair routes planning/digest drift at recovery
+REQ-007: When `repair` encounters planning/digest drift it MUST point the
+operator at `slipway evidence restamp --dry-run` and state that repair does not
+mutate engine-owned evidence digests, instead of generic next-action text.
+
+#### Scenario: repair points digest drift at evidence restamp
+GIVEN a planning/digest drift reason
+WHEN repair derives the next action
+THEN the next action references `slipway evidence restamp` and explains repair
+does not mutate engine-owned digests.

--- a/artifacts/changes/archived/recovery-ux-p0-issue-83-break-the-input-digest-missing-deadl/research.md
+++ b/artifacts/changes/archived/recovery-ux-p0-issue-83-break-the-input-digest-missing-deadl/research.md
@@ -1,0 +1,185 @@
+# Research
+
+## Research Findings
+
+### Architecture
+- Affected modules:
+  - `internal/engine/progression/evidence_digests.go` — engine-owned digest
+    stamping + freshness. Two emitters of the deadlock token `input_digest_missing`:
+    the read path `skillDigestFreshnessBlockersWithSummary` (`:163-173`) and the
+    stamp path `stampPassingSkillDigests` (`:262-266`). Both short-circuit on
+    `digests != nil` instead of applying the `digestInputsChangedAfterVerdict`
+    safety check used by the `== nil` branch (`:174-181`).
+  - `internal/engine/progression/advance_governed.go` — `beginStalePlanningRecovery`
+    (`:459-556`) deletes 5 skill verification records (plan-audit + spec/code
+    reviews + goal-verification + final-closeout) and wave-plan/execution-summary,
+    via `removeFileIfExists` (`:558`); it does **not** prune `evidence-digests.yaml`,
+    leaving zombie digests. `stalePlanningRecoveryNeededForPlanAuditDigest`
+    (`:568-592`) triggers reopen only when plan-audit has a
+    `required_skill_stale:plan-audit:` digest blocker.
+  - `internal/engine/progression/evidence.go` — `evaluateRequiredSkills`
+    (`:124-130`) calls `skillDigestFreshnessBlockers` and routes digest drift to
+    `required_skill_stale:<skill>:<input>` blockers (second return), which become
+    `readiness.Blockers`.
+  - `cmd/next_skill_view.go` — `isRequiredSkillBlocker` (`:443`) omits
+    `required_skill_stale`; `buildRequiredSkillEvidence` (`:463`) renders skill
+    `Status` with only `missing`/`passing` on the precomputed path (`:500-514`)
+    and `stale` only for run-version mismatch on the non-precomputed path
+    (`:533-547`). `view.Blockers` already carries the `required_skill_stale`
+    blockers (`cmd/next.go:375`) before this runs (`cmd/next.go:417`).
+  - `cmd/evidence.go` — `makeEvidenceCmd` parent with only the `task` subcommand.
+  - `cmd/repair.go` — `repairDriftNextAction` (`:587-599`) maps a drift reason to
+    a generic next action; repair has no governance-skill digest-staleness
+    detector today.
+- Dependency chain: `cmd/next.go` → `EvaluateGovernanceReadiness` →
+  `evaluateRequiredSkills` → `skillDigestFreshnessBlockers` →
+  `certifiedSkillInputDigest`/`addPlanningArtifactInputs`. `cmd/evidence restamp`
+  will → `progression` Tier-0 wrapper → `stampEvidenceDigestForSkill`.
+- Blast radius: digest staleness semantics (read + stamp), the destructive
+  reopen, the `next` skill-evidence view, and a new additive CLI subcommand. No
+  change to durable artifact shapes (`change.yaml`, `verification/*.yaml`,
+  `evidence-digests.yaml`).
+- Constraints/invariants: never silently forge a pass (Tier-0 only when the
+  verdict provably still holds); digests still detect judgment-affecting drift; a
+  digest entry never outlives its verification record; recovery is idempotent;
+  the view must not re-implement gate decisions (single source of truth).
+
+### Patterns
+- Existing conventions: `cobra` subcommands built by `make*Cmd()`, registered via
+  `cmd.AddCommand`; typed CLI errors via `newInvalidUsageError`/
+  `newStateIntegrityError` with `(code, message, remediation, details)`; table-
+  driven tests with `withWorkspace`/`initTestWorkspace`/temp git repos.
+- Reusable abstractions to leverage (no re-implementation):
+  - `digestInputsChangedAfterVerdict` (`evidence_digests.go:859`) — the canonical
+    "did certified inputs change after the verdict" check. Both deadlock paths and
+    the new restamp wrapper must reuse it.
+  - `StampEvidenceDigestForSkill` (`:89`) / `stampEvidenceDigestForSkill` (`:99`).
+  - `state.LoadOptionalEvidenceDigestsForChange` / `state.SaveEvidenceDigests` for
+    digest prune.
+  - `blockerSkillName` + `model.ReasonCode{Code,Detail}` (split on first `:`,
+    `reason_code.go:235`) to derive the stale skill set from `view.Blockers`.
+- Convention deviations: none required. The `stale` view status is derived from
+  existing blockers so the evidence view cannot diverge from the blocker list.
+
+### Risks
+- Technical risks:
+  - **Tier-0 over-trust (high if wrong)**: backfilling a digest when inputs truly
+    changed would forge a pass. Mitigation: gate strictly on
+    `digestInputsChangedAfterVerdict` returning empty (mtime <= verdict) AND verdict
+    passing; this is the existing conservative semantics, only now applied to the
+    `digests != nil` branch too.
+  - **Decoupling under-coverage (low)**: removing `assurance.md` from the
+    plan-audit digest could open an audit gap only if plan-audit were the assurance
+    authority. It is not — `AssuranceContractBlockers` returns nil before
+    `S3_REVIEW` (`validation.go:482-487`) and plan-audit runs at S1; assurance is
+    enforced at S3/S4 and stays a `final-closeout` digest input
+    (`evidence_digests.go:648-668`). Verified.
+  - **Prune over-reach (medium)**: pruning a digest whose record survives would
+    violate the invariant inversely. Mitigation: prune only for the exact skill
+    records `beginStalePlanningRecovery` deletes; wave-orchestration's record (and
+    digest) is preserved.
+  - **Prior plan-audit input sets (accepted)**: existing changes may already
+    have a stored plan-audit digest *with* `assurance.md`. This change does not
+    add a compatibility shim for that prior input set; such records follow the
+    normal stale/re-certification path.
+  - **Dry-run over-eligibility (medium)**: `evidence restamp --dry-run` could
+    report Tier-0 eligibility before `stampEvidenceDigestForSkill` had a chance
+    to detect unavailable inputs. Mitigation: preflight digest input availability
+    in the engine wrapper before the changed-after-verdict check.
+- Guardrail domains: none. P0 introduces no Tier-2 attested bypass; the existing
+  fail-closed `domain_review`/`rollback_required` policy is untouched.
+- Reversibility: high. All changes are additive or localized; no destructive
+  data migration.
+
+### Test Strategy
+- Existing coverage that locks the old/destructive contract (to convert):
+  - `evidence_digests_test.go:17` `TestPlanAuditInputDigestIncludesAssuranceAndSemanticTasks`
+    asserts the plan-audit digest **contains** `assurance.md` → invert to exclude.
+  - `evidence_digests_test.go:46` `TestEvaluateRequiredSkillsUsesContentDigestNotMTime`
+    uses `assurance.md` as the drift example and asserts
+    `required_skill_stale:plan-audit:assurance.md` → switch the example artifact to
+    a real plan-audit input (e.g. `requirements.md`).
+  - `evidence_digests_test.go:540` and `:580` lock the `input_digest_missing`
+    deadlock → convert to: orphan with inputs **unchanged after verdict** is
+    backfilled (heals); orphan with inputs **changed after verdict** reports the
+    specific `required_skill_stale:<skill>:<input>` (not the generic token).
+  - `cmd/repair_test.go:1051` `TestRepairDoesNotRebuildWhenPlanningEvidenceIsStale`
+    → keep "repair does not rebuild", extend next-action to point at recovery.
+  - `cmd/lifecycle_commands_test.go:965`
+    `TestRunStalePlanningEvidenceReopensPlanAuditAndPreservesRuntimeEvidence` →
+    add evidence-digests setup + assert the 5 deleted skills' digests are pruned
+    while wave-orchestration's digest survives.
+- New tests:
+  - Characterization: a late `assurance.md` edit at S1 does not stale the
+    plan-audit digest or produce plan-audit blockers (acceptance #1 mechanism).
+  - `evidence restamp --skill X --dry-run` Tier-0 refusal explains why + which
+    skill to re-run, including unavailable digest inputs; eligible orphan reports
+    it would stamp; non-dry-run stamps.
+- Infrastructure: reuse `writeDigestPlanningBundle`, `writeVerificationForTest`,
+  `os.Chtimes` (mtime control vs verdict), `prepareStalePlanningRecoveryFixture`.
+- Verification approach: `go build ./...` and `go test ./...` green; targeted
+  package runs for `internal/engine/progression` and `cmd` during iteration.
+
+## Alternatives Considered
+- **A. RFC-faithful (recommended)**: unify the `changedAfterVerdict` check in
+  both digest paths; clean-remove `assurance.md` from the plan-audit digest;
+  prune via one helper that deletes a verification record and its digest entry
+  together; derive the view `stale` status from `view.Blockers`; add
+  `evidence restamp` over a **new exported engine Tier-0 wrapper** that reuses
+  `digestInputsChangedAfterVerdict` + `stampEvidenceDigestForSkill`; route repair
+  minimally (digest-aware next-action + a cheap non-repairable finding).
+  Tradeoffs: keeps Tier-0 semantics in one canonical place (engine), faithful to
+  the reviewed governance invariants; adds a small engine API surface.
+- **B. cmd-inline Tier-0**: put the Tier-0 safety check inside `cmd/evidence.go`
+  and call the existing `StampEvidenceDigestForSkill` directly. Tradeoffs: smaller
+  engine surface but **duplicates digest semantics in cmd/**, risking drift from
+  the canonical check — violates the single-source-of-truth invariant. Rejected.
+- **C. Full repair detector in P0**: add a complete governance-skill
+  digest-staleness scanner to `repair` for every active change. Tradeoffs: nicer
+  repair UX but overlaps P1's recovery vocabulary/surface and risks phase scope
+  creep. Defer the breadth to P1; P0 keeps repair routing minimal.
+- Selected: **A** — see `decision.md`.
+
+## Unknowns
+- Resolved: RFC line refs / behavior at current `main` → all verified
+  (digest paths, `addPlanningArtifactInputs` membership, recovery deletion set,
+  view paths, `StampEvidenceDigestForSkill`, `repairDriftNextAction`).
+- Resolved: does removing `assurance.md` from plan-audit open an audit gap? → No;
+  `AssuranceContractBlockers` enforces only at S3/S4, independent of the
+  plan-audit digest.
+- Resolved: where does the view get staleness from? → `view.Blockers` (populated
+  from `readiness.Blockers` at `cmd/next.go:375`) before
+  `buildRequiredSkillEvidence` runs.
+- Resolved: `input_digest_missing` token blast radius → only two non-test emit
+  sites (`evidence_digests.go:170,264`), both being changed; one test file
+  references it.
+- Remaining (for plan-audit): exact phrasing of the `evidence restamp` refusal
+  reasons and the repair next-action string; pick during planning. No open
+  technical blocker.
+
+## Assumptions
+- `digestInputsChangedAfterVerdict`'s mtime-vs-verdict comparison is the accepted
+  Tier-0 conservatism (mtime change with identical content refuses → re-run).
+  Evidence: existing `== nil` branch (`evidence_digests.go:174-181`) and tests
+  `evidence_digests_test.go:46,79`.
+- `validate` already surfaces `required_skill_stale` via its blocker list (per
+  issue #81 repro); the explicit `stale` evidence-status change targets the
+  `next` skill-evidence view. Evidence: issue #81 `validate --json` output.
+- No compatibility filter is required for prior plan-audit digest input sets;
+  stale prior records are re-certified through the standard evidence path.
+
+## Canonical References
+- `internal/engine/progression/evidence_digests.go:163` (read path),
+  `:262` (stamp path), `:452` (`addPlanningArtifactInputs`), `:859`
+  (`digestInputsChangedAfterVerdict`), `:89` (`StampEvidenceDigestForSkill`)
+- `internal/engine/progression/advance_governed.go:459`
+  (`beginStalePlanningRecovery`), `:568`
+  (`stalePlanningRecoveryNeededForPlanAuditDigest`)
+- `internal/engine/progression/validation.go:476` (`AssuranceContractBlockers`)
+- `internal/engine/progression/evidence.go:124` (digest-blocker routing)
+- `internal/model/evidence_digests.go:100` (`EvidenceFreshness`),
+  `internal/model/reason_code.go:235` (Code/Detail split)
+- `cmd/next_skill_view.go:443` (`isRequiredSkillBlocker`), `:463`
+  (`buildRequiredSkillEvidence`); `cmd/next.go:375,417`
+- `cmd/evidence.go:28` (`makeEvidenceCmd`); `cmd/repair.go:587`
+  (`repairDriftNextAction`)

--- a/artifacts/changes/archived/recovery-ux-p0-issue-83-break-the-input-digest-missing-deadl/tasks.md
+++ b/artifacts/changes/archived/recovery-ux-p0-issue-83-break-the-input-digest-missing-deadl/tasks.md
@@ -1,0 +1,65 @@
+# Tasks
+## Project Context
+- Tech Stack: Go
+- Conventions: cmd/* CLI over internal/engine/* kernel; table-driven tests
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Task List
+
+- [x] `t-01` Engine digest changes in evidence_digests.go: unify the
+  `digestInputsChangedAfterVerdict` safety check across both the read path
+  (`skillDigestFreshnessBlockersWithSummary`) and the stamp path
+  (`stampPassingSkillDigests`) so a recorded orphan with inputs unchanged after
+  the verdict is backfilled and genuine drift reports specific stale inputs;
+  remove `assurance.md` from `addPlanningArtifactInputs`; add exported
+  `RestampEvidenceDigestTier0`. Convert the deadlock/assurance-coupling tests to
+  the new contract (test-first) and add the late-assurance-edit characterization
+  test.
+  - wave: 1
+  - depends_on: []
+  - target_files: ["internal/engine/progression/evidence_digests.go", "internal/engine/progression/evidence_digests_test.go"]
+  - task_kind: code
+  - covers: [REQ-001, REQ-002, REQ-006]
+
+- [x] `t-02` Prune digests on stale-planning recovery in advance_governed.go: add
+  a helper that removes a verification record and its `evidence-digests.yaml`
+  entry together, and use it in `beginStalePlanningRecovery` for the five cleared
+  skills while preserving wave-orchestration. Extend the recovery integration
+  test with digest-prune assertions.
+  - wave: 1
+  - depends_on: []
+  - target_files: ["internal/engine/progression/advance_governed.go", "cmd/lifecycle_commands_test.go"]
+  - task_kind: code
+  - covers: [REQ-003]
+
+- [x] `t-03` Surface stale in cmd/next_skill_view.go: add `required_skill_stale`
+  to `isRequiredSkillBlocker`, and report `stale` for digest drift on both the
+  precomputed and non-precomputed evidence paths (derived from the
+  `required_skill_stale` entries in `view.Blockers`). Add view tests.
+  - wave: 1
+  - depends_on: []
+  - target_files: ["cmd/next_skill_view.go", "cmd/progression_next_test.go"]
+  - task_kind: code
+  - covers: [REQ-004, REQ-005]
+
+- [x] `t-04` Route repair planning/digest drift in cmd/repair.go: make
+  `repairDriftNextAction` (and the digest-drift finding) point at
+  `slipway evidence restamp --dry-run`, stating repair does not mutate
+  engine-owned digests. Extend repair tests.
+  - wave: 1
+  - depends_on: []
+  - target_files: ["cmd/repair.go", "cmd/repair_test.go"]
+  - task_kind: code
+  - covers: [REQ-007]
+
+- [x] `t-05` Add the `slipway evidence restamp --skill X [--dry-run]` subcommand
+  in cmd/evidence.go over `RestampEvidenceDigestTier0`, registered on
+  `makeEvidenceCmd`; refuse with the skill to re-run when not Tier-0 eligible,
+  including dry-run cases where digest inputs are unavailable. Add command tests.
+  - wave: 2
+  - depends_on: [t-01]
+  - target_files: ["cmd/evidence.go", "cmd/evidence_test.go"]
+  - task_kind: code
+  - covers: [REQ-006]

--- a/cmd/evidence.go
+++ b/cmd/evidence.go
@@ -31,7 +31,154 @@ func makeEvidenceCmd() *cobra.Command {
 		Short: desc("evidence"),
 	}
 	cmd.AddCommand(makeEvidenceTaskCmd())
+	cmd.AddCommand(makeEvidenceRestampCmd())
 	return cmd
+}
+
+type evidenceRestampView struct {
+	Slug          string   `json:"slug"`
+	Skill         string   `json:"skill"`
+	Eligible      bool     `json:"eligible"`
+	Stamped       bool     `json:"stamped"`
+	DryRun        bool     `json:"dry_run"`
+	Reason        string   `json:"reason,omitempty"`
+	ChangedInputs []string `json:"changed_inputs,omitempty"`
+	RerunSkill    string   `json:"rerun_skill,omitempty"`
+	Message       string   `json:"message"`
+}
+
+// makeEvidenceRestampCmd exposes the minimal Tier-0 evidence-digest restamp.
+// It stamps a skill's engine-owned digest only when the recorded verdict is
+// still passing and the certified inputs did not change after the verdict;
+// otherwise it refuses and names the host skill to re-run. It never edits the
+// digest file directly and never fabricates a pass.
+func makeEvidenceRestampCmd() *cobra.Command {
+	var (
+		jsonOutput bool
+		changeSlug string
+		skillName  string
+		dryRun     bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "restamp",
+		Short: "Restamp a governance skill's engine-owned evidence digest (Tier 0 only)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			root, err := projectRootFromCommand(cmd)
+			if err != nil {
+				return err
+			}
+			skillName = strings.TrimSpace(skillName)
+			if skillName == "" {
+				return newInvalidUsageError(
+					"evidence_restamp_skill_required",
+					"--skill is required",
+					"Pass the governance skill whose evidence digest should be restamped, e.g. --skill plan-audit.",
+					nil,
+				)
+			}
+			ref, err := resolveActiveChangeRef(root, changeSlug)
+			if err != nil {
+				return err
+			}
+
+			run := func() error {
+				change, err := loadActiveChange(
+					root,
+					ref.Slug,
+					"cannot restamp evidence for governed status %q",
+					"Evidence digests can only be restamped for an active governed change.",
+				)
+				if err != nil {
+					return err
+				}
+				outcome, err := progression.RestampEvidenceDigestTier0(root, change, skillName, dryRun)
+				if err != nil {
+					return err
+				}
+				if outcome.Stamped {
+					if err := appendCLILifecycleEvent(root, change, state.LifecycleEvent{
+						Command:     "evidence restamp",
+						EventType:   "evidence_digest.restamped",
+						Action:      "restamped",
+						Result:      "stamped",
+						BeforeState: change.CurrentState,
+						AfterState:  change.CurrentState,
+						Diagnostics: []string{"skill=" + outcome.Skill, "tier=0"},
+					}); err != nil {
+						return err
+					}
+				}
+				return renderEvidenceRestampOutcome(cmd, change.Slug, outcome, jsonOutput)
+			}
+
+			// --dry-run is read-only and must not contend for the change lock.
+			if dryRun {
+				return run()
+			}
+			return withChangeStateLock(root, ref.Slug, "evidence restamp", run)
+		},
+	}
+
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "JSON output")
+	addChangeSelectorFlags(cmd, &changeSlug, "Explicit change slug")
+	cmd.Flags().StringVar(&skillName, "skill", "", "Governance skill whose evidence digest should be restamped (required)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Assess Tier-0 eligibility without writing the digest")
+
+	return cmd
+}
+
+func renderEvidenceRestampOutcome(cmd *cobra.Command, slug string, outcome progression.EvidenceRestampOutcome, jsonOutput bool) error {
+	view := evidenceRestampView{
+		Slug:          slug,
+		Skill:         outcome.Skill,
+		Eligible:      outcome.Eligible,
+		Stamped:       outcome.Stamped,
+		DryRun:        outcome.DryRun,
+		Reason:        outcome.Reason,
+		ChangedInputs: outcome.ChangedInputs,
+		Message:       evidenceRestampMessage(outcome),
+	}
+	if !outcome.Eligible {
+		view.RerunSkill = outcome.RerunSkill
+	}
+	if jsonOutput {
+		return encodeJSONResponse(cmd, view)
+	}
+	writer := newFormatWriter(cmd.OutOrStdout())
+	writer.Writef("%s\n", view.Message)
+	return writer.Err()
+}
+
+func evidenceRestampMessage(outcome progression.EvidenceRestampOutcome) string {
+	switch {
+	case outcome.Stamped:
+		return fmt.Sprintf("Restamped the Tier-0 evidence digest for %q.", outcome.Skill)
+	case outcome.Eligible && outcome.DryRun:
+		return fmt.Sprintf("%q is Tier-0 eligible: the verdict is passing and inputs are unchanged after the verdict. Re-run without --dry-run to restamp.", outcome.Skill)
+	default:
+		return evidenceRestampRefusalMessage(outcome)
+	}
+}
+
+func evidenceRestampRefusalMessage(outcome progression.EvidenceRestampOutcome) string {
+	rerun := outcome.RerunSkill
+	if strings.TrimSpace(rerun) == "" {
+		rerun = outcome.Skill
+	}
+	switch outcome.Reason {
+	case progression.EvidenceRestampReasonNoEvidence:
+		return fmt.Sprintf("Refused: no passing %q evidence is recorded. Run the %q host skill first.", outcome.Skill, rerun)
+	case progression.EvidenceRestampReasonVerdictNotPassing:
+		return fmt.Sprintf("Refused: the recorded %q verdict is not passing. Re-run the %q host skill.", outcome.Skill, rerun)
+	case progression.EvidenceRestampReasonInputsChanged:
+		return fmt.Sprintf("Refused: %q inputs changed after the verdict (%s). Re-run the %q host skill to re-certify.", outcome.Skill, strings.Join(outcome.ChangedInputs, ", "), rerun)
+	case progression.EvidenceRestampReasonInputsUnavailable:
+		return fmt.Sprintf("Refused: %q digest inputs are unavailable. Re-run the %q host skill.", outcome.Skill, rerun)
+	default:
+		return fmt.Sprintf("Refused: %q is not Tier-0 eligible. Re-run the %q host skill.", outcome.Skill, rerun)
+	}
 }
 
 func makeEvidenceTaskCmd() *cobra.Command {

--- a/cmd/evidence_test.go
+++ b/cmd/evidence_test.go
@@ -1,13 +1,167 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/signalridge/slipway/internal/engine/progression"
 	"github.com/signalridge/slipway/internal/model"
 	"github.com/signalridge/slipway/internal/state"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestEvidenceRestampTier0EligibleDryRunThenApply(t *testing.T) {
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		slug := createGovernedRequest(t, root, "L2", "evidence restamp tier0 eligible")
+		change, err := state.LoadChange(root, slug)
+		require.NoError(t, err)
+		change.CurrentState = model.StateS1Plan
+		change.PlanSubStep = model.PlanSubStepAudit
+		require.NoError(t, state.SaveChange(root, change))
+
+		verdictAt := time.Now().UTC().Add(-time.Hour)
+		rec := model.VerificationRecord{
+			Verdict:   model.VerificationVerdictPass,
+			Blockers:  []model.ReasonCode{},
+			Timestamp: verdictAt,
+		}
+		writeSkillVerification(t, root, slug, progression.SkillPlanAudit, rec)
+
+		// Planning inputs settled before the verdict → Tier-0 eligible.
+		bundlePath := filepath.Join(root, "artifacts", "changes", slug)
+		beforeVerdict := verdictAt.Add(-time.Minute)
+		for _, rel := range []string{"intent.md", "requirements.md", "research.md", "decision.md", "tasks.md"} {
+			p := filepath.Join(bundlePath, rel)
+			if _, statErr := os.Stat(p); statErr == nil {
+				require.NoError(t, os.Chtimes(p, beforeVerdict, beforeVerdict))
+			}
+		}
+
+		// --dry-run reports eligible without writing the digest.
+		var dryOut bytes.Buffer
+		dryCmd := commandForRoot(t, root, makeEvidenceCmd())
+		dryCmd.SetOut(&dryOut)
+		dryCmd.SetArgs([]string{"restamp", "--skill", progression.SkillPlanAudit, "--dry-run", "--json", "--change", slug})
+		require.NoError(t, dryCmd.Execute())
+		var dryView evidenceRestampView
+		require.NoError(t, json.Unmarshal(dryOut.Bytes(), &dryView))
+		assert.True(t, dryView.Eligible)
+		assert.False(t, dryView.Stamped)
+		assert.True(t, dryView.DryRun)
+		if dig, derr := state.LoadOptionalEvidenceDigestsForChange(root, change); derr == nil && dig != nil {
+			assert.NotContains(t, dig.Skills, progression.SkillPlanAudit, "dry-run must not write the digest")
+		}
+
+		// Without --dry-run the eligible digest is stamped.
+		var applyOut bytes.Buffer
+		applyCmd := commandForRoot(t, root, makeEvidenceCmd())
+		applyCmd.SetOut(&applyOut)
+		applyCmd.SetArgs([]string{"restamp", "--skill", progression.SkillPlanAudit, "--json", "--change", slug})
+		require.NoError(t, applyCmd.Execute())
+		var applyView evidenceRestampView
+		require.NoError(t, json.Unmarshal(applyOut.Bytes(), &applyView))
+		assert.True(t, applyView.Stamped)
+		assert.True(t, applyView.Eligible)
+
+		digests, err := state.LoadEvidenceDigestsForChange(root, change)
+		require.NoError(t, err)
+		assert.Contains(t, digests.Skills, progression.SkillPlanAudit)
+	})
+}
+
+func TestEvidenceRestampTier0RefusesInputsChangedAfterVerdict(t *testing.T) {
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		slug := createGovernedRequest(t, root, "L2", "evidence restamp refuses drift")
+		change, err := state.LoadChange(root, slug)
+		require.NoError(t, err)
+		change.CurrentState = model.StateS1Plan
+		change.PlanSubStep = model.PlanSubStepAudit
+		require.NoError(t, state.SaveChange(root, change))
+
+		verdictAt := time.Now().UTC().Add(-time.Hour)
+		rec := model.VerificationRecord{
+			Verdict:   model.VerificationVerdictPass,
+			Blockers:  []model.ReasonCode{},
+			Timestamp: verdictAt,
+		}
+		writeSkillVerification(t, root, slug, progression.SkillPlanAudit, rec)
+
+		// An input changed after the verdict → not Tier-0 safe.
+		bundlePath := filepath.Join(root, "artifacts", "changes", slug)
+		requirementsPath := filepath.Join(bundlePath, "requirements.md")
+		require.NoError(t, os.WriteFile(requirementsPath, []byte("# Requirements\nREQ-001 changed after verdict\n"), 0o644))
+		afterVerdict := verdictAt.Add(time.Hour)
+		require.NoError(t, os.Chtimes(requirementsPath, afterVerdict, afterVerdict))
+
+		var out bytes.Buffer
+		cmd := commandForRoot(t, root, makeEvidenceCmd())
+		cmd.SetOut(&out)
+		cmd.SetArgs([]string{"restamp", "--skill", progression.SkillPlanAudit, "--json", "--change", slug})
+		require.NoError(t, cmd.Execute())
+		var view evidenceRestampView
+		require.NoError(t, json.Unmarshal(out.Bytes(), &view))
+		assert.False(t, view.Eligible)
+		assert.False(t, view.Stamped)
+		assert.Equal(t, "inputs_changed_after_verdict", view.Reason)
+		assert.Contains(t, view.ChangedInputs, "requirements.md")
+		assert.Equal(t, progression.SkillPlanAudit, view.RerunSkill)
+		assert.Contains(t, view.Message, "Re-run")
+	})
+}
+
+func TestEvidenceRestampTier0DryRunRefusesUnavailableInputs(t *testing.T) {
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		slug := createGovernedRequest(t, root, "L2", "evidence restamp refuses unavailable inputs")
+
+		writeSkillVerification(t, root, slug, progression.SkillFinalCloseout, model.VerificationRecord{
+			Verdict:   model.VerificationVerdictPass,
+			Blockers:  []model.ReasonCode{},
+			Timestamp: time.Now().UTC(),
+		})
+
+		var out bytes.Buffer
+		cmd := commandForRoot(t, root, makeEvidenceCmd())
+		cmd.SetOut(&out)
+		cmd.SetArgs([]string{"restamp", "--skill", progression.SkillFinalCloseout, "--dry-run", "--json", "--change", slug})
+		require.NoError(t, cmd.Execute())
+
+		var view evidenceRestampView
+		require.NoError(t, json.Unmarshal(out.Bytes(), &view))
+		assert.False(t, view.Eligible)
+		assert.False(t, view.Stamped)
+		assert.True(t, view.DryRun)
+		assert.Equal(t, progression.EvidenceRestampReasonInputsUnavailable, view.Reason)
+		assert.Equal(t, progression.SkillFinalCloseout, view.RerunSkill)
+		assert.Contains(t, view.Message, "digest inputs are unavailable")
+	})
+}
+
+func TestEvidenceRestampRequiresSkill(t *testing.T) {
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		_ = createGovernedRequest(t, root, "L2", "evidence restamp requires skill")
+
+		cmd := commandForRoot(t, root, makeEvidenceCmd())
+		cmd.SetArgs([]string{"restamp", "--json"})
+		err := cmd.Execute()
+		require.Error(t, err)
+		cliErr := asCLIError(err)
+		require.NotNil(t, cliErr)
+		assert.Equal(t, "evidence_restamp_skill_required", cliErr.ErrorCode)
+	})
+}
 
 func TestEvidenceTaskWrongStateInS4RoutesToGoalVerificationAndFinalCloseout(t *testing.T) {
 	t.Parallel()

--- a/cmd/lifecycle_commands_test.go
+++ b/cmd/lifecycle_commands_test.go
@@ -1001,6 +1001,31 @@ func TestRunStalePlanningEvidenceReopensPlanAuditAndPreservesRuntimeEvidence(t *
 			require.FileExists(t, waveRunPath)
 			require.FileExists(t, taskEvidencePath)
 
+			// Stamp evidence digests for the skills recovery clears, plus
+			// wave-orchestration (whose record recovery preserves).
+			refreshPassingSkillDigestsForTest(t, root, slug,
+				progression.SkillPlanAudit,
+				progression.SkillSpecComplianceReview,
+				progression.SkillCodeQualityReview,
+				progression.SkillGoalVerification,
+				progression.SkillFinalCloseout,
+				progression.SkillWaveOrchestration,
+			)
+			preChange, err := state.LoadChange(root, slug)
+			require.NoError(t, err)
+			preDigests, err := state.LoadEvidenceDigestsForChange(root, preChange)
+			require.NoError(t, err)
+			for _, skillName := range []string{
+				progression.SkillPlanAudit,
+				progression.SkillSpecComplianceReview,
+				progression.SkillCodeQualityReview,
+				progression.SkillGoalVerification,
+				progression.SkillFinalCloseout,
+				progression.SkillWaveOrchestration,
+			} {
+				require.Contains(t, preDigests.Skills, skillName, "fixture should stamp a digest for %s", skillName)
+			}
+
 			runCmd := commandForRoot(t, root, makeRunCmd())
 			runCmd.SetArgs([]string{"--json", "--diagnostics", "--change", slug})
 			var buf bytes.Buffer
@@ -1034,6 +1059,20 @@ func TestRunStalePlanningEvidenceReopensPlanAuditAndPreservesRuntimeEvidence(t *
 			require.NoFileExists(t, finalCloseoutPath)
 			require.FileExists(t, waveRunPath)
 			require.FileExists(t, taskEvidencePath)
+
+			// Digest prune: a digest entry never outlives its verification record.
+			postDigests, err := state.LoadEvidenceDigestsForChange(root, recovered)
+			require.NoError(t, err)
+			for _, skillName := range []string{
+				progression.SkillPlanAudit,
+				progression.SkillSpecComplianceReview,
+				progression.SkillCodeQualityReview,
+				progression.SkillGoalVerification,
+				progression.SkillFinalCloseout,
+			} {
+				assert.NotContains(t, postDigests.Skills, skillName, "stale-planning recovery must prune the %s digest with its record", skillName)
+			}
+			assert.Contains(t, postDigests.Skills, progression.SkillWaveOrchestration, "wave-orchestration record is preserved, so its digest must remain")
 		})
 	}
 }

--- a/cmd/next_skill_view.go
+++ b/cmd/next_skill_view.go
@@ -133,7 +133,13 @@ func assembleSkillViewWithOptions(
 	}
 
 	if options.IncludeSkillEvidence && evidenceMap != nil {
-		requiredSkillEvidence, err := buildRequiredSkillEvidence(root, *governedChange, view.CurrentState, execCtx, precomputedPassingSkills)
+		staleSkills := requiredSkillStaleSet(view.Blockers)
+		if advanced.Action == "blocked" {
+			for skillName := range requiredSkillStaleSet(advanced.Blockers) {
+				staleSkills[skillName] = true
+			}
+		}
+		requiredSkillEvidence, err := buildRequiredSkillEvidence(root, *governedChange, view.CurrentState, execCtx, precomputedPassingSkills, staleSkills)
 		if err != nil {
 			return wrapRequiredSkillsEvaluationError("evaluate required skill evidence", ref.Slug, err)
 		}
@@ -442,11 +448,27 @@ func skillHasPassingEvidence(evidenceMap map[string]model.VerificationRecord, sk
 
 func isRequiredSkillBlocker(code string) bool {
 	switch strings.TrimSpace(code) {
-	case "required_skill_missing", "required_skill_not_ready", "required_skill_not_passed", "required_skill_blockers_present":
+	case "required_skill_missing", "required_skill_not_ready", "required_skill_not_passed", "required_skill_blockers_present", "required_skill_stale":
 		return true
 	default:
 		return false
 	}
+}
+
+// requiredSkillStaleSet collects the skills carrying a required_skill_stale
+// digest-drift blocker, keyed by skill name (the first segment of the blocker
+// detail, e.g. "plan-audit" from "plan-audit:assurance.md").
+func requiredSkillStaleSet(blockers []model.ReasonCode) map[string]bool {
+	out := map[string]bool{}
+	for _, blocker := range blockers {
+		if strings.TrimSpace(blocker.Code) != "required_skill_stale" {
+			continue
+		}
+		if name := blockerSkillName(blocker.Detail); name != "" {
+			out[name] = true
+		}
+	}
+	return out
 }
 
 func blockerSkillName(detail string) string {
@@ -466,6 +488,7 @@ func buildRequiredSkillEvidence(
 	workflowState model.WorkflowState,
 	execCtx *executionContext,
 	precomputedPassingSkills map[string]model.VerificationRecord,
+	staleSkills map[string]bool,
 ) ([]skillEvidenceEntry, error) {
 	presetPolicy, err := governance.ResolvePresetPolicy(root, change)
 	if err != nil {
@@ -508,6 +531,12 @@ func buildRequiredSkillEvidence(
 				entry.Verdict = rec.Verdict
 				entry.Status = "passing"
 			}
+			// A digest-drift blocker supersedes missing/passing: the recorded
+			// verdict exists but its certified inputs are stale.
+			if staleSkills[skillName] {
+				entry.HasEvidence = true
+				entry.Status = "stale"
+			}
 			evidence = append(evidence, entry)
 		}
 		return evidence, nil
@@ -544,6 +573,11 @@ func buildRequiredSkillEvidence(
 			}
 		} else if rec.IsPassing() {
 			entry.Status = "passing"
+		}
+		// Digest drift (certified inputs changed after the verdict) is stale even
+		// when the recorded verdict itself passes.
+		if staleSkills[skillName] {
+			entry.Status = "stale"
 		}
 		evidence = append(evidence, entry)
 	}

--- a/cmd/progression_next_test.go
+++ b/cmd/progression_next_test.go
@@ -929,6 +929,90 @@ func TestNextJSONReportsActionableRequiredSkillAfterPassingReviewEvidence(t *tes
 	})
 }
 
+func TestRequiredSkillStaleIsActionableAndSetExtractsSkillNames(t *testing.T) {
+	t.Parallel()
+
+	// required_skill_stale is now an actionable required-skill blocker, so the
+	// stale skill is routed/surfaced as the next skill.
+	assert.True(t, isRequiredSkillBlocker("required_skill_stale"))
+
+	blockers := []model.ReasonCode{
+		model.NewReasonCode("required_skill_stale", "plan-audit:assurance.md"),
+		model.NewReasonCode("required_skill_stale", "goal-verification:run_version"),
+		model.NewReasonCode("required_skill_missing", "wave-orchestration"),
+	}
+	stale := requiredSkillStaleSet(blockers)
+	assert.True(t, stale["plan-audit"], "skill name is the first segment of the detail")
+	assert.True(t, stale["goal-verification"])
+	assert.NotContains(t, stale, "wave-orchestration", "non-stale blockers are excluded")
+}
+
+func TestBuildRequiredSkillEvidenceMarksDigestDriftedSkillStale(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		slug := createGovernedRequest(t, root, "L2", "stale evidence status surface")
+		change, err := state.LoadChange(root, slug)
+		require.NoError(t, err)
+		change.CurrentState = model.StateS1Plan
+		change.PlanSubStep = model.PlanSubStepAudit
+		require.NoError(t, state.SaveChange(root, change))
+
+		// Precomputed path: plan-audit has a passing verdict but a digest-drift
+		// blocker, so the evidence view must report "stale" (not "passing").
+		passing := map[string]model.VerificationRecord{
+			progression.SkillPlanAudit: {Verdict: model.VerificationVerdictPass},
+		}
+		stale := map[string]bool{progression.SkillPlanAudit: true}
+		evidence, err := buildRequiredSkillEvidence(root, change, model.StateS1Plan, nil, passing, stale)
+		require.NoError(t, err)
+
+		byName := map[string]skillEvidenceEntry{}
+		for _, e := range evidence {
+			byName[e.SkillName] = e
+		}
+		require.Contains(t, byName, progression.SkillPlanAudit)
+		assert.Equal(t, "stale", byName[progression.SkillPlanAudit].Status)
+		assert.True(t, byName[progression.SkillPlanAudit].HasEvidence)
+	})
+}
+
+func TestBuildRequiredSkillEvidenceNonPrecomputedMarksDigestDriftedSkillStale(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		slug := createGovernedRequest(t, root, "L2", "non-precomputed stale evidence status")
+		change, err := state.LoadChange(root, slug)
+		require.NoError(t, err)
+		change.CurrentState = model.StateS1Plan
+		change.PlanSubStep = model.PlanSubStepAudit
+		require.NoError(t, state.SaveChange(root, change))
+
+		// A passing plan-audit verdict on disk; the non-precomputed path reads it.
+		writeSkillVerification(t, root, slug, progression.SkillPlanAudit, model.VerificationRecord{
+			Verdict:   model.VerificationVerdictPass,
+			Blockers:  []model.ReasonCode{},
+			Timestamp: time.Now().UTC(),
+		})
+
+		// precomputedPassingSkills == nil forces the non-precomputed path.
+		stale := map[string]bool{progression.SkillPlanAudit: true}
+		evidence, err := buildRequiredSkillEvidence(root, change, model.StateS1Plan, nil, nil, stale)
+		require.NoError(t, err)
+
+		byName := map[string]skillEvidenceEntry{}
+		for _, e := range evidence {
+			byName[e.SkillName] = e
+		}
+		require.Contains(t, byName, progression.SkillPlanAudit)
+		assert.Equal(t, "stale", byName[progression.SkillPlanAudit].Status, "digest drift is stale even when the recorded verdict passes")
+	})
+}
+
 func TestReviewStateActionableNextSkillConsistentAcrossCommandSurfaces(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/repair.go
+++ b/cmd/repair.go
@@ -228,7 +228,11 @@ func makeRepairCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				summary.UnrepairedDrift = normalizeRepairDriftFindings(append(buildUnrepairedDriftFindings(summary.NonRepairableFindings), freshnessDrift...))
+				digestDrift, err := buildGovernanceDigestDriftFindings(root, allChanges)
+				if err != nil {
+					return err
+				}
+				summary.UnrepairedDrift = normalizeRepairDriftFindings(append(append(buildUnrepairedDriftFindings(summary.NonRepairableFindings), freshnessDrift...), digestDrift...))
 				summary.PathAuthority = buildRepairPathAuthority(root, allChanges, summary)
 				applyRepairInvocationWorkspacePath(cmd, root, &summary)
 				if repairSummaryHasLifecycleActivity(summary) {
@@ -382,7 +386,7 @@ func buildUnrepairedDriftFindings(findings []string) []repairDriftFinding {
 		out = append(out, repairDriftFinding{
 			Reason:     reason,
 			Target:     target,
-			NextAction: repairDriftNextAction(reason),
+			NextAction: repairDriftNextAction(reason, target),
 		})
 	}
 	return out
@@ -481,7 +485,7 @@ func normalizeRepairDriftFindings(findings []repairDriftFinding) []repairDriftFi
 			finding.Target = "workspace"
 		}
 		if finding.NextAction == "" {
-			finding.NextAction = repairDriftNextAction(finding.Reason)
+			finding.NextAction = repairDriftNextAction(finding.Reason, finding.Target)
 		}
 		normalized = append(normalized, finding)
 	}
@@ -584,9 +588,14 @@ func repairFindingMentionsSlug(finding repairDriftFinding, slug string) bool {
 		haystack == slug
 }
 
-func repairDriftNextAction(reason string) string {
+func repairDriftNextAction(reason, target string) string {
 	lower := strings.ToLower(reason)
 	switch {
+	case strings.Contains(lower, "evidence digest"), strings.Contains(lower, "required_skill_stale"):
+		// For digest/stale drift the target is the governance skill, so route to
+		// the same restamp guidance the main digest-drift path emits — a single
+		// source of truth that always carries the required --skill.
+		return governanceDigestRestampNextAction(target)
 	case strings.Contains(lower, "wave plan"):
 		return "regenerate or rescope tasks.md and rerun wave orchestration"
 	case strings.Contains(lower, "execution summary"):
@@ -596,6 +605,60 @@ func repairDriftNextAction(reason string) string {
 	default:
 		return "inspect the named artifact and rerun the owning Slipway command after correction"
 	}
+}
+
+// buildGovernanceDigestDriftFindings surfaces governance-skill evidence-digest
+// drift (`required_skill_stale`) as a non-repairable finding routed at
+// `slipway evidence restamp`. repair does not mutate engine-owned digests: the
+// operator either restamps (Tier 0, when the verdict still holds) or re-runs the
+// named host skill. This closes the "repair is a dead-end for stale digests" gap
+// without adding the full P1 recovery surface.
+func buildGovernanceDigestDriftFindings(root string, changes []model.Change) ([]repairDriftFinding, error) {
+	out := []repairDriftFinding{}
+	for _, change := range changes {
+		if change.Status != model.ChangeStatusActive {
+			continue
+		}
+		readiness, err := progression.EvaluateGovernanceReadiness(root, change, progression.GovernanceReadinessOptions{})
+		if err != nil {
+			// repair is best-effort diagnostics; skip a change whose readiness
+			// cannot be evaluated rather than failing the whole repair pass.
+			continue
+		}
+		staleSkills := []string{}
+		seen := map[string]bool{}
+		for _, blocker := range readiness.Blockers {
+			if strings.TrimSpace(blocker.Code) != "required_skill_stale" {
+				continue
+			}
+			skillName := blockerSkillName(blocker.Detail)
+			if skillName == "" || seen[skillName] {
+				continue
+			}
+			seen[skillName] = true
+			staleSkills = append(staleSkills, skillName)
+		}
+		slices.Sort(staleSkills)
+		for _, skillName := range staleSkills {
+			out = append(out, repairDriftFinding{
+				Reason:     fmt.Sprintf("%s: evidence digest for governance skill %q is stale", change.Slug, skillName),
+				Target:     skillName,
+				NextAction: governanceDigestRestampNextAction(skillName),
+			})
+		}
+	}
+	return out, nil
+}
+
+func governanceDigestRestampNextAction(skillName string) string {
+	skillName = strings.TrimSpace(skillName)
+	if skillName == "" {
+		// No skill in hand: never emit a bare `restamp --dry-run`, which fails
+		// `evidence_restamp_skill_required`. Keep the placeholder explicit so a
+		// copied command is obviously incomplete rather than silently invalid.
+		return "run `slipway evidence restamp --skill <skill> --dry-run` to assess a Tier-0 restamp; repair does not mutate engine-owned evidence digests — re-run the named host skill if the restamp refuses"
+	}
+	return fmt.Sprintf("run `slipway evidence restamp --skill %s --dry-run` to assess a Tier-0 restamp; repair does not mutate engine-owned evidence digests — re-run the %s host skill if the restamp refuses", skillName, skillName)
 }
 
 func repairAppliedFindingStrings(findings []repairAppliedFinding) []string {

--- a/cmd/repair_test.go
+++ b/cmd/repair_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/signalridge/slipway/internal/engine/progression"
 	"github.com/signalridge/slipway/internal/fsutil"
 	"github.com/signalridge/slipway/internal/model"
 	"github.com/signalridge/slipway/internal/state"
@@ -1126,6 +1127,83 @@ REQ-001: Original requirement.
 		}
 		assert.True(t, foundPlanningDrift, "expected stale planning evidence to remain unrepaired")
 	})
+}
+
+func TestRepairRoutesStaleGovernanceDigestToEvidenceRestamp(t *testing.T) {
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+
+		slug := createGovernedRequest(t, root, "L2", "repair routes stale digest to restamp")
+		change, err := state.LoadChange(root, slug)
+		require.NoError(t, err)
+		change.CurrentState = model.StateS1Plan
+		change.PlanSubStep = model.PlanSubStepAudit
+		require.NoError(t, state.SaveChange(root, change))
+
+		verdictAt := time.Now().UTC().Add(-time.Hour)
+		rec := model.VerificationRecord{
+			Verdict:   model.VerificationVerdictPass,
+			Blockers:  []model.ReasonCode{},
+			Timestamp: verdictAt,
+		}
+		writeSkillVerification(t, root, slug, progression.SkillPlanAudit, rec)
+		require.NoError(t, progression.StampEvidenceDigestForSkill(root, change, progression.SkillPlanAudit, rec, nil))
+
+		// Drift a plan-audit input after the verdict so its digest goes stale.
+		bundlePath := filepath.Join(root, "artifacts", "changes", slug)
+		requirementsPath := filepath.Join(bundlePath, "requirements.md")
+		require.NoError(t, os.WriteFile(requirementsPath, []byte("# Requirements\nREQ-001 changed after verdict\n"), 0o644))
+		afterVerdict := verdictAt.Add(time.Hour)
+		require.NoError(t, os.Chtimes(requirementsPath, afterVerdict, afterVerdict))
+
+		var out bytes.Buffer
+		cmd := makeRepairCmd()
+		cmd.SetArgs([]string{"--json"})
+		cmd.SetOut(&out)
+		require.NoError(t, cmd.Execute())
+
+		var summary repairSummary
+		require.NoError(t, json.Unmarshal(out.Bytes(), &summary))
+
+		found := false
+		for _, drift := range summary.UnrepairedDrift {
+			if drift.Target == progression.SkillPlanAudit && strings.Contains(drift.Reason, "evidence digest") {
+				found = true
+				assert.Contains(t, drift.NextAction, "evidence restamp")
+				assert.Contains(t, drift.NextAction, "--skill plan-audit")
+			}
+		}
+		assert.True(t, found, "expected repair to route the stale plan-audit digest at slipway evidence restamp")
+	})
+}
+
+func TestRepairDriftNextActionDigestGuidanceAlwaysCarriesSkill(t *testing.T) {
+	t.Parallel()
+
+	// A digest/stale next-action must never emit a bare `restamp --dry-run`:
+	// without --skill the command fails evidence_restamp_skill_required, so a
+	// user copying the guidance verbatim would hit an invalid-usage dead-end.
+	cases := []struct {
+		name   string
+		reason string
+		target string
+		want   string
+	}{
+		{name: "required_skill_stale with skill target", reason: "required_skill_stale: plan-audit:requirements.md", target: "plan-audit", want: "--skill plan-audit"},
+		{name: "evidence digest reason with skill target", reason: `slug: evidence digest for governance skill "research-orchestration" is stale`, target: "research-orchestration", want: "--skill research-orchestration"},
+		{name: "digest reason without a known skill", reason: "required_skill_stale drift", target: "", want: "--skill <skill>"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := repairDriftNextAction(tc.reason, tc.target)
+			assert.Contains(t, got, tc.want)
+			assert.Contains(t, got, "--dry-run")
+			assert.NotContains(t, got, "restamp --dry-run", "guidance must never drop the required --skill")
+		})
+	}
 }
 
 func TestRepairPathAuthorityUsesLinkedWorktreeInvocationWorkspace(t *testing.T) {

--- a/internal/engine/progression/advance_governed.go
+++ b/internal/engine/progression/advance_governed.go
@@ -466,39 +466,43 @@ func beginStalePlanningRecovery(root string, change *model.Change, fromState mod
 	}
 
 	verificationDir := filepath.Join(paths.GovernedBundleDir, "verification")
-	planningEvidenceFiles := []string{
-		filepath.Join(verificationDir, SkillPlanAudit+".yaml"),
-		filepath.Join(verificationDir, state.WavePlanFileName),
-		filepath.Join(verificationDir, state.ExecutionSummaryFileName),
+	// Skill records carry a skill name so their evidence-digest entry is pruned
+	// alongside the deleted record (no zombie digests). wave-plan.yaml and
+	// execution-summary.yaml are artifacts, not skill records: wave-orchestration's
+	// own record is preserved here, so its digest is left intact.
+	planningEvidenceFiles := []recoveryEvidenceFile{
+		{path: filepath.Join(verificationDir, SkillPlanAudit+".yaml"), skill: SkillPlanAudit},
+		{path: filepath.Join(verificationDir, state.WavePlanFileName)},
+		{path: filepath.Join(verificationDir, state.ExecutionSummaryFileName)},
 	}
-	downstreamVerificationFiles := []string{
-		filepath.Join(verificationDir, SkillSpecComplianceReview+".yaml"),
-		filepath.Join(verificationDir, SkillCodeQualityReview+".yaml"),
-		filepath.Join(verificationDir, SkillGoalVerification+".yaml"),
-		filepath.Join(verificationDir, SkillFinalCloseout+".yaml"),
+	downstreamVerificationFiles := []recoveryEvidenceFile{
+		{path: filepath.Join(verificationDir, SkillSpecComplianceReview+".yaml"), skill: SkillSpecComplianceReview},
+		{path: filepath.Join(verificationDir, SkillCodeQualityReview+".yaml"), skill: SkillCodeQualityReview},
+		{path: filepath.Join(verificationDir, SkillGoalVerification+".yaml"), skill: SkillGoalVerification},
+		{path: filepath.Join(verificationDir, SkillFinalCloseout+".yaml"), skill: SkillFinalCloseout},
 	}
 	sideEffects := make([]SideEffect, 0, len(planningEvidenceFiles)+len(downstreamVerificationFiles)+1)
-	for _, path := range planningEvidenceFiles {
-		removed, err := removeFileIfExists(path)
+	for _, ev := range planningEvidenceFiles {
+		removed, err := clearRecoveryEvidence(root, *change, ev)
 		if err != nil {
 			return AdvanceSummary{}, err
 		}
 		if removed {
 			sideEffects = append(sideEffects, SideEffect{
 				Kind:   "cleared_stale_planning_evidence",
-				Detail: state.DisplayPath(root, path),
+				Detail: state.DisplayPath(root, ev.path),
 			})
 		}
 	}
-	for _, path := range downstreamVerificationFiles {
-		removed, err := removeFileIfExists(path)
+	for _, ev := range downstreamVerificationFiles {
+		removed, err := clearRecoveryEvidence(root, *change, ev)
 		if err != nil {
 			return AdvanceSummary{}, err
 		}
 		if removed {
 			sideEffects = append(sideEffects, SideEffect{
 				Kind:   "cleared_stale_downstream_verification",
-				Detail: state.DisplayPath(root, path),
+				Detail: state.DisplayPath(root, ev.path),
 			})
 		}
 	}
@@ -563,6 +567,40 @@ func removeFileIfExists(path string) (bool, error) {
 		return false, err
 	}
 	return true, nil
+}
+
+// recoveryEvidenceFile pairs a verification artifact path with the skill that
+// owns it. The skill is empty for non-skill artifacts (wave-plan.yaml,
+// execution-summary.yaml), which have no evidence-digest entry of their own.
+type recoveryEvidenceFile struct {
+	path  string
+	skill string
+}
+
+// clearRecoveryEvidence deletes a recovery evidence file. When the file is a
+// skill verification record, its evidence-digest entry is pruned in the same
+// step so a digest never outlives its record.
+func clearRecoveryEvidence(root string, change model.Change, ev recoveryEvidenceFile) (bool, error) {
+	if strings.TrimSpace(ev.skill) != "" {
+		return removeVerificationRecordAndDigest(root, change, ev.path, ev.skill)
+	}
+	return removeFileIfExists(ev.path)
+}
+
+// removeVerificationRecordAndDigest deletes a skill's verification record file
+// and, when the file existed, prunes its evidence-digest entry so a digest entry
+// never outlives the record it certifies.
+func removeVerificationRecordAndDigest(root string, change model.Change, path, skillName string) (bool, error) {
+	removed, err := removeFileIfExists(path)
+	if err != nil {
+		return false, err
+	}
+	if removed {
+		if err := pruneEvidenceDigestForSkill(root, change, skillName); err != nil {
+			return false, err
+		}
+	}
+	return removed, nil
 }
 
 func stalePlanningRecoveryNeededForPlanAuditDigest(root string, change model.Change) (bool, error) {

--- a/internal/engine/progression/evidence_digests.go
+++ b/internal/engine/progression/evidence_digests.go
@@ -126,6 +126,118 @@ func stampEvidenceDigestForSkill(
 	return state.SaveEvidenceDigests(root, change.Slug, next)
 }
 
+// Tier-0 evidence-restamp refusal reasons.
+const (
+	EvidenceRestampReasonNoEvidence        = "no_passing_evidence"
+	EvidenceRestampReasonVerdictNotPassing = "verdict_not_passing"
+	EvidenceRestampReasonInputsChanged     = "inputs_changed_after_verdict"
+	EvidenceRestampReasonInputsUnavailable = "input_digest_unavailable"
+)
+
+// EvidenceRestampOutcome reports the result of a Tier-0 evidence-restamp attempt.
+type EvidenceRestampOutcome struct {
+	Skill         string   // skill whose digest was assessed
+	Eligible      bool     // Tier-0 safe: verdict passing + inputs unchanged after verdict
+	Stamped       bool     // digest was written (always false in dry-run)
+	DryRun        bool     // assessment only; no state mutated
+	Reason        string   // refusal reason, set when !Eligible
+	ChangedInputs []string // inputs that changed after the verdict, when refused for drift
+	RerunSkill    string   // host skill to re-run when not eligible
+}
+
+// RestampEvidenceDigestTier0 records the engine-owned input digest for a skill
+// when (and only when) the recorded verdict is still passing and the certified
+// inputs did not change after the verdict — Tier 0, provably safe. It never
+// fabricates a pass: a missing or non-passing verdict, or any input changed
+// after the verdict, is refused, and the caller is told which host skill to
+// re-run. With dryRun the eligibility is assessed without writing the digest.
+func RestampEvidenceDigestTier0(root string, change model.Change, skillName string, dryRun bool) (EvidenceRestampOutcome, error) {
+	skillName = strings.TrimSpace(skillName)
+	outcome := EvidenceRestampOutcome{Skill: skillName, DryRun: dryRun, RerunSkill: skillName}
+	if skillName == "" {
+		return outcome, fmt.Errorf("skill name is required")
+	}
+	record, err := state.LoadVerification(root, change.Slug, skillName)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) || errors.Is(err, os.ErrNotExist) {
+			outcome.Reason = EvidenceRestampReasonNoEvidence
+			return outcome, nil
+		}
+		return outcome, err
+	}
+	if !record.IsPassing() {
+		outcome.Reason = EvidenceRestampReasonVerdictNotPassing
+		return outcome, nil
+	}
+	if err := ensureDigestInputsAvailableForRestamp(root, change, skillName); err != nil {
+		if digestStampUnavailable(err) {
+			outcome.Reason = EvidenceRestampReasonInputsUnavailable
+			return outcome, nil
+		}
+		return outcome, err
+	}
+	// Tier-0 safety: refuse if any certified input changed after the verdict.
+	changedAfterVerdict, err := digestInputsChangedAfterVerdict(root, change, skillName, record.Timestamp)
+	if err != nil {
+		if digestStampUnavailable(err) {
+			outcome.Reason = EvidenceRestampReasonInputsUnavailable
+			return outcome, nil
+		}
+		return outcome, err
+	}
+	if len(changedAfterVerdict) > 0 {
+		outcome.Reason = EvidenceRestampReasonInputsChanged
+		outcome.ChangedInputs = changedAfterVerdict
+		return outcome, nil
+	}
+	outcome.Eligible = true
+	if dryRun {
+		return outcome, nil
+	}
+	summary, err := state.LoadOptionalRelevantExecutionSummary(root, change)
+	if err != nil {
+		return outcome, err
+	}
+	if err := stampEvidenceDigestForSkill(root, change, skillName, record, summary); err != nil {
+		if digestStampUnavailable(err) {
+			outcome.Eligible = false
+			outcome.Reason = EvidenceRestampReasonInputsUnavailable
+			return outcome, nil
+		}
+		return outcome, err
+	}
+	outcome.Stamped = true
+	return outcome, nil
+}
+
+func ensureDigestInputsAvailableForRestamp(root string, change model.Change, skillName string) error {
+	_, err := digestInputArtifactPaths(root, change, skillName)
+	return err
+}
+
+// pruneEvidenceDigestForSkill removes a skill's entry from evidence-digests.yaml
+// when present. It is the digest half of removing a verification record, so a
+// digest entry never outlives the record it certifies.
+func pruneEvidenceDigestForSkill(root string, change model.Change, skillName string) error {
+	skillName = strings.TrimSpace(skillName)
+	if skillName == "" {
+		return nil
+	}
+	digests, err := state.LoadOptionalEvidenceDigestsForChange(root, change)
+	if err != nil {
+		return err
+	}
+	if digests == nil {
+		return nil
+	}
+	digests.Normalize()
+	if _, ok := digests.Skills[skillName]; !ok {
+		return nil
+	}
+	delete(digests.Skills, skillName)
+	return state.SaveEvidenceDigests(root, change.Slug, *digests)
+}
+
 func skillDigestFreshnessBlockers(
 	root string,
 	change model.Change,
@@ -161,16 +273,22 @@ func skillDigestFreshnessBlockersWithSummary(
 	}
 
 	if !hasStored {
+		// No stored digest entry yet. If the skill was never recorded and a digest
+		// file already exists for other skills, there is nothing to be stale about.
 		if digests != nil {
 			recorded, err := lifecycleHasRecordedSkillEvidence(root, change, skillName)
 			if err != nil {
 				return nil, err
 			}
-			if recorded {
-				return []string{"required_skill_stale:" + strings.TrimSpace(skillName) + ":input_digest_missing"}, nil
+			if !recorded {
+				return nil, nil
 			}
-			return nil, nil
 		}
+		// Tier-0: a recorded (or legacy file-absent) orphan is healable when its
+		// certified inputs did not change after the verdict; only report stale, with
+		// the specific changed inputs, when they genuinely did. Unifying the
+		// digests==nil and digests!=nil branches here means a missing digest entry no
+		// longer deadlocks on the generic input_digest_missing token.
 		changedAfterVerdict, err := digestInputsChangedAfterVerdict(root, change, skillName, record.Timestamp)
 		if err != nil {
 			return nil, err
@@ -260,10 +378,11 @@ func stampPassingSkillDigests(
 			if recorded, err := lifecycleHasRecordedSkillEvidence(root, change, skillName); err != nil {
 				return skillDigestStampResult{}, err
 			} else if recorded && !digestChecked {
-				if existingDigests != nil {
-					result.Blockers = append(result.Blockers, "required_skill_stale:"+skillName+":input_digest_missing")
-					continue
-				}
+				// Tier-0 backfill: a recorded orphan with no digest entry is healable
+				// when its certified inputs did not change after the verdict; only block,
+				// with the specific changed inputs, when they genuinely did. This applies
+				// whether or not a digest file already exists for other skills, so a
+				// missing entry no longer deadlocks on input_digest_missing.
 				changedAfterVerdict, err := digestInputsChangedAfterVerdict(root, change, skillName, record.Timestamp)
 				if err != nil {
 					if digestStampUnavailable(err) {
@@ -455,7 +574,11 @@ func addPlanningArtifactInputs(root string, change model.Change, inputs map[stri
 		return err
 	}
 	seenAny := false
-	for _, rel := range []string{"intent.md", "requirements.md", "research.md", "decision.md", "assurance.md"} {
+	// assurance.md is intentionally excluded: plan-audit (S1) never audits the
+	// assurance contract — AssuranceContractBlockers enforces it only at S3_REVIEW
+	// and later — so a late assurance.md edit must not retroactively stale the
+	// plan-audit digest. assurance.md remains an input to the final-closeout digest.
+	for _, rel := range []string{"intent.md", "requirements.md", "research.md", "decision.md"} {
 		path := filepath.Join(bundleDir, rel)
 		if _, err := os.Stat(path); err != nil {
 			if errors.Is(err, fs.ErrNotExist) {

--- a/internal/engine/progression/evidence_digests_test.go
+++ b/internal/engine/progression/evidence_digests_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPlanAuditInputDigestIncludesAssuranceAndSemanticTasks(t *testing.T) {
+func TestPlanAuditInputDigestExcludesAssuranceAndIncludesSemanticTasks(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
@@ -24,7 +24,8 @@ func TestPlanAuditInputDigestIncludesAssuranceAndSemanticTasks(t *testing.T) {
 
 	first, err := certifiedSkillInputDigest(root, change, SkillPlanAudit, nil)
 	require.NoError(t, err)
-	require.Contains(t, first.Inputs, "assurance.md")
+	require.NotContains(t, first.Inputs, "assurance.md", "plan-audit never audits assurance.md; it must not be a plan-audit digest input")
+	require.Contains(t, first.Inputs, "decision.md")
 	require.Contains(t, first.Inputs, "tasks.md")
 
 	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "intent.md"), []byte("# Intent\r\nship digest freshness\r\n"), 0o644))
@@ -40,7 +41,48 @@ func TestPlanAuditInputDigestIncludesAssuranceAndSemanticTasks(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "assurance.md"), []byte("# Assurance\nchanged\n"), 0o644))
 	changedAssurance, err := certifiedSkillInputDigest(root, change, SkillPlanAudit, nil)
 	require.NoError(t, err)
-	assert.NotEqual(t, first.Inputs["assurance.md"], changedAssurance.Inputs["assurance.md"])
+	assert.NotContains(t, changedAssurance.Inputs, "assurance.md", "editing assurance.md must not introduce a plan-audit digest input")
+	assert.Equal(t, first.Inputs, changedAssurance.Inputs, "assurance.md changes must not affect the plan-audit digest")
+}
+
+func TestLateAssuranceEditDoesNotStalePlanAuditAtS1(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	change := model.NewChange("late-assurance-edit")
+	change.CurrentState = model.StateS1Plan
+	change.PlanSubStep = model.PlanSubStepAudit
+	require.NoError(t, state.SaveChange(root, change))
+	bundleDir := writeDigestPlanningBundle(t, root, change, uncheckedDigestTasks())
+
+	verdictAt := time.Date(2026, 6, 4, 1, 0, 0, 0, time.UTC)
+	rec := model.VerificationRecord{
+		Verdict:   model.VerificationVerdictPass,
+		Blockers:  []model.ReasonCode{},
+		Timestamp: verdictAt,
+	}
+	// Planning inputs settled before the verdict; the plan-audit digest is stamped.
+	beforeVerdict := verdictAt.Add(-time.Minute)
+	for _, rel := range []string{"intent.md", "requirements.md", "research.md", "decision.md", "assurance.md", "tasks.md"} {
+		require.NoError(t, os.Chtimes(filepath.Join(bundleDir, rel), beforeVerdict, beforeVerdict))
+	}
+	writeVerificationForTest(t, root, change.Slug, SkillPlanAudit, rec)
+	require.NoError(t, stampEvidenceDigestForSkill(root, change, SkillPlanAudit, rec, nil))
+
+	// A late closeout-style edit to assurance.md, well after the plan-audit verdict.
+	afterVerdict := verdictAt.Add(time.Hour)
+	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "assurance.md"), []byte("# Assurance\nrewritten during closeout\n"), 0o644))
+	require.NoError(t, os.Chtimes(filepath.Join(bundleDir, "assurance.md"), afterVerdict, afterVerdict))
+
+	passing, blockers, err := EvaluateRequiredSkillsForChange(root, change, model.StateS1Plan, 0, false, model.PlanSubStepAudit)
+	require.NoError(t, err)
+	require.Empty(t, blockers, "a late assurance.md edit must not stale plan-audit")
+	assert.Contains(t, passing, SkillPlanAudit)
+
+	// The stamped plan-audit digest must not carry an assurance.md input at all.
+	digests, err := state.LoadEvidenceDigestsForChange(root, change)
+	require.NoError(t, err)
+	assert.NotContains(t, digests.Skills[SkillPlanAudit].Inputs, "assurance.md")
 }
 
 func TestEvaluateRequiredSkillsUsesContentDigestNotMTime(t *testing.T) {
@@ -62,18 +104,18 @@ func TestEvaluateRequiredSkillsUsesContentDigestNotMTime(t *testing.T) {
 	require.NoError(t, stampEvidenceDigestForSkill(root, change, SkillPlanAudit, rec, nil))
 
 	olderThanEvidence := rec.Timestamp.Add(-time.Hour)
-	require.NoError(t, os.Chtimes(filepath.Join(bundleDir, "assurance.md"), olderThanEvidence, olderThanEvidence))
+	require.NoError(t, os.Chtimes(filepath.Join(bundleDir, "requirements.md"), olderThanEvidence, olderThanEvidence))
 	passing, blockers, err := EvaluateRequiredSkillsForChange(root, change, model.StateS1Plan, 0, false, model.PlanSubStepAudit)
 	require.NoError(t, err)
 	require.Empty(t, blockers)
 	assert.Contains(t, passing, SkillPlanAudit)
 
-	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "assurance.md"), []byte("# Assurance\nreal change\n"), 0o644))
-	require.NoError(t, os.Chtimes(filepath.Join(bundleDir, "assurance.md"), olderThanEvidence, olderThanEvidence))
+	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "requirements.md"), []byte("# Requirements\nREQ-001 real change\n"), 0o644))
+	require.NoError(t, os.Chtimes(filepath.Join(bundleDir, "requirements.md"), olderThanEvidence, olderThanEvidence))
 	passing, blockers, err = EvaluateRequiredSkillsForChange(root, change, model.StateS1Plan, 0, false, model.PlanSubStepAudit)
 	require.NoError(t, err)
 	assert.Empty(t, passing)
-	assert.Contains(t, blockers, "required_skill_stale:plan-audit:assurance.md")
+	assert.Contains(t, blockers, "required_skill_stale:plan-audit:requirements.md")
 }
 
 func TestEvaluateRequiredSkillsAcceptsRefreshedVerdictAfterDigestDrift(t *testing.T) {
@@ -195,10 +237,10 @@ func TestDigestBackfillRefusesArtifactsChangedAfterVerdict(t *testing.T) {
 	writeVerificationForTest(t, driftRoot, driftChange.Slug, SkillPlanAudit, rec)
 
 	afterVerdict := verdictAt.Add(time.Minute)
-	require.NoError(t, os.Chtimes(filepath.Join(driftBundleDir, "assurance.md"), afterVerdict, afterVerdict))
+	require.NoError(t, os.Chtimes(filepath.Join(driftBundleDir, "decision.md"), afterVerdict, afterVerdict))
 	_, blockers, err = EvaluateRequiredSkillsForChange(driftRoot, driftChange, model.StateS1Plan, 0, false, model.PlanSubStepAudit)
 	require.NoError(t, err)
-	assert.Contains(t, blockers, "required_skill_stale:plan-audit:assurance.md")
+	assert.Contains(t, blockers, "required_skill_stale:plan-audit:decision.md")
 }
 
 func TestLegacyWaveDigestBackfillRefusesRuntimeTaskEvidenceChangedAfterVerdict(t *testing.T) {
@@ -537,7 +579,7 @@ func TestStampPassingSkillDigestsDoesNotLetHistoricalIntakeBlockPlanAcceptance(t
 	assert.NotContains(t, digests.Skills, SkillIntakeClarification)
 }
 
-func TestFeatureActiveMissingDigestEntryBlocksOnlyPreviouslyAcceptedSkill(t *testing.T) {
+func TestFeatureActiveMissingDigestEntryBackfillsWhenInputsUnchanged(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
@@ -545,14 +587,20 @@ func TestFeatureActiveMissingDigestEntryBlocksOnlyPreviouslyAcceptedSkill(t *tes
 	change.CurrentState = model.StateS1Plan
 	change.PlanSubStep = model.PlanSubStepAudit
 	require.NoError(t, state.SaveChange(root, change))
-	writeDigestPlanningBundle(t, root, change, uncheckedDigestTasks())
+	bundleDir := writeDigestPlanningBundle(t, root, change, uncheckedDigestTasks())
 
+	verdictAt := time.Date(2026, 6, 4, 1, 0, 0, 0, time.UTC)
 	rec := model.VerificationRecord{
 		Verdict:   model.VerificationVerdictPass,
 		Blockers:  []model.ReasonCode{},
-		Timestamp: time.Date(2026, 6, 4, 1, 0, 0, 0, time.UTC),
+		Timestamp: verdictAt,
 	}
 	writeVerificationForTest(t, root, change.Slug, SkillPlanAudit, rec)
+	// Inputs settled before the verdict, so the orphan is Tier-0 healable.
+	beforeVerdict := verdictAt.Add(-time.Minute)
+	for _, rel := range []string{"intent.md", "requirements.md", "research.md", "decision.md", "tasks.md"} {
+		require.NoError(t, os.Chtimes(filepath.Join(bundleDir, rel), beforeVerdict, beforeVerdict))
+	}
 	require.NoError(t, state.SaveEvidenceDigests(root, change.Slug, model.EvidenceDigests{
 		Version: model.EvidenceDigestsVersion,
 		Skills:  map[string]model.SkillDigest{},
@@ -571,13 +619,23 @@ func TestFeatureActiveMissingDigestEntryBlocksOnlyPreviouslyAcceptedSkill(t *tes
 	})
 	require.NoError(t, err)
 
+	// New contract: a recorded orphan with inputs unchanged after the verdict is
+	// Tier-0 healable, not a deadlock — it stays passing with no input_digest_missing.
 	passing, blockers, err = EvaluateRequiredSkillsForChange(root, change, model.StateS1Plan, 0, false, model.PlanSubStepAudit)
 	require.NoError(t, err)
-	assert.Empty(t, passing)
-	assert.Contains(t, blockers, "required_skill_stale:plan-audit:input_digest_missing")
+	require.Empty(t, blockers)
+	assert.Contains(t, passing, SkillPlanAudit)
+
+	// Mutating advancement backfills the missing digest entry.
+	result, err := stampPassingSkillDigests(root, change, map[string]model.VerificationRecord{SkillPlanAudit: rec})
+	require.NoError(t, err)
+	require.Empty(t, result.Blockers)
+	digests, err := state.LoadEvidenceDigestsForChange(root, change)
+	require.NoError(t, err)
+	assert.Contains(t, digests.Skills, SkillPlanAudit)
 }
 
-func TestStampPassingSkillDigestsBlocksFeatureActiveMissingPreviouslyAcceptedResearchDigest(t *testing.T) {
+func TestStampPassingSkillDigestsBackfillsFeatureActiveMissingResearchDigestWhenUnchanged(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
@@ -614,21 +672,21 @@ func TestStampPassingSkillDigestsBlocksFeatureActiveMissingPreviouslyAcceptedRes
 
 	passing, blockers, err := EvaluateRequiredSkillsForChange(root, change, model.StateS1Plan, 0, false, model.PlanSubStepResearch)
 	require.NoError(t, err)
-	assert.Empty(t, passing)
-	assert.Contains(t, blockers, "required_skill_stale:research-orchestration:input_digest_missing")
+	require.Empty(t, blockers)
+	assert.Contains(t, passing, SkillResearchOrchestration)
 
 	result, err := stampPassingSkillDigests(root, change, map[string]model.VerificationRecord{})
 	require.NoError(t, err)
-	assert.Empty(t, result.BackfilledSkills, "feature-active missing entries are not legacy file-absent backfill")
-	assert.Contains(t, result.Blockers, "required_skill_stale:research-orchestration:input_digest_missing")
+	require.Empty(t, result.Blockers)
+	assert.Empty(t, result.BackfilledSkills, "non-legacy backfill does not emit a legacy file-absent backfill event")
 	digests, err := state.LoadEvidenceDigestsForChange(root, change)
 	require.NoError(t, err)
-	assert.NotContains(t, digests.Skills, SkillResearchOrchestration)
+	assert.Contains(t, digests.Skills, SkillResearchOrchestration, "Tier-0 backfill stamps the previously-accepted orphan when inputs are unchanged after the verdict")
 
 	passing, blockers, err = EvaluateRequiredSkillsForChange(root, change, model.StateS1Plan, 0, false, model.PlanSubStepResearch)
 	require.NoError(t, err)
-	assert.Empty(t, passing)
-	assert.Contains(t, blockers, "required_skill_stale:research-orchestration:input_digest_missing")
+	require.Empty(t, blockers)
+	assert.Contains(t, passing, SkillResearchOrchestration)
 }
 
 func TestResearchOrchestrationInputDigestIncludesResearchArtifact(t *testing.T) {
@@ -752,11 +810,11 @@ func TestGatePlanningSkillRecordsPreservesStaleDigestArtifactName(t *testing.T) 
 	}
 	writeVerificationForTest(t, root, change.Slug, SkillPlanAudit, rec)
 	require.NoError(t, stampEvidenceDigestForSkill(root, change, SkillPlanAudit, rec, nil))
-	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "assurance.md"), []byte("# Assurance\nchanged after plan audit\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "decision.md"), []byte("# Decision\nchanged after plan audit\n"), 0o644))
 
 	_, blockers, err := gatePlanningSkillRecords(root, change, model.PlanSubStepAudit)
 	require.NoError(t, err)
-	assert.Contains(t, blockers, "required_skill_stale:plan-audit:assurance.md")
+	assert.Contains(t, blockers, "required_skill_stale:plan-audit:decision.md")
 }
 
 func TestExecutionSummaryFreshnessUsesTaskPlanHashNotTaskMTime(t *testing.T) {


### PR DESCRIPTION

## Summary
- add Tier-0 `slipway evidence restamp --skill X [--dry-run]` over the canonical engine digest checks
- backfill missing evidence digest entries only when the recorded verdict is passing and certified inputs are unchanged after the verdict
- decouple `assurance.md` from the plan-audit digest, prune stale-planning zombie digest entries, and surface `required_skill_stale` as actionable/stale evidence
- route repair diagnostics toward the public restamp recovery path without adding a compatibility shim for prior digest input sets
- archive the governed change bundle after `slipway done`

## Verification
- `go vet ./...`
- `git diff --check`
- `go build ./...`
- `go test ./... -count=1`
- `go run . validate --json --change recovery-ux-p0-issue-83-break-the-input-digest-missing-deadl` -> `G_plan/G_scope/G_ship` approved, `blockers=null`, `evidence_freshness=fresh`
- `go run . run --json --diagnostics --change recovery-ux-p0-issue-83-break-the-input-digest-missing-deadl` -> `advanced.action=done_ready`
- `go run . done --json --change recovery-ux-p0-issue-83-break-the-input-digest-missing-deadl` -> `status=done`, `archived=true`

Closes #83
Part of #81
