### PR TITLE
feat(recovery): add read-only recovery guidance surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,26 @@ JSON is intentionally compact; use `--diagnostics` for gate status, artifact
 status, skill evidence, context-budget details, wave plans, and transition
 traces.
 
+When a state carries a known recovery-relevant blocker — or a ready-to-advance/
+finalize next action — `next --json`, `run --json`, and `validate --json` carry a
+read-only `recovery` object, and so does a governance-blocked `CLIError`.
+`recovery.primary_command` and `recovery.primary_action` name the single
+highest-priority next action (selected by a static stage-priority rule, not a
+dependency planner), and `recovery.steps[]` carries one entry per actionable
+`(code, subject)` group with its parsed `code`/`subject`, the sorted `details[]`
+the group spans, a `remediation` string, a `command`, and a `recovery_class`;
+blockers that share a code and subject but differ only in detail (one stale skill
+across many artifacts) collapse into a single step. The field is additive and `omitempty` —
+derived from the blockers, never written to evidence, and absent only when no
+listed blocker maps to a remediation — and is presentation only: it never alters
+which blockers apply or any gate decision. The `primary_command` is always a
+public surface valid in the current state (e.g. plan-audit budget exhaustion in
+S1 routes to `slipway pivot --reroute`, never the S2_EXECUTE-only rescope). The
+same blocker vocabulary backs every surface through one parser, so `validate`,
+the compact `next`/`run` handoff, and `CLIError` describe the same blocker
+identically. The dependency-ordered recovery planner and a first-class
+`slipway recover` command are not part of this surface.
+
 `next_skill.technique_hints` may include exported `skill:*` hints and optional
 `capability:*` hints. `capability:language-testing` is a host-resolution hint:
 when `skill:test-design` is present and Slipway detects one or more project

--- a/README.md
+++ b/README.md
@@ -175,6 +175,17 @@ slipway done --json
 ```
 
 `next`, `status`, and `validate` are read-only inspection surfaces. `run`, `new`, `preset`, `checkpoint`, `repair`, `cancel`, `abort`, and `done` can mutate local governed state.
+The blocked/stale `next` and `validate` views, the `run --json` handoff, and
+governance-blocked `CLIError` envelopes carry an additive, read-only `recovery`
+object whenever a listed blocker — or a ready-to-advance/finalize next action —
+maps to a known remediation: a `primary_command` / `primary_action` (the single
+highest-priority next action) plus `steps[]` — one entry per `(code, subject)`
+group, with `code`, `subject`, the collected `details`, `remediation`, and
+`command`, so one skill's many stale artifacts surface as a single step. The
+object is derived from the blockers and never
+written to evidence; it is `omitempty` (absent only when no listed blocker has a
+recovery vocabulary) and presentation-only — it never changes which blockers
+apply or any gate decision.
 Diagnostic JSON uses explicit review and freshness contracts: review evidence
 must record exact layer tokens such as `layer:R0=pass` or `layer:IR1=pass`, and
 execution freshness is based on structural task inputs plus semantic

--- a/artifacts/changes/archived/recovery-ux-p1-issue-84-prefix-aware-blocker-parser-parsedbl/assurance.md
+++ b/artifacts/changes/archived/recovery-ux-p1-issue-84-prefix-aware-blocker-parser-parsedbl/assurance.md
@@ -1,0 +1,145 @@
+# Assurance
+## Project Context
+- Tech Stack: Go
+- Conventions: governance engine under `internal/engine`, model types under `internal/model`, CLI views under `cmd/`
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Scope Summary
+Recovery UX P1 (#84), part of the broader issue #81 recovery UX track, delivers a
+presentation-only recovery vocabulary for blocked/stale governed states. The
+implemented scope is:
+
+- a single prefix-aware blocker parser (`ParsedBlocker`, `ParseBlocker`, and
+  `ParseBlockerSpec`) in `internal/model`;
+- a Code-keyed remediation table parallel to `canonicalReasonDefinitions`;
+- a read-only `recovery` object on `next --json`, `run --json`, `validate --json`,
+  and governance-blocked `CLIError` envelopes;
+- grouped `recovery.steps[]` entries keyed by `(code, subject)`, so one skill's
+  many stale artifacts surface as one actionable step with sorted `details[]`;
+- a static stage-priority `primary_command` / `primary_action`, explicitly not
+  the P2 dependency planner;
+- canonical messages for recovery-relevant internal prefix tokens; and
+- README.md / CLAUDE.md documentation for the additive JSON surface.
+
+The change is additive and read-only. Existing `blockers[]` arrays remain
+`[]ReasonCode`; persisted `ReasonCode` serialization is unchanged; blocker
+producers, gates, state transitions, and governed semantics are not changed.
+The P2 recovery planner / `slipway recover` / Tier-2 restamp (#85) and P3
+narrow-gap lifecycle fixes (#86) remain out of scope.
+
+## Verification Verdict
+Current S1/S2/S3 governance evidence is refreshed and passing. The active
+`validate --json` proof captured with `/tmp/slipway-p1-closeout validate --json
+--change recovery-ux-p1-issue-84-prefix-aware-blocker-parser-parsedbl` reports:
+
+- `evidence_freshness: fresh`;
+- `G_plan: approved`;
+- `G_scope: approved`;
+- `scope_contract.status: pass`;
+- `requirements_contract.status: valid`;
+- `G_ship: blocked` only because S4 `goal-verification` and `final-closeout`
+  evidence still need to be written and accepted before `done`.
+
+Fresh local command proof for the current source state:
+
+- `go build ./...` passed;
+- `go test -count=1 ./...` passed across all packages;
+- `go vet ./...` passed;
+- `git diff --check` passed;
+- `gofmt -l` over changed Go files returned no files.
+
+The two required review layers have been re-run after the post-review repair:
+`spec-compliance-review.yaml` records `layer:R0=pass`, `scope_contract:pass`,
+and `negative_path:pass`; `code-quality-review.yaml` records `layer:IR1=pass`.
+
+## Evidence Index
+- `verification/intake-clarification.yaml` — pass, scoped P1 standalone and
+  explicitly excludes P2/P3 work.
+- `verification/research-orchestration.yaml` — pass, re-certified after wording
+  repair; selected approach C remains current.
+- `verification/plan-audit.yaml` — pass, required artifacts present, 8D checklist
+  passes, codebase map partiality recorded as advisory.
+- `verification/wave-plan.yaml` — 7 tasks, 4 waves,
+  `tasks_plan_hash=e4b1ed38ed3d079c34a45ecfe3b06c51f3cfc50b90ec941e066ef134be44d47e`.
+- `verification/wave-orchestration.yaml` — pass, run_version 1, t-01..t-07 task
+  evidence recorded via `slipway evidence task` with the current tasks plan hash.
+- `verification/execution-summary.yaml` — pass, run_summary_version 1,
+  completed_tasks t-01..t-07.
+- `verification/spec-compliance-review.yaml` — pass, `layer:R0=pass`,
+  `scope_contract:pass`, `negative_path:pass`.
+- `verification/code-quality-review.yaml` — pass, `layer:IR1=pass`.
+- S4 records still to be accepted before `done`: `verification/goal-verification.yaml`
+  and `verification/final-closeout.yaml`.
+
+Primary source/test references:
+
+- `internal/model/recovery.go`
+- `internal/model/reason_code.go`
+- `cmd/next.go`
+- `cmd/next_handoff.go`
+- `cmd/validate.go`
+- `cmd/next_skill_view.go`
+- `cmd/errors.go`
+- `cmd/repair.go`
+- `internal/model/recovery_test.go`
+- `cmd/recovery_view_test.go`
+- `cmd/lifecycle_commands_test.go`
+- `cmd/validate_artifact_gate_test.go`
+- `README.md`
+- `CLAUDE.md`
+
+## Requirement Coverage
+- REQ-001 single parser: implemented by `internal/model/recovery.go`, consumed by
+  `cmd/next_skill_view.go` and `cmd/repair.go`, covered by
+  `TestParseBlockerSegments` and `TestParseBlockerIsSingleDecompositionPoint`.
+- REQ-002 remediation table: implemented by `blockerRemediations`, covered by
+  remediation table completeness, recovery-relevant canonical token coverage,
+  and produced-token recovery tests.
+- REQ-003 recovery object on next/run/validate: implemented by `nextView`,
+  `nextHandoffView`, `validateView`, and validate gate-detail recovery, covered
+  by command tests including compact handoff and validate recovery tests.
+- REQ-004 compact handoff primary command: implemented by
+  `buildNextHandoffView`, covered by `TestNextHandoffViewCarriesRecovery`.
+- REQ-005 canonical messages: implemented in `canonicalReasonDefinitions` for
+  recovery-relevant internal tokens, covered by canonical-message and
+  produced-token tests.
+- REQ-006 CLIError parity: implemented in `cmd/errors.go`, covered by
+  `TestGovernanceBlockedErrorCarriesRecovery`.
+- REQ-007 read-only/additive/docs: implemented with `omitempty` recovery fields,
+  unchanged `ReasonCode` persistence, and README/CLAUDE docs; covered by
+  serialization-shape and clean-state omitempty tests.
+
+All requirements have Exists, Substantive, and Wired proof through source,
+tests, and S2 execution evidence. No requirement is deferred.
+
+## Residual Risks and Exceptions
+- `primary_command` uses a static recovery-class priority list, not a
+  dependency-ordered planner. This is intentional P1 scope; the planner remains
+  P2 (#85).
+- The remediation table covers recovery-relevant tokens. Non-recovery diagnostic
+  tokens may still render through their existing paths; this is outside P1.
+- JSON consumers that reject unknown fields could notice the additive
+  `recovery` field. The field is `omitempty`, documented, and read-only; this is
+  accepted as a backward-compatible host-facing extension.
+- Codebase map status is partial and some map prose describes older work. The
+  current governed bundle and direct source/test reads are the authority for this
+  change; the map limitation is advisory and did not block plan audit.
+
+## Rollback Readiness
+Rollback is clean and immediate: remove `internal/model/recovery.go`, remove the
+additive `Recovery` fields and `model.BuildRecovery` calls from the CLI views
+and `CLIError`, remove the `blockerSkillName` parser delegation, remove the new
+canonical/remediation entries, and revert the tests/docs. No persisted state,
+evidence schema, gate behavior, migration, or destructive operation is involved.
+
+## Archive Decision
+Archive-ready after the S4 verification records are accepted and final active
+validation confirms `G_ship: approved`. The active pre-done validation proof has
+already been captured against the active bundle and current worktree with the
+fresh local binary `/tmp/slipway-p1-closeout`; at this stage it reports only the
+expected missing `goal-verification` / `final-closeout` S4 evidence blockers.
+`slipway done` must be run only after those records are written, the
+final-closeout assurance attestation `closeout:assurance_complete=pass` is
+accepted, and active `validate --json` reports no blockers.

--- a/artifacts/changes/archived/recovery-ux-p1-issue-84-prefix-aware-blocker-parser-parsedbl/change.yaml
+++ b/artifacts/changes/archived/recovery-ux-p1-issue-84-prefix-aware-blocker-parser-parsedbl/change.yaml
@@ -1,0 +1,57 @@
+version: 1
+slug: recovery-ux-p1-issue-84-prefix-aware-blocker-parser-parsedbl
+description: 'Recovery UX P1 (issue #84): prefix-aware blocker parser (ParsedBlocker with Code/Subject/Detail/Raw), a code/prefix-family remediation vocabulary table parallel to canonicalReasonDefinitions, a top-level read-only recovery object carrying grouped recovery.steps[] remediation and command on next/run/validate JSON while blockers[] remains ReasonCode, compact handoff preserving the primary recovery command, and canonical messages for internal prefix tokens such as required_skill_stale:* and tasks_plan_changed_since_task_evidence:*'
+status: done
+current_state: DONE
+needs_discovery: true
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-06-05T12:19:40.220532Z
+quality_mode: standard
+workflow_preset: standard
+worktree_branch: feat/recovery-ux-p1-issue-84-prefix-aware-blocker-parser-parsedbl
+artifact_schema: expanded
+project_context:
+    tech_stack: Go
+    test_cmd: go test ./...
+    build_cmd: go build ./...
+    languages:
+        - Go
+    recent_work: 'P0 #83 recovery tier-0 restamp merged via #87 (6d65fcc)'
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: b5e1dbff6308bccf3858978c6b8cb637edfcc685a358dcf05a91a9be69a789cb
+        updated_at: 2026-06-05T16:21:16.304908193Z
+    decision:
+        id: decision
+        path: decision.md
+        state: frozen
+        content_hash: 7ed81782fa66329b15e47b477a2df9516b965b6e7224d1ff2209640e64389342
+        updated_at: 2026-06-05T12:38:02.939530672Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: ad7b1038e3eeaaa0cc662fcb585ccd8bfd9e51ab3598ed1a5fd6e92f490aa7a4
+        updated_at: 2026-06-05T16:08:01.312941794Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: 8797e6f61ce4272a5c6516a4102cc7ac5a4c66a9487c5010fc7b82080cb8b321
+        updated_at: 2026-06-05T16:08:01.313314944Z
+    research:
+        id: research
+        path: research.md
+        state: frozen
+        content_hash: 2accba2e1b8744bf72924ac68f704eb57e0d0b5db19d33df8e4dd56972a91eaf
+        updated_at: 2026-06-05T16:08:24.529903538Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: bfedda9f26e82f9978c09def585aa1cc41ba1b371aaea573e4bebc3a82a7f68c
+        updated_at: 2026-06-05T16:04:00.783571718Z

--- a/artifacts/changes/archived/recovery-ux-p1-issue-84-prefix-aware-blocker-parser-parsedbl/decision.md
+++ b/artifacts/changes/archived/recovery-ux-p1-issue-84-prefix-aware-blocker-parser-parsedbl/decision.md
@@ -1,0 +1,42 @@
+# Decision
+
+## Project Context
+- Tech Stack: Go
+- Languages: Go
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Change: Recovery UX P1 (#84), part of #81; depends on merged P0 (#83/#87).
+
+## Alternatives Considered
+- **A — Enrich `ReasonCode` with Remediation/Command fields.** Max reuse, but `ReasonCode` is persisted (`yaml:` tags) so it leaks presentation into verification/gate evidence and forces broad golden-test churn. Rejected.
+- **B — Replace every view's `Blockers []ReasonCode` with a rendered blocker type.** Per-blocker remediation inline, but `nextView.Blockers` is used internally across `assembleSkillView`, so the type change ripples invasively. Rejected.
+- **C — New `internal/model` vocabulary + a top-level `recovery` projection at the view boundary.** Selected (see below).
+
+## Selected Approach
+**Approach C.** Add a presentation-only recovery vocabulary in `internal/model`, projected onto the read-only views without mutating the persisted `ReasonCode` or any blocker producer.
+
+New in `internal/model` (one new file, e.g. `recovery.go`):
+- `ParsedBlocker{Code, Subject, Detail, Raw}` + `ParseBlocker(ReasonCode) ParsedBlocker` (and a spec-string variant). The **single** decomposition point: it reuses the existing Code/Detail split and further splits Detail into Subject (2nd `:`-segment) + Detail (remainder). `cmd`'s ad-hoc `blockerSkillName` (`next_skill_view.go:474`) is refactored to call it.
+- `blockerRemediation{Remediation, CommandTemplate, RecoveryClass}` and a `blockerRemediations map[string]blockerRemediation` table keyed by Code (parallel to `canonicalReasonDefinitions`). Because every prefix family's Code is its first segment, Code-keying covers all families; `CommandTemplate` is filled from the parsed Subject/Detail.
+- `RecoverySummary{PrimaryCommand, PrimaryAction, RecoveryClass, Steps []RecoveryStep}` and `RecoveryStep{Code, Subject, Detail, Severity, Message, Remediation, Command, RecoveryClass}`. `BuildRecovery(blockers []ReasonCode) *RecoverySummary` parses each blocker, looks up its remediation, builds one Step per actionable blocker, and picks the primary by a **static stage-priority constant** (a fixed ordered list of recovery classes — NOT a derived dependency graph). Returns `nil` when no actionable recovery exists (so the field stays absent via `omitempty`).
+- Add the missing canonical message for `tasks_plan_changed_since_task_evidence` (and any peer recovery-relevant prefix tokens that currently humanize-fallthrough) to `canonicalReasonDefinitions`.
+
+Surface wiring (additive, `omitempty`):
+- `nextView` (cmd/next.go), `nextHandoffView` (cmd/next_handoff.go), and `validateView` (cmd/validate.go) each gain `Recovery *model.RecoverySummary json:"recovery,omitempty"`, populated from their existing `[]ReasonCode` blockers via `model.BuildRecovery`. The compact handoff (`buildNextHandoffView`) carries the same `recovery` (preserving the primary command — the surface a host hits first).
+- `CLIError` (cmd/errors.go) gains `Recovery *model.RecoverySummary json:"recovery,omitempty"`, built from its `Reasons` in `newCLIErrorWithReasons`, so views and the error surface consume the **same** builder.
+
+## Interfaces and Data Flow
+- Producers (`internal/engine/progression/*`, gates) → `[]model.ReasonCode` (unchanged) → `model.NormalizeReasonCodes` → view structs.
+- At each serialized view boundary: `view.Recovery = model.BuildRecovery(view.Blockers)`. `BuildRecovery` → `ParseBlocker` (per blocker) → `blockerRemediations[code]` lookup → `RecoveryStep` list → primary selection by `recoveryClassPriority`.
+- JSON shape (additive): each affected surface gains
+  `"recovery": { "primary_command": "...", "primary_action": "...", "recovery_class": "...", "steps": [ { "code","subject","detail","severity","message","remediation","command","recovery_class" } ] }`,
+  present only when there is an actionable blocker. Existing `blockers` arrays are byte-identical otherwise.
+
+## Rollout and Rollback
+- Rollout: pure additive surface + new model file; no migration, no state change, no producer change. Ships behind no flag (additive JSON is safe).
+- Rollback: delete the new model file and the `Recovery` fields/wiring; persisted state and evidence are untouched, so rollback is clean and immediate.
+
+## Risk
+- Low: additive JSON drift (mitigated by `omitempty` + docs) and golden-test churn (only blocked/stale fixtures gain the field).
+- Medium: the primary-command rule must not grow into the P2 dependency planner — held by implementing it as a static class-priority list with its own unit test and a documented P1/P2 boundary.
+- No guardrail domains; fully reversible.

--- a/artifacts/changes/archived/recovery-ux-p1-issue-84-prefix-aware-blocker-parser-parsedbl/intent.md
+++ b/artifacts/changes/archived/recovery-ux-p1-issue-84-prefix-aware-blocker-parser-parsedbl/intent.md
@@ -1,0 +1,75 @@
+# Intent
+
+## Project Context
+<!-- Auto-filled by InferProjectContext(); .slipway.yaml overrides -->
+- Tech Stack: Go
+- Languages: Go
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Conventions: standard Go; governance engine under `internal/engine`, model types under `internal/model`, CLI views under `cmd/`
+
+## Summary
+Recovery UX P1 (issue #84): prefix-aware blocker parser (ParsedBlocker with Code/Subject/Detail/Raw), a code/prefix-family remediation vocabulary table parallel to canonicalReasonDefinitions, a top-level read-only recovery object carrying grouped `recovery.steps[]` remediation and command on next/run/validate JSON while `blockers[]` remains `[]ReasonCode`, compact handoff preserving the primary recovery command, and canonical messages for internal prefix tokens such as required_skill_stale:* and tasks_plan_changed_since_task_evidence:*
+
+## Complexity Assessment
+complex
+<!-- Rationale -->
+Multi-surface, coordination-heavy: touches the model layer (new ParsedBlocker type + remediation vocabulary parallel to canonicalReasonDefinitions), three CLI read-only views (next, run, validate), the compact handoff path, and CLIError — all of which must consume one shared parse result. Read-only/additive, but the single-parse invariant and cross-surface consistency make it more than a bounded one-file change.
+
+## Guardrail Domains
+<!-- none detected -->
+None. Read-only, additive JSON surface + internal vocabulary. No auth, credentials, PII, financial, schema/migration, irreversible, or external-contract behavior is changed. New JSON fields are backward-compatible (optional, additive); existing gate/evaluation/state-transition logic is untouched. Consistent with the P0 (#83) precedent which was also `guardrail_domain=""`.
+
+## In Scope
+<!-- What is explicitly included -->
+- **Blocker parser.** New `ParsedBlocker{Code, Subject, Detail, Raw}` type and a parser that decomposes prefix tokens (`required_skill_stale:<skill>:<artifact>`, `tasks_plan_changed_since_task_evidence:<taskID>`, and the other prefix families) exactly once. This is the single decomposition point.
+- **Remediation vocabulary table.** A `code / prefix-family -> {Remediation, CommandTemplate, RecoveryClass}` table parallel to `canonicalReasonDefinitions` (`internal/model/reason_code.go`), supporting both exact codes and prefix families.
+- **Read-only `recovery` object on views.** Added to `next`, `run`, and `validate` JSON. `recovery.steps[]` carries `remediation` / `command` per parsed `(code, subject)` blocker group while the existing `blockers[]` array remains `[]ReasonCode`. The object carries one `primary_recovery_command` / next-action chosen by a simple stage-priority rule. `cmd/validate.go` currently has no warnings/recovery channel — add one.
+- **Compact handoff preserves the primary recovery command.** `cmd/next_handoff.go` must keep the single primary recovery command / next-action in the compact `next` / `run` JSON (the surface a host hits first), instead of stripping it the way `freshness_diagnostics` is stripped.
+- **Canonical messages for internal tokens.** Definitions/messages for `required_skill_stale:*`, `tasks_plan_changed_since_task_evidence:*`, and the other prefix tokens that currently fall through `humanizeReasonCode` to bare titles.
+- **Docs.** Document the new read-only `recovery` object and its grouped remediation steps in README/CLAUDE.md (they change the host-facing JSON contract).
+- **Tests** covering parser, vocabulary coverage, recovery object on all three views, compact-handoff preservation, and canonical messages.
+
+## Out of Scope
+<!-- What is explicitly excluded -->
+- The cross-gate dependency-ordering **recovery planner** (`internal/engine/recovery`) and the digest input dependency index → **P2 (#85)**.
+- The **`slipway recover`** command (`--dry-run`, `--from-artifact`, `--restamp`) → **P2 (#85)**.
+- **Tier-2 operator-attested restamp** + its audit event + guardrail fail-closed → **P2 (#85)**.
+- **P3 narrow-gap** lifecycle dead-ends (worktree rebind, dual-active naming, abort→repair loop, S2 scope guidance) and the broad README/docs sweep → **P3 (#86)**.
+- Any change to gate/evaluation logic, governance semantics, state transitions, or what blocks. P1 changes only **how** blockers are described/surfaced, never **whether** they block.
+
+## Constraints
+<!-- Technical / business / time constraints -->
+- **Read-only / additive only.** Must not change governance decisions, gate outcomes, or state transitions. New JSON fields must be backward-compatible (optional/additive); a host unaware of `recovery` keeps working.
+- **Single-parse invariant.** The parser is the only place prefix tokens are decomposed; views and `CLIError` consume the same parse result (no re-splitting tokens at call sites).
+- Reuse existing infrastructure: `CLIError.Remediation` already exists (`cmd/errors.go`); the vocabulary sits parallel to `canonicalReasonDefinitions`.
+- Go; `go build ./...` and `go test ./...` must stay green.
+
+## Acceptance Signals
+<!-- What verifiable signals indicate completion -->
+- `validate --json` and the default compact `next` / `run` JSON carry a non-empty primary recovery command / next-action for stale/blocked states (test: construct a blocked/stale change, assert the field is present and non-empty).
+- Every recovery-relevant blocker rendered through `recovery.steps[]` carries a remediation string — no bare humanized fallthrough for the known internal tokens (test asserts a non-empty remediation for each known exact code and prefix family).
+- The parser is the single decomposition point; views and `CLIError` consume the same parse result (parser unit tests + assertion that the surfacing paths route through it).
+- `go build ./...` and `go test ./...` green.
+
+## Open Questions
+<!-- All entry-time unknowns were RESOLVED during S1 research; see research.md `## Unknowns`. -->
+- RESOLVED (S1 research): `ParsedBlocker` lives in `internal/model` (new `recovery.go`) beside `reason_code.go`; the three serialized views (`nextView`, `nextHandoffView`, `validateView`) construct `Blockers []ReasonCode` directly.
+- RESOLVED (S1 research): the single `primary_recovery_command` is selected by a static `recoveryClassPriority` constant list (not a per-change dependency graph), which keeps it inside `internal/model` and away from the P2 planner.
+- RESOLVED (S1 research): `CLIError` already carries `Remediation`/`Reasons`; it consumes the shared `model.BuildRecovery` over its `Reasons` in `newCLIErrorWithReasons`.
+- RESOLVED (S1 research): the recovery-relevant prefix-token inventory is enumerated in the `blockerRemediations` table; only `tasks_plan_changed_since_task_evidence` needed a new canonical message.
+
+## Deferred Ideas
+<!-- Identified but postponed ideas -->
+- Full dependency-ordered recovery planner + `slipway recover` + Tier-2 attested restamp → P2 (#85).
+- P3 narrow-gap lifecycle dead-ends and broad docs sweep → P3 (#86).
+
+## Approved Summary
+<!-- Re-confirmed after rescope pivot (2026-06-05): scope amended to include the cmd/repair.go caller of the refactored blockerSkillName. -->
+P1 (#84) is done **standalone** per user direction ("P1 单独做", 2026-06-05), under the standing `/goal` authorization to drive this change to done-ready.
+
+The change adds, as a **read-only / additive** layer only: (1) a prefix-aware blocker parser (`ParsedBlocker`), (2) a remediation vocabulary table parallel to `canonicalReasonDefinitions`, (3) a read-only `recovery` object — grouped `recovery.steps[]` with `remediation`/`command` plus one `primary_recovery_command` selected by a static stage-priority rule — on `next`/`run`/`validate` and `CLIError`, (4) compact-handoff preservation of that primary command, (5) canonical messages for internal prefix tokens, and (6) docs for the new JSON fields. The existing `blockers[]` arrays remain `[]ReasonCode`; the `blockerSkillName` refactor to the shared parser updates both call sites (`cmd/next_skill_view.go` and `cmd/repair.go`).
+
+It explicitly **excludes** the P2 recovery planner, the `slipway recover` command, Tier-2 attested restamp (all → #85), and the P3 narrow-gap lifecycle fixes (→ #86). It changes only how blockers are described/surfaced, never whether they block, and makes no gate/semantics/state changes.
+
+Primary acceptance: blocked/stale states surface a non-empty primary recovery command on `validate`/`next`/`run`, and every known internal blocker token renders a remediation string; build and tests stay green.

--- a/artifacts/changes/archived/recovery-ux-p1-issue-84-prefix-aware-blocker-parser-parsedbl/requirements.md
+++ b/artifacts/changes/archived/recovery-ux-p1-issue-84-prefix-aware-blocker-parser-parsedbl/requirements.md
@@ -1,0 +1,137 @@
+# Requirements
+## Project Context
+- Tech Stack: Go
+- Conventions: governance engine in `internal/engine`, model types in `internal/model`, CLI views in `cmd/`
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Requirements
+
+### Requirement: Single prefix-aware blocker parser
+REQ-001: The system MUST provide one `ParsedBlocker{Code, Subject, Detail, Raw}`
+type and a single parser that decomposes a blocker (a `model.ReasonCode` or its
+`code:subject:detail` spec) into Code (first segment), Subject (second segment,
+e.g. a skill name or task ID), and Detail (remainder). This MUST be the only
+decomposition point for prefix tokens; the existing ad-hoc split in
+`cmd/next_skill_view.go` (`blockerSkillName`) MUST be refactored to call it.
+
+#### Scenario: Three-segment stale token parses into code/subject/detail
+GIVEN the blocker spec `required_skill_stale:plan-audit:assurance.md`
+WHEN it is parsed
+THEN Code is `required_skill_stale`, Subject is `plan-audit`, Detail is
+`assurance.md`, and Raw is the original spec.
+
+#### Scenario: Two-segment and bare tokens parse without panicking
+GIVEN the specs `tasks_plan_changed_since_task_evidence:t-03` and `plan_audit_failed`
+WHEN each is parsed
+THEN the first yields Subject `t-03` with empty Detail, and the second yields
+empty Subject and empty Detail, with Code set in both cases.
+
+### Requirement: Code-keyed remediation vocabulary
+REQ-002: The system MUST provide a remediation table parallel to
+`canonicalReasonDefinitions`, keyed by Code, mapping each recovery-relevant
+blocker to `{Remediation, CommandTemplate, RecoveryClass}`. Because every prefix
+family's Code is its first segment, Code-keying MUST cover both exact codes and
+prefix families. Lookups MUST return a non-empty remediation for every
+recovery-relevant token (`required_skill_*`, `tasks_plan_changed_since_task_evidence`,
+`stale_planning_*`, `stale_execution_evidence`, `plan_audit_*`, `scope_contract_*`,
+`wave_*`, `verification_evidence_missing`, `preset_confirmation_required`,
+`run_slipway_run_to_advance`), and CommandTemplates MUST be filled from the parsed
+Subject/Detail.
+
+#### Scenario: Stale skill token yields a rerun remediation and command
+GIVEN a blocker `required_skill_stale:plan-audit:assurance.md`
+WHEN its remediation is looked up
+THEN the remediation names re-running the `plan-audit` skill, and the command
+references a real public surface (`slipway run`, or `slipway evidence restamp
+--skill plan-audit --dry-run`), with the skill drawn from the parsed Subject.
+
+#### Scenario: Every table entry is non-empty
+GIVEN the full remediation table
+WHEN each entry is inspected
+THEN every entry has a non-empty Remediation and a RecoveryClass.
+
+### Requirement: Read-only recovery object on next/run/validate
+REQ-003: `next --json`, `run --json`, and `validate --json` MUST carry a top-level
+`recovery` object when an actionable blocker is present, containing one
+`primary_command` / `primary_action` chosen by a static stage-priority rule and a
+`steps` list. Actionable blockers MUST be grouped by their parsed `(Code,
+Subject)`: each step carries its `Code`/`Subject`, the sorted, de-duplicated
+`Details` the group spans, plus Remediation and Command — neither of which may
+vary by Detail within a group, so one skill's many stale artifacts surface as a
+single step rather than one step per artifact. The object MUST be absent
+(omitempty) when no actionable recovery exists. `cmd/validate.go`, which has no
+recovery channel today, MUST gain one. No blocker producer, gate, or state
+transition may change.
+
+#### Scenario: Blocked state surfaces a recovery object with a primary command
+GIVEN an active change whose blockers include a `required_skill_stale` token
+WHEN `validate --json` (and the compact `next`/`run` JSON) is produced
+THEN `recovery.primary_command` is present and non-empty and `recovery.steps`
+includes a step for the stale blocker with a non-empty remediation.
+
+#### Scenario: One skill's stale artifacts collapse into a single step
+GIVEN blockers `required_skill_stale:code-quality-review:CLAUDE.md` and
+`required_skill_stale:code-quality-review:README.md`
+WHEN the recovery object is produced
+THEN it contains a single `code-quality-review` step whose `details` list both
+artifacts, not one step per artifact.
+
+#### Scenario: Clean state omits the recovery object
+GIVEN an active change with no actionable blockers
+WHEN the views are produced
+THEN the `recovery` field is absent and the existing `blockers` array is
+unchanged.
+
+### Requirement: Compact handoff preserves the primary recovery command
+REQ-004: The compact `next`/`run` handoff (`buildNextHandoffView`) MUST carry the
+same `recovery` object — at minimum its `primary_command`/`primary_action` — so
+the first surface a host hits is not left without a next action, unlike
+`freshness_diagnostics` which the compact view intentionally strips.
+
+#### Scenario: Primary recovery command survives the compact projection
+GIVEN a blocked change whose full view carries a recovery primary command
+WHEN the compact handoff view is built
+THEN the compact JSON still contains `recovery.primary_command`.
+
+### Requirement: Canonical messages for internal prefix tokens
+REQ-005: Prefix tokens that currently fall through `humanizeReasonCode` to bare
+titles MUST gain canonical messages in `canonicalReasonDefinitions`, at minimum
+`tasks_plan_changed_since_task_evidence`, so no recovery-relevant token renders a
+machine-derived title.
+
+#### Scenario: tasks_plan_changed_since_task_evidence renders a written message
+GIVEN a blocker `tasks_plan_changed_since_task_evidence:t-03`
+WHEN its message is rendered
+THEN the message is the written canonical sentence, not the humanized
+"Tasks plan changed since task evidence".
+
+### Requirement: CLIError surfaces the same recovery builder
+REQ-006: `CLIError` MUST expose a `recovery` object built from its `Reasons` by
+the same `model.BuildRecovery` the views use, so the error surface and the view
+surfaces present an identical recovery vocabulary for the same blockers.
+
+#### Scenario: Governance-blocked error carries a recovery object
+GIVEN a governance-blocked `CLIError` constructed with reasons including an
+actionable blocker
+WHEN the error is encoded to JSON
+THEN it carries a `recovery` object whose primary command matches what the views
+would produce for the same reasons.
+
+### Requirement: Read-only/additive contract and documentation
+REQ-007: The change MUST be additive and read-only: all new JSON fields are
+`omitempty`, the persisted `model.ReasonCode` shape (its yaml-tagged fields) is
+unchanged, and no producer/gate/transition logic changes. The new host-facing
+`recovery`/remediation JSON fields MUST be documented in README.md and CLAUDE.md.
+
+#### Scenario: Persisted evidence shape is unchanged
+GIVEN the change is applied
+WHEN `model.ReasonCode` serialization to YAML is inspected
+THEN it contains no new presentation fields, and existing verification/gate
+records are byte-compatible.
+
+#### Scenario: Docs describe the new fields
+GIVEN README.md and CLAUDE.md after the change
+WHEN the routed-command JSON documentation is read
+THEN it describes the read-only `recovery` object and grouped remediation steps.

--- a/artifacts/changes/archived/recovery-ux-p1-issue-84-prefix-aware-blocker-parser-parsedbl/research.md
+++ b/artifacts/changes/archived/recovery-ux-p1-issue-84-prefix-aware-blocker-parser-parsedbl/research.md
@@ -1,0 +1,64 @@
+# Research
+
+## Research Findings
+
+### Architecture
+- **Affected modules (all read directly, file:line):**
+  - `internal/model/reason_code.go` — `ReasonCode{Code,Severity,Message,Detail}` (`:26`) carries `yaml:` tags, so it is **persisted** in verification/gate records and MUST NOT gain presentation fields. `canonicalReasonDefinitions` is the exact-code vocabulary (`:38-207`); `ReasonCodeFromSpec` already does a single `Cut(":")` into {Code, Detail} (`:230-242`); `humanizeReasonCode` is the bare-title fallthrough (`:395-406`).
+  - `cmd/next.go` — `nextView` (`:16-54`, the rich internal view, also serialized by `--diagnostics`) with `Blockers []model.ReasonCode` (`:50`) used internally across `assembleSkillView`; `confirmationRequirement` (`:56-66`).
+  - `cmd/next_handoff.go` — `nextHandoffView` (`:12-25`, the compact next/run output) built by `buildNextHandoffView` (`:190-234`); the comment at `:109-112` records that the compact view deliberately omits freshness diagnostics.
+  - `cmd/next_skill_view.go` — `isRequiredSkillBlocker` already includes `required_skill_stale` post-P0 (`:449-456`); `requiredSkillStaleSet` (`:461-472`); `blockerSkillName` is an ad-hoc `Cut(":")` (`:474-483`) — the scattered decomposition P1 centralizes; `buildRequiredSkillEvidence` already emits a `stale` status on both paths (`:536-539`, `:579-581`, from P0).
+  - `cmd/validate.go` — `validateView` (`:16-46`) has `Blockers []model.ReasonCode` but **no warnings/recovery channel** (only `Diagnostics []string`); built by `buildValidateViewForSlug` (`:180-277`).
+  - `cmd/errors.go` — `CLIError` already has `Remediation string` (`:43`) and `Reasons []model.ReasonCode` (`:47`); `newCLIErrorWithReasons` (`:68-87`) is the single constructor.
+  - `cmd/run.go` — emits `nextHandoffView` compact (`:76`) or the full `nextView` under `--diagnostics` (`:74,79`).
+- **Dependency chains:** blocker specs are produced in `internal/engine/progression/*` (`evidence_digests.go`, `wave_sync.go`, `authority.go`, `advance_governed.go`) and `internal/engine/gate`, normalized to `[]model.ReasonCode`, then surfaced by the three `cmd` views + `CLIError`. New vocabulary/parser belongs in `internal/model` (where ReasonCode lives) and is projected at the `cmd` view boundary.
+- **Blast radius:** additive only — three view structs and `CLIError` each gain one `recovery` field; `internal/model` gains one new file. No producer/gate logic changes; all `Blockers []ReasonCode` fields keep their type (zero internal ripple).
+- **Constraints/invariants preserved:** persisted ReasonCode shape unchanged (no new yaml fields); gates/state transitions untouched; new JSON fields are `omitempty`/backward-compatible.
+
+### Patterns
+- **Vocabulary-table pattern:** `canonicalReasonDefinitions map[string]ReasonDefinition` (`reason_code.go:38`) is the established exact-code → {severity, message} table. The remediation table mirrors it: `map[string]blockerRemediation{Remediation, CommandTemplate, RecoveryClass}`, same key space.
+- **Prefix family == Code:** every prefix token (`required_skill_stale:<skill>:<artifact>`, `tasks_plan_changed_since_task_evidence:<taskID>`, `review_layer_failed:<layer>`, `missing_required_artifact:<name>`, …) has its family as the first `:`-segment, which `ReasonCodeFromSpec` already stores as `Code`. Keying remediation by `Code` covers all families; the parser only further splits `Detail` into `Subject` (2nd segment) + `Detail` (rest).
+- **Single normalization seam:** every blocker passes through `model.NormalizeReasonCodes` before serialization, and CLIError reasons too — the natural single place to project a recovery view.
+- **Reuse of P0 surface:** `CLIError.Remediation`/`Reasons` already exist; the P0 `evidence restamp --skill X --dry-run` command (`cmd/evidence.go:50-120`) and `repair` recovery-routing (`cmd/repair.go:594-631`) already exist — remediation command templates point at them rather than inventing new commands (those are P2).
+
+### Risks
+- **Low — additive JSON contract drift:** a new `recovery` field could surprise strict consumers. Mitigation: `omitempty` + additive + documented (in-scope docs task). 
+- **Low — golden-test churn:** existing view-JSON assertions may need the new field; mitigated because it is `omitempty` (absent unless an actionable recovery exists), so only blocked/stale fixtures change.
+- **Medium — primary-command rule drifting toward the P2 planner:** the simple stage-priority selection must stay a static constant, not a derived dependency graph. Mitigation: implement as a fixed ordered list of recovery classes; unit-test it; document the P1/P2 boundary; never build a per-change graph or `--from-artifact` index (those are #85).
+- **Guardrail domains:** none touched (read-only surface). **Reversibility:** fully reversible (additive fields + one new file).
+
+### Test Strategy
+- **Existing coverage:** there is no `cmd/next_test.go`/`validate_test.go`; view behavior is exercised via `cmd/lifecycle_commands_test.go`, `cmd/error_contract_test.go`, `cmd/status_view_build_test.go`, with helpers in `cmd/common_test.go` (`withCommandWorkspace`, `commandForRoot`, change-state seeding patterns like `change.CurrentState = model.StateS2Execute`). `internal/model` has no `reason_code_test.go` yet.
+- **Infrastructure needs:** none new — reuse the cmd harness to seed a governed change in a blocked/stale state and assert the `recovery` object on next/run/validate JSON; plain table-driven unit tests for the model layer.
+- **Verification approach per acceptance signal:**
+  - *Primary recovery command present* → seed a `required_skill_stale`/blocked change; run next/run/validate; assert `recovery.primary_command` non-empty.
+  - *Every known token renders a remediation* → table test over every remediation-table key + representative prefix tokens; assert non-empty Remediation, no humanize fallthrough; add the missing canonical message for `tasks_plan_changed_since_task_evidence`.
+  - *Single parser* → unit-test `ParseBlocker` for all prefix families; refactor `blockerSkillName` to use it; assert surfacing routes through `model.BuildRecovery`.
+  - build + tests green via `go build ./...` / `go test ./...`.
+
+## Alternatives Considered
+- **A — Enrich `ReasonCode` with Remediation/Command fields populated in `Normalize`.** Max reuse (every blocker everywhere carries remediation). Tradeoff: `ReasonCode` is persisted via `yaml:` tags → leaks presentation into verification/gate evidence (would need `yaml:"-"` hacks); broad golden-test churn across all commands. **Rejected:** pollutes the persisted evidence type.
+- **B — Change every view's `Blockers []ReasonCode` to a rendered `[]RenderedBlocker`.** Per-blocker remediation directly on the blockers array. Tradeoff: `nextView.Blockers` is used internally throughout `assembleSkillView` (`appendReasonCodes`, `NormalizeReasonCodes`, `requiredSkillStaleSet`, capability signals) → invasive ripple, higher regression risk. **Rejected:** violates the minimal/read-only constraint.
+- **C — New `internal/model` vocabulary + a top-level `recovery` projection at the view boundary.** Add `ParsedBlocker{Code,Subject,Detail,Raw}`+parser, a `blockerRemediation` table keyed by Code, and `RecoverySummary{PrimaryCommand, PrimaryAction, RecoveryClass, Steps[]}` where each Step is an actionable blocker rendered with parsed Subject/Detail + remediation + command. `nextView`/`nextHandoffView`/`validateView` and `CLIError` each gain one `recovery *RecoverySummary` field, all built by the same `model.BuildRecovery`. The `blockers` arrays stay `[]ReasonCode` (zero ripple; persisted ReasonCode unpolluted). Primary command is chosen by a static stage-priority constant (NOT the P2 planner). Also add the missing canonical message for `tasks_plan_changed_since_task_evidence` and peers so they no longer humanize-fallthrough.
+
+- **Selected: C.** It satisfies all three acceptance signals (grouped remediation via recovery steps, one top-level primary recovery command, a single parser consumed by views + CLIError) while honoring read-only/additive, keeping the persisted ReasonCode shape intact, and cleanly isolating the P1/P2 boundary. See `decision.md` `## Selected Approach`.
+
+## Unknowns
+- Resolved: `ParsedBlocker` lives in `internal/model` (new file beside `reason_code.go`). Evidence: `reason_code.go` owns the blocker vocabulary.
+- Resolved: views construct blockers as three serialized structs with `Blockers []ReasonCode`. Evidence: `cmd/next.go:50`, `cmd/next_handoff.go:22`, `cmd/validate.go:33`.
+- Resolved: primary-command rule = static recovery-class stage-priority list, first match wins; not a dependency graph. Evidence: #84 non-goals exclude the planner.
+- Resolved: CLIError wiring = add `recovery` built from `Reasons` in `newCLIErrorWithReasons`. Evidence: `cmd/errors.go:43,47,68-87`.
+- Remaining for plan-audit: the exact remediation-table key/message set (the recovery-relevant subset) and the precise stage-priority ordering — to be enumerated in `requirements.md`/`tasks.md`.
+
+## Assumptions
+- The recovery surface is presentation-only; producers keep emitting the same `[]ReasonCode`. Evidence: `internal/engine/progression/*` producers + `model.NormalizeReasonCodes`.
+- An `omitempty` recovery pointer keeps existing non-blocked outputs byte-identical. Evidence: Go `encoding/json` omitempty on a nil pointer.
+- The P0 `evidence restamp --skill X --dry-run` command and `repair` routing remain the command targets for digest-drift remediation. Evidence: `cmd/evidence.go:50-120`, `cmd/repair.go:594-631`.
+
+## Canonical References
+- `internal/model/reason_code.go` — blocker vocabulary, normalization, current decomposition.
+- `cmd/next.go`, `cmd/next_handoff.go`, `cmd/next_skill_view.go` — next/run views + blocker surfacing.
+- `cmd/validate.go` — validate view (needs the recovery channel).
+- `cmd/errors.go` — CLIError remediation/reasons.
+- `cmd/evidence.go`, `cmd/repair.go` — P0 recovery command targets the remediation templates reference.
+- `internal/engine/progression/{evidence_digests,wave_sync,advance_governed,authority}.go` — prefix-token blocker producers.

--- a/artifacts/changes/archived/recovery-ux-p1-issue-84-prefix-aware-blocker-parser-parsedbl/tasks.md
+++ b/artifacts/changes/archived/recovery-ux-p1-issue-84-prefix-aware-blocker-parser-parsedbl/tasks.md
@@ -1,0 +1,90 @@
+# Tasks
+## Project Context
+- Tech Stack: Go
+- Conventions: governance engine in `internal/engine`, model types in `internal/model`, CLI views in `cmd/`
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Task List
+
+- [x] `t-01` Model recovery foundation in a new `internal/model/recovery.go` plus
+  `internal/model/reason_code.go`: add `ParsedBlocker{Code, Subject, Detail, Raw}`
+  and the single `ParseBlocker` parser (Detail split into Subject (2nd segment) +
+  Detail (remainder)); the Code-keyed `blockerRemediation{Remediation,
+  CommandTemplate, RecoveryClass}` table + lookup covering every recovery-relevant
+  token; `RecoverySummary`/`RecoveryStep` + `BuildRecovery([]ReasonCode)` that
+  builds one step per actionable `(code, subject)` group (collecting the distinct
+  `Details`) and selects the primary by a static `recoveryClassPriority` list (not
+  a dependency graph), returning nil when none;
+  and the missing canonical message(s) (at least `tasks_plan_changed_since_task_evidence`).
+  - wave: 1
+  - depends_on: []
+  - target_files: ["internal/model/recovery.go", "internal/model/reason_code.go", "internal/engine/progression/advance_governed.go"]
+  - task_kind: code
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-005]
+
+- [x] `t-02` Wire the recovery object into the read-only views and centralize
+  decomposition: add `Recovery *model.RecoverySummary json:"recovery,omitempty"`
+  to `nextView` (cmd/next.go), `nextHandoffView` (cmd/next_handoff.go), and
+  `validateView` (cmd/validate.go), each populated from the view's existing
+  `[]ReasonCode` via `model.BuildRecovery`; make `buildNextHandoffView` copy the
+  recovery so the compact handoff preserves the primary command; refactor
+  `blockerSkillName` (cmd/next_skill_view.go) to delegate to `model.ParseBlocker`
+  and update its other caller in `cmd/repair.go` to pass the ReasonCode.
+  - wave: 2
+  - depends_on: [t-01]
+  - target_files: ["cmd/next.go", "cmd/next_handoff.go", "cmd/validate.go", "cmd/next_skill_view.go", "cmd/repair.go"]
+  - task_kind: code
+  - covers: [REQ-001, REQ-003, REQ-004]
+
+- [x] `t-03` Wire the same recovery into `CLIError` (cmd/errors.go): add
+  `Recovery *model.RecoverySummary json:"recovery,omitempty"`, populated from
+  `Reasons` via `model.BuildRecovery` inside `newCLIErrorWithReasons`.
+  - wave: 2
+  - depends_on: [t-01]
+  - target_files: ["cmd/errors.go"]
+  - task_kind: code
+  - covers: [REQ-006]
+
+- [x] `t-04` Document the new read-only `recovery` object and grouped
+  `recovery.steps[]` remediation JSON fields under the routed-command sections
+  of README.md and CLAUDE.md, noting they are additive/omitempty and leave
+  existing `blockers[]` arrays unchanged.
+  - wave: 3
+  - depends_on: [t-02]
+  - target_files: ["README.md", "CLAUDE.md"]
+  - task_kind: code
+  - covers: [REQ-007]
+
+- [x] `t-05` Model unit tests in `internal/model/recovery_test.go`: table-driven
+  `ParseBlocker` (3-/2-/1-segment), remediation-table coverage (every entry
+  non-empty; every recovery-relevant token resolves), `BuildRecovery` (steps per
+  blocker, static primary selection, nil on clean), the canonical-message
+  assertion for `tasks_plan_changed_since_task_evidence`, and a `ReasonCode` YAML
+  round-trip asserting no new persisted fields.
+  - wave: 3
+  - depends_on: [t-01]
+  - target_files: ["internal/model/recovery_test.go"]
+  - task_kind: verification
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-005, REQ-007]
+
+- [x] `t-06` CLI tests in `cmd/recovery_view_test.go`: seed a blocked/stale
+  governed change and assert `recovery.primary_command` non-empty on `validate`,
+  compact `next`, and compact `run`; assert the compact handoff preserves the
+  primary command; assert a governance-blocked `CLIError` carries a matching
+  `recovery`; assert a clean state omits `recovery` (omitempty).
+  - wave: 3
+  - depends_on: [t-02, t-03]
+  - target_files: ["cmd/recovery_view_test.go", "cmd/validate_artifact_gate_test.go", "cmd/lifecycle_commands_test.go"]
+  - task_kind: verification
+  - covers: [REQ-003, REQ-004, REQ-006, REQ-007]
+
+- [x] `t-07` Run `go build ./...` and `go test ./...`; both MUST be green
+  (evidence: full build + test transcript). Gates compilation of the new model
+  code and that both new test suites pass.
+  - wave: 4
+  - depends_on: [t-04, t-05, t-06]
+  - target_files: ["internal/model/recovery.go", "internal/model/recovery_test.go", "cmd/recovery_view_test.go"]
+  - task_kind: verification
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004, REQ-005, REQ-006, REQ-007]

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -37,14 +37,15 @@ const (
 )
 
 type CLIError struct {
-	ErrorCode   string             `json:"error_code"`
-	Category    FailureCategory    `json:"category"`
-	Message     string             `json:"message"`
-	Remediation string             `json:"remediation"`
-	ExitCode    int                `json:"exit_code"`
-	Slug        string             `json:"slug,omitempty"`
-	Details     map[string]any     `json:"details,omitempty"`
-	Reasons     []model.ReasonCode `json:"reasons,omitempty"`
+	ErrorCode   string                 `json:"error_code"`
+	Category    FailureCategory        `json:"category"`
+	Message     string                 `json:"message"`
+	Remediation string                 `json:"remediation"`
+	ExitCode    int                    `json:"exit_code"`
+	Slug        string                 `json:"slug,omitempty"`
+	Details     map[string]any         `json:"details,omitempty"`
+	Reasons     []model.ReasonCode     `json:"reasons,omitempty"`
+	Recovery    *model.RecoverySummary `json:"recovery,omitempty"`
 }
 
 func (e *CLIError) Error() string {
@@ -83,6 +84,7 @@ func newCLIErrorWithReasons(
 		Slug:        strings.TrimSpace(slug),
 		Details:     details,
 		Reasons:     model.NormalizeReasonCodes(reasons),
+		Recovery:    model.BuildRecovery(reasons),
 	}
 }
 

--- a/cmd/lifecycle_commands_test.go
+++ b/cmd/lifecycle_commands_test.go
@@ -586,6 +586,9 @@ func TestDoneRejectsReviewLayerBlockersBeforeArchive(t *testing.T) {
 		require.NotNil(t, cliErr)
 		assert.Equal(t, "ship_gate_blocked", cliErr.ErrorCode)
 		assert.Contains(t, strings.ToLower(cliErr.Message), "review_layer_missing:ir1")
+		require.NotNil(t, cliErr.Recovery)
+		assert.Contains(t, recoveryStepCodes(cliErr.Recovery), "review_layer_missing")
+		assert.NotEmpty(t, cliErr.Recovery.PrimaryCommand)
 
 		_, loadErr := state.LoadChange(root, slug)
 		require.NoError(t, loadErr)

--- a/cmd/next.go
+++ b/cmd/next.go
@@ -48,6 +48,7 @@ type nextView struct {
 	FreshnessDiagnostics      *state.ExecutionFreshnessDiagnostics `json:"freshness_diagnostics,omitempty"`
 	Warnings                  []string                             `json:"warnings,omitempty"`
 	Blockers                  []model.ReasonCode                   `json:"blockers"`
+	Recovery                  *model.RecoverySummary               `json:"recovery,omitempty"`
 	ConfirmationRequirement   confirmationRequirement              `json:"confirmation_requirement"`
 
 	consumeActiveCheckpoint bool
@@ -329,6 +330,7 @@ func buildNextView(root string, ref changeRef, resumeResponse string, preview bo
 	if pending, err := checkPresetPendingEarlyReturn(root, ref, &view); err != nil {
 		return nextView{}, err
 	} else if pending {
+		view.Recovery = model.BuildRecovery(view.Blockers)
 		return view, nil
 	}
 
@@ -341,6 +343,7 @@ func buildNextView(root string, ref changeRef, resumeResponse string, preview bo
 		if err := consumeNextCheckpoint(root, governedChange, &view); err != nil {
 			return nextView{}, err
 		}
+		view.Recovery = model.BuildRecovery(view.Blockers)
 		return view, nil
 	}
 	view.Phase = model.PhaseFor(view.CurrentState)

--- a/cmd/next_handoff.go
+++ b/cmd/next_handoff.go
@@ -20,6 +20,7 @@ type nextHandoffView struct {
 	InputContext     nextHandoffContext      `json:"input_context"`
 	AutoPassEligible []model.AutoPassedState `json:"auto_pass_eligible,omitempty"`
 	Blockers         []model.ReasonCode      `json:"blockers"`
+	Recovery         *model.RecoverySummary  `json:"recovery,omitempty"`
 	Warnings         []string                `json:"warnings,omitempty"`
 	Confirmation     confirmationRequirement `json:"confirmation_requirement"`
 }
@@ -228,6 +229,7 @@ func buildNextHandoffView(view nextView) nextHandoffView {
 		},
 		AutoPassEligible: append([]model.AutoPassedState(nil), view.AutoPassEligible...),
 		Blockers:         view.Blockers,
+		Recovery:         model.BuildRecovery(view.Blockers),
 		Warnings:         view.Warnings,
 		Confirmation:     view.ConfirmationRequirement,
 	}

--- a/cmd/next_skill_view.go
+++ b/cmd/next_skill_view.go
@@ -413,7 +413,7 @@ func resolveActionableBlockingSkill(
 		if !isRequiredSkillBlocker(blocker.Code) {
 			continue
 		}
-		skillName := blockerSkillName(blocker.Detail)
+		skillName := blockerSkillName(blocker)
 		if skillName == "" || skillName == current {
 			continue
 		}
@@ -431,7 +431,7 @@ func hasRequiredSkillBlockerFor(blockers []model.ReasonCode, skillName string) b
 		if !isRequiredSkillBlocker(blocker.Code) {
 			continue
 		}
-		if blockerSkillName(blocker.Detail) == skillName {
+		if blockerSkillName(blocker) == skillName {
 			return true
 		}
 	}
@@ -456,30 +456,27 @@ func isRequiredSkillBlocker(code string) bool {
 }
 
 // requiredSkillStaleSet collects the skills carrying a required_skill_stale
-// digest-drift blocker, keyed by skill name (the first segment of the blocker
-// detail, e.g. "plan-audit" from "plan-audit:assurance.md").
+// digest-drift blocker, keyed by the parsed blocker subject (e.g. "plan-audit"
+// from "required_skill_stale:plan-audit:assurance.md").
 func requiredSkillStaleSet(blockers []model.ReasonCode) map[string]bool {
 	out := map[string]bool{}
 	for _, blocker := range blockers {
 		if strings.TrimSpace(blocker.Code) != "required_skill_stale" {
 			continue
 		}
-		if name := blockerSkillName(blocker.Detail); name != "" {
+		if name := blockerSkillName(blocker); name != "" {
 			out[name] = true
 		}
 	}
 	return out
 }
 
-func blockerSkillName(detail string) string {
-	detail = strings.TrimSpace(detail)
-	if detail == "" {
-		return ""
-	}
-	if before, _, ok := strings.Cut(detail, ":"); ok {
-		return strings.TrimSpace(before)
-	}
-	return detail
+// blockerSkillName returns the skill-name subject of a required-skill blocker,
+// delegating to model.ParseBlocker so prefix-token decomposition lives in one
+// place (the blocker subject, e.g. "plan-audit" from
+// "required_skill_stale:plan-audit:assurance.md").
+func blockerSkillName(blocker model.ReasonCode) string {
+	return model.ParseBlocker(blocker).Subject
 }
 
 func buildRequiredSkillEvidence(

--- a/cmd/recovery_view_test.go
+++ b/cmd/recovery_view_test.go
@@ -1,0 +1,120 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/signalridge/slipway/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The compact next/run handoff must carry the recovery object so the first
+// surface a host hits is not left without a next action (REQ-003, REQ-004).
+func TestNextHandoffViewCarriesRecovery(t *testing.T) {
+	t.Parallel()
+
+	view := nextView{
+		Blockers: model.ReasonCodesFromSpecs([]string{"required_skill_stale:plan-audit:assurance.md"}),
+	}
+	handoff := buildNextHandoffView(view)
+
+	require.NotNil(t, handoff.Recovery, "compact handoff must preserve the recovery object")
+	assert.NotEmpty(t, handoff.Recovery.PrimaryCommand, "primary recovery command must survive the compact projection")
+	require.NotEmpty(t, handoff.Recovery.Steps)
+	assert.Equal(t, "required_skill_stale", handoff.Recovery.Steps[0].Code)
+	assert.Equal(t, "plan-audit", handoff.Recovery.Steps[0].Subject)
+	assert.Equal(t, []string{"assurance.md"}, handoff.Recovery.Steps[0].Details)
+	assert.NotEmpty(t, handoff.Recovery.Steps[0].Remediation, "every rendered blocker must carry a remediation")
+}
+
+// A clean state (only informational blockers) must omit the recovery object so
+// existing healthy outputs stay byte-identical (REQ-007 omitempty).
+func TestNextHandoffViewOmitsRecoveryOnCleanState(t *testing.T) {
+	t.Parallel()
+
+	view := nextView{
+		Blockers: model.ReasonCodesFromSpecs([]string{"no_skill_required:S2_EXECUTE"}),
+	}
+	handoff := buildNextHandoffView(view)
+	assert.Nil(t, handoff.Recovery)
+}
+
+// CLIError must surface the same recovery the views do, built from its reasons
+// by the shared model.BuildRecovery (REQ-006).
+func TestGovernanceBlockedErrorCarriesRecovery(t *testing.T) {
+	t.Parallel()
+
+	reasons := model.ReasonCodesFromSpecs([]string{"required_skill_stale:plan-audit:assurance.md"})
+	err := newGovernanceBlockedErrorWithReasons("governance_blocked", "blocked", "remediation", "slug", reasons, nil)
+
+	require.NotNil(t, err.Recovery)
+	assert.NotEmpty(t, err.Recovery.PrimaryCommand)
+	assert.Equal(t, model.BuildRecovery(reasons).PrimaryCommand, err.Recovery.PrimaryCommand,
+		"CLIError recovery must match what the views produce for the same reasons")
+}
+
+// validate --json must carry a primary recovery command for blocked states
+// (REQ-003); buildValidateViewBase is the seam both validate paths share.
+func TestValidateViewBaseCarriesRecovery(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	change := model.NewChange("recovery-validate")
+	change.CurrentState = model.StateS1Plan
+	blockers := model.ReasonCodesFromSpecs([]string{"plan_audit_failed"})
+
+	view := buildValidateViewBase(root, change, governedExecutionMode, nil, blockers, nil, nil)
+
+	require.NotNil(t, view.Recovery)
+	assert.NotEmpty(t, view.Recovery.PrimaryCommand)
+}
+
+func TestValidateRecoveryIncludesGateDetailBlockers(t *testing.T) {
+	t.Parallel()
+
+	recovery := buildValidateRecovery(nil, map[string]model.GateRecord{
+		"G_plan": {
+			GateID: "G_plan",
+			Status: model.GateStatusBlocked,
+			ReasonCodes: model.ReasonCodesFromSpecs([]string{
+				"required_skill_stale:plan-audit:requirements.md",
+				"required_skill_stale:plan-audit:tasks.md",
+			}),
+		},
+	})
+
+	require.NotNil(t, recovery, "gate_details blockers must contribute to validate recovery")
+	var step *model.RecoveryStep
+	for i := range recovery.Steps {
+		if recovery.Steps[i].Code == "required_skill_stale" && recovery.Steps[i].Subject == "plan-audit" {
+			step = &recovery.Steps[i]
+			break
+		}
+	}
+	require.NotNil(t, step, "plan-audit gate_details blocker must render a recovery step")
+	assert.Equal(t, []string{"requirements.md", "tasks.md"}, step.Details)
+	assert.Contains(t, step.Command, "--skill plan-audit")
+	assert.NotEmpty(t, step.Remediation)
+}
+
+func TestValidateViewBaseOmitsRecoveryWhenClean(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	change := model.NewChange("clean-validate")
+	change.CurrentState = model.StateS1Plan
+
+	view := buildValidateViewBase(root, change, governedExecutionMode, nil, nil, nil, nil)
+	assert.Nil(t, view.Recovery)
+}
+
+func recoveryStepCodes(recovery *model.RecoverySummary) []string {
+	if recovery == nil {
+		return nil
+	}
+	codes := make([]string, 0, len(recovery.Steps))
+	for _, step := range recovery.Steps {
+		codes = append(codes, step.Code)
+	}
+	return codes
+}

--- a/cmd/repair.go
+++ b/cmd/repair.go
@@ -631,7 +631,7 @@ func buildGovernanceDigestDriftFindings(root string, changes []model.Change) ([]
 			if strings.TrimSpace(blocker.Code) != "required_skill_stale" {
 				continue
 			}
-			skillName := blockerSkillName(blocker.Detail)
+			skillName := blockerSkillName(blocker)
 			if skillName == "" || seen[skillName] {
 				continue
 			}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -31,6 +31,7 @@ type validateView struct {
 	PlanningNote              string                               `json:"planning_note,omitempty"`
 	SkillsReady               map[string]string                    `json:"skills_ready"`
 	Blockers                  []model.ReasonCode                   `json:"blockers"`
+	Recovery                  *model.RecoverySummary               `json:"recovery,omitempty"`
 	CanAdvance                bool                                 `json:"can_advance"`
 	GateStatus                map[string]string                    `json:"gate_status,omitempty"`
 	GateDetails               map[string]model.GateRecord          `json:"gate_details,omitempty"`
@@ -112,6 +113,7 @@ func buildValidateViewBase(
 		PlanningNote:  planningNote(change.CurrentState, change.PlanSubStep),
 		SkillsReady:   skillsReady,
 		Blockers:      model.NormalizeReasonCodes(blockers),
+		Recovery:      buildValidateRecovery(blockers, nil),
 		CanAdvance:    len(blockers) == 0,
 		Diagnostics:   diagnostics,
 		EvidenceFreshness: projectFreshnessForExecMode(
@@ -121,6 +123,14 @@ func buildValidateViewBase(
 			blockers,
 		),
 	}
+}
+
+func buildValidateRecovery(blockers []model.ReasonCode, gateDetails map[string]model.GateRecord) *model.RecoverySummary {
+	all := append([]model.ReasonCode(nil), blockers...)
+	for _, gate := range gateDetails {
+		all = append(all, gate.ReasonCodes...)
+	}
+	return model.BuildRecovery(all)
 }
 
 func makeValidateCmd() *cobra.Command {
@@ -270,6 +280,7 @@ func buildValidateViewForSlug(root, slug string) (validateView, error) {
 	}
 	view.GateStatus = gateStatus
 	view.GateDetails = gateDetails
+	view.Recovery = buildValidateRecovery(view.Blockers, gateDetails)
 	if readiness.ArtifactProjection != nil && len(readiness.ArtifactProjection.Amendments) > 0 {
 		view.ArtifactAmendments = append([]artifact.AmendmentEvent(nil), readiness.ArtifactProjection.Amendments...)
 	}

--- a/cmd/validate_artifact_gate_test.go
+++ b/cmd/validate_artifact_gate_test.go
@@ -47,6 +47,9 @@ func TestValidateBlocksWhenGovernedBundleIsIncompleteAtSpecBundle(t *testing.T) 
 		assert.Contains(t, model.ReasonSpecs(view.Blockers), "missing_required_artifact:decision.md")
 		require.NotEmpty(t, view.Blockers)
 		assert.Equal(t, "missing_required_artifact", view.Blockers[0].Code)
+		require.NotNil(t, view.Recovery)
+		assert.Contains(t, recoveryStepCodes(view.Recovery), "missing_required_artifact")
+		assert.NotEmpty(t, view.Recovery.PrimaryCommand)
 	})
 }
 
@@ -422,6 +425,9 @@ REQ-001: The system must authenticate requests.
 	view, err := buildValidateViewForSlug(root, slug)
 	require.NoError(t, err)
 	assert.Contains(t, model.ReasonSpecs(view.Blockers), "plan_dimension_dependency_unknown:t-01->t-99")
+	require.NotNil(t, view.Recovery)
+	assert.Contains(t, recoveryStepCodes(view.Recovery), "plan_dimension_dependency_unknown")
+	assert.NotEmpty(t, view.Recovery.PrimaryCommand)
 }
 
 func TestValidateAtShipGateRequiresReviewEvidence(t *testing.T) {

--- a/internal/model/reason_code.go
+++ b/internal/model/reason_code.go
@@ -44,6 +44,18 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 		Severity: ReasonSeverityError,
 		Message:  "The governed change is missing a frozen artifact schema",
 	},
+	"assurance_structure_invalid": {
+		Severity: ReasonSeverityError,
+		Message:  "The assurance artifact structure is invalid",
+	},
+	"closeout_assurance_attestation_missing": {
+		Severity: ReasonSeverityError,
+		Message:  "The final-closeout assurance attestation is missing",
+	},
+	"closeout_goal_verification_reuse_invalid": {
+		Severity: ReasonSeverityError,
+		Message:  "Final-closeout cannot reuse the recorded goal-verification evidence",
+	},
 	"dedicated_worktree_branch_mismatch": {
 		Severity: ReasonSeverityError,
 		Message:  "The bound worktree branch does not match the recorded change branch",
@@ -63,6 +75,14 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 	"execution_interrupted": {
 		Severity: ReasonSeverityWarning,
 		Message:  "Governed execution was interrupted",
+	},
+	"governance_action_required": {
+		Severity: ReasonSeverityError,
+		Message:  "A required governance control must be satisfied before continuing",
+	},
+	"governed_bundle_path_invalid": {
+		Severity: ReasonSeverityError,
+		Message:  "The governed bundle path is invalid",
 	},
 	"high_risk_check_failed": {
 		Severity: ReasonSeverityError,
@@ -96,6 +116,10 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 		Severity: ReasonSeverityError,
 		Message:  "Required discovery evidence is missing",
 	},
+	"missing_required_artifact": {
+		Severity: ReasonSeverityError,
+		Message:  "A required governed artifact is missing",
+	},
 	"missing_task_evidence_for_run_summary": {
 		Severity: ReasonSeverityError,
 		Message:  "Task evidence is missing for the recorded run summary; rerun wave-orchestration to capture task evidence",
@@ -112,17 +136,113 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 		Severity: ReasonSeverityInfo,
 		Message:  "No skill is required for the current workflow state",
 	},
+	"non_pass_task": {
+		Severity: ReasonSeverityError,
+		Message:  "A governed task did not pass",
+	},
 	"pivot_not_approved": {
 		Severity: ReasonSeverityError,
 		Message:  "The requested pivot is not approved",
+	},
+	"plan_audit_budget_exhausted": {
+		Severity: ReasonSeverityError,
+		Message:  "Plan audit exhausted its checker iteration budget",
+	},
+	"plan_audit_evidence_missing": {
+		Severity: ReasonSeverityError,
+		Message:  "Plan audit evidence is missing",
 	},
 	"plan_audit_failed": {
 		Severity: ReasonSeverityError,
 		Message:  "Plan audit did not pass",
 	},
+	"plan_audit_iteration": {
+		Severity: ReasonSeverityError,
+		Message:  "Plan audit checker iteration is in progress",
+	},
 	"plan_audit_stalled": {
 		Severity: ReasonSeverityError,
 		Message:  "Plan audit feedback did not improve",
+	},
+	"plan_checker_feedback_required": {
+		Severity: ReasonSeverityError,
+		Message:  "Plan checker feedback must be incorporated before continuing",
+	},
+	"plan_checker_loop_terminated": {
+		Severity: ReasonSeverityError,
+		Message:  "Plan checker loop terminated before plan audit could pass",
+	},
+	"plan_dimension_completeness_missing_objective": {
+		Severity: ReasonSeverityError,
+		Message:  "A task is missing a concrete objective",
+	},
+	"plan_dimension_execution_missing_wave": {
+		Severity: ReasonSeverityError,
+		Message:  "A task is missing an execution wave",
+	},
+	"plan_dimension_key_links_missing_target_files": {
+		Severity: ReasonSeverityError,
+		Message:  "A code task is missing target files",
+	},
+	"plan_dimension_scope_invalid_target": {
+		Severity: ReasonSeverityError,
+		Message:  "A task target file entry is invalid",
+	},
+	"plan_dimension_scope_out_of_bounds_target": {
+		Severity: ReasonSeverityError,
+		Message:  "A task target file is outside the repository",
+	},
+	"plan_dimension_dependency_self_reference": {
+		Severity: ReasonSeverityError,
+		Message:  "A task dependency references itself",
+	},
+	"plan_dimension_dependency_unknown": {
+		Severity: ReasonSeverityError,
+		Message:  "A task dependency references an unknown task",
+	},
+	"plan_dimension_dependency_cycle_detected": {
+		Severity: ReasonSeverityError,
+		Message:  "Task dependencies contain a cycle",
+	},
+	"plan_dimension_execution_invalid_wave_plan": {
+		Severity: ReasonSeverityError,
+		Message:  "The task wave plan is invalid",
+	},
+	"plan_dimension_coverage_spec_unreadable": {
+		Severity: ReasonSeverityError,
+		Message:  "Requirement coverage input is unreadable",
+	},
+	"plan_dimension_coverage_requirements_invalid": {
+		Severity: ReasonSeverityError,
+		Message:  "Requirement coverage input is invalid",
+	},
+	"plan_dimension_coverage_requirement_id_missing": {
+		Severity: ReasonSeverityError,
+		Message:  "A requirement is missing an explicit ID",
+	},
+	"plan_dimension_coverage_unknown_requirement": {
+		Severity: ReasonSeverityError,
+		Message:  "A task covers an unknown requirement",
+	},
+	"plan_dimension_coverage_missing_requirement": {
+		Severity: ReasonSeverityError,
+		Message:  "A requirement has no task coverage",
+	},
+	"preset_confirmation_required": {
+		Severity: ReasonSeverityError,
+		Message:  "Workflow preset confirmation is required before continuing",
+	},
+	"required_artifact_schema_missing": {
+		Severity: ReasonSeverityError,
+		Message:  "A required governed artifact is missing from the artifact schema",
+	},
+	"required_artifact_dependency_missing": {
+		Severity: ReasonSeverityError,
+		Message:  "A required governed artifact dependency is missing",
+	},
+	"required_artifact_unreadable": {
+		Severity: ReasonSeverityError,
+		Message:  "A required governed artifact is unreadable",
 	},
 	"required_skill_blockers_present": {
 		Severity: ReasonSeverityError,
@@ -144,6 +264,14 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 		Severity: ReasonSeverityError,
 		Message:  "A required governance skill certified inputs that changed; rerun the skill to re-certify the named artifact",
 	},
+	"research_structure_invalid": {
+		Severity: ReasonSeverityError,
+		Message:  "The research artifact structure is invalid",
+	},
+	"run_slipway_done_to_finalize": {
+		Severity: ReasonSeverityWarning,
+		Message:  "Run `slipway done` to finalize the governed change",
+	},
 	"run_slipway_run_to_advance": {
 		Severity: ReasonSeverityWarning,
 		Message:  "Run `slipway run` to advance the workflow",
@@ -155,6 +283,14 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 	"rescope_state_invalid": {
 		Severity: ReasonSeverityError,
 		Message:  "Rescope pivots are only allowed from S2_EXECUTE",
+	},
+	"review_layer_missing": {
+		Severity: ReasonSeverityError,
+		Message:  "Required review layer evidence is missing",
+	},
+	"review_layer_failed": {
+		Severity: ReasonSeverityError,
+		Message:  "Required review layer evidence did not pass",
 	},
 	"scope_contract_changed_files_missing": {
 		Severity: ReasonSeverityError,
@@ -172,6 +308,10 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 		Severity: ReasonSeverityError,
 		Message:  "Scope Contract is missing required target files",
 	},
+	"ship_gate_blocked": {
+		Severity: ReasonSeverityError,
+		Message:  "The ship gate blocked finalization",
+	},
 	"stale_execution_evidence": {
 		Severity: ReasonSeverityError,
 		Message:  "Execution evidence is stale; rerun wave-orchestration for affected tasks",
@@ -188,6 +328,34 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 		Severity: ReasonSeverityError,
 		Message:  "The governed tasks checklist format is invalid",
 	},
+	"tasks_checklist_missing": {
+		Severity: ReasonSeverityError,
+		Message:  "The governed tasks checklist is missing",
+	},
+	"tasks_checklist_path_invalid": {
+		Severity: ReasonSeverityError,
+		Message:  "The governed tasks checklist path is invalid",
+	},
+	"tasks_checklist_unreadable": {
+		Severity: ReasonSeverityError,
+		Message:  "The governed tasks checklist is unreadable",
+	},
+	"tasks_checklist_empty": {
+		Severity: ReasonSeverityError,
+		Message:  "The governed tasks checklist has no tasks",
+	},
+	"tasks_checklist_task_id_missing": {
+		Severity: ReasonSeverityError,
+		Message:  "A governed task checklist entry is missing a task ID",
+	},
+	"tasks_checklist_duplicate_task_id": {
+		Severity: ReasonSeverityError,
+		Message:  "The governed tasks checklist contains a duplicate task ID",
+	},
+	"tasks_plan_changed_since_task_evidence": {
+		Severity: ReasonSeverityError,
+		Message:  "The tasks plan changed after this task's evidence was captured; rerun wave-orchestration for the affected task",
+	},
 	"verification_evidence_missing": {
 		Severity: ReasonSeverityError,
 		Message:  "Required verification evidence is missing; in S4_VERIFY recovery, rerun goal-verification, then rerun final-closeout",
@@ -203,6 +371,14 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 	"wave_plan_missing": {
 		Severity: ReasonSeverityError,
 		Message:  "The wave plan is missing; materialize the wave plan from tasks.md before wave execution",
+	},
+	"worktree_validation_error": {
+		Severity: ReasonSeverityError,
+		Message:  "Worktree validation failed",
+	},
+	"worktree_metadata_persist_failed": {
+		Severity: ReasonSeverityError,
+		Message:  "Worktree metadata could not be persisted",
 	},
 }
 

--- a/internal/model/recovery.go
+++ b/internal/model/recovery.go
@@ -1,0 +1,769 @@
+package model
+
+import (
+	"sort"
+	"strings"
+)
+
+// ParsedBlocker is the structured decomposition of a blocker. It is the single
+// decomposition point for prefix tokens such as
+// "required_skill_stale:<skill>:<artifact>" or
+// "tasks_plan_changed_since_task_evidence:<taskID>". Code is the reason code
+// (the first ':'-segment of any prefix token, already isolated by
+// ReasonCodeFromSpec); Subject is the first segment of the reason Detail (a
+// skill name, task ID, layer, ...); Detail is the remainder.
+type ParsedBlocker struct {
+	Code    string `json:"code"`
+	Subject string `json:"subject,omitempty"`
+	Detail  string `json:"detail,omitempty"`
+	Raw     string `json:"raw"`
+}
+
+// ParseBlocker decomposes a ReasonCode into Code/Subject/Detail/Raw. It is the
+// only place prefix-token detail is split into Subject + Detail, so views, the
+// recovery builder, and CLIError all share one parse.
+func ParseBlocker(rc ReasonCode) ParsedBlocker {
+	rc.Normalize()
+	subject, detail := splitSubjectDetail(rc.Detail)
+	raw := rc.Code
+	if trimmed := strings.TrimSpace(rc.Detail); trimmed != "" {
+		raw = rc.Code + ":" + trimmed
+	}
+	return ParsedBlocker{
+		Code:    rc.Code,
+		Subject: subject,
+		Detail:  detail,
+		Raw:     raw,
+	}
+}
+
+// ParseBlockerSpec decomposes a raw "code:subject:detail" spec string through
+// the same ReasonCode path used everywhere else.
+func ParseBlockerSpec(spec string) ParsedBlocker {
+	return ParseBlocker(ReasonCodeFromSpec(spec))
+}
+
+func splitSubjectDetail(detail string) (string, string) {
+	detail = strings.TrimSpace(detail)
+	if detail == "" {
+		return "", ""
+	}
+	if before, after, ok := strings.Cut(detail, ":"); ok {
+		return strings.TrimSpace(before), strings.TrimSpace(after)
+	}
+	return detail, ""
+}
+
+// RecoveryClass categorizes how a blocker is recovered and drives primary-step
+// selection. These are stable presentation-layer labels, not gate codes.
+type RecoveryClass string
+
+const (
+	RecoveryClassConfirmPreset  RecoveryClass = "confirm_preset"
+	RecoveryClassSatisfyControl RecoveryClass = "satisfy_control"
+	RecoveryClassReopenPlanning RecoveryClass = "reopen_planning"
+	RecoveryClassRerunSkill     RecoveryClass = "rerun_skill"
+	RecoveryClassRestampDigest  RecoveryClass = "restamp_evidence"
+	RecoveryClassFixScope       RecoveryClass = "fix_scope"
+	RecoveryClassRefreshWave    RecoveryClass = "refresh_execution"
+	RecoveryClassAdvance        RecoveryClass = "advance"
+)
+
+// recoveryClassPriority orders recovery classes from root-most (earliest
+// lifecycle authority a stuck operator should address first) to latest. It is a
+// STATIC ordering, deliberately NOT a per-change dependency graph — the
+// dependency-ordered recovery planner is the P2 scope (#85). Lower index =
+// higher priority for selecting the single primary command.
+var recoveryClassPriority = []RecoveryClass{
+	RecoveryClassConfirmPreset,
+	RecoveryClassSatisfyControl,
+	RecoveryClassReopenPlanning,
+	RecoveryClassRerunSkill,
+	RecoveryClassRestampDigest,
+	RecoveryClassFixScope,
+	RecoveryClassRefreshWave,
+	RecoveryClassAdvance,
+}
+
+type blockerRemediation struct {
+	// Remediation and CommandTemplate may contain {subject}/{detail}
+	// placeholders filled from the ParsedBlocker.
+	Remediation     string
+	CommandTemplate string
+	Class           RecoveryClass
+	// SplitDetail forces recovery to expose the first detail segment as Subject
+	// even when templates are static. Templates with {subject}/{detail} split
+	// automatically; opaque prose details stay in Details as a whole.
+	SplitDetail bool
+	// Priority breaks ties inside one RecoveryClass. Lower wins; zero means the
+	// default class-local priority.
+	Priority int
+}
+
+const defaultRecoveryPriority = 100
+
+// blockerRemediations maps a blocker Code to its remediation. Because every
+// prefix family's Code is its first ':'-segment, Code-keying covers both exact
+// codes and prefix families. It is the recovery-facing companion to
+// canonicalReasonDefinitions, scoped to recovery-relevant tokens.
+var blockerRemediations = map[string]blockerRemediation{
+	"artifact_not_ready": {
+		Remediation:     "Complete the governed artifact readiness issue named in the blocker detail, then re-run the workflow.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"artifact_schema_missing": {
+		Remediation:     "Repair or regenerate the governed artifact schema before continuing.",
+		CommandTemplate: "slipway repair",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"assurance_structure_invalid": {
+		Remediation:     "Fix assurance.md so it satisfies the required assurance structure, then re-run validation.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"closeout_goal_verification_reuse_invalid": {
+		Remediation:     "Final-closeout cannot safely reuse goal-verification evidence; re-run goal-verification, then re-run final-closeout.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRerunSkill,
+		Priority:        15,
+	},
+	"dedicated_worktree_branch_mismatch": {
+		Remediation:     "Repair the dedicated worktree binding so the recorded branch matches the bound worktree.",
+		CommandTemplate: "slipway repair",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"dedicated_worktree_metadata_required": {
+		Remediation:     "Record or repair dedicated worktree metadata before continuing.",
+		CommandTemplate: "slipway repair",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"dedicated_worktree_path_invalid": {
+		Remediation:     "Repair the recorded dedicated worktree path before continuing.",
+		CommandTemplate: "slipway repair",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"dedicated_worktree_required": {
+		Remediation:     "Bind the change to a dedicated worktree before continuing.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"preset_confirmation_required": {
+		Remediation:     "Confirm the workflow preset before continuing.",
+		CommandTemplate: "slipway preset <light|standard|strict>",
+		Class:           RecoveryClassConfirmPreset,
+	},
+	"governance_action_required": {
+		Remediation:     "Satisfy the required {subject} governance control before continuing.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"governed_bundle_path_invalid": {
+		Remediation:     "Repair the governed bundle path before continuing.",
+		CommandTemplate: "slipway repair",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"high_risk_check_failed": {
+		Remediation:     "Resolve the named high-risk safety check failure before continuing.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"high_risk_check_missing": {
+		Remediation:     "Provide the named high-risk safety check before continuing.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"intake_confirmation_incomplete": {
+		Remediation:     "Complete the Approved Summary in intent.md before continuing.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRerunSkill,
+	},
+	"intake_substep_invalid": {
+		Remediation:     "Repair the intake substep state before continuing.",
+		CommandTemplate: "slipway repair",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"manifest_r0_invalid": {
+		Remediation:     "Fix the R0 review manifest evidence and re-run review.",
+		CommandTemplate: "slipway review",
+		Class:           RecoveryClassRerunSkill,
+	},
+	"missing_task_evidence_for_run_summary": {
+		Remediation:     "Task evidence is missing for the recorded run summary; re-run wave-orchestration to capture it.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRefreshWave,
+	},
+	"missing_worktree_branch": {
+		Remediation:     "Repair the change worktree binding so it records a branch.",
+		CommandTemplate: "slipway repair",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"missing_worktree_path": {
+		Remediation:     "Repair the change worktree binding so it records a path.",
+		CommandTemplate: "slipway repair",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"non_pass_task": {
+		Remediation:     "Resolve the failing task evidence for task {subject}, then re-run wave-orchestration.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRefreshWave,
+	},
+	"plan_dimension_completeness_missing_objective": {
+		Remediation:     "Fix tasks.md so every task has a concrete objective.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassFixScope,
+	},
+	"plan_dimension_execution_missing_wave": {
+		Remediation:     "Fix tasks.md so every task declares an execution wave.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassFixScope,
+	},
+	"plan_dimension_key_links_missing_target_files": {
+		Remediation:     "Fix tasks.md so every code task declares target_files.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassFixScope,
+	},
+	"plan_dimension_scope_invalid_target": {
+		Remediation:     "Fix invalid task target_files entries in tasks.md.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassFixScope,
+	},
+	"plan_dimension_scope_out_of_bounds_target": {
+		Remediation:     "Move task target_files back inside the repository or remove the out-of-bounds target.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassFixScope,
+	},
+	"plan_dimension_dependency_self_reference": {
+		Remediation:     "Fix tasks.md so tasks do not depend on themselves.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassFixScope,
+	},
+	"plan_dimension_dependency_unknown": {
+		Remediation:     "Fix tasks.md dependencies so every dependency references a declared task.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassFixScope,
+	},
+	"plan_dimension_dependency_cycle_detected": {
+		Remediation:     "Break the dependency cycle in tasks.md before continuing.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassFixScope,
+	},
+	"plan_dimension_execution_invalid_wave_plan": {
+		Remediation:     "Fix the wave/dependency plan in tasks.md before continuing.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassFixScope,
+	},
+	"plan_dimension_coverage_spec_unreadable": {
+		Remediation:     "Restore readable requirements.md coverage input, then re-run validation.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassFixScope,
+	},
+	"plan_dimension_coverage_requirements_invalid": {
+		Remediation:     "Fix invalid requirements.md requirement identifiers, then re-run validation.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassFixScope,
+	},
+	"plan_dimension_coverage_requirement_id_missing": {
+		Remediation:     "Add explicit requirement IDs in requirements.md, then re-run validation.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassFixScope,
+	},
+	"plan_dimension_coverage_unknown_requirement": {
+		Remediation:     "Fix tasks.md covers entries so they reference declared requirements.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassFixScope,
+	},
+	"plan_dimension_coverage_missing_requirement": {
+		Remediation:     "Add task coverage for every requirement or update requirements.md.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassFixScope,
+	},
+	"required_artifact_schema_missing": {
+		Remediation:     "Fix the governed artifact schema so required artifact {subject} is defined.",
+		CommandTemplate: "slipway repair",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"required_artifact_dependency_missing": {
+		Remediation:     "Fix the governed artifact schema dependency {subject}, then re-run validation.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"required_artifact_unreadable": {
+		Remediation:     "Fix the required governed artifact {subject} so it is readable, then re-run validation.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"required_skill_missing": {
+		Remediation:     "Run the {subject} governance skill and record its verification evidence, then advance.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRerunSkill,
+	},
+	"required_skill_not_ready": {
+		Remediation:     "The {subject} skill evidence is present but not ready; re-run it and record fresh evidence.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRerunSkill,
+	},
+	"required_skill_not_passed": {
+		Remediation:     "The {subject} skill did not pass; resolve its findings and re-run it.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRerunSkill,
+	},
+	"required_skill_blockers_present": {
+		Remediation:     "The {subject} skill still reports blockers; resolve them and re-run it.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRerunSkill,
+	},
+	"required_skill_stale": {
+		Remediation:     "Inputs certified by {subject} changed; re-run {subject} to re-certify the affected artifacts, or restamp if the recorded verdict still holds.",
+		CommandTemplate: "slipway evidence restamp --skill {subject} --dry-run",
+		Class:           RecoveryClassRestampDigest,
+	},
+	"research_structure_invalid": {
+		Remediation:     "Fix research.md so it satisfies the required research structure, then re-run validation.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"tasks_plan_changed_since_task_evidence": {
+		Remediation:     "Task {subject}'s plan changed after its evidence was captured; re-run wave-orchestration for the affected task.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRefreshWave,
+	},
+	"stale_planning_evidence": {
+		Remediation:     "Planning artifacts changed after execution evidence; reopen planning audit, then refresh execution evidence in order.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassReopenPlanning,
+	},
+	"stale_planning_recovery_available": {
+		Remediation:     "Stale planning evidence can be recovered by reopening planning audit.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassReopenPlanning,
+	},
+	"stale_execution_evidence": {
+		Remediation:     "Execution evidence is stale; re-run wave-orchestration for the affected tasks.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRefreshWave,
+	},
+	"plan_audit_failed": {
+		Remediation:     "Plan audit did not pass; fix the bundle blockers and re-run plan-audit.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRerunSkill,
+	},
+	"plan_audit_evidence_missing": {
+		Remediation:     "Plan audit evidence is missing; run plan-audit and record passing evidence.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRerunSkill,
+	},
+	"plan_audit_iteration": {
+		Remediation:     "Plan audit is iterating; incorporate checker feedback before continuing.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRerunSkill,
+	},
+	"plan_audit_stalled": {
+		Remediation:     "Plan audit feedback did not improve; revise the bundle and re-run plan-audit.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRerunSkill,
+	},
+	"plan_audit_budget_exhausted": {
+		// rescope is S2_EXECUTE-only (gate.EvaluateGPivot); from S1 plan-audit the
+		// runnable escape is reroute (valid S1-S4) or manual bundle revision.
+		Remediation:     "Plan audit exhausted its checker iteration budget; revise the plan bundle to resolve the outstanding checker feedback and re-run plan-audit, or reroute the change to a different approach.",
+		CommandTemplate: "slipway pivot --reroute",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"plan_checker_feedback_required": {
+		Remediation:     "Apply the plan checker feedback to the bundle before re-running plan-audit.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRerunSkill,
+	},
+	"plan_checker_loop_terminated": {
+		// Same S1 constraint as plan_audit_budget_exhausted: reroute, not rescope.
+		Remediation:     "The plan checker loop terminated before plan audit could pass; revise the plan bundle and re-run plan-audit, or reroute the change to a different approach.",
+		CommandTemplate: "slipway pivot --reroute",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"verification_evidence_missing": {
+		Remediation:     "Required verification evidence is missing; in S4 recovery re-run goal-verification, then final-closeout.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRerunSkill,
+		Priority:        10,
+	},
+	"closeout_assurance_attestation_missing": {
+		// Detail carries a colon-bearing sentence, so this remediation/command are
+		// static and recovery treats the detail as opaque to avoid a misleading
+		// subject split.
+		Remediation:     "Final-closeout did not record the closeout assurance attestation (closeout:assurance_complete=pass) required on standard/strict workflows; re-run final-closeout and record it.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRerunSkill,
+		Priority:        20,
+	},
+	"review_layer_missing": {
+		Remediation:     "Re-run review and record passing evidence for review layer {subject}.",
+		CommandTemplate: "slipway review",
+		Class:           RecoveryClassRerunSkill,
+	},
+	"review_layer_failed": {
+		Remediation:     "Resolve review findings for layer {subject}, then re-run review.",
+		CommandTemplate: "slipway review",
+		Class:           RecoveryClassRerunSkill,
+	},
+	"ship_gate_blocked": {
+		Remediation:     "Refresh verification evidence, resolve the ship gate blockers, and re-run finalization.",
+		CommandTemplate: "slipway done",
+		Class:           RecoveryClassRerunSkill,
+		Priority:        90,
+	},
+	"scope_contract_drift": {
+		Remediation:     "Changed files fall outside the planned Scope Contract; add the targets to tasks.md or revert the out-of-scope change.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassFixScope,
+	},
+	"scope_contract_missing": {
+		Remediation:     "The Scope Contract is missing required target files; add them to the tasks.md plan.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassFixScope,
+	},
+	"scope_contract_changed_files_missing": {
+		Remediation:     "Task changed_files evidence is missing for the Scope Contract; re-run wave-orchestration to record it.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRefreshWave,
+	},
+	"scope_contract_evaluation_failed": {
+		Remediation:     "Fix the Scope Contract evaluation error, then re-run validation.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassFixScope,
+	},
+	"tasks_checklist_invalid_format": {
+		Remediation:     "Fix the tasks.md checklist format before continuing.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassFixScope,
+	},
+	"tasks_checklist_missing": {
+		Remediation:     "Create tasks.md with the governed task checklist before continuing.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassFixScope,
+	},
+	"tasks_checklist_path_invalid": {
+		Remediation:     "Fix the tasks.md path or governed bundle path before continuing.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassFixScope,
+	},
+	"tasks_checklist_unreadable": {
+		Remediation:     "Fix tasks.md so it is readable before continuing.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassFixScope,
+	},
+	"tasks_checklist_empty": {
+		Remediation:     "Add at least one governed task entry to tasks.md before continuing.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassFixScope,
+	},
+	"tasks_checklist_task_id_missing": {
+		Remediation:     "Add a task ID to each tasks.md checklist item before continuing.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassFixScope,
+	},
+	"tasks_checklist_duplicate_task_id": {
+		Remediation:     "Make tasks.md task IDs unique before continuing.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassFixScope,
+	},
+	"wave_plan_missing": {
+		Remediation:     "Materialize the wave plan from tasks.md before wave execution.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRefreshWave,
+	},
+	"wave_orchestration_run_summary_version_invalid": {
+		Remediation:     "Re-run wave-orchestration to produce a versioned run summary.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRefreshWave,
+	},
+	"wave_orchestration_stale_task_evidence": {
+		Remediation:     "Task evidence post-dates the wave record; re-run wave-orchestration to refresh it.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRefreshWave,
+	},
+	"worktree_validation_error": {
+		Remediation:     "Repair the worktree validation failure before continuing.",
+		CommandTemplate: "slipway repair",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"worktree_metadata_persist_failed": {
+		Remediation:     "Repair the worktree metadata persistence failure before continuing.",
+		CommandTemplate: "slipway repair",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"missing_discovery_evidence": {
+		Remediation:     "Provide discovery (research-orchestration) evidence before planning.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRerunSkill,
+	},
+	"missing_required_artifact": {
+		Remediation:     "Create or restore the required governed artifact {subject}, then re-run validation.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"intake_clarification_incomplete": {
+		Remediation:     "Complete intake clarification before planning.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRerunSkill,
+	},
+	"run_slipway_run_to_advance": {
+		Remediation:     "The current step is ready; advance the workflow.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassAdvance,
+	},
+	"run_slipway_done_to_finalize": {
+		Remediation:     "All governance gates passed; finalize the governed change.",
+		CommandTemplate: "slipway done",
+		Class:           RecoveryClassAdvance,
+	},
+}
+
+// RecoveryStep is one actionable (code, subject) group rendered with its parsed
+// segments and remediation. Blockers that share a code and subject but differ
+// only in their detail (e.g. one stale skill spanning many artifacts) collapse
+// into a single step whose Details list the distinct remainders.
+type RecoveryStep struct {
+	Code          string         `json:"code"`
+	Subject       string         `json:"subject,omitempty"`
+	Details       []string       `json:"details,omitempty"`
+	Severity      ReasonSeverity `json:"severity"`
+	Message       string         `json:"message"`
+	Remediation   string         `json:"remediation"`
+	Command       string         `json:"command,omitempty"`
+	RecoveryClass RecoveryClass  `json:"recovery_class,omitempty"`
+	priority      int
+}
+
+// RecoverySummary is the top-level read-only recovery object surfaced on
+// next/run/validate and CLIError. It carries one primary command/action chosen
+// by a static stage-priority rule plus a step per actionable blocker.
+type RecoverySummary struct {
+	PrimaryCommand string         `json:"primary_command,omitempty"`
+	PrimaryAction  string         `json:"primary_action,omitempty"`
+	RecoveryClass  RecoveryClass  `json:"recovery_class,omitempty"`
+	Steps          []RecoveryStep `json:"steps,omitempty"`
+}
+
+// BuildRecovery projects actionable blockers into a RecoverySummary. Blockers
+// that share a (code, subject) collapse into one step whose Details list the
+// distinct remainders — neither the command nor the remediation varies by detail
+// within a group — so a multi-artifact drift surfaces one actionable step instead
+// of N near-identical ones. It returns nil when no blocker has a recovery-relevant
+// remediation, so the field stays absent (omitempty). It never re-judges gates —
+// it only renders the blockers it is given.
+func BuildRecovery(blockers []ReasonCode) *RecoverySummary {
+	type groupKey struct{ code, subject string }
+	groups := map[groupKey][]ReasonCode{}
+	var order []groupKey
+	for _, rc := range NormalizeReasonCodes(blockers) {
+		remediation, ok := blockerRemediations[rc.Code]
+		if !ok {
+			continue
+		}
+		parsed := parseBlockerForRecovery(rc, remediation)
+		key := groupKey{parsed.Code, parsed.Subject}
+		if _, seen := groups[key]; !seen {
+			order = append(order, key)
+		}
+		groups[key] = append(groups[key], rc)
+	}
+	if len(order) == 0 {
+		return nil
+	}
+	steps := make([]RecoveryStep, 0, len(order))
+	for _, key := range order {
+		steps = append(steps, recoveryStepForGroup(groups[key]))
+	}
+	primary := selectPrimaryStep(steps)
+	return &RecoverySummary{
+		PrimaryCommand: primary.Command,
+		PrimaryAction:  primary.Remediation,
+		RecoveryClass:  primary.RecoveryClass,
+		Steps:          steps,
+	}
+}
+
+// recoveryStepFor resolves a single blocker into a RecoveryStep. It is a small
+// single-blocker wrapper used mostly by tests and local callers that do not need
+// group collapse. The second return is false for blockers with no
+// recovery-relevant remediation (e.g. informational no_skill_required), which
+// are skipped.
+func recoveryStepFor(rc ReasonCode) (RecoveryStep, bool) {
+	rc.Normalize()
+	if _, ok := blockerRemediations[rc.Code]; !ok {
+		return RecoveryStep{}, false
+	}
+	return recoveryStepForGroup([]ReasonCode{rc}), true
+}
+
+// recoveryStepForGroup renders one step for a group of blockers sharing a
+// (code, subject). The representative drives the remediation/command; Details
+// collects the distinct, sorted remainders the group spans.
+func recoveryStepForGroup(group []ReasonCode) RecoveryStep {
+	rep := group[0]
+	rep.Normalize()
+	base := blockerRemediations[rep.Code]
+	parsed := parseBlockerForRecovery(rep, base)
+	return RecoveryStep{
+		Code:          parsed.Code,
+		Subject:       parsed.Subject,
+		Details:       groupDetails(group, base),
+		Severity:      rep.Severity,
+		Message:       groupMessage(parsed.Code, rep, len(group)),
+		Remediation:   fillTemplate(base.Remediation, parsed),
+		Command:       resolveCommandTemplate(base.CommandTemplate, parsed),
+		RecoveryClass: base.Class,
+		priority:      recoveryPriority(base),
+	}
+}
+
+// groupDetails returns the sorted, de-duplicated non-empty details across a group.
+func groupDetails(group []ReasonCode, remediation blockerRemediation) []string {
+	seen := map[string]struct{}{}
+	var details []string
+	for _, rc := range group {
+		detail := parseBlockerForRecovery(rc, remediation).Detail
+		if detail == "" {
+			continue
+		}
+		if _, ok := seen[detail]; ok {
+			continue
+		}
+		seen[detail] = struct{}{}
+		details = append(details, detail)
+	}
+	sort.Strings(details)
+	return details
+}
+
+func parseBlockerForRecovery(rc ReasonCode, remediation blockerRemediation) ParsedBlocker {
+	rc.Normalize()
+	if remediationShouldSplitDetail(remediation) {
+		return ParseBlocker(rc)
+	}
+	detail := strings.TrimSpace(rc.Detail)
+	raw := rc.Code
+	if detail != "" {
+		raw = rc.Code + ":" + detail
+	}
+	return ParsedBlocker{
+		Code:   rc.Code,
+		Detail: detail,
+		Raw:    raw,
+	}
+}
+
+func remediationShouldSplitDetail(remediation blockerRemediation) bool {
+	if remediation.SplitDetail {
+		return true
+	}
+	return strings.Contains(remediation.Remediation, "{subject}") ||
+		strings.Contains(remediation.Remediation, "{detail}") ||
+		strings.Contains(remediation.CommandTemplate, "{subject}") ||
+		strings.Contains(remediation.CommandTemplate, "{detail}")
+}
+
+// groupMessage keeps the representative's specific message for a singleton group
+// (it still names the one detail) and falls back to the code-level canonical
+// message when several details were collapsed, since the specifics now live in
+// Details.
+func groupMessage(code string, rep ReasonCode, size int) string {
+	if size <= 1 {
+		return rep.Message
+	}
+	return NewReasonCode(code, "").Message
+}
+
+// resolveCommandTemplate fills a command template and falls back to a generic
+// advance command if the template needs a subject the blocker did not carry, so
+// a recovery command is never emitted with an empty placeholder.
+func resolveCommandTemplate(template string, parsed ParsedBlocker) string {
+	if template == "" {
+		return ""
+	}
+	if strings.Contains(template, "{subject}") && strings.TrimSpace(parsed.Subject) == "" {
+		return "slipway run"
+	}
+	return fillTemplate(template, parsed)
+}
+
+func fillTemplate(template string, parsed ParsedBlocker) string {
+	out := strings.ReplaceAll(template, "{subject}", parsed.Subject)
+	out = strings.ReplaceAll(out, "{detail}", parsed.Detail)
+	return tidyTemplate(out)
+}
+
+// tidyTemplate removes the artifacts an absent {subject}/{detail} would leave —
+// the double space where the placeholder was, and a space orphaned in front of
+// punctuation — so a remediation never surfaces "  " or " .".
+func tidyTemplate(s string) string {
+	s = strings.Join(strings.Fields(s), " ")
+	for _, p := range []string{" .", " ,", " :", " ;"} {
+		s = strings.ReplaceAll(s, p, p[1:])
+	}
+	return strings.TrimSpace(s)
+}
+
+// selectPrimaryStep picks the single primary recovery step by static class
+// priority, breaking ties by severity (error before warning) then code, so the
+// selection is deterministic and independent of blocker ordering.
+func selectPrimaryStep(steps []RecoveryStep) RecoveryStep {
+	best := steps[0]
+	for _, step := range steps[1:] {
+		if lessRecoveryStep(step, best) {
+			best = step
+		}
+	}
+	return best
+}
+
+func lessRecoveryStep(a, b RecoveryStep) bool {
+	pa, pb := recoveryClassRank(a.RecoveryClass), recoveryClassRank(b.RecoveryClass)
+	if pa != pb {
+		return pa < pb
+	}
+	ra, rb := recoveryStepPriority(a), recoveryStepPriority(b)
+	if ra != rb {
+		return ra < rb
+	}
+	sa, sb := severityRank(a.Severity), severityRank(b.Severity)
+	if sa != sb {
+		return sa < sb
+	}
+	return a.Code < b.Code
+}
+
+func recoveryClassRank(class RecoveryClass) int {
+	for i, c := range recoveryClassPriority {
+		if c == class {
+			return i
+		}
+	}
+	return len(recoveryClassPriority)
+}
+
+func recoveryPriority(remediation blockerRemediation) int {
+	if remediation.Priority > 0 {
+		return remediation.Priority
+	}
+	return defaultRecoveryPriority
+}
+
+func recoveryStepPriority(step RecoveryStep) int {
+	if step.priority > 0 {
+		return step.priority
+	}
+	return defaultRecoveryPriority
+}
+
+func severityRank(s ReasonSeverity) int {
+	switch s {
+	case ReasonSeverityError:
+		return 0
+	case ReasonSeverityWarning:
+		return 1
+	default:
+		return 2
+	}
+}

--- a/internal/model/recovery_test.go
+++ b/internal/model/recovery_test.go
@@ -1,0 +1,500 @@
+package model
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseBlockerSegments(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		spec    string
+		code    string
+		subject string
+		detail  string
+		raw     string
+	}{
+		{
+			name:    "three segment stale token",
+			spec:    "required_skill_stale:plan-audit:assurance.md",
+			code:    "required_skill_stale",
+			subject: "plan-audit",
+			detail:  "assurance.md",
+			raw:     "required_skill_stale:plan-audit:assurance.md",
+		},
+		{
+			name:    "two segment task token",
+			spec:    "tasks_plan_changed_since_task_evidence:t-03",
+			code:    "tasks_plan_changed_since_task_evidence",
+			subject: "t-03",
+			detail:  "",
+			raw:     "tasks_plan_changed_since_task_evidence:t-03",
+		},
+		{
+			name:    "bare token",
+			spec:    "plan_audit_failed",
+			code:    "plan_audit_failed",
+			subject: "",
+			detail:  "",
+			raw:     "plan_audit_failed",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := ParseBlockerSpec(tc.spec)
+			assert.Equal(t, tc.code, got.Code)
+			assert.Equal(t, tc.subject, got.Subject)
+			assert.Equal(t, tc.detail, got.Detail)
+			assert.Equal(t, tc.raw, got.Raw)
+		})
+	}
+}
+
+func TestParseBlockerIsSingleDecompositionPoint(t *testing.T) {
+	t.Parallel()
+
+	// ParseBlocker must accept an already-split ReasonCode and re-derive the same
+	// segments, so callers can route either a spec string or a ReasonCode through
+	// the one parser.
+	rc := NewReasonCode("required_skill_stale", "plan-audit:assurance.md")
+	got := ParseBlocker(rc)
+	assert.Equal(t, "plan-audit", got.Subject)
+	assert.Equal(t, "assurance.md", got.Detail)
+}
+
+func TestRemediationTableEntriesAreComplete(t *testing.T) {
+	t.Parallel()
+
+	for code, rem := range blockerRemediations {
+		_, hasCanonical := canonicalReasonDefinitions[code]
+		assert.Truef(t, hasCanonical, "recovery code %q must have a canonical reason message", code)
+		assert.NotEmptyf(t, strings.TrimSpace(rem.Remediation), "remediation for %q must be non-empty", code)
+		assert.NotEmptyf(t, strings.TrimSpace(string(rem.Class)), "recovery class for %q must be non-empty", code)
+		assert.Lessf(t, recoveryClassRank(rem.Class), len(recoveryClassPriority),
+			"remediation class %q for %q must be in recoveryClassPriority", rem.Class, code)
+	}
+}
+
+func TestRecoveryRelevantTokensResolveToRemediation(t *testing.T) {
+	t.Parallel()
+
+	// Every recovery-relevant family named in the requirements must render a
+	// non-empty remediation. This is derived from canonical reason codes so adding
+	// a new scope_contract_*/plan_audit_*/wave_* code without remediation goes red.
+	for _, code := range recoveryRelevantCanonicalCodes() {
+		rc := NewReasonCode(code, sampleRecoveryDetail(code))
+		step, ok := recoveryStepFor(rc)
+		require.Truef(t, ok, "token %q must produce a recovery step", rc.Key())
+		assert.NotEmptyf(t, strings.TrimSpace(step.Remediation), "token %q must produce a remediation", rc.Key())
+		assert.NotEmptyf(t, strings.TrimSpace(step.Command), "token %q must produce a command", rc.Key())
+		assert.NotContainsf(t, step.Remediation, "{", "token %q remediation must not leak a placeholder", rc.Key())
+		assert.NotContainsf(t, step.Command, "{", "token %q command must not leak a placeholder", rc.Key())
+	}
+}
+
+func TestInScopeProducedBlockersResolveToCanonicalRecovery(t *testing.T) {
+	t.Parallel()
+
+	// This list is intentionally derived from known validate/next/run/done
+	// producers, not from canonicalReasonDefinitions. It catches a real blocker
+	// that can reach an in-scope user surface before it is added to the canonical
+	// reason and remediation tables.
+	for _, spec := range inScopeProducedRecoverySpecs() {
+		rc := ReasonCodeFromSpec(spec)
+		_, hasCanonical := canonicalReasonDefinitions[rc.Code]
+		assert.Truef(t, hasCanonical, "produced blocker %q must have a canonical reason message", rc.Code)
+
+		step, ok := recoveryStepFor(rc)
+		require.Truef(t, ok, "produced blocker %q must produce a recovery step", rc.Key())
+		assert.NotEmptyf(t, strings.TrimSpace(step.Remediation), "produced blocker %q must produce a remediation", rc.Key())
+		assert.NotEmptyf(t, strings.TrimSpace(step.Command), "produced blocker %q must produce a command", rc.Key())
+		assert.NotContainsf(t, step.Remediation, "{", "produced blocker %q remediation must not leak a placeholder", rc.Key())
+		assert.NotContainsf(t, step.Command, "{", "produced blocker %q command must not leak a placeholder", rc.Key())
+		assert.NotEqualf(t, humanizeReasonCode(rc.Code), strings.TrimSuffix(rc.Message, ": "+rc.Detail),
+			"produced blocker %q must not render through humanize fallthrough", rc.Key())
+	}
+}
+
+func inScopeProducedRecoverySpecs() []string {
+	return []string{
+		"research_structure_invalid:section \"Findings\" must have non-empty content",
+		"non_pass_task:t-01",
+		"closeout_goal_verification_reuse_invalid:goal-verification evidence was produced before final-closeout input changed; rerun goal-verification, then rerun final-closeout",
+		"worktree_metadata_persist_failed:permission denied",
+	}
+}
+
+func recoveryRelevantCanonicalCodes() []string {
+	exact := map[string]bool{
+		"assurance_structure_invalid":              true,
+		"artifact_not_ready":                       true,
+		"artifact_schema_missing":                  true,
+		"closeout_assurance_attestation_missing":   true,
+		"closeout_goal_verification_reuse_invalid": true,
+		"dedicated_worktree_branch_mismatch":       true,
+		"dedicated_worktree_metadata_required":     true,
+		"dedicated_worktree_path_invalid":          true,
+		"dedicated_worktree_required":              true,
+		"governance_action_required":               true,
+		"governed_bundle_path_invalid":             true,
+		"high_risk_check_failed":                   true,
+		"high_risk_check_missing":                  true,
+		"intake_clarification_incomplete":          true,
+		"intake_confirmation_incomplete":           true,
+		"intake_substep_invalid":                   true,
+		"manifest_r0_invalid":                      true,
+		"missing_discovery_evidence":               true,
+		"missing_required_artifact":                true,
+		"missing_task_evidence_for_run_summary":    true,
+		"missing_worktree_branch":                  true,
+		"missing_worktree_path":                    true,
+		"non_pass_task":                            true,
+		"preset_confirmation_required":             true,
+		"research_structure_invalid":               true,
+		"run_slipway_done_to_finalize":             true,
+		"run_slipway_run_to_advance":               true,
+		"ship_gate_blocked":                        true,
+		"tasks_checklist_invalid_format":           true,
+		"verification_evidence_missing":            true,
+		"worktree_metadata_persist_failed":         true,
+		"worktree_validation_error":                true,
+	}
+	prefixes := []string{
+		"plan_audit_",
+		"plan_checker_",
+		"plan_dimension_",
+		"required_artifact_",
+		"required_skill_",
+		"review_layer_",
+		"scope_contract_",
+		"stale_execution_",
+		"stale_planning_",
+		"tasks_checklist_",
+		"tasks_plan_",
+		"wave_",
+	}
+	codes := make([]string, 0, len(canonicalReasonDefinitions))
+	for code := range canonicalReasonDefinitions {
+		if exact[code] || hasAnyPrefix(code, prefixes) {
+			codes = append(codes, code)
+		}
+	}
+	sort.Strings(codes)
+	return codes
+}
+
+func hasAnyPrefix(code string, prefixes []string) bool {
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(code, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func sampleRecoveryDetail(code string) string {
+	switch code {
+	case "assurance_structure_invalid":
+		return "missing required Evidence section: closeout:assurance_complete=pass"
+	case "closeout_assurance_attestation_missing":
+		return "final-closeout must record closeout:assurance_complete=pass on standard/strict"
+	case "closeout_goal_verification_reuse_invalid":
+		return "goal-verification evidence was produced before final-closeout input changed; rerun goal-verification, then rerun final-closeout"
+	case "governance_action_required":
+		return "domain-review:run domain-aware review"
+	case "governed_bundle_path_invalid":
+		return "../outside"
+	case "high_risk_check_failed", "high_risk_check_missing":
+		return "sast"
+	case "missing_required_artifact", "required_artifact_schema_missing", "required_artifact_unreadable":
+		return "decision.md"
+	case "required_artifact_dependency_missing":
+		return "decision.md->requirements.md"
+	case "missing_task_evidence_for_run_summary":
+		return "run_summary_version=1"
+	case "non_pass_task":
+		return "t-01"
+	case "plan_audit_budget_exhausted":
+		return "checker iteration budget exhausted before plan audit passed (rescope is S2_EXECUTE-only)"
+	case "plan_audit_iteration":
+		return "1/2"
+	case "plan_checker_feedback_required":
+		return "rerun_plan_audit_with_blocker_feedback"
+	case "plan_dimension_scope_out_of_bounds_target":
+		return "t-01:../outside.go"
+	case "plan_dimension_dependency_unknown", "plan_dimension_coverage_unknown_requirement":
+		return "t-01->t-99"
+	case "plan_dimension_coverage_missing_requirement", "plan_dimension_coverage_requirement_id_missing":
+		return "REQ-001"
+	case "review_layer_missing", "review_layer_failed":
+		return "IR1"
+	case "required_skill_stale":
+		return "plan-audit:assurance.md"
+	case "required_skill_blockers_present", "required_skill_missing", "required_skill_not_passed", "required_skill_not_ready":
+		return "plan-audit"
+	case "research_structure_invalid":
+		return "section \"Findings\" must have non-empty content"
+	case "ship_gate_blocked":
+		return "required_skill_missing:final-closeout"
+	case "scope_contract_changed_files_missing", "scope_contract_missing", "wave_orchestration_stale_task_evidence":
+		return "t-01"
+	case "scope_contract_drift":
+		return "cmd/next.go"
+	case "tasks_checklist_duplicate_task_id":
+		return "t-01"
+	case "tasks_checklist_task_id_missing":
+		return "index_0"
+	case "tasks_plan_changed_since_task_evidence":
+		return "t-03"
+	case "worktree_validation_error":
+		return "missing branch"
+	case "worktree_metadata_persist_failed":
+		return "permission denied"
+	case "wave_plan_missing":
+		return "change-slug"
+	default:
+		return ""
+	}
+}
+
+func TestRecoveryStepFillsSubjectIntoCommand(t *testing.T) {
+	t.Parallel()
+
+	rc := ReasonCodeFromSpec("required_skill_stale:plan-audit:assurance.md")
+	step, ok := recoveryStepFor(rc)
+	require.True(t, ok)
+	assert.Contains(t, step.Command, "--skill plan-audit", "command must interpolate the subject")
+	assert.NotContains(t, step.Remediation, "{subject}")
+	assert.NotContains(t, step.Remediation, "{detail}")
+}
+
+func TestRecoveryStepFallsBackWhenSubjectMissing(t *testing.T) {
+	t.Parallel()
+
+	// A subjectless stale token must not emit a command with an empty placeholder.
+	rc := ReasonCodeFromSpec("required_skill_stale")
+	step, ok := recoveryStepFor(rc)
+	require.True(t, ok)
+	assert.NotContains(t, step.Command, "{subject}")
+	assert.Equal(t, "slipway run", step.Command, "must fall back when the subject is missing")
+}
+
+func TestBuildRecoveryNilOnCleanState(t *testing.T) {
+	t.Parallel()
+
+	// Informational, non-actionable blockers must not produce a recovery object.
+	blockers := []ReasonCode{NewReasonCode("no_skill_required", "S1_PLAN")}
+	assert.Nil(t, BuildRecovery(blockers))
+	assert.Nil(t, BuildRecovery(nil))
+}
+
+func TestBuildRecoverySelectsPrimaryByStagePriority(t *testing.T) {
+	t.Parallel()
+
+	// reopen_planning (root-most) must win over refresh_execution (later stage),
+	// regardless of blocker order.
+	blockers := []ReasonCode{
+		NewReasonCode("stale_execution_evidence", ""),
+		NewReasonCode("stale_planning_evidence", ""),
+		NewReasonCode("no_skill_required", "S2_EXECUTE"),
+	}
+	got := BuildRecovery(blockers)
+	require.NotNil(t, got)
+	assert.Equal(t, RecoveryClassReopenPlanning, got.RecoveryClass)
+	assert.NotEmpty(t, got.PrimaryCommand)
+	for _, step := range got.Steps {
+		assert.NotEqual(t, "no_skill_required", step.Code, "informational blocker must not appear as a step")
+	}
+}
+
+func TestRecoveryTokensUseCanonicalMessages(t *testing.T) {
+	t.Parallel()
+
+	specs := []string{
+		"governance_action_required:domain-review:run domain-aware review",
+		"preset_confirmation_required",
+		"tasks_plan_changed_since_task_evidence:t-03",
+	}
+	for _, spec := range specs {
+		rc := ReasonCodeFromSpec(spec)
+		assert.NotEqualf(t, humanizeReasonCode(rc.Code), strings.TrimSuffix(rc.Message, ": "+rc.Detail),
+			"message for %q must be canonical, not the humanize fallthrough", spec)
+	}
+}
+
+func TestReasonCodeJSONShapeHasNoPresentationFields(t *testing.T) {
+	t.Parallel()
+
+	// Read-only/additive invariant: the persisted ReasonCode must not gain
+	// recovery/remediation presentation fields.
+	rc := NewReasonCode("required_skill_stale", "plan-audit:assurance.md")
+	raw, err := json.Marshal(rc)
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(raw, &m))
+	got := make([]string, 0, len(m))
+	for k := range m {
+		got = append(got, k)
+	}
+	sort.Strings(got)
+	assert.Equal(t, []string{"code", "detail", "message", "severity"}, got,
+		"ReasonCode JSON must carry no presentation fields")
+}
+
+func TestPlanAuditRecoveryDoesNotRecommendRescopeInS1(t *testing.T) {
+	t.Parallel()
+
+	// rescope is S2_EXECUTE-only (gate.EvaluateGPivot), but these blockers are
+	// produced on the S1 plan-audit path. The recovery command must therefore not
+	// hand the operator a `pivot --rescope` the gate will reject; reroute is valid
+	// from S1 through S4.
+	for _, code := range []string{"plan_audit_budget_exhausted", "plan_checker_loop_terminated"} {
+		rc := NewReasonCode(code, "")
+		step, ok := recoveryStepFor(rc)
+		require.Truef(t, ok, "%s must produce a recovery step", code)
+		assert.Equalf(t, "slipway pivot --reroute", step.Command, "%s must recommend reroute, not rescope", code)
+		assert.NotContainsf(t, step.Command, "rescope", "%s command must not point at S1-invalid rescope", code)
+		assert.NotContainsf(t, step.Remediation, "--rescope", "%s remediation must not point at S1-invalid rescope", code)
+	}
+}
+
+func TestCloseoutAttestationMissingResolvesToRecovery(t *testing.T) {
+	t.Parallel()
+
+	// closeout_assurance_attestation_missing is a real G_ship blocker but was not
+	// canonicalized or in the remediation table, so BuildRecovery silently skipped
+	// it on real S4 output. It must now render a step with a remediation/command.
+	rc := NewReasonCode("closeout_assurance_attestation_missing",
+		"final-closeout must record closeout:assurance_complete=pass on standard/strict")
+	step, ok := recoveryStepFor(rc)
+	require.True(t, ok, "closeout_assurance_attestation_missing must produce a recovery step")
+	assert.NotEmpty(t, step.Remediation)
+	assert.NotEmpty(t, step.Command)
+	assert.Contains(t, step.Remediation, "final-closeout")
+	assert.NotContains(t, step.Remediation, "{", "static remediation must not leak a placeholder")
+	assert.Empty(t, step.Subject, "opaque prose detail must not become a synthetic subject")
+	assert.Equal(t,
+		[]string{"final-closeout must record closeout:assurance_complete=pass on standard/strict"},
+		step.Details,
+		"the colon-bearing attestation token must stay intact in Details")
+	// Canonical message, not the humanizeReasonCode fallthrough.
+	assert.NotEqual(t, humanizeReasonCode(rc.Code), strings.TrimSuffix(rc.Message, ": "+rc.Detail),
+		"message must be the written canonical sentence")
+}
+
+func TestBuildRecoveryCoversRealValidationAndShipBlockers(t *testing.T) {
+	t.Parallel()
+
+	blockers := []ReasonCode{
+		NewReasonCode("missing_required_artifact", "decision.md"),
+		NewReasonCode("plan_dimension_dependency_unknown", "t-01->t-99"),
+		NewReasonCode("review_layer_missing", "IR1"),
+		NewReasonCode("tasks_checklist_empty", ""),
+	}
+	got := BuildRecovery(blockers)
+	require.NotNil(t, got)
+	assert.ElementsMatch(t,
+		[]string{
+			"missing_required_artifact",
+			"plan_dimension_dependency_unknown",
+			"review_layer_missing",
+			"tasks_checklist_empty",
+		},
+		recoveryCodes(got.Steps),
+		"real validate/done blockers must not be silently skipped")
+}
+
+func TestBuildRecoveryPrioritizesVerificationBeforeCloseout(t *testing.T) {
+	t.Parallel()
+
+	got := BuildRecovery([]ReasonCode{
+		NewReasonCode("closeout_assurance_attestation_missing",
+			"final-closeout must record closeout:assurance_complete=pass on standard/strict"),
+		NewReasonCode("closeout_goal_verification_reuse_invalid",
+			"goal-verification evidence was produced before final-closeout input changed; rerun goal-verification, then rerun final-closeout"),
+		NewReasonCode("verification_evidence_missing", "goal-verification"),
+	})
+	require.NotNil(t, got)
+	assert.Equal(t, RecoveryClassRerunSkill, got.RecoveryClass)
+	assert.Contains(t, got.PrimaryAction, "goal-verification",
+		"goal-verification recovery must precede final-closeout when both S4 blockers are present")
+}
+
+func TestReadyStatesSurfaceAdvanceRecovery(t *testing.T) {
+	t.Parallel()
+
+	// A ready-to-advance or ready-to-finalize state is not blocked, but its single
+	// trustworthy next action is still surfaced as the primary command, and the two
+	// ready advisories are handled symmetrically.
+	advance := BuildRecovery([]ReasonCode{
+		NewReasonCode("run_slipway_run_to_advance", "S2_EXECUTE"),
+		NewReasonCode("no_skill_required", "S2_EXECUTE"),
+	})
+	require.NotNil(t, advance)
+	assert.Equal(t, "slipway run", advance.PrimaryCommand)
+	assert.Equal(t, RecoveryClassAdvance, advance.RecoveryClass)
+
+	finalize := BuildRecovery([]ReasonCode{NewReasonCode("run_slipway_done_to_finalize", "")})
+	require.NotNil(t, finalize)
+	assert.Equal(t, "slipway done", finalize.PrimaryCommand)
+}
+
+func TestBuildRecoveryGroupsBlockersByCodeAndSubject(t *testing.T) {
+	t.Parallel()
+
+	// Many stale artifacts under one skill must collapse into a single step that
+	// lists the artifacts in Details, not N near-identical restamp steps; a second
+	// skill stays a distinct step.
+	blockers := []ReasonCode{
+		NewReasonCode("required_skill_stale", "code-quality-review:CLAUDE.md"),
+		NewReasonCode("required_skill_stale", "code-quality-review:README.md"),
+		NewReasonCode("required_skill_stale", "code-quality-review:cmd/next.go"),
+		NewReasonCode("required_skill_stale", "code-quality-review:CLAUDE.md"), // duplicate
+		NewReasonCode("required_skill_stale", "plan-audit:tasks.md"),
+	}
+	got := BuildRecovery(blockers)
+	require.NotNil(t, got)
+	require.Len(t, got.Steps, 2, "one step per (code, subject), not per blocker")
+
+	var cqr *RecoveryStep
+	for i := range got.Steps {
+		if got.Steps[i].Subject == "code-quality-review" {
+			cqr = &got.Steps[i]
+		}
+	}
+	require.NotNil(t, cqr, "the code-quality-review group must be one step")
+	assert.Equal(t, []string{"CLAUDE.md", "README.md", "cmd/next.go"}, cqr.Details,
+		"details are de-duplicated and sorted")
+	assert.Contains(t, cqr.Command, "--skill code-quality-review")
+	assert.NotContains(t, cqr.Remediation, "{", "remediation must not embed a per-detail placeholder")
+}
+
+func TestGovernanceActionRemediationStaysCleanWithoutDetail(t *testing.T) {
+	t.Parallel()
+
+	// A subjectless/detailless token must not leak the artifacts of an empty
+	// placeholder substitution (empty quotes, dangling separator, double space).
+	step, ok := recoveryStepFor(NewReasonCode("governance_action_required", ""))
+	require.True(t, ok)
+	assert.NotContains(t, step.Remediation, "''")
+	assert.NotContains(t, step.Remediation, ": .")
+	assert.NotContains(t, step.Remediation, "  ")
+	assert.NotContains(t, step.Remediation, "{")
+}
+
+func recoveryCodes(steps []RecoveryStep) []string {
+	codes := make([]string, 0, len(steps))
+	for _, step := range steps {
+		codes = append(codes, step.Code)
+	}
+	return codes
+}


### PR DESCRIPTION
## Summary
- add a prefix-aware blocker parser and Code-keyed recovery/remediation vocabulary in `internal/model`
- surface additive `recovery` guidance on `next`/`run`/`validate` JSON and governance-blocked `CLIError` without changing existing `blockers[]` or gate behavior
- preserve compact handoff primary recovery commands, add canonical messages for recovery-relevant tokens, and document the new JSON surface
- close the governed Slipway change and commit the archived artifact bundle

## Verification
- `go build ./...`
- `go test -count=1 ./...`
- `go vet ./...`
- `git diff --check`
- `/tmp/slipway-p1-closeout validate --json --change recovery-ux-p1-issue-84-prefix-aware-blocker-parser-parsedbl` -> `can_advance=true`, `G_ship=approved`, `evidence_freshness=fresh`
- `/tmp/slipway-p1-closeout done --json --change recovery-ux-p1-issue-84-prefix-aware-blocker-parser-parsedbl` -> `status=done`, `archived=true`, `archive_commit_required=true`

Closes #84
Refs #81