### PR TITLE
feat(governance)!: execution-completeness gate, safety-baseline satisfy-path, per-change worktrees (#95, #88)

### DIFF
--- a/artifacts/changes/archived/fix-issue-95-governed-execution-advances-s2-execute-to-s3-re/change.yaml
+++ b/artifacts/changes/archived/fix-issue-95-governed-execution-advances-s2-execute-to-s3-re/change.yaml
@@ -1,0 +1,44 @@
+version: 1
+slug: fix-issue-95-governed-execution-advances-s2-execute-to-s3-re
+description: 'Fix issue #95: governed execution advances S2_EXECUTE to S3_REVIEW even when planned wave-plan tasks have no recorded task evidence. The wave-orchestration sync loads the full wave-plan task set but never asserts every planned task has passing evidence, so a host that records evidence for only the early tasks advances to review with later tasks unexecuted. Enforce execution completeness: block advancement with an actionable per-task blocker (and recovery remediation) until every planned execution/verification task has passing evidence or the plan is rescoped.'
+status: done
+current_state: DONE
+needs_discovery: true
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-06-06T11:27:07.526865Z
+quality_mode: standard
+workflow_preset: light
+worktree_branch: feat/fix-issue-95-governed-execution-advances-s2-execute-to-s3-re
+artifact_schema: expanded
+artifacts:
+    decision:
+        id: decision
+        path: decision.md
+        state: frozen
+        content_hash: d85b7badd7fc6e359a6dd1b0aef65466d92bfff05710a832c42c676e7453bf67
+        updated_at: 2026-06-06T12:10:16.039577313Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: c7305c905dd457eb4e00d89d3b4d4f7bf8cc8864dc3543637cf4cac07ac13c4e
+        updated_at: 2026-06-06T12:04:47.254239145Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: 04266c0c181163d50b9e12452f1b9b6210c404d7effebaa8625fe30bef5690b7
+        updated_at: 2026-06-06T11:58:50.378827368Z
+    research:
+        id: research
+        path: research.md
+        state: frozen
+        content_hash: 93e35f350288be7cbe4b92362830ed4518ab53d9c2455069cdc96e45902fa182
+        updated_at: 2026-06-06T12:09:28.140137454Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: 84f501a016a695d47013ef18257388cd4a4376456dcb4ac0ea209daa53c1bbc4
+        updated_at: 2026-06-06T12:41:37.578038275Z

--- a/artifacts/changes/archived/fix-issue-95-governed-execution-advances-s2-execute-to-s3-re/decision.md
+++ b/artifacts/changes/archived/fix-issue-95-governed-execution-advances-s2-execute-to-s3-re/decision.md
@@ -1,0 +1,75 @@
+# Decision
+## Project Context
+- Tech Stack: Go
+- Conventions: cmd/* CLI over internal/engine/* kernel; generated skills/docs via toolgen; table-driven tests
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Alternatives Considered
+
+This change has three independent design forks, one per concern.
+
+**Fork 1 — #88 `<domain>.safety_baseline` producer/satisfy-path.**
+- **Option A — new conditionally-required `guardrail-baseline` skill.** A new
+  governance skill, required when `guardrail_domain != ""`, records the token.
+  Tradeoffs: explicit ownership, but a whole new required skill + registry wiring
+  + lifecycle plumbing for what the existing S4 verifier already covers.
+- **Option B — goal-verification documents and records the token (selected).**
+  goal-verification already runs at S4_VERIFY and its verification-record
+  References already feed `ExtractHighRiskChecks` → the ship gate. The defect is
+  purely missing guidance (the host never knew the exact token format) + a vague
+  remediation. Tradeoffs: smallest change, no new required skill, fail-closed
+  (token reflects a real goal-verification verdict); relies on the host reading
+  the SKILL.md (mitigated by an actionable remediation + a `slipway next` token
+  hint).
+
+**Fork 2 — #88 `repair --focus sast`.**
+- **Option A — make repair run semgrep/CodeQL.** Tradeoffs: violates repair's
+  bounded local-state-integrity contract; repair must never execute external
+  scanners.
+- **Option B — emit a routing hint from repair but keep the focus.** Tradeoffs:
+  keeps a focus that does nothing on repair; still a half-promise.
+- **Option C — remove the false focus from repair, redirect to review/validate
+  (selected).** Tradeoffs: honest and smallest; SAST guidance stays reachable on
+  review/validate where it legitimately hydrates sast-orchestration; the rejection
+  message redirects.
+
+**Fork 3 — #95 incomplete-execution gate + worktree provisioning.**
+- #95 blocker shape: **one `incomplete_execution_task:<taskID>` per missing task
+  (selected)** vs a single aggregate blocker (less actionable). Recovery:
+  **fail-closed complete-or-rescope (selected)** vs a new defer/skip bypass
+  (rejected — weakens the gate).
+- worktree provisioning: **(A) default-true unconditional with config opt-out
+  (selected)** vs (B) preset/complexity-gated vs (C) opt-in default-false. A
+  frees the main checkout for every governed change (the user's goal), is the
+  most consistent, and `git worktree add` is cheap; `auto_provision_worktree`
+  preserves opt-out. Confirmed with the user as "A".
+
+## Selected Approach
+- **#95:** add an execution-completeness assertion in
+  `evaluateGovernedWaveExecution` that compares `WavePlan.TaskIDs()` to the
+  evidenced runs and emits one `incomplete_execution_task:<taskID>` per missing
+  task (both preview and mutate paths, suppressed under plan-drift); register the
+  canonical reason + a refresh-execution recovery remediation; document the
+  completeness contract in the wave-orchestration skill.
+- **#88:** goal-verification SKILL.md documents recording
+  `high_risk_check:<domain>.safety_baseline=pass|fail` from a real SAST run;
+  upgrade the `high_risk_check_missing`/`high_risk_check_failed` remediations to
+  name the token + producer + action and surface the required token in the
+  `slipway next` goal-verification handoff; remove the `sast` focus from the
+  `repair` surface and redirect to review/validate; clarify final-closeout's
+  guardrail recheck. No bypass / self-attestation / stamp-it path.
+- **worktree:** add `governance.auto_provision_worktree` (default true) and drop
+  the `!NeedsDiscovery` skip in `EnsureDefaultWorktreeForChange` so every governed
+  change binds `.worktrees/<slug>` on `feat/<slug>` at `slipway new` with the
+  bundle inside it; keep the single-active-change guard isolation-correct; archive
+  still strips the worktree path.
+
+## Constraints
+- Sensitive-domain gates stay fail-closed; no bypass/force-close/self-attestation.
+- Slipway never runs external scanners; the host runs them and records evidence.
+- The guardrail catalog (which domains require safety_baseline) is unchanged.
+- Code, generated skills, docs, and agent instructions stay aligned (toolgen
+  self-loop zero drift); `go build/vet/test` green.
+- Preserve unrelated local work (`evidence-task-dx-issue.md`).

--- a/artifacts/changes/archived/fix-issue-95-governed-execution-advances-s2-execute-to-s3-re/intent.md
+++ b/artifacts/changes/archived/fix-issue-95-governed-execution-advances-s2-execute-to-s3-re/intent.md
@@ -1,0 +1,156 @@
+# Intent
+
+## Summary
+Fix two P1 governed-lifecycle defects plus a related governance-UX gap in
+Slipway's own engine, in one change:
+
+- **#95 — premature advance.** At S2_EXECUTE the wave-orchestration sync loads
+  the full wave-plan task set but never asserts every planned task has passing
+  evidence, so a host that records evidence for only the early tasks advances to
+  S3_REVIEW with later tasks unexecuted.
+- **#88 — high-risk dead-end + false repair surface.** A guardrail-domain change
+  is blocked at G_ship by `high_risk_check_missing: <domain>.safety_baseline`
+  with no operator-visible, fail-closed way to satisfy it, and
+  `slipway repair --focus sast` is a no-op that falsely advertises running SAST.
+- **worktree provisioning — main occupied, no parallelism.** Governed changes
+  only get a dedicated `.worktrees/<slug>` (`feat/<slug>`) worktree when
+  `needs_discovery` is true; non-discovery changes are skipped
+  (`worktree_skipped_reason: discovery_not_required`) and run their entire
+  S0→done lifecycle in the main checkout, so the user cannot work in parallel and
+  the documented "auto-provision `feat/<slug>`" contract is not honored.
+
+## Complexity Assessment
+complex
+<!-- Rationale -->
+Three governance-engine concerns spanning many surfaces (progression engine,
+gate catalog, reason codes, recovery remediation, capability registry, worktree
+provisioning + change creation, generated skill templates, docs, toolgen,
+tests). #88 touches high-risk safety-gate semantics that must stay fail-closed
+with no new bypass; the worktree change alters change-creation/lifecycle wiring
+with non-trivial test blast radius. This change runs in the main checkout as the
+bootstrap (the worktree fix cannot retroactively relocate itself); subsequent
+governed changes inherit dedicated worktrees.
+
+## Guardrail Domains
+none. This change modifies Slipway's own governance engine and CLI/JSON surface;
+it does not operate in a sensitive product domain (no auth / credentials / PII /
+financial / schema-migration / irreversible-ops / external-API **product**
+change). The `safety_baseline` gate code is edited, but the change keeps it
+fail-closed and adds no bypass. Public CLI, JSON, generated skills, and docs are
+reviewed as external contracts.
+
+## In Scope
+**#95 — execution completeness (fail-closed; per-task blocker):**
+- `internal/engine/progression/wave_sync.go`: in `evaluateGovernedWaveExecution`,
+  after building `runs`, assert every planned `WavePlan.TaskIDs()` task has a
+  passing run; emit one `incomplete_execution_task:<taskID>` blocker per missing
+  task in both the preview and mutate paths (guarded by no plan-drift).
+- `internal/model/reason_code.go`: register canonical `incomplete_execution_task`.
+- `internal/model/recovery.go`: add a `blockerRemediations` entry (refresh-wave
+  class) — execute & record the task, or rescope `tasks.md`, then re-run.
+- `internal/tmpl/templates/skills/wave-orchestration/SKILL.md.tmpl`: state the
+  completeness contract (every planned task needs passing evidence before review;
+  rescope to intentionally drop a task).
+
+**#88 — safety_baseline satisfy-path + repair `--focus sast`:**
+- Make the high-risk satisfy-path operator-visible and fail-closed: the owning
+  governance skill records the `<domain>.safety_baseline` verdict from a real
+  SAST run/triage; the public surface (blocker remediation, `slipway next`
+  handoff, generated SKILL.md) carries the exact reference token, the producing
+  skill, and the required action. No bypass / self-attestation path.
+- `internal/model/recovery.go` (+ gate reason detail): make
+  `high_risk_check_missing` / `high_risk_check_failed` remediation actionable
+  (name the token, the producer skill, the command).
+- `slipway repair --focus sast`: remove the false-promise focus from the `repair`
+  command surface; keep the SAST focus where it legitimately hydrates
+  sast-orchestration guidance (review / validate). repair must never advertise a
+  scan it cannot run.
+- Generated skill templates updated to document how/when the domain-specific
+  `safety_baseline` reference is recorded.
+- `docs/` + toolgen regeneration (zero drift).
+
+**worktree provisioning — dedicated worktree for every governed change:**
+- `internal/state/worktree.go` (`EnsureDefaultWorktreeForChange`): provision the
+  dedicated `.worktrees/<slug>` worktree on `feat/<slug>` at `slipway new` for
+  ALL governed changes, not only `needs_discovery`; keep skipping only when the
+  environment cannot support it (not a git repo / no HEAD). The governed bundle
+  is created inside the worktree from S0, so intake/planning/execution leave the
+  main checkout free for parallel work.
+- Reconcile the downstream lifecycle for a bound non-discovery change: the
+  `advance_governed.go` worktree gates (`NeedsDiscovery`-only today) must
+  short-circuit cleanly when already bound; `ValidateChangeWorktree`, the
+  single-active-change creation guard (worktree-scoped per #50), and
+  `done`/archive worktree cleanup must behave for non-discovery bound changes.
+- Update affected tests/fixtures (prefer a single central default over per-test
+  churn) so `slipway new` worktree provisioning is covered without breaking
+  unrelated suites.
+
+## Out of Scope
+- Changing which guardrail domains require `safety_baseline` (keep the catalog).
+- Running external SAST tooling from inside any Slipway command (the host runs
+  scanners and records evidence; Slipway never executes scanners).
+- Any bypass / force-close / private-attestation path for high-risk checks.
+- `evidence-task-dx-issue.md` (unrelated local draft) and issue #96.
+
+## Constraints
+- Sensitive-domain `safety_baseline` must come from a real owning-skill verdict;
+  no manual digest/timestamp edits, no self-attested gate tokens.
+- Keep code, generated skills, docs, and agent instructions aligned (toolgen
+  self-loop zero drift).
+- Preserve unrelated local work.
+- Smallest clean design; remove obsolete/false surfaces over compatibility shims.
+
+## Acceptance Signals
+- **#95:** a change at S2_EXECUTE with a planned task lacking evidence is BLOCKED
+  from S3_REVIEW with `incomplete_execution_task:<taskID>` and an actionable
+  remediation; completing or rescoping the task unblocks; `slipway validate`
+  surfaces the same blocker; the all-tasks-recorded happy path still advances.
+- **#88:** a guardrail-domain change has a documented, operator-visible,
+  fail-closed path to satisfy `<domain>.safety_baseline` via the owning skill's
+  recorded evidence (no bypass); the `high_risk_check_missing` remediation names
+  the exact next action; `slipway repair --focus sast` no longer makes a false
+  promise.
+- **worktree:** `slipway new` for a non-discovery governed change provisions a
+  dedicated `.worktrees/<slug>` worktree on `feat/<slug>` with the bundle inside
+  it (the main checkout stays clean); the change advances S0→done bound to that
+  worktree; `worktree_skipped_reason` is no longer `discovery_not_required`.
+- `go build ./... && go vet ./... && go test ./...` green; toolgen zero drift.
+
+## Open Questions
+<!-- none requiring research; the #88 producer/recording wiring is a design
+decision resolved during S1 planning from the current engine source. -->
+
+## Deferred Ideas
+- A short top-level alias for the highest-frequency `slipway evidence task`
+  mutation (tracked separately in evidence-task-dx-issue.md).
+
+## Approved Summary
+Confirmed 2026-06-06T12:04:29Z (rescoped from the original two-issue change to add
+the worktree-provisioning concern at the user's request; worktree design = "A").
+
+One governed change fixes three related Slipway governance-engine concerns.
+**#95:** the S2_EXECUTE wave sync gains an execution-completeness assertion — any
+planned wave-plan task lacking passing evidence is blocked fail-closed from
+S3_REVIEW with a per-task `incomplete_execution_task:<taskID>` blocker
+(remediation: execute & record the task, or rescope `tasks.md`); the same blocker
+surfaces under `slipway validate`; the all-recorded happy path still advances.
+**#88:** goal-verification (already required at S4, its References already feed
+the ship gate) documents recording `high_risk_check:<domain>.safety_baseline=pass|fail`
+from a real SAST run; the `high_risk_check_missing/failed` remediation and the
+`slipway next` handoff name the exact token, the producer, and the action; and
+`slipway repair --focus sast` stops falsely advertising a scan it cannot run
+(focus removed from repair, redirected to review/validate). **worktree:** a new
+`governance.auto_provision_worktree` config (default true — chosen design A:
+unconditional with opt-out) makes `slipway new` provision a dedicated
+`.worktrees/<slug>` worktree on `feat/<slug>` for every governed change with the
+bundle inside it, freeing the main checkout; the single-active-change guard stays
+isolation-correct and archive still strips the worktree path; non-git / disabled
+environments degrade gracefully.
+
+Boundaries: **no** bypass / force-close / self-attestation for high-risk checks;
+Slipway never runs external scanners itself; the guardrail catalog and the
+unrelated `evidence-task-dx-issue.md` draft are untouched. This change runs in the
+main checkout as the bootstrap; subsequent governed changes inherit dedicated
+worktrees. Primary acceptance: incomplete execution cannot reach review, the
+high-risk dead-end has a fail-closed next action, governed changes get isolated
+worktrees, and `go build/vet/test` + toolgen self-loop stay green with zero drift.

--- a/artifacts/changes/archived/fix-issue-95-governed-execution-advances-s2-execute-to-s3-re/requirements.md
+++ b/artifacts/changes/archived/fix-issue-95-governed-execution-advances-s2-execute-to-s3-re/requirements.md
@@ -1,0 +1,159 @@
+# Requirements
+## Project Context
+- Tech Stack: Go
+- Conventions: cmd/* CLI over internal/engine/* kernel; generated skills/docs via toolgen; table-driven tests
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Requirements
+
+### Requirement: Execution completeness gates S2_EXECUTE → S3_REVIEW (#95)
+REQ-001: At S2_EXECUTE, the wave-execution sync MUST block advancement to
+S3_REVIEW unless every task declared in the materialized wave-plan has a passing
+run at the active `run_summary_version`. A planned task with no recorded task
+evidence MUST surface as `incomplete_execution_task:<taskID>` (one reason code
+per missing task), in BOTH the mutating sync (`SyncGovernedWaveExecution`) and
+the read-only preview (`PreviewGovernedWaveExecution`/`slipway validate`), and
+MUST be suppressed only when plan-drift blockers already own the remediation. The
+all-tasks-recorded-and-passing path MUST still advance unchanged.
+
+#### Scenario: Planned task missing evidence blocks review
+GIVEN a change at S2_EXECUTE whose wave-plan declares tasks t-01..t-03 and a
+passing wave-orchestration record, but task evidence exists only for t-01 and t-02
+WHEN `slipway run` evaluates wave execution
+THEN advancement is blocked with `incomplete_execution_task:t-03` and the change
+stays at S2_EXECUTE; `slipway validate` reports the same blocker.
+
+#### Scenario: All planned tasks recorded still advances
+GIVEN the same change with passing task evidence for t-01, t-02, and t-03
+WHEN `slipway run` evaluates wave execution
+THEN no `incomplete_execution_task` blocker is produced and the change advances
+to S3_REVIEW.
+
+### Requirement: Incomplete execution has a fail-closed, actionable recovery (#95)
+REQ-002: `incomplete_execution_task` MUST be a canonical reason code carrying an
+error message, and MUST resolve to a recovery remediation (refresh-execution
+class) that directs the operator to execute and record the named task via
+`slipway evidence task`, or to rescope `tasks.md` so the plan no longer claims it,
+then re-run. No new defer/skip/bypass path is introduced.
+
+#### Scenario: Recovery names the task and the next command
+GIVEN an `incomplete_execution_task:t-03` blocker reaches a user surface
+WHEN recovery guidance is rendered
+THEN the remediation names task t-03 and instructs to record its evidence or
+rescope the plan, with a non-empty next command and no leaked placeholders.
+
+### Requirement: Wave-orchestration skill states the completeness contract (#95)
+REQ-003: The generated wave-orchestration skill MUST state that every planned
+task needs a passing task-evidence record before the change can advance to
+review, and that an intentionally-dropped task is removed by rescoping `tasks.md`
+(not by skipping evidence).
+
+#### Scenario: Skill documents completeness before advance
+GIVEN the wave-orchestration generated skill
+WHEN an agent reads its task-evidence/advancement guidance
+THEN it learns that leaving a planned task without passing evidence blocks
+advancement and that rescoping is the way to intentionally drop a task.
+
+### Requirement: Operator-visible, fail-closed safety_baseline satisfy-path (#88)
+REQ-004: For a change with a guardrail domain, there MUST be a documented,
+operator-visible, fail-closed path to satisfy the required
+`<domain>.safety_baseline` high-risk check: the goal-verification generated skill
+documents that the host records `high_risk_check:<domain>.safety_baseline=pass`
+(or `=fail`, which blocks ship) in its verification References, derived from a
+real SAST run / triage. No bypass, force-close, self-attestation, or CLI
+stamp-it shortcut is introduced; the token MUST reflect a real goal-verification
+verdict.
+
+#### Scenario: Guardrail change can satisfy the ship gate without a bypass
+GIVEN a change whose guardrail domain requires `<domain>.safety_baseline`
+WHEN the host follows the goal-verification skill, runs SAST, and records
+`high_risk_check:<domain>.safety_baseline=pass` in goal-verification References
+THEN the G_ship high-risk check is satisfied and no bypass surface was used.
+
+#### Scenario: No stamp-it shortcut exists
+GIVEN the satisfy-path documentation and CLI surfaces
+WHEN searched for a command that records the safety_baseline without a real
+goal-verification verdict
+THEN none exists; the only producer is the goal-verification verification record.
+
+### Requirement: High-risk blockers carry the next action (#88)
+REQ-005: The `high_risk_check_missing` and `high_risk_check_failed` recovery
+remediations MUST name the exact token (`high_risk_check:<domain>.safety_baseline`),
+the producing skill (goal-verification), and that the verdict must come from a
+real SAST run; AND `slipway next` MUST surface the required
+`<domain>.safety_baseline` token(s) in the goal-verification handoff when the
+change has a guardrail domain.
+
+#### Scenario: Missing high-risk check remediation is actionable
+GIVEN a `high_risk_check_missing:<domain>.safety_baseline` blocker
+WHEN recovery guidance is rendered
+THEN the remediation names the token, names goal-verification, and references a
+real SAST run, with a non-empty command and no leaked placeholders.
+
+#### Scenario: next handoff lists the required token
+GIVEN a change with a guardrail domain whose next skill is goal-verification
+WHEN `slipway next --json` is read
+THEN the goal-verification handoff lists the required `<domain>.safety_baseline`
+token.
+
+### Requirement: repair --focus sast stops making a false promise (#88)
+REQ-006: `slipway repair --focus sast` MUST NOT advertise running SAST. The
+`sast` explicit focus is removed from the `repair` command surface (retained on
+`review` and `validate`, where it legitimately hydrates sast-orchestration
+guidance). Selecting `--focus sast` on `repair` MUST fail with an error that
+redirects to `slipway review --focus sast` / `slipway validate --focus sast`. No
+SAST guidance capability is lost.
+
+#### Scenario: repair rejects sast and redirects
+GIVEN `slipway repair --focus sast`
+WHEN the focus is validated
+THEN it is rejected with an error naming the valid path
+(`slipway review --focus sast` or `slipway validate --focus sast`).
+
+#### Scenario: review/validate keep the sast focus
+GIVEN `slipway review --focus sast` and `slipway validate --focus sast`
+WHEN the focus is validated
+THEN both resolve to the sast-orchestration backing as before.
+
+### Requirement: Governed changes get a dedicated worktree at creation (worktree)
+REQ-008: `slipway new` MUST provision a dedicated `.worktrees/<slug>` worktree on
+branch `feat/<slug>` for EVERY governed change by default — not only discovery
+changes — with the governed bundle created inside that worktree, so the main
+checkout stays free for parallel work. This is governed by a new
+`governance.auto_provision_worktree` config (default true); when disabled, or
+when the environment cannot support a worktree (not a git repository / no HEAD),
+creation MUST degrade gracefully with a clear `worktree_skipped_reason` and the
+bundle in the project root. The single-active-change creation guard MUST stay
+correct (a change isolated in its own worktree does not wrongly block creating
+another), and `done`/archive MUST still strip the worktree path.
+
+#### Scenario: Non-discovery change is provisioned a worktree
+GIVEN a git repository with `governance.auto_provision_worktree` unset (default)
+WHEN `slipway new` creates a governed change with `needs_discovery=false`
+THEN the change is bound to `.worktrees/<slug>` on `feat/<slug>`, its bundle is
+created under that worktree, and `worktree_skipped_reason` is not
+`discovery_not_required`.
+
+#### Scenario: Provisioning can be disabled
+GIVEN `governance.auto_provision_worktree=false`
+WHEN `slipway new` creates a non-discovery governed change
+THEN no worktree is created, the bundle lives in the project root, and
+`worktree_skipped_reason` reports the disabled/unsupported reason.
+
+#### Scenario: Worktree-isolated changes do not block each other
+GIVEN an active governed change bound to its own dedicated worktree
+WHEN `slipway new` creates another governed change in its own worktree
+THEN the single-active-change guard does not wrongly reject creation.
+
+### Requirement: Generated surfaces stay aligned with zero drift (#88, #95)
+REQ-007: After the source, skill-template, and surface changes, all generated
+skills, command references, and docs MUST be regenerated so the toolgen
+self-loop reports zero drift, and `go build ./... && go vet ./... &&
+go test ./...` MUST pass.
+
+#### Scenario: Toolgen self-loop is clean
+GIVEN the change is implemented
+WHEN toolgen regeneration and the drift check run
+THEN there is zero drift and the build, vet, and test commands pass.

--- a/artifacts/changes/archived/fix-issue-95-governed-execution-advances-s2-execute-to-s3-re/research.md
+++ b/artifacts/changes/archived/fix-issue-95-governed-execution-advances-s2-execute-to-s3-re/research.md
@@ -1,0 +1,156 @@
+# Research
+
+## Project Context
+- Tech Stack: Go
+- Conventions: cmd/* CLI over internal/engine/* kernel; generated skills/docs via toolgen; table-driven tests
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Research Findings
+
+### Architecture
+- Affected modules:
+  - #95: `internal/engine/progression/wave_sync.go` (`evaluateGovernedWaveExecution`),
+    `internal/model/reason_code.go`, `internal/model/recovery.go`,
+    `internal/tmpl/templates/skills/wave-orchestration/SKILL.md.tmpl`.
+  - #88: `internal/engine/gate/gate.go` (highRiskCatalog/EvaluateGShip),
+    `internal/engine/progression/evidence.go` (ExtractHighRiskChecks/
+    ParseHighRiskCheckReference), `internal/engine/progression/authority.go`
+    (buildShipAuthorityFromReadiness), `internal/model/recovery.go`,
+    `internal/engine/capability/surfaces.go`, `internal/engine/capability/registry_b3.go`,
+    `cmd/route_flags.go`, `cmd/next.go`/`cmd/next_skill.go`, and the
+    goal-verification / final-closeout SKILL templates.
+  - worktree: `internal/state/worktree.go` (`EnsureDefaultWorktreeForChange`),
+    `internal/model/config.go` (ConfigGovernance), `cmd/new.go`, `cmd/common.go`.
+- Dependency chains:
+  - `slipway run` → `AdvanceGoverned` → (S2) `SyncGovernedWaveExecution`
+    → `LoadWavePlanForChange` + `LoadExecutionTasksFromEvidence` → blockers.
+  - G_ship → `EvaluateShipAuthority` → `buildShipAuthorityFromReadiness`
+    → `ExtractHighRiskChecks(verifyPassingSkills)` → `gate.EvaluateGShip`.
+  - `slipway new` → `createDirectGovernedChange` → `EnsureDefaultWorktreeForChange`.
+- Blast radius: governance kernel + CLI surfaces + generated skills/docs + tests.
+  The worktree change touches change-creation; ~9 `slipway new`-based tests are
+  affected, while ~250+ engine tests construct `model.Change` directly and are
+  unaffected.
+- Constraints: sensitive-domain gates stay fail-closed (no bypass); the wave-plan
+  is the authority for the full task set; the goal-verification verification
+  record's References already feed the high-risk gate; toolgen self-loop must
+  report zero drift.
+
+### Patterns
+- Existing conventions:
+  - Reason codes registered in `canonicalReasonDefinitions` (reason_code.go) with
+    recovery entries in `blockerRemediations` (recovery.go); contract tests in
+    `recovery_test.go` enforce remediation coverage
+    (`recoveryRelevantCanonicalCodes`, `sampleRecoveryDetail`,
+    `inScopeProducedRecoverySpecs`).
+  - High-risk checks satisfied by reference tokens
+    `high_risk_check:<id>=<verdict>` parsed by `ParseHighRiskCheckReference`
+    against `gate.IsRegisteredCheckID`.
+  - Explicit `--focus` aliases registered per command in
+    `capability/surfaces.go` (review/validate/repair × focus); `validateFocus`
+    rejects unknown aliases with an allowed-list.
+  - Worktree default path `.worktrees/<slug>` and branch `feat/<slug>` already
+    exist in `EnsureDefaultWorktreeForChange`; only the `!NeedsDiscovery` skip
+    gates it off.
+- Reusable abstractions: `WavePlan.TaskIDs()`/`TotalTasks` (full planned set),
+  `ExecutionSummary.TaskRunMap()`, `gate.RequiredHighRiskChecks(domain)`,
+  `ConfigGovernance` (config gating), `ResolveChangePaths`/`changeWorkspaceRoot`
+  (bundle routes into the worktree automatically when bound).
+- Convention deviations: none required; all fixes extend existing patterns.
+
+### Risks
+- Technical risks:
+  - Fail-closed integrity (high): the #88 satisfy-path MUST NOT add a bypass or a
+    CLI that stamps the safety_baseline without a real goal-verification verdict.
+    Mitigation: the token comes only from goal-verification References (already
+    validated by `ParseHighRiskCheckReference`); no new stamp command.
+  - Test blast radius (medium): worktree-at-creation changes `slipway new`
+    behavior. Mitigation: `governance.auto_provision_worktree` config (default
+    true) lets the ~9 affected `new`-based tests disable it centrally; engine
+    tests that build `model.Change` directly are unaffected.
+  - Single-active-change guard correctness (medium): with every change in its own
+    worktree, the worktree-scoped guard (#50) must treat each as isolated.
+    Mitigation: order worktree binding vs the guard and have
+    `newChangeTargetWorkspaceRoot` use the bound/would-be worktree path.
+  - False positives in the #95 gate (low): a planned task could be intentionally
+    dropped. Mitigation: rescoping `tasks.md` removes it from `WavePlan.TaskIDs()`
+    (the documented out-of-scope path); the check is suppressed under plan-drift.
+- Guardrail domains: none for THIS change (it edits Slipway's own engine; the
+  safety_baseline gate is edited but kept fail-closed). Public CLI/JSON/generated
+  skills/docs reviewed as external contracts.
+- Reversibility: high — additive reason code, additive config flag (default
+  preserves current high-risk behavior), focus removal is a surface change. All
+  guarded by tests.
+
+### Test Strategy
+- Existing coverage: `wave_sync_test.go`, `recovery_test.go` (contract),
+  `gate_test.go`, `evidence` parse tests, `surfaces_test.go`,
+  `route_flags_test.go`, `new_test.go`, `next_skill_constraints_test.go`.
+- Infrastructure needs: a config-driven test default for worktree provisioning
+  (`auto_provision_worktree=false`) in `new`-based tests; no new mocks otherwise.
+- Verification approach per acceptance criterion:
+  - #95: table-driven wave_sync tests (missing-task blocks, all-recorded
+    advances, drift suppresses) + recovery contract tests.
+  - #88: gate/evidence tests for the domain token, recovery remediation tests,
+    surfaces/route_flags tests for repair-focus removal + redirect,
+    next-handoff token test.
+  - worktree: worktree_test (bind/skip/disabled), new_test (non-discovery binds),
+    common_test (guard isolation).
+  - cross-cutting: `go build/vet/test` + toolgen zero-drift self-loop.
+
+## Alternatives Considered
+- **#88 safety_baseline producer** — (1) a new dedicated `guardrail-baseline`
+  skill made conditionally required; (2) **goal-verification documents + records
+  the token** (selected). goal-verification already runs at S4 and its
+  References already feed `ExtractHighRiskChecks`, so the satisfy-path already
+  exists structurally — the only gap is guidance + actionable remediation. No new
+  required skill, smallest change, fail-closed.
+- **#88 repair --focus sast** — (1) make `repair` actually run semgrep; (2) emit
+  a routing hint from repair; (3) **remove the false focus from repair, redirect
+  to review/validate** (selected). repair is bounded local-state integrity and
+  must never run external scanners; removing the false promise + redirect is the
+  honest, smallest design.
+- **#95 incomplete execution** — (1) a single aggregate blocker; (2) **one
+  `incomplete_execution_task:<taskID>` per missing task** (selected, mirrors
+  `non_pass_task`, names the next task). Recovery: fail-closed complete-or-rescope
+  (selected) vs a new defer/skip bypass (rejected — it would weaken the gate).
+- **worktree provisioning** — (A) **default-true unconditional with config
+  opt-out** (selected); (B) preset/complexity-gated; (C) opt-in default-false.
+  A directly frees the main checkout for all governed changes (the user's goal),
+  is the most consistent, and `git worktree add` is cheap; opt-out preserves
+  control. Confirmed with the user as "A".
+- Selected: the per-concern selections above, all confirmed with the user; the
+  locked decision is recorded in `decision.md`.
+
+## Unknowns
+- Resolved: which skill produces `<domain>.safety_baseline` -> goal-verification
+  (its References already feed the gate via authority.go).
+- Resolved: worktree test blast radius -> bounded to `slipway new`-based tests;
+  the config flag minimizes churn.
+- Resolved: bundle location when worktree-bound -> `ResolveChangePaths` routes the
+  bundle into the worktree automatically.
+- Remaining: None.
+
+## Assumptions
+- goal-verification is the sole producer of high-risk check verdicts - Evidence:
+  `internal/engine/progression/authority.go:145,171` (verifyPassingSkills feeds
+  ExtractHighRiskChecks) and `internal/engine/progression/evidence.go:140-203`.
+- The S2 worktree gate and `applyPendingWorktreePreflight` short-circuit when a
+  change is already worktree-bound - Evidence:
+  `internal/engine/progression/advance_governed.go:178,411` (guards on
+  `WorktreePath == ""`).
+- Most engine/state tests bypass `EnsureDefaultWorktreeForChange` - Evidence: it
+  is called only from `cmd/new.go:475`.
+
+## Canonical References
+- `internal/engine/progression/wave_sync.go` (#95 sync + blockers)
+- `internal/engine/gate/gate.go`, `internal/engine/progression/evidence.go`,
+  `internal/engine/progression/authority.go` (#88 high-risk gate + token flow)
+- `internal/engine/capability/surfaces.go`, `internal/engine/capability/registry_b3.go`,
+  `cmd/route_flags.go` (#88 repair-focus surface)
+- `internal/state/worktree.go`, `internal/model/config.go`, `cmd/new.go`,
+  `cmd/common.go` (worktree provisioning)
+- `internal/model/reason_code.go`, `internal/model/recovery.go`,
+  `internal/model/recovery_test.go` (reason codes + recovery contract)

--- a/artifacts/changes/archived/fix-issue-95-governed-execution-advances-s2-execute-to-s3-re/tasks.md
+++ b/artifacts/changes/archived/fix-issue-95-governed-execution-advances-s2-execute-to-s3-re/tasks.md
@@ -1,0 +1,115 @@
+# Tasks
+## Project Context
+- Tech Stack: Go
+- Conventions: cmd/* CLI over internal/engine/* kernel; generated skills/docs via toolgen; table-driven tests
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Task List
+
+- [x] `t-01` (#95) Enforce execution completeness in the wave sync. In
+  `internal/engine/progression/wave_sync.go` add `IncompleteExecutionTaskBlockers(plan, runs)`
+  (planned `WavePlan.TaskIDs()` minus tasks with a recorded run → one
+  `incomplete_execution_task:<taskID>` each) and call it in BOTH the preview and
+  mutate branches of `evaluateGovernedWaveExecution`, guarded by
+  `len(planDriftBlockers) == 0`. Register the canonical `incomplete_execution_task`
+  reason (`internal/model/reason_code.go`) and its recovery remediation
+  (refresh-execution class) in `internal/model/recovery.go`. Test-first: extend
+  `wave_sync_test.go` (missing-task blocks, all-recorded advances, drift
+  suppresses) and the `recovery_test.go` contract (add to the recovery-relevant
+  exact set, `sampleRecoveryDetail`, and `inScopeProducedRecoverySpecs`).
+  - wave: 1
+  - depends_on: []
+  - target_files: ["internal/engine/progression/wave_sync.go", "internal/engine/progression/wave_sync_test.go", "internal/model/reason_code.go", "internal/model/recovery.go", "internal/model/recovery_test.go"]
+  - task_kind: code
+  - covers: [REQ-001, REQ-002]
+
+- [x] `t-03` (#88) Remove the false-promise `--focus sast` from the `repair`
+  command surface. Delete the `repair`+`sast` `SurfaceRecord` in
+  `internal/engine/capability/surfaces.go` (keep `review`/`validate`); update the
+  `sast-orchestration` summary/comment in
+  `internal/engine/capability/registry_b3.go` to drop `repair` from its trigger
+  list; enhance `validateFocus` in `cmd/route_flags.go` to redirect a
+  `repair`+`sast` selection to `slipway review --focus sast` /
+  `slipway validate --focus sast`. Test-first: update `surfaces_test.go`
+  (repair → no explicit focuses), `route_flags_test.go` (drop the repair+sast
+  accept case, add a rejection+redirect test), and `route_surface_command_test.go`
+  (drop the repair sast-orchestration mode case).
+  - wave: 1
+  - depends_on: []
+  - target_files: ["internal/engine/capability/surfaces.go", "internal/engine/capability/surfaces_test.go", "cmd/route_flags.go", "cmd/route_flags_test.go", "internal/engine/capability/registry_b3.go", "cmd/route_surface_command_test.go"]
+  - task_kind: code
+  - covers: [REQ-006]
+
+- [x] `t-02` (#88) Make high-risk blockers carry the next action and surface the
+  required token in the handoff. In `internal/model/recovery.go` upgrade the
+  `high_risk_check_missing` / `high_risk_check_failed` remediations to name the
+  exact `high_risk_check:<domain>.safety_baseline` token, the producing skill
+  (goal-verification), and a real SAST run. Add a `required_high_risk_tokens`
+  field to the `slipway next` skill-constraints surface
+  (`cmd/next.go` / `cmd/next_skill.go`), populated from
+  `gate.RequiredHighRiskChecks(change.GuardrailDomain)` when the next skill is
+  goal-verification and a guardrail domain is set. Test-first: extend
+  `recovery_test.go` (remediation names token + goal-verification; expand
+  `sampleRecoveryDetail` to `<domain>.safety_baseline`; add to
+  `inScopeProducedRecoverySpecs`) and `next_skill_constraints_test.go`
+  (token populated when guardrail domain set).
+  - wave: 2
+  - depends_on: [t-01]
+  - target_files: ["internal/model/recovery.go", "internal/model/recovery_test.go", "cmd/next.go", "cmd/next_skill.go", "cmd/next_skill_constraints_test.go"]
+  - task_kind: code
+  - covers: [REQ-005]
+
+- [x] `t-05` (worktree) Provision a dedicated worktree for every governed change
+  (engine/state core). Add a `governance.auto_provision_worktree` config (default
+  true) to `internal/model/config.go`; in
+  `internal/state/worktree.go` `EnsureDefaultWorktreeForChange`, replace the
+  `!change.NeedsDiscovery` skip with the config gate so ALL governed changes
+  provision `.worktrees/<slug>` on `feat/<slug>` (keep the git-availability
+  skips; when disabled, skip with `worktree_provisioning_disabled`). Test-first:
+  extend the worktree/state tests (non-discovery change binds a worktree when
+  enabled; skips with the disabled reason when off; git-availability skips
+  intact).
+  - wave: 1
+  - depends_on: []
+  - target_files: ["internal/model/config.go", "internal/state/worktree.go", "internal/state/worktree_test.go"]
+  - task_kind: code
+  - covers: [REQ-008]
+
+- [x] `t-06` (worktree) Wire worktree provisioning into `slipway new` and keep
+  the single-active-change guard correct. In `cmd/new.go`, ensure
+  `EnsureDefaultWorktreeForChange` and the conflict guard order so the guard sees
+  the change's target worktree, and update `newChangeTargetWorkspaceRoot` (in
+  `cmd/common.go`) to use the bound/would-be worktree path so a worktree-isolated
+  change does not wrongly block creation. Test-first: update `cmd/new_test.go`
+  and `cmd/common_test.go` (set `auto_provision_worktree=false` where worktrees
+  are not under test; add coverage that a non-discovery change binds a worktree
+  and that isolated changes do not conflict); update any affected
+  `cmd/cli_e2e_test.go` bundle-path assertions.
+  - wave: 2
+  - depends_on: [t-05]
+  - target_files: ["cmd/new.go", "cmd/common.go", "cmd/new_test.go", "cmd/common_test.go", "cmd/cli_e2e_test.go"]
+  - task_kind: code
+  - covers: [REQ-008]
+
+- [x] `t-04` (#88, #95) Update generated-skill sources and regenerate all
+  surfaces with zero drift. Edit
+  `internal/tmpl/templates/skills/wave-orchestration/SKILL.md.tmpl` (state the
+  completeness-before-review contract; rescope to drop a task — REQ-003),
+  `internal/tmpl/templates/skills/goal-verification/SKILL.md.tmpl` (document
+  recording `high_risk_check:<domain>.safety_baseline=pass|fail` from a real SAST
+  run when a guardrail domain is set; fail-closed — REQ-004), and
+  `internal/tmpl/templates/skills/final-closeout/SKILL.md.tmpl` (clarify the
+  guardrail-baseline recheck/reuse). Regenerate all generated skills, command
+  references, and docs via the toolgen self-loop and confirm zero drift; run
+  `go build ./... && go vet ./... && go test ./...`. Regeneration also absorbs
+  any generated-surface drift from the repair-focus (t-03) and worktree (t-06)
+  changes, including the `sast-orchestration/SKILL.md` frontmatter (its
+  `bindings`/`summary`/`trigger_signals` must mirror the registry's dropped
+  `repair` binding so the binding-compare gate stays green).
+  - wave: 3
+  - depends_on: [t-01, t-02, t-03, t-05, t-06]
+  - target_files: ["internal/tmpl/templates/skills/wave-orchestration/SKILL.md.tmpl", "internal/tmpl/templates/skills/goal-verification/SKILL.md.tmpl", "internal/tmpl/templates/skills/final-closeout/SKILL.md.tmpl", "internal/tmpl/templates/skills/sast-orchestration/SKILL.md"]
+  - task_kind: doc
+  - covers: [REQ-003, REQ-004, REQ-007]

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -928,7 +928,12 @@ func createGuardInvocationWorkspaceRoot(root string) (string, error) {
 
 func newChangeTargetWorkspaceRoot(root string, change model.Change) (string, error) {
 	target := root
-	if change.NeedsDiscovery {
+	// Every governed change is worktree-provisioned by default (not just discovery
+	// changes), so predict the dedicated `.worktrees/<slug>` target whenever
+	// provisioning is enabled and the repo can support it. This keeps the
+	// single-active-change guard correct: worktree-isolated changes do not
+	// conflict with one another.
+	if autoProvisionWorktreeEnabled(root) {
 		repoRoot, err := state.ResolveGitWorkspaceRoot(root)
 		if err != nil {
 			if !strings.Contains(err.Error(), "not a git repository") {
@@ -939,6 +944,20 @@ func newChangeTargetWorkspaceRoot(root string, change model.Change) (string, err
 		}
 	}
 	return normalizePathForCompare(target), nil
+}
+
+// autoProvisionWorktreeEnabled reports whether `slipway new` will bind a
+// dedicated worktree for a governed change. It mirrors the gate used by
+// state.EnsureDefaultWorktreeForChange so the create guard predicts the same
+// target workspace the change will actually occupy. A missing config defaults to
+// enabled; an unreadable/invalid config also falls back to enabled so the guard
+// never blocks creation on a config read error (binding surfaces the real error).
+func autoProvisionWorktreeEnabled(root string) bool {
+	cfg, err := model.LoadConfig(state.ConfigPath(root))
+	if err != nil {
+		return true
+	}
+	return cfg.Governance.AutoProvisionWorktreeEnabled()
 }
 
 func existingChangeWorkspaceRoot(root string, ch model.Change) (string, error) {

--- a/cmd/new_test.go
+++ b/cmd/new_test.go
@@ -180,6 +180,84 @@ func TestNewDiscoveryChangeBindsDefaultWorktreeBeforeIntentArtifact(t *testing.T
 	})
 }
 
+func TestNewNonDiscoveryChangeBindsDefaultWorktreeByDefault(t *testing.T) {
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		runGit(t, root, "add", ".")
+		runGit(t, root, "commit", "-m", "init")
+
+		// A non-discovery change is exactly the case that previously ran its
+		// whole lifecycle in the main checkout (worktree_skipped_reason:
+		// discovery_not_required). With auto_provision_worktree defaulting on it
+		// now binds a dedicated worktree at creation, freeing the main checkout.
+		classifier := &recordingIntentClassifier{
+			classification: progression.IntentClassification{
+				GuardrailDomain: "",
+				NeedsDiscovery:  false,
+				Complexity:      "simple",
+			},
+		}
+
+		var buf bytes.Buffer
+		cmd := makeNewCmd()
+		cmd.SetOut(&buf)
+		cmd.SetContext(withIntentClassifierContext(cmd.Context(), classifier))
+		cmd.SetArgs([]string{"--json", "rename a helper function"})
+		require.NoError(t, cmd.Execute())
+
+		var payload createOutput
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &payload))
+		require.True(t, payload.WorktreeCreated, "non-discovery change should bind a worktree by default")
+		require.NotEmpty(t, payload.WorktreePath)
+		require.NotEqual(t, "discovery_not_required", payload.WorktreeSkippedReason)
+		assert.Equal(t, state.DefaultWorktreeBranch(payload.Slug), payload.WorktreeBranch)
+
+		rootIntent := filepath.Join(root, "artifacts", "changes", payload.Slug, "intent.md")
+		_, err := os.Stat(rootIntent)
+		assert.True(t, os.IsNotExist(err), "new must not create the bundle in the root workspace once the worktree is bound")
+
+		worktreeIntent := filepath.Join(payload.WorktreePath, "artifacts", "changes", payload.Slug, "intent.md")
+		_, err = os.Stat(worktreeIntent)
+		require.NoError(t, err, "bundle must live inside the dedicated worktree")
+	})
+}
+
+func TestNewNonDiscoveryWorktreeProvisioningCanBeDisabled(t *testing.T) {
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		require.NoError(t, os.WriteFile(filepath.Join(root, ".slipway.yaml"),
+			[]byte("governance:\n  auto_provision_worktree: false\n"), 0o644))
+		runGit(t, root, "add", ".")
+		runGit(t, root, "commit", "-m", "init")
+
+		classifier := &recordingIntentClassifier{
+			classification: progression.IntentClassification{
+				NeedsDiscovery: false,
+				Complexity:     "simple",
+			},
+		}
+
+		var buf bytes.Buffer
+		cmd := makeNewCmd()
+		cmd.SetOut(&buf)
+		cmd.SetContext(withIntentClassifierContext(cmd.Context(), classifier))
+		cmd.SetArgs([]string{"--json", "rename a helper function"})
+		require.NoError(t, cmd.Execute())
+
+		var payload createOutput
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &payload))
+		assert.False(t, payload.WorktreeCreated)
+		assert.Equal(t, "worktree_provisioning_disabled", payload.WorktreeSkippedReason)
+		assert.Empty(t, payload.WorktreePath)
+
+		rootIntent := filepath.Join(root, "artifacts", "changes", payload.Slug, "intent.md")
+		_, err := os.Stat(rootIntent)
+		require.NoError(t, err, "with provisioning disabled the bundle stays in the project root")
+	})
+}
+
 func TestNewCommandPassesDescriptionAndDocContentToIntentClassifier(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {

--- a/cmd/next.go
+++ b/cmd/next.go
@@ -124,6 +124,11 @@ type skillConstraints struct {
 	GuardrailDomain  string   `json:"guardrail_domain,omitempty"`
 	MitigationTarget string   `json:"mitigation_target,omitempty"`
 	RunSummaryBound  bool     `json:"run_summary_bound,omitempty"`
+	// RequiredHighRiskTokens lists the exact reference tokens the goal-verification
+	// host must record (from a real SAST run) to satisfy the ship gate's high-risk
+	// checks when the change has a guardrail domain. Populated only for the
+	// goal-verification handoff so the next agent never has to guess the format.
+	RequiredHighRiskTokens []string `json:"required_high_risk_tokens,omitempty"`
 }
 
 type techniqueHint struct {

--- a/cmd/next_skill.go
+++ b/cmd/next_skill.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/signalridge/slipway/internal/engine/artifact"
+	"github.com/signalridge/slipway/internal/engine/gate"
 	"github.com/signalridge/slipway/internal/engine/progression"
 	"github.com/signalridge/slipway/internal/engine/review"
 	"github.com/signalridge/slipway/internal/engine/skill"
@@ -29,9 +30,30 @@ func buildSkillConstraints(root string, def skill.Definition, governedChange *mo
 		if paths, err := state.ResolveChangePaths(root, *governedChange); err == nil {
 			sc.LockedDecisions = parseLockedDecisions(filepath.Join(paths.GovernedBundleDir, "decision.md"))
 		}
+
+		// Surface the exact high-risk reference tokens goal-verification must
+		// record so a guardrail-domain change is never a dead-end (issue #88).
+		if def.Name == progression.SkillGoalVerification && governedChange.GuardrailDomain != "" {
+			sc.RequiredHighRiskTokens = requiredHighRiskTokenHints(governedChange.GuardrailDomain)
+		}
 	}
 
 	return sc
+}
+
+// requiredHighRiskTokenHints returns the recordable goal-verification reference
+// tokens (one per required high-risk check) for a guardrail domain, e.g.
+// "high_risk_check:external_api_contracts.safety_baseline=pass".
+func requiredHighRiskTokenHints(domain string) []string {
+	checks := gate.RequiredHighRiskChecks(domain)
+	if len(checks) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(checks))
+	for _, checkID := range checks {
+		out = append(out, "high_risk_check:"+checkID+"=pass")
+	}
+	return out
 }
 
 // parseLockedDecisions extracts locked decision items from decision.md.

--- a/cmd/next_skill_constraints_test.go
+++ b/cmd/next_skill_constraints_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/signalridge/slipway/internal/bootstrap"
+	"github.com/signalridge/slipway/internal/engine/progression"
 	"github.com/signalridge/slipway/internal/engine/skill"
 	"github.com/signalridge/slipway/internal/model"
 	"github.com/signalridge/slipway/internal/state"
@@ -15,6 +16,36 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestRequiredHighRiskTokenHints(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t,
+		[]string{"high_risk_check:external_api_contracts.safety_baseline=pass"},
+		requiredHighRiskTokenHints(model.GuardrailDomainExternalAPIContracts),
+	)
+	assert.Nil(t, requiredHighRiskTokenHints(""))
+}
+
+func TestBuildSkillConstraintsSurfacesHighRiskTokensForGoalVerification(t *testing.T) {
+	t.Parallel()
+	change := model.NewChange("guardrail-change")
+	change.GuardrailDomain = model.GuardrailDomainExternalAPIContracts
+	def := skill.Definition{Name: progression.SkillGoalVerification}
+
+	sc := buildSkillConstraints(t.TempDir(), def, &change)
+	require.NotNil(t, sc)
+	assert.Contains(t, sc.RequiredHighRiskTokens, "high_risk_check:external_api_contracts.safety_baseline=pass")
+}
+
+func TestBuildSkillConstraintsNoHighRiskTokensWithoutGuardrailDomain(t *testing.T) {
+	t.Parallel()
+	change := model.NewChange("plain-change") // no guardrail domain
+	def := skill.Definition{Name: progression.SkillGoalVerification}
+
+	sc := buildSkillConstraints(t.TempDir(), def, &change)
+	require.NotNil(t, sc)
+	assert.Empty(t, sc.RequiredHighRiskTokens)
+}
 
 func TestParseLockedDecisions(t *testing.T) {
 	t.Parallel()

--- a/cmd/repair.go
+++ b/cmd/repair.go
@@ -259,7 +259,7 @@ func makeRepairCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "JSON output")
-	cmd.Flags().StringVar(&focus, "focus", "", "Repair focus (e.g. sast)")
+	cmd.Flags().StringVar(&focus, "focus", "", "Repair focus alias (see --list-focuses)")
 	cmd.Flags().BoolVar(&listFocuses, "list-focuses", false, "List public --focus aliases for this command and exit")
 	cmd.Flags().StringVar(&discoveryFormat, "format", "text", "Output format for --list-focuses: text|json")
 	return cmd

--- a/cmd/repair_test.go
+++ b/cmd/repair_test.go
@@ -18,6 +18,16 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+func TestRepairFocusFlagHelpDoesNotAdvertiseSast(t *testing.T) {
+	t.Parallel()
+	// repair removed the false-promise `sast` focus (issue #88); the --focus flag
+	// help must not keep advertising it (it was "Repair focus (e.g. sast)").
+	flag := makeRepairCmd().Flags().Lookup("focus")
+	require.NotNil(t, flag)
+	assert.NotContains(t, strings.ToLower(flag.Usage), "sast",
+		"repair --focus help must not advertise the removed sast focus, got %q", flag.Usage)
+}
+
 func TestRepairRejectsPlainGitRepoWithoutSlipwayMarkers(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {

--- a/cmd/route_flags.go
+++ b/cmd/route_flags.go
@@ -22,10 +22,17 @@ func validateFocus(command, alias string) error {
 		return nil
 	}
 	allowed := focusAliases(command)
+	remediation := fmt.Sprintf("Use one of: %s", strings.Join(allowed, ", "))
+	// `repair` deliberately drops the `sast` focus: repair never runs external
+	// scanners. Redirect the operator to the surfaces that legitimately hydrate
+	// SAST guidance instead of leaving a bare allowed-list.
+	if command == "repair" && alias == "sast" {
+		remediation = "repair performs local-state integrity only and does not run SAST; to run SAST analysis use `slipway review --focus sast` or `slipway validate --focus sast`."
+	}
 	return newInvalidUsageError(
 		"unknown_route_mode",
 		fmt.Sprintf("unknown --focus=%q for `%s`", alias, command),
-		fmt.Sprintf("Use one of: %s", strings.Join(allowed, ", ")),
+		remediation,
 		map[string]any{"command": command, "focus": alias, "allowed": allowed},
 	)
 }

--- a/cmd/route_flags_test.go
+++ b/cmd/route_flags_test.go
@@ -30,7 +30,6 @@ func TestValidateFocus_AcceptsPublicAliases(t *testing.T) {
 		{"validate", "sast"},
 		{"validate", "property"},
 		{"validate", "mutation"},
-		{"repair", "sast"},
 	}
 	for _, tc := range cases {
 		if err := validateFocus(tc.command, tc.alias); err != nil {
@@ -63,6 +62,26 @@ func TestValidateFocus_RejectsLegacySecondOpinion(t *testing.T) {
 	cliErr := asCLIError(err)
 	if cliErr == nil || cliErr.ErrorCode != "unknown_route_mode" {
 		t.Fatalf("expected unknown_route_mode, got %v", err)
+	}
+}
+
+func TestValidateFocus_RejectsSastForRepairAndRedirects(t *testing.T) {
+	t.Parallel()
+
+	// repair no longer advertises SAST (issue #88): the false-promise focus was
+	// removed, and selecting it must redirect to the surfaces that actually
+	// hydrate SAST guidance rather than silently no-op.
+	err := validateFocus("repair", "sast")
+	if err == nil {
+		t.Fatal("expected rejection for `repair --focus sast`")
+	}
+	cliErr := asCLIError(err)
+	if cliErr == nil || cliErr.ErrorCode != "unknown_route_mode" {
+		t.Fatalf("expected unknown_route_mode, got %v", err)
+	}
+	if !strings.Contains(cliErr.Remediation, "slipway review --focus sast") ||
+		!strings.Contains(cliErr.Remediation, "slipway validate --focus sast") {
+		t.Fatalf("expected redirect to review/validate sast focus, got remediation %q", cliErr.Remediation)
 	}
 }
 

--- a/internal/engine/capability/registry_b3.go
+++ b/internal/engine/capability/registry_b3.go
@@ -26,14 +26,15 @@ func sastOrchestration() Skill {
 		Function:          "run SAST tooling (CodeQL/Semgrep) with SARIF triage",
 		Tier:              TierT2,
 		PrimaryAttachment: AttachmentToolRecipe,
-		Summary:           "Use when running SAST tooling against the change. Triggers on review, validate, or repair commands and user text naming SAST tools.",
-		Evidence:          EvidenceArtifact, // Explicit-focus backing for `--focus sast` on review / validate /
-		// repair (resolved via surfaces.go). Command-auto bindings also let
-		// the skill appear in suggested_capabilities[] when SAST triggers fire.
+		Summary:           "Use when running SAST tooling against the change. Triggers on review or validate commands and user text naming SAST tools.",
+		Evidence:          EvidenceArtifact, // Explicit-focus backing for `--focus sast` on review /
+		// validate (resolved via surfaces.go). repair is intentionally excluded:
+		// it performs bounded local-state integrity only and never runs scanners.
+		// Command-auto bindings also let the skill appear in suggested_capabilities[]
+		// when SAST triggers fire.
 		Bindings: []Binding{
 			{Type: BindingCommandAuto, Target: "review", Attachment: AttachmentToolRecipe},
 			{Type: BindingCommandAuto, Target: "validate", Attachment: AttachmentToolRecipe},
-			{Type: BindingCommandAuto, Target: "repair", Attachment: AttachmentToolRecipe},
 		},
 		HydrateReferences: []HydrateReference{
 			{Name: "codeql-ruleset-catalog.md", Reason: "Pick a CodeQL query pack, threat model, language caveat, and build-fix path"},

--- a/internal/engine/capability/surfaces.go
+++ b/internal/engine/capability/surfaces.go
@@ -79,11 +79,10 @@ var surfacePolicy = []SurfaceRecord{
 		PublicName: "sast", BackingID: "sast-orchestration",
 		Summary: "Run SAST tooling (CodeQL/Semgrep) with SARIF triage.",
 	},
-	{
-		Command: "repair", Class: SurfaceExplicitFocus,
-		PublicName: "sast", BackingID: "sast-orchestration",
-		Summary: "Run SAST tooling (CodeQL/Semgrep) with SARIF triage.",
-	},
+	// NOTE: `repair` intentionally has no `sast` focus. repair performs bounded
+	// local-state integrity only and never runs external scanners; SAST is
+	// orchestrated via `review`/`validate --focus sast`. validateFocus redirects
+	// a `repair --focus sast` selection to those surfaces.
 	{
 		Command: "review", Class: SurfaceExplicitFocus,
 		PublicName: "calibration", BackingID: "multi-reviewer-calibration",

--- a/internal/engine/capability/surfaces_test.go
+++ b/internal/engine/capability/surfaces_test.go
@@ -64,7 +64,9 @@ func TestExplicitFocusRegistryPerCommand(t *testing.T) {
 	}{
 		{command: "review", want: []string{"calibration", "sast"}},
 		{command: "validate", want: []string{"mutation", "property", "sast", "spec-trace"}},
-		{command: "repair", want: []string{"sast"}},
+		// repair intentionally exposes NO explicit focus (issue #88): it never
+		// runs external scanners, so the false `sast` focus was removed.
+		{command: "repair", want: []string{}},
 	}
 
 	for _, tc := range cases {

--- a/internal/engine/progression/wave_sync.go
+++ b/internal/engine/progression/wave_sync.go
@@ -159,14 +159,26 @@ func evaluateGovernedWaveExecution(root string, change model.Change, mutate bool
 		executionSummary.OpenBlockers = model.NormalizeReasonCodes(append(executionSummary.OpenBlockers, model.ReasonCodesFromSpecs(append(parseIssues, planDriftBlockers...))...))
 		executionSummary.SyncDerivedFields()
 	}
+	// Make incomplete-execution blockers durable in the summary's OpenBlockers so
+	// read-only readiness (validate/next/status) surfaces them too. Once a
+	// "ready" summary exists, refineS2WaveExecutionSkillBlockers short-circuits
+	// the preview path, so a returned-only blocker would vanish from read-only
+	// surfaces after the partial summary is written (issue #95 REQ-001).
+	// Suppressed under plan-drift, which owns its own remediation.
+	var incompleteBlockers []model.ReasonCode
+	if len(planDriftBlockers) == 0 {
+		incompleteBlockers = IncompleteExecutionTaskBlockers(wavePlan, executionSummary.TaskRunMap())
+		if len(incompleteBlockers) > 0 {
+			executionSummary.OpenBlockers = model.NormalizeReasonCodes(append(executionSummary.OpenBlockers, incompleteBlockers...))
+			executionSummary.SyncDerivedFields()
+		}
+	}
 	if !mutate {
 		runs := executionSummary.TaskRunMap()
 		blockers := model.ReasonCodesFromSpecs(parseIssues)
 		blockers = append(blockers, model.ReasonCodesFromSpecs(planDriftBlockers)...)
 		blockers = append(blockers, CollectNonPassTaskBlockers(runs)...)
-		if len(planDriftBlockers) == 0 {
-			blockers = append(blockers, IncompleteExecutionTaskBlockers(wavePlan, runs)...)
-		}
+		blockers = append(blockers, incompleteBlockers...)
 		return WaveSyncResult{Blockers: model.NormalizeReasonCodes(blockers)}, nil
 	}
 
@@ -207,9 +219,7 @@ func evaluateGovernedWaveExecution(root string, change model.Change, mutate bool
 	blockers := model.ReasonCodesFromSpecs(parseIssues)
 	blockers = append(blockers, model.ReasonCodesFromSpecs(planDriftBlockers)...)
 	blockers = append(blockers, CollectNonPassTaskBlockers(runs)...)
-	if len(planDriftBlockers) == 0 {
-		blockers = append(blockers, IncompleteExecutionTaskBlockers(wavePlan, runs)...)
-	}
+	blockers = append(blockers, incompleteBlockers...)
 	return WaveSyncResult{
 		Updated:  updated,
 		Blockers: model.NormalizeReasonCodes(blockers),

--- a/internal/engine/progression/wave_sync.go
+++ b/internal/engine/progression/wave_sync.go
@@ -164,6 +164,9 @@ func evaluateGovernedWaveExecution(root string, change model.Change, mutate bool
 		blockers := model.ReasonCodesFromSpecs(parseIssues)
 		blockers = append(blockers, model.ReasonCodesFromSpecs(planDriftBlockers)...)
 		blockers = append(blockers, CollectNonPassTaskBlockers(runs)...)
+		if len(planDriftBlockers) == 0 {
+			blockers = append(blockers, IncompleteExecutionTaskBlockers(wavePlan, runs)...)
+		}
 		return WaveSyncResult{Blockers: model.NormalizeReasonCodes(blockers)}, nil
 	}
 
@@ -204,6 +207,9 @@ func evaluateGovernedWaveExecution(root string, change model.Change, mutate bool
 	blockers := model.ReasonCodesFromSpecs(parseIssues)
 	blockers = append(blockers, model.ReasonCodesFromSpecs(planDriftBlockers)...)
 	blockers = append(blockers, CollectNonPassTaskBlockers(runs)...)
+	if len(planDriftBlockers) == 0 {
+		blockers = append(blockers, IncompleteExecutionTaskBlockers(wavePlan, runs)...)
+	}
 	return WaveSyncResult{
 		Updated:  updated,
 		Blockers: model.NormalizeReasonCodes(blockers),
@@ -534,6 +540,42 @@ func CollectNonPassTaskBlockers(runs map[string]model.TaskRun) []model.ReasonCod
 		for _, blocker := range run.Blockers {
 			blockers = append(blockers, taskScopedReasonCode("task_blocker", taskID, blocker))
 		}
+	}
+	return model.NormalizeReasonCodes(blockers)
+}
+
+// IncompleteExecutionTaskBlockers reports planned wave-plan tasks that have no
+// recorded run at the active run_summary_version. The wave-plan is the authority
+// for the full task set, so a task missing from runs has no task evidence at all
+// — distinct from a recorded-but-failing task, which CollectNonPassTaskBlockers
+// reports. Without this check a host that records evidence for only the early
+// tasks would let wave-orchestration "pass" and advance S2_EXECUTE -> S3_REVIEW
+// while later planned tasks were never executed (issue #95). The remedy is to
+// execute and record the named task, or rescope tasks.md so the plan no longer
+// claims it.
+func IncompleteExecutionTaskBlockers(plan model.WavePlan, runs map[string]model.TaskRun) []model.ReasonCode {
+	plannedIDs := plan.TaskIDs()
+	if len(plannedIDs) == 0 {
+		return nil
+	}
+	missing := make([]string, 0, len(plannedIDs))
+	for _, taskID := range plannedIDs {
+		taskID = strings.TrimSpace(taskID)
+		if taskID == "" {
+			continue
+		}
+		if _, ok := runs[taskID]; ok {
+			continue
+		}
+		missing = append(missing, taskID)
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	slices.Sort(missing)
+	blockers := make([]model.ReasonCode, 0, len(missing))
+	for _, taskID := range missing {
+		blockers = append(blockers, model.NewReasonCode("incomplete_execution_task", taskID))
 	}
 	return model.NormalizeReasonCodes(blockers)
 }

--- a/internal/engine/progression/wave_sync_test.go
+++ b/internal/engine/progression/wave_sync_test.go
@@ -464,6 +464,96 @@ func TestSyncGovernedWaveExecution_PersistsExecutionSummaryAndRuntimeSummary(t *
 	}
 }
 
+func TestSyncGovernedWaveExecution_PersistsIncompleteExecutionBlockerInSummary(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	slug := "wave-sync-incomplete"
+	recordedAt := time.Date(2026, 4, 6, 10, 0, 0, 0, time.UTC)
+	change := model.NewChange(slug)
+	change.CurrentState = model.StateS2Execute
+	change.PlanSubStep = model.PlanSubStepNone
+	require.NoError(t, state.SaveChange(root, change))
+
+	writeVerificationForTest(t, root, slug, SkillWaveOrchestration, model.VerificationRecord{
+		Verdict:    model.VerificationVerdictPass,
+		Blockers:   []model.ReasonCode{},
+		Timestamp:  recordedAt,
+		RunVersion: 1,
+	})
+	// Plan has three tasks; evidence is recorded for only the first two.
+	writeTasksAndMaterializeWavePlan(t, root, change, `# Tasks
+
+- [ ] `+"`task-a`"+` A
+  - target_files: ["cmd/next.go"]
+  - wave: 1
+  - task_kind: code
+
+- [ ] `+"`task-b`"+` B
+  - target_files: ["cmd/run.go"]
+  - wave: 1
+  - task_kind: code
+
+- [ ] `+"`task-c`"+` C
+  - target_files: ["cmd/status.go"]
+  - wave: 1
+  - task_kind: code
+`)
+
+	writeTaskEvidence := func(taskID string) {
+		t.Helper()
+		ev := map[string]any{
+			"task_id":             taskID,
+			"run_summary_version": 1,
+			"task_kind":           "code",
+			"verdict":             "pass",
+			"changed_files":       []string{"cmd/next.go"},
+			"blockers":            []string{},
+			"evidence_ref":        "test:" + taskID,
+			"captured_at":         recordedAt.Format(time.RFC3339Nano),
+			"freshness_inputs":    expectedTaskFreshnessInputsForWavePlan(t, root, change, 1, taskID),
+		}
+		raw, err := json.Marshal(ev)
+		require.NoError(t, err)
+		taskPath := filepath.Join(state.EvidenceTasksDir(root, slug), taskID+".json")
+		require.NoError(t, os.MkdirAll(filepath.Dir(taskPath), 0o755))
+		require.NoError(t, os.WriteFile(taskPath, raw, 0o644))
+	}
+	writeTaskEvidence("task-a")
+	writeTaskEvidence("task-b")
+
+	hasIncomplete := func(blockers []model.ReasonCode) bool {
+		for _, b := range blockers {
+			if b.Code == "incomplete_execution_task" && b.Detail == "task-c" {
+				return true
+			}
+		}
+		return false
+	}
+
+	result, err := SyncGovernedWaveExecution(root, change)
+	require.NoError(t, err)
+	// The mutating sync returns the incomplete blocker (gates the advance)...
+	require.True(t, hasIncomplete(result.Blockers), "sync must return incomplete_execution_task:task-c, got %+v", result.Blockers)
+
+	// ...and it must be DURABLE in the saved summary's OpenBlockers so read-only
+	// readiness (which surfaces summary OpenBlockers via SummaryIssues) reports
+	// it too even though the summary is otherwise "ready" (issue #95 REQ-001).
+	summary, err := state.LoadExecutionSummary(root, slug)
+	require.NoError(t, err)
+	require.True(t, hasIncomplete(summary.OpenBlockers),
+		"incomplete_execution_task must persist in the saved summary OpenBlockers, got %+v", summary.OpenBlockers)
+	assert.Equal(t, model.ExecutionVerdictFail, summary.OverallVerdict)
+
+	// End-to-end: read-only readiness must surface the durable blocker too — this
+	// is exactly the path that previously dropped it once the partial summary was
+	// written (refineS2WaveExecutionSkillBlockers short-circuits the preview).
+	readiness, err := EvaluateGovernanceReadiness(root, change, GovernanceReadinessOptions{})
+	require.NoError(t, err)
+	assert.True(t, hasIncomplete(readiness.Blockers),
+		"read-only readiness must surface incomplete_execution_task:task-c, got %+v", readiness.Blockers)
+}
+
 func TestSyncGovernedWaveExecutionRejectsWaveEvidenceOlderThanTaskEvidence(t *testing.T) {
 	t.Parallel()
 

--- a/internal/engine/progression/wave_sync_test.go
+++ b/internal/engine/progression/wave_sync_test.go
@@ -73,6 +73,56 @@ func TestCollectNonPassTaskBlockers_Empty(t *testing.T) {
 	}
 }
 
+func incompleteTestWavePlan() model.WavePlan {
+	return model.WavePlan{
+		Version: model.WavePlanVersion,
+		Waves: []model.WavePlanWave{
+			{WaveIndex: 1, Tasks: []model.WavePlanTask{{TaskID: "t1"}, {TaskID: "t2"}}},
+			{WaveIndex: 2, Tasks: []model.WavePlanTask{{TaskID: "t3"}}},
+		},
+	}
+}
+
+func TestIncompleteExecutionTaskBlockers_MissingPlannedTaskBlocks(t *testing.T) {
+	t.Parallel()
+	// Evidence recorded only for the early tasks; t3 was planned but never run.
+	runs := map[string]model.TaskRun{
+		"t1": {TaskID: "t1", Verdict: model.TaskVerdictPass},
+		"t2": {TaskID: "t2", Verdict: model.TaskVerdictPass},
+	}
+	blockers := IncompleteExecutionTaskBlockers(incompleteTestWavePlan(), runs)
+	require.Len(t, blockers, 1)
+	assert.Equal(t, "incomplete_execution_task", blockers[0].Code)
+	assert.Equal(t, "t3", blockers[0].Detail)
+}
+
+func TestIncompleteExecutionTaskBlockers_AllRecordedNoBlock(t *testing.T) {
+	t.Parallel()
+	// Presence in runs is what matters here; a recorded-but-failing task is
+	// reported by CollectNonPassTaskBlockers, not this check.
+	runs := map[string]model.TaskRun{
+		"t1": {TaskID: "t1", Verdict: model.TaskVerdictPass},
+		"t2": {TaskID: "t2", Verdict: model.TaskVerdictPass},
+		"t3": {TaskID: "t3", Verdict: model.TaskVerdictPass},
+	}
+	assert.Empty(t, IncompleteExecutionTaskBlockers(incompleteTestWavePlan(), runs))
+}
+
+func TestIncompleteExecutionTaskBlockers_MultipleMissingSorted(t *testing.T) {
+	t.Parallel()
+	blockers := IncompleteExecutionTaskBlockers(incompleteTestWavePlan(), map[string]model.TaskRun{
+		"t2": {TaskID: "t2", Verdict: model.TaskVerdictPass},
+	})
+	require.Len(t, blockers, 2)
+	assert.Equal(t, "t1", blockers[0].Detail)
+	assert.Equal(t, "t3", blockers[1].Detail)
+}
+
+func TestIncompleteExecutionTaskBlockers_EmptyPlan(t *testing.T) {
+	t.Parallel()
+	assert.Nil(t, IncompleteExecutionTaskBlockers(model.WavePlan{}, map[string]model.TaskRun{}))
+}
+
 func TestBuildExecutionSummarySyncsDerivedFieldsAndWaveBlockers(t *testing.T) {
 	t.Parallel()
 

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -35,6 +35,17 @@ type ConfigGovernance struct {
 	DisabledControls []ControlID `yaml:"disabled_controls,omitempty" json:"disabled_controls,omitempty"`
 	// Thresholds overrides the blast-radius activation thresholds for controls.
 	Thresholds ConfigGovernanceThresholds `yaml:"thresholds,omitempty" json:"thresholds,omitempty"`
+	// AutoProvisionWorktree controls whether `slipway new` provisions a dedicated
+	// `.worktrees/<slug>` worktree (branch `feat/<slug>`) for every governed
+	// change so the main checkout stays free for parallel work. nil means the
+	// default (enabled); set false to keep governed changes in the project root.
+	AutoProvisionWorktree *bool `yaml:"auto_provision_worktree,omitempty" json:"auto_provision_worktree,omitempty"`
+}
+
+// AutoProvisionWorktreeEnabled reports whether governed changes should bind a
+// dedicated worktree at creation. Default (unset) is enabled.
+func (g ConfigGovernance) AutoProvisionWorktreeEnabled() bool {
+	return g.AutoProvisionWorktree == nil || *g.AutoProvisionWorktree
 }
 
 // PolicyPack registers an external advisory governance pack. Policy packs are

--- a/internal/model/reason_code.go
+++ b/internal/model/reason_code.go
@@ -92,6 +92,10 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 		Severity: ReasonSeverityError,
 		Message:  "A required high-risk safety check is missing",
 	},
+	"incomplete_execution_task": {
+		Severity: ReasonSeverityError,
+		Message:  "A planned execution task has no recorded passing evidence",
+	},
 	"invalid_pivot_kind": {
 		Severity: ReasonSeverityError,
 		Message:  "The requested pivot kind is invalid",

--- a/internal/model/recovery.go
+++ b/internal/model/recovery.go
@@ -162,14 +162,19 @@ var blockerRemediations = map[string]blockerRemediation{
 		Class:           RecoveryClassSatisfyControl,
 	},
 	"high_risk_check_failed": {
-		Remediation:     "Resolve the named high-risk safety check failure before continuing.",
-		CommandTemplate: "slipway validate",
+		Remediation:     "The high-risk safety check {subject} failed in goal-verification; fix the SAST findings, re-run goal-verification, and record `high_risk_check:{subject}=pass` in its References before continuing.",
+		CommandTemplate: "slipway validate --focus sast",
 		Class:           RecoveryClassSatisfyControl,
 	},
 	"high_risk_check_missing": {
-		Remediation:     "Provide the named high-risk safety check before continuing.",
-		CommandTemplate: "slipway validate",
+		Remediation:     "Record the required high-risk safety check {subject} from goal-verification: run SAST (e.g. `slipway validate --focus sast`), triage findings, then add `high_risk_check:{subject}=pass` to the goal-verification References (use `=fail` to block ship); then continue.",
+		CommandTemplate: "slipway validate --focus sast",
 		Class:           RecoveryClassSatisfyControl,
+	},
+	"incomplete_execution_task": {
+		Remediation:     "Execute task {subject} and record its evidence with `slipway evidence task`, or rescope tasks.md to drop it, then re-run wave-orchestration.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRefreshWave,
 	},
 	"intake_confirmation_incomplete": {
 		Remediation:     "Complete the Approved Summary in intent.md before continuing.",

--- a/internal/model/recovery_test.go
+++ b/internal/model/recovery_test.go
@@ -128,6 +128,9 @@ func inScopeProducedRecoverySpecs() []string {
 	return []string{
 		"research_structure_invalid:section \"Findings\" must have non-empty content",
 		"non_pass_task:t-01",
+		"incomplete_execution_task:t-19",
+		"high_risk_check_missing:external_api_contracts.safety_baseline",
+		"high_risk_check_failed:external_api_contracts.safety_baseline",
 		"closeout_goal_verification_reuse_invalid:goal-verification evidence was produced before final-closeout input changed; rerun goal-verification, then rerun final-closeout",
 		"worktree_metadata_persist_failed:permission denied",
 	}
@@ -148,6 +151,7 @@ func recoveryRelevantCanonicalCodes() []string {
 		"governed_bundle_path_invalid":             true,
 		"high_risk_check_failed":                   true,
 		"high_risk_check_missing":                  true,
+		"incomplete_execution_task":                true,
 		"intake_clarification_incomplete":          true,
 		"intake_confirmation_incomplete":           true,
 		"intake_substep_invalid":                   true,
@@ -214,7 +218,9 @@ func sampleRecoveryDetail(code string) string {
 	case "governed_bundle_path_invalid":
 		return "../outside"
 	case "high_risk_check_failed", "high_risk_check_missing":
-		return "sast"
+		return "external_api_contracts.safety_baseline"
+	case "incomplete_execution_task":
+		return "t-19"
 	case "missing_required_artifact", "required_artifact_schema_missing", "required_artifact_unreadable":
 		return "decision.md"
 	case "required_artifact_dependency_missing":

--- a/internal/state/worktree.go
+++ b/internal/state/worktree.go
@@ -162,8 +162,20 @@ func EnsureDefaultWorktreeForChange(root string, change *model.Change) (DefaultW
 			Branch: change.WorktreeBranch,
 		}, nil
 	}
-	if !change.NeedsDiscovery {
-		return DefaultWorktreeBinding{SkippedReason: "discovery_not_required"}, nil
+	// Every governed change gets a dedicated worktree by default so the main
+	// checkout stays free for parallel work; `governance.auto_provision_worktree:
+	// false` opts out. Discovery is no longer the gate — non-discovery changes
+	// previously ran their entire lifecycle in the main checkout.
+	autoProvision := true
+	if cfg, cfgErr := model.LoadConfig(ConfigPath(root)); cfgErr != nil {
+		if !os.IsNotExist(cfgErr) {
+			return DefaultWorktreeBinding{}, cfgErr
+		}
+	} else {
+		autoProvision = cfg.Governance.AutoProvisionWorktreeEnabled()
+	}
+	if !autoProvision {
+		return DefaultWorktreeBinding{SkippedReason: "worktree_provisioning_disabled"}, nil
 	}
 
 	repoRoot, err := gitWorkspaceRoot(root)

--- a/internal/state/worktree_test.go
+++ b/internal/state/worktree_test.go
@@ -235,3 +235,55 @@ func runGit(t *testing.T, dir string, args ...string) {
 	out, err := cmd.CombinedOutput()
 	require.NoErrorf(t, err, "git %v failed: %s", args, string(out))
 }
+
+func initGitRepoAt(t *testing.T, root string) {
+	t.Helper()
+	runGit(t, root, "init", "--initial-branch=main")
+	runGit(t, root, "config", "user.email", "test@example.com")
+	runGit(t, root, "config", "user.name", "Test User")
+	require.NoError(t, os.WriteFile(filepath.Join(root, "README.md"), []byte("hello"), 0o644))
+	runGit(t, root, "add", ".")
+	runGit(t, root, "commit", "-m", "init")
+}
+
+func TestEnsureDefaultWorktreeForChange_ProvisionsNonDiscoveryByDefault(t *testing.T) {
+	root := t.TempDir()
+	initGitRepoAt(t, root)
+
+	// A non-discovery change is exactly the case that used to be skipped with
+	// "discovery_not_required" and run its whole lifecycle in the main checkout.
+	change := model.NewChange("my-change")
+	change.NeedsDiscovery = false
+
+	binding, err := EnsureDefaultWorktreeForChange(root, &change)
+	require.NoError(t, err)
+	assert.True(t, binding.Created, "non-discovery change should provision a worktree by default")
+	assert.Empty(t, binding.SkippedReason)
+	assert.Equal(t, "feat/my-change", binding.Branch)
+	assert.Contains(t, filepath.ToSlash(binding.Path), ".worktrees/my-change")
+	assert.NotEmpty(t, change.WorktreePath, "binding metadata must be persisted on the change")
+}
+
+func TestEnsureDefaultWorktreeForChange_DisabledByConfig(t *testing.T) {
+	root := t.TempDir()
+	initGitRepoAt(t, root)
+	require.NoError(t, os.WriteFile(filepath.Join(root, ".slipway.yaml"),
+		[]byte("governance:\n  auto_provision_worktree: false\n"), 0o644))
+
+	change := model.NewChange("my-change")
+	binding, err := EnsureDefaultWorktreeForChange(root, &change)
+	require.NoError(t, err)
+	assert.False(t, binding.Created)
+	assert.Equal(t, "worktree_provisioning_disabled", binding.SkippedReason)
+	assert.Empty(t, change.WorktreePath)
+}
+
+func TestEnsureDefaultWorktreeForChange_SkipsNonGitRepo(t *testing.T) {
+	root := t.TempDir() // never `git init`ed
+
+	change := model.NewChange("my-change")
+	binding, err := EnsureDefaultWorktreeForChange(root, &change)
+	require.NoError(t, err)
+	assert.Equal(t, "not_git_repository", binding.SkippedReason)
+	assert.False(t, binding.Created)
+}

--- a/internal/tmpl/templates/skills/final-closeout/SKILL.md.tmpl
+++ b/internal/tmpl/templates/skills/final-closeout/SKILL.md.tmpl
@@ -44,7 +44,10 @@ Verify ALL of the following before producing closeout verification:
 - [ ] `assurance.md` is complete on standard/strict preset
 - [ ] both review skills have passing verification
 - [ ] artifact staleness propagation is clean
-- [ ] guardrail baseline is rechecked when a guardrail domain is active
+- [ ] when a guardrail domain is active, goal-verification carries a fresh
+      `high_risk_check:<domain>.safety_baseline=pass` (the ship-gate check); the
+      goal-verification reuse branch reuses it only when still fresh, otherwise
+      rerun the SAST baseline. Record `closeout:guardrail_baseline=pass` once confirmed.
 
 Each unchecked item is a blocker.
 
@@ -117,7 +120,7 @@ references:
   - "closeout:goal_verification_reuse=pass"              # only when using the reuse branch
   - "closeout:goal_verification_reuse_run_version=1"     # only when using the reuse branch
   - "closeout:reviewer_independence=pass"
-  - "closeout:guardrail_baseline=pass"
+  - "closeout:guardrail_baseline=pass"   # closeout's recheck; the ship-gate check itself is goal-verification's high_risk_check:<domain>.safety_baseline
   - "closeout:assurance_complete=pass"   # REQUIRED on standard/strict; omit on light
 notes: |
   <verification notes>

--- a/internal/tmpl/templates/skills/goal-verification/SKILL.md.tmpl
+++ b/internal/tmpl/templates/skills/goal-verification/SKILL.md.tmpl
@@ -73,9 +73,26 @@ Also block:
 - `pass`: every criterion passes at Exists, Substantive, and Wired levels
 - `fail`: any criterion is `fail` or `blocked`
 - Populate `blockers[]` with failed criterion IDs
-- Run guardrail high-risk checks when applicable
+- Run guardrail high-risk checks when applicable (see Guardrail Safety Baseline)
 - Use fresh test execution, not cached output
 - For performance or regression claims, require baseline and candidate measurements from the same environment
+
+## Guardrail Safety Baseline
+When the change has a guardrail domain (`skill_constraints.guardrail_domain` is
+set), the ship gate requires a `<domain>.safety_baseline` high-risk check, and
+this skill is its producer. `slipway next` lists the exact token(s) under
+`skill_constraints.required_high_risk_tokens`.
+
+1. Run SAST against the change — hydrate the recipe with
+   `slipway validate --focus sast` (CodeQL/Semgrep), then triage the findings.
+2. Record the verdict as a reference in THIS verification record:
+   - `high_risk_check:<domain>.safety_baseline=pass` — baseline clean / findings mitigated.
+   - `high_risk_check:<domain>.safety_baseline=fail` — unmitigated findings; this blocks ship.
+
+The verdict must reflect a real SAST run. A missing token leaves the ship gate
+blocked with `high_risk_check_missing`; there is no other satisfy-path and no
+bypass. This is the only way the gate is satisfied — do not invent a different
+reference format.
 
 ## Write Verification
 ```yaml
@@ -87,6 +104,7 @@ run_version: 1
 references:
   - "fresh:command_ref=<path or transcript ref>"
   - "scope_contract:pass"
+  - "high_risk_check:<domain>.safety_baseline=pass"   # required when guardrail_domain is set
 notes: |
   Criteria:
     AC-1: <criterion text> — pass — <concrete proof>
@@ -102,10 +120,13 @@ After confirmation: `slipway next`
 1. Fresh verification record, not cached evidence.
 2. Evidence-backed claims only.
 3. Scope Contract pass/fail/not-applicable statement when contract evidence exists.
-4. Guardrail high-risk checks when applicable.
+4. Guardrail high-risk checks when applicable, recording the
+   `high_risk_check:<domain>.safety_baseline` reference from a real SAST run.
 
 ## Block If
 - A criterion lacks fresh evidence.
 - The implementation is stubbed, placeholder-only, or unwired.
 - Scope Contract evidence exists and reports fail without an accepted amendment or rollback.
-- Guardrail-domain proof or performance proof is missing for a claimed outcome.
+- A guardrail domain is set but the `high_risk_check:<domain>.safety_baseline`
+  reference (from a real SAST run) is missing or `=fail`.
+- Performance proof is missing for a claimed outcome.

--- a/internal/tmpl/templates/skills/sast-orchestration/SKILL.md
+++ b/internal/tmpl/templates/skills/sast-orchestration/SKILL.md
@@ -4,10 +4,10 @@ domain: review-security
 function: run SAST tooling (CodeQL/Semgrep) with SARIF triage
 tier: T2
 primary_attachment: tool-recipe
-summary: "Use when running SAST tooling against the change. Triggers on review, validate, or repair commands and user text naming SAST tools."
+summary: "Use when running SAST tooling against the change. Triggers on review or validate commands and user text naming SAST tools."
 trigger_signals:
-  - command: ["review", "validate", "repair"]
-    reason: "Review/validate/repair command invoked; SAST may apply"
+  - command: ["review", "validate"]
+    reason: "Review/validate command invoked; SAST may apply"
   - user_text_matches: ["codeql", "semgrep", "sast", "sarif"]
     reason: "User text names a SAST tool"
 evidence_contract: artifact
@@ -26,9 +26,6 @@ bindings:
     attachment: tool-recipe
   - type: command-auto
     target: validate
-    attachment: tool-recipe
-  - type: command-auto
-    target: repair
     attachment: tool-recipe
 ---
 

--- a/internal/tmpl/templates/skills/wave-orchestration/SKILL.md.tmpl
+++ b/internal/tmpl/templates/skills/wave-orchestration/SKILL.md.tmpl
@@ -83,6 +83,12 @@ complete. Slipway computes `freshness_inputs` and `captured_at` unless
 `--captured-at` is explicitly provided. A passing wave-orchestration record
 without task evidence blocks execution-summary generation.
 
+**Completeness contract:** record passing evidence for EVERY planned task in the
+wave plan before the change can advance to review. A planned task left without
+passing evidence blocks advancement with `incomplete_execution_task:<task_id>` —
+partial execution does not reach S3_REVIEW. To intentionally drop a task, rescope
+`tasks.md` (re-plan) so the wave plan no longer claims it; never skip its evidence.
+
 ## Guardrails
 - The orchestrator stays below 15% of context budget. Do not read task source files just to "help."
 - Auto-fix only issues directly blocking the current task and directly caused by the current task's change.
@@ -122,3 +128,5 @@ After confirmation: `slipway next`
 - Retry budget is exhausted.
 - A checkpoint resumes without a fresh subagent context.
 - Task evidence was not recorded through the supported CLI.
+- Any planned task lacks passing evidence (`incomplete_execution_task`) and has
+  not been removed by rescoping `tasks.md`.


### PR DESCRIPTION
## Summary

Fixes three governed-lifecycle defects in Slipway's own engine in one change:

- **#95 — premature advance.** At `S2_EXECUTE` the wave-orchestration sync loaded the full wave-plan task set but never asserted every planned task had passing evidence, so a host that recorded evidence for only the early tasks advanced to `S3_REVIEW` with later tasks unexecuted. Now an execution-completeness gate blocks the advance with one `incomplete_execution_task:<taskID>` reason code per planned-but-unrecorded task. The blocker is **durable** in the execution summary's `OpenBlockers` so read-only readiness (`validate`/`next`/`status`) surfaces it too — the path that previously dropped it once a partial "ready" summary was written. Suppressed only when plan-drift blockers already own the remediation.
- **#88 — high-risk dead-end + false repair surface.** A guardrail-domain change was blocked at the ship gate by `high_risk_check_missing:<domain>.safety_baseline` with no operator-visible, fail-closed way to satisfy it; and `slipway repair --focus sast` was a no-op that falsely advertised running SAST. Now `slipway next` surfaces the exact `required_high_risk_tokens` at the goal-verification handoff, the generated skill documents the single real-SAST satisfy-path, and the false `repair --focus sast` focus is removed (with a redirect to `review`/`validate --focus sast`). **No new bypass / self-attestation path.**
- **worktree provisioning.** Governed changes only got a dedicated `.worktrees/<slug>` (`feat/<slug>`) worktree when `needs_discovery` was true; non-discovery changes ran their whole lifecycle in the main checkout. Now every governed change is worktree-provisioned by default so the main checkout stays free for parallel work; `governance.auto_provision_worktree: false` opts out.

## Why one change

These were authored and reviewed together as a governance-engine bundle (the worktree fix is a bootstrap: it cannot retroactively relocate itself, so it runs in the main checkout and subsequent changes inherit dedicated worktrees). The full intent/requirements/decision bundle is archived under `artifacts/changes/archived/fix-issue-95-...`.

## Breaking changes

- **CLI:** `slipway repair --focus sast` is removed. Selecting it now returns `unknown_route_mode` with a remediation redirecting to `slipway review --focus sast` / `slipway validate --focus sast`. `repair` performs local-state integrity only and never runs external scanners.
- **JSON:** the `worktree_skipped_reason: discovery_not_required` value no longer exists; non-discovery changes now either provision a worktree or report `worktree_provisioning_disabled` (when opted out via config).
- **Default behavior:** governed changes are worktree-provisioned by default (bundles live in `.worktrees/<slug>` instead of the project root). Opt out with `governance.auto_provision_worktree: false`.

## Additive (backward-compatible)

- New reason code `incomplete_execution_task` with a refresh-execution recovery remediation.
- New optional `required_high_risk_tokens[]` field on the goal-verification `slipway next` handoff.

## Testing

- `go build ./...` — clean
- `go vet ./...` — clean
- `golangci-lint run` — 0 issues
- `go test -timeout=20m ./... -count=1` — pass

New coverage: `IncompleteExecutionTaskBlockers` unit cases (missing / all-recorded / multiple-sorted / empty-plan); end-to-end `SyncGovernedWaveExecution` durability test asserting the blocker persists in the saved summary **and** surfaces via `EvaluateGovernanceReadiness` (the exact regression path); recovery-vocab coverage; `repair`/`route_flags` focus rejection + redirect; `required_high_risk_tokens` skill-constraint surfacing; worktree-by-default provisioning + config-disable, at both the `state` and `cmd new` layers.

Closes #95
Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)
