### PR TITLE
fix(progression): reopen to S2_EXECUTE when the Scope Contract fails

### DIFF
--- a/cmd/evidence_task_test.go
+++ b/cmd/evidence_task_test.go
@@ -33,8 +33,11 @@ func TestEvidenceTaskRecordsRuntimeEvidenceAndBuildsExecutionSummary(t *testing.
 			"--task-kind", "verification",
 			"--verdict", "pass",
 			"--evidence-ref", "test:evidence-task",
-			"--changed-file", "cmd/evidence.go",
-			"--target-file", "cmd/evidence.go",
+			// Must stay within the fixture wave-plan's target_files
+			// (cmd/lifecycle_commands_test.go) so the Scope Contract passes; an
+			// out-of-scope changed_file now reopens to S2 (scope_contract gate).
+			"--changed-file", "cmd/lifecycle_commands_test.go",
+			"--target-file", "cmd/lifecycle_commands_test.go",
 			"--captured-at", capturedAt.Format(time.RFC3339Nano),
 			"--session-id", "session-a",
 		})
@@ -65,8 +68,8 @@ func TestEvidenceTaskRecordsRuntimeEvidenceAndBuildsExecutionSummary(t *testing.
 		assert.Equal(t, "t-01", task.TaskID)
 		assert.Equal(t, model.TaskVerdictPass, task.Verdict)
 		assert.Equal(t, model.TaskKindVerification, task.TaskKind)
-		assert.Equal(t, []string{"cmd/evidence.go"}, task.ChangedFiles)
-		assert.Equal(t, []string{"cmd/evidence.go"}, task.TargetFiles)
+		assert.Equal(t, []string{"cmd/lifecycle_commands_test.go"}, task.ChangedFiles)
+		assert.Equal(t, []string{"cmd/lifecycle_commands_test.go"}, task.TargetFiles)
 		assert.True(t, capturedAt.Equal(parsedAt))
 		assert.Equal(t, "session-a", sessionID)
 		assert.True(t, task.FreshnessInputs.Equal(expectedFreshnessInputs))

--- a/internal/engine/progression/advance_governed.go
+++ b/internal/engine/progression/advance_governed.go
@@ -109,6 +109,17 @@ func AdvanceGoverned(root, slug string, opts ...AdvanceOptions) (summary Advance
 		return blockedAdvanceSummary(fromState, model.ReasonCodesFromSpecs(executionSummaryCtx.Issues)), nil
 	}
 
+	// Scope Contract gate (owned by S2_EXECUTE): a satisfied execution summary
+	// must also satisfy the Scope Contract. On failure, reopen to S2_EXECUTE so
+	// the agent re-records task evidence in the owning stage instead of advancing
+	// into S3_REVIEW, where the failure is detected but cannot be repaired (task
+	// evidence is only recordable during S2_EXECUTE) — which would strand the change.
+	if target, err := scopeContractReopenTarget(root, change, executionSummaryCtx.Summary); err != nil {
+		return AdvanceSummary{}, err
+	} else if target.SkillName != "" {
+		return reopenToStaleStage(root, &change, target, fromState)
+	}
+
 	preTransitionSideEffects := make([]SideEffect, 0, 2)
 
 	// Ensure research artifact exists for discovery changes entering S1_PLAN/research.

--- a/internal/engine/progression/scope_contract_gate_test.go
+++ b/internal/engine/progression/scope_contract_gate_test.go
@@ -1,0 +1,87 @@
+package progression
+
+import (
+	"testing"
+
+	"github.com/signalridge/slipway/internal/engine/scopecontract"
+	"github.com/signalridge/slipway/internal/model"
+	"github.com/signalridge/slipway/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// codeTaskSummary builds a ready execution summary with a single passing code
+// task whose changed-files set is supplied by the caller.
+func codeTaskSummary(changedFiles []string) *model.ExecutionSummary {
+	return &model.ExecutionSummary{
+		Version:           model.ExecutionSummaryVersion,
+		RunSummaryVersion: 1,
+		Tasks: []model.ExecutionTaskSummary{{
+			TaskID:       "task-a",
+			Verdict:      model.TaskVerdictPass,
+			TaskKind:     model.TaskKindCode,
+			ChangedFiles: changedFiles,
+			TargetFiles:  []string{"cmd/next.go"},
+			EvidenceRef:  "test:task-a",
+		}},
+	}
+}
+
+func seedScopeContractChange(t *testing.T, state2 model.WorkflowState) (string, model.Change) {
+	t.Helper()
+	root := t.TempDir()
+	slug := "scope-reopen"
+	change := model.NewChange(slug)
+	change.CurrentState = state2
+	change.PlanSubStep = model.PlanSubStepNone
+	require.NoError(t, state.SaveChange(root, change))
+	writeTasksAndMaterializeWavePlan(t, root, change, "# Tasks\n\n"+
+		"- [x] `task-a` Implement task A\n"+
+		"  - target_files: [\"cmd/next.go\"]\n"+
+		"  - wave: 1\n"+
+		"  - task_kind: code\n")
+	return root, change
+}
+
+// A code task recorded without changed files fails the Scope Contract. Because
+// the failure can only be repaired by re-recording task evidence in S2_EXECUTE,
+// the gate must reopen there instead of leaving the change stranded downstream.
+func TestScopeContractReopenTargetReopensToS2WhenChangedFilesMissing(t *testing.T) {
+	t.Parallel()
+	root, change := seedScopeContractChange(t, model.StateS3Review)
+
+	target, err := scopeContractReopenTarget(root, change, codeTaskSummary(nil))
+	require.NoError(t, err)
+
+	assert.Equal(t, SkillWaveOrchestration, target.SkillName)
+	assert.Equal(t, model.StateS2Execute, target.State)
+	require.NotEmpty(t, target.Blockers, "scope-contract failure must carry blockers into the reopen target")
+	found := false
+	for _, b := range target.Blockers {
+		if b.Code == scopecontract.ReasonScopeContractChangedFilesMissing {
+			found = true
+		}
+	}
+	assert.True(t, found, "reopen target should surface scope_contract_changed_files_missing")
+}
+
+// When the same task records its changed files, the Scope Contract is satisfied
+// and the gate must not reopen (advance proceeds normally).
+func TestScopeContractReopenTargetEmptyWhenContractSatisfied(t *testing.T) {
+	t.Parallel()
+	root, change := seedScopeContractChange(t, model.StateS3Review)
+
+	target, err := scopeContractReopenTarget(root, change, codeTaskSummary([]string{"cmd/next.go"}))
+	require.NoError(t, err)
+	assert.Empty(t, target.SkillName, "a satisfied scope contract must not trigger a reopen")
+}
+
+// The gate is a no-op before the change has produced a ready execution summary.
+func TestScopeContractReopenTargetEmptyWhenSummaryNotReady(t *testing.T) {
+	t.Parallel()
+	root, change := seedScopeContractChange(t, model.StateS3Review)
+
+	target, err := scopeContractReopenTarget(root, change, nil)
+	require.NoError(t, err)
+	assert.Empty(t, target.SkillName, "no reopen without a ready execution summary")
+}

--- a/internal/engine/progression/stale_evidence_recovery.go
+++ b/internal/engine/progression/stale_evidence_recovery.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/signalridge/slipway/internal/engine/action"
 	"github.com/signalridge/slipway/internal/engine/governance"
+	"github.com/signalridge/slipway/internal/engine/scopecontract"
 	"github.com/signalridge/slipway/internal/engine/skill"
 	"github.com/signalridge/slipway/internal/model"
 	"github.com/signalridge/slipway/internal/state"
@@ -428,4 +429,45 @@ func staleEvidenceAuthorityLabel(workflowState model.WorkflowState, subStep mode
 		return string(workflowState) + "/" + string(subStep)
 	}
 	return string(workflowState)
+}
+
+// scopeContractReopenTarget returns an S2_EXECUTE reopen target when a satisfied
+// execution summary nonetheless fails the Scope Contract. The Scope Contract is
+// owned by S2_EXECUTE (it scores the wave-execution evidence), but it can only
+// be evaluated once the run summary exists — which is produced at the moment the
+// change advances out of S2. Without this gate the failure first surfaces in
+// S3_REVIEW, where task evidence can no longer be recorded, stranding the change
+// with a recovery hint that points at a command that cannot fix it. Reopening to
+// S2_EXECUTE makes the failure fail closed to a rerun of wave-orchestration in
+// its owning stage. Returns the zero target when the summary is not ready, the
+// change has not yet reached S2_EXECUTE, evaluation errors (surfaced via
+// readiness), or the contract passes.
+func scopeContractReopenTarget(root string, change model.Change, summary *model.ExecutionSummary) (StaleEvidenceTarget, error) {
+	if !state.ExecutionSummaryReady(summary) {
+		return StaleEvidenceTarget{}, nil
+	}
+	if compareStaleEvidencePosition(
+		currentStaleEvidencePosition(change),
+		staleEvidencePositionFor(model.StateS2Execute, model.PlanSubStepNone),
+	) < 0 {
+		return StaleEvidenceTarget{}, nil
+	}
+	paths, err := state.ResolveChangePaths(root, change)
+	if err != nil {
+		return StaleEvidenceTarget{}, err
+	}
+	report, err := scopecontract.EvaluateBundleWithChangedFiles(
+		paths.GovernedBundleDir,
+		summary,
+		scopeContractWorkspaceChangedFiles(paths),
+	)
+	if err != nil || len(report.Blockers) == 0 {
+		return StaleEvidenceTarget{}, nil
+	}
+	return StaleEvidenceTarget{
+		SkillName:   SkillWaveOrchestration,
+		State:       model.StateS2Execute,
+		PlanSubStep: model.PlanSubStepNone,
+		Blockers:    report.Blockers,
+	}, nil
 }


### PR DESCRIPTION
## Problem

The `S2_EXECUTE → S3_REVIEW` advance gate (`advance_governed.go`) evaluated assurance, wave-sync, summary issues, skill evidence, and worktree readiness — **but not the Scope Contract**. The Scope Contract is owned by S2_EXECUTE (it scores wave-execution evidence), yet it can only be evaluated once the run summary exists, which is produced *at the moment* the change advances out of S2.

So a Scope Contract failure (e.g. a `code` task whose evidence has no `changed_files`) first surfaced in **S3_REVIEW**, where task evidence can no longer be recorded. The change was **stranded with no public recovery path**:
- `slipway evidence task` requires S2
- `slipway abort` requires S2
- `slipway run` would not return to S2
- the recovery hint pointed at `slipway run`, which could not fix it

(Matches the `s3-scope-contract-friction` observation: previously "only fixable via pivot".)

## Fix

Add a Scope Contract gate to the advance path: when a ready execution summary fails the contract, **reopen to S2_EXECUTE** — clearing verification + execution summary, **preserving runtime task evidence** — so the failure fails closed to a rerun of wave-orchestration in its owning stage. Reuses the existing stale-evidence reopen machinery (`reopenToStaleStage`), so it does not over-reset the wave plan.

- `stale_evidence_recovery.go`: new `scopeContractReopenTarget` helper (no-op unless the summary is ready, the change has reached S2, and the contract has blockers).
- `advance_governed.go`: wire the gate in after the execution-summary load.

## Tests

`scope_contract_gate_test.go` (3 cases): reopens to S2 with the `scope_contract_changed_files_missing` blocker when changed files are missing; no reopen when the contract is satisfied; no-op before a ready summary. Full `progression` + `scopecontract` suites green.

Verified end-to-end: a change stranded in S3 by this exact failure reopened to S2, accepted corrected evidence, and advanced cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #101
