### PR TITLE
fix(recovery): make live P3 lifecycle dead-ends name an executable next action (#86)

### DIFF
--- a/artifacts/changes/archived/resolve-the-live-recovery-ux-p3-lifecycle-dead-ends-from-iss/assurance.md
+++ b/artifacts/changes/archived/resolve-the-live-recovery-ux-p3-lifecycle-dead-ends-from-iss/assurance.md
@@ -1,0 +1,81 @@
+# Assurance
+## Project Context
+- Tech Stack: Go
+- Conventions: engine packages under internal/engine (read-only over model); cmd thin orchestrators; model is a leaf; one verdict-evidence YAML per skill under verification/.
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Scope Summary
+Resolves the live Recovery UX P3 lifecycle dead-ends from issue #86 (rescoped) so
+every blocked governance state names an executable next action: (1) a bound
+worktree on a mismatched git branch now reconciles its recorded branch to the
+worktree's actual HEAD via `slipway run` (recovery vocabulary retargeted from the
+hollow `slipway repair`); (2) `slipway repair` dual-active findings name the
+conflicting slugs plus `slipway status` / `slipway cancel --change` /
+`slipway done --change`, and the generic-drift default routes to `slipway run`;
+(3) `slipway abort`'s repair branch also names `slipway run` as the
+interrupted-execution clearer; (4) the scope-contract recovery guidance
+diagnostic gains surface parity at S2_EXECUTE. The obsolete #86 item 5
+(restamp/recover/Tier docs) is dropped — PR #99 removed that surface. Classified
+`external_api_contracts` because public CLI/JSON recovery vocabulary changes;
+recovery JSON object field shape (`primary_command`/`primary_action`/
+`recovery_class`/`steps[]`) is preserved.
+
+## Verification Verdict
+Pass for implementation, tests, and review up to the S4 goal/closeout handoff.
+`go build ./...`, `go vet ./...`, `go test ./...` are green; `golangci-lint run`
+reports 0 issues; `go run . init --refresh --tools all` + `git diff --check`
+leaves zero project-visible drift (no generated surface references the changed
+vocabulary). Each dead-end carries a focused regression test.
+
+## Evidence Index
+- Runtime execution: `verification/wave-plan.yaml` + `verification/execution-summary.yaml`
+  record run_summary_version 1 with all five planned tasks passing.
+- Worktree rebind (t-01): `internal/state/worktree.go` `ReconcileWorktreeBranchBinding`;
+  tests `TestReconcileWorktreeBranchBindingRealignsBranchMismatch`,
+  `TestReconcileWorktreeBranchBindingLeavesNonBranchMismatchAlone`,
+  `TestBuildRecoveryWorktreeBranchMismatchRoutesToRun`.
+- Repair actionability (t-02): `cmd/repair.go`; tests
+  `TestBuildUnrepairedDriftFindingsKeepsActionableTargets`,
+  `TestRepairDriftNextActionGenericAndDualActive`.
+- Abort guidance (t-03): `cmd/abort.go`; test `TestAbortRepairBranchGuidanceNamesRun`.
+- Scope parity (t-04): `internal/engine/progression/readiness.go`; test
+  `TestScopeContractRecoveryGuidanceHasSurfaceParity`.
+- Proof (t-05): build/vet/test, golangci-lint, init-refresh zero-drift.
+
+## Requirement Coverage
+- REQ-001: `internal/state/worktree.go` + `internal/engine/progression/advance_governed.go`
+  (reconcile) + `internal/model/recovery.go` (vocab → slipway run); reconcile +
+  recovery tests.
+- REQ-002: `cmd/repair.go` dual-active + `repairDriftNextAction`; repair tests.
+- REQ-003: `cmd/abort.go` repair-branch guidance; abort test.
+- REQ-004: `internal/engine/progression/readiness.go` `scopeContractNeedsRecoveryGuidance`;
+  scope parity test.
+- REQ-005: recovery JSON shape preserved (only vocabulary values change), each
+  change test-covered, init-refresh zero drift.
+
+## Residual Risks and Exceptions
+- The worktree rebind reconciles recorded metadata to the worktree's actual git
+  HEAD via the canonical `PersistScopeWorktreeMetadata` setter (no `git checkout`,
+  no second branch-authority writer); it fires only for a pure branch mismatch on
+  an otherwise-valid dedicated worktree and fails closed for every other
+  authenticity failure (unbound/invalid/unregistered/non-dedicated).
+- The S2 scope guidance change is narrative parity only; per-blocker remediations
+  and the scope-contract advance-reopen gate are unchanged, so the executable
+  next action at S2 is unaffected.
+- The codebase map remains advisory; source, governed artifacts, runtime
+  evidence, and live `go run .` output are the closeout authorities.
+
+## Rollback Readiness
+Rollback is a branch revert. No data migration; the worktree rebind only
+reconciles recorded metadata and is reversible. Public docs/generated surfaces
+require no change (zero drift), so rollback restores prior behavior with code
+alone.
+
+## Archive Decision
+Proceed to done-ready after S4 `goal-verification` and `final-closeout` pass,
+including `check:external_api_contracts.safety_baseline=pass` and
+`closeout:assurance_complete=pass`. Active `go run . validate --json` freshness/
+readiness proof must be captured before `slipway done`; archived bundles are not
+described as revalidated through the active validate gate.

--- a/artifacts/changes/archived/resolve-the-live-recovery-ux-p3-lifecycle-dead-ends-from-iss/change.yaml
+++ b/artifacts/changes/archived/resolve-the-live-recovery-ux-p3-lifecycle-dead-ends-from-iss/change.yaml
@@ -1,0 +1,50 @@
+version: 1
+slug: resolve-the-live-recovery-ux-p3-lifecycle-dead-ends-from-iss
+description: 'Resolve the live Recovery UX P3 lifecycle dead-ends from issue #86 (rescoped). Fix four user-facing dead-ends so every blocked state names an executable next action: (1) a governed change bound to a worktree on a mismatched git branch has no rebind path, and the recovery vocabulary points to `slipway repair` which has no branch-rebind code path (hollow remediation); (2) `slipway repair` dual-active and generic-drift findings yield non-actionable ''inspect the named artifact and rerun'' dead-ends; (3) abort then repair can loop because only `slipway run` clears InterruptedExecutionAt while `slipway abort` advises `slipway repair`; (4) the scope-contract recovery guidance diagnostic is suppressed at S2_EXECUTE. Drop the obsolete #86 item about restamp/recover/Tier docs, since PR #99 removed that surface entirely.'
+status: done
+current_state: DONE
+needs_discovery: true
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-06-06T14:00:10.929918Z
+quality_mode: standard
+workflow_preset: standard
+worktree_branch: feat/resolve-the-live-recovery-ux-p3-lifecycle-dead-ends-from-iss
+artifact_schema: expanded
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: a6ca9ce7965487e7255a5f5dce816d325c613732ba0b953892ccb615f00ad894
+        updated_at: 2026-06-06T14:35:42.557993684Z
+    decision:
+        id: decision
+        path: decision.md
+        state: frozen
+        content_hash: f16c5a6c39ef9ae485194ed28590a1efd8ed029f1a8cc61c4df2894c2c66b6f5
+        updated_at: 2026-06-06T14:11:39.170912918Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: 37eb9be536841115adead128c5ad457dd25634beaeb5192b515883e85025ea4c
+        updated_at: 2026-06-06T14:06:25.330981302Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: e7b7fd81b51336a26906998054188a19df690d90f84b3be37e03feac43048e6f
+        updated_at: 2026-06-06T14:11:02.002231908Z
+    research:
+        id: research
+        path: research.md
+        state: frozen
+        content_hash: 086af036db725ae8133f9475b8385ce6a6bf406eb96319780dfb12f199b332f0
+        updated_at: 2026-06-06T14:08:56.417562779Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: b549cab750f5c63682e36fcddff3643cf84b36158fa1ed2a4d69ec442e5e3b58
+        updated_at: 2026-06-06T14:35:01.291563821Z

--- a/artifacts/changes/archived/resolve-the-live-recovery-ux-p3-lifecycle-dead-ends-from-iss/decision.md
+++ b/artifacts/changes/archived/resolve-the-live-recovery-ux-p3-lifecycle-dead-ends-from-iss/decision.md
@@ -1,0 +1,94 @@
+# Decision
+## Project Context
+- Tech Stack: Go
+- Conventions: engine packages under internal/engine (read-only over model); cmd thin orchestrators; model is a leaf; one verdict-evidence YAML per skill under verification/.
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Selected Approach
+Make every live #86 dead-end name an executable next action by reusing existing
+primitives and the post-#99 `slipway run` recovery model — no new command
+surfaces, no new git mutation, no fail-open path.
+
+1. **Worktree branch-mismatch rebind (REQ-001).** Reach the existing
+   worktree-preflight rebind for the bound-but-mismatched case: relax the
+   `WorktreePath == ""` precondition in `resolveS2Execute`, `DeriveWorktreeBlockers`,
+   and the advance/readiness gates so a `dedicated_worktree_branch_mismatch`
+   re-enters preflight. Retarget the recovery vocabulary
+   (`internal/model/recovery.go`) for `dedicated_worktree_branch_mismatch` from
+   `slipway repair` to `slipway run`. worktree-preflight stays the sole writer of
+   `WorktreeBranch`; the rebind reconciles recorded metadata to the worktree's
+   actual git HEAD (no `git checkout`).
+2. **Repair actionability (REQ-002).** In `cmd/repair.go`: the dual-active finding
+   names the conflicting slugs (already in `activeChanges`/`unique`) plus
+   `slipway status` / `slipway cancel --change <slug>` / `slipway done --change <slug>`;
+   the `repairDriftNextAction` default returns the `slipway run` reopen
+   instruction (matching `governanceDigestRunNextAction`).
+3. **Abort guidance (REQ-003).** In `cmd/abort.go`, the `case "repair":` arm also
+   names `slipway run` as the interrupted-execution clearer.
+4. **S2 scope guidance parity (REQ-004).** In
+   `internal/engine/progression/readiness.go`, drop the
+   `state != S3 && state != S4` early-return in `scopeContractNeedsRecoveryGuidance`
+   so the diagnostic is emitted whenever there are scope blockers.
+
+## Key Decisions
+- Reuse worktree-preflight as the single branch-authority writer; do NOT add a
+  branch-rebind to `repair` (rejected: second writer, non-`run` path). [research]
+- Route both repair gaps and the abort marker to `slipway run`, the canonical
+  post-#99 mutating recovery action. [research]
+- Do NOT make `repair` clear `InterruptedExecutionAt` (rejected: wrong layer;
+  would forge a resumed state without execution evidence). [research]
+- S2 scope item is narrative parity only; the executable path is already covered
+  by per-blocker remediation + the #102 `scopeContractReopenTarget` gate, so the
+  fix is a one-line gate relaxation, not a new mechanism. [research]
+- Drop #86 item 5 (restamp/recover/Tier docs): obsolete — PR #99 removed that
+  surface. [intent]
+- Guardrail domain `external_api_contracts` because public CLI/JSON recovery
+  vocabulary changes; preserve recovery object field shape with contract tests.
+
+## Rejected Alternatives
+- Add `RepairBoundWorktreeBranchBinding` to repair (Option B for REQ-001): more
+  code, second `WorktreeBranch` writer, keeps a non-`run` recovery path.
+- Make `repair` clear `InterruptedExecutionAt` (Option b for REQ-003): couples a
+  "resumed" state to repair with no execution evidence.
+- A dedicated `slipway worktree rebind` subcommand: unnecessary new surface; the
+  `slipway run` re-walk covers it.
+
+## Interfaces and Data Flow
+- `internal/engine/progression/skill_resolution.go` `resolveS2Execute`: route to
+  worktree-preflight when `WorktreePath == ""` OR the bound worktree fails
+  authenticity with `dedicated_worktree_branch_mismatch`.
+- `internal/engine/progression/validation.go` `DeriveWorktreeBlockers` +
+  `internal/engine/progression/readiness.go` + `advance_governed.go`: admit the
+  branch-mismatch case into the re-derive path so fresh preflight evidence
+  overwrites the stale `WorktreeBranch`.
+- `internal/model/recovery.go`: `dedicated_worktree_branch_mismatch` →
+  `CommandTemplate: "slipway run"`; generic repair drift → `slipway run`.
+- `cmd/repair.go`: dual-active finding string + `repairDriftNextAction` cases.
+- `cmd/abort.go`: `case "repair":` guidance string.
+- No schema changes; recovery JSON object fields unchanged (only vocabulary
+  values).
+
+## Rollout and Rollback
+- Rollout: behavior is the recovery vocabulary/routing itself; no flag. Verified
+  by `go build/vet/test ./...`, `go test ./internal/toolgen/...`,
+  `go run . init --refresh --tools all` + `git diff --check` (zero drift),
+  contract/regression tests per dead-end, and `go run . validate --json`.
+- Rollback: revert the branch. No data migration; the worktree rebind only
+  reconciles recorded metadata, reversible by reverting. Public docs/generated
+  surfaces revert with code (external contract change).
+
+## Risk
+- Relaxing the `WorktreePath == ""` precondition could re-enter preflight for an
+  unintended case → gate strictly on the `dedicated_worktree_branch_mismatch`
+  authenticity reason, and rely on preflight's existing fail-closed authenticity
+  check (registered + dedicated worktree only); add a regression test.
+- Vocabulary changes could break host tools parsing recovery JSON → preserve the
+  object field shape; only values change; contract tests assert the new values
+  and the stable shape.
+- Dual-active guidance must name real commands → confirmed `slipway cancel`/`done`
+  accept `--change`; test asserts the rendered command.
+- S2 scope parity must not change the executable next action → it only adds the
+  narrative diagnostic; per-blocker remediations are unchanged; test asserts the
+  diagnostic presence without altering blockers.

--- a/artifacts/changes/archived/resolve-the-live-recovery-ux-p3-lifecycle-dead-ends-from-iss/intent.md
+++ b/artifacts/changes/archived/resolve-the-live-recovery-ux-p3-lifecycle-dead-ends-from-iss/intent.md
@@ -1,0 +1,149 @@
+# Intent
+
+## Summary
+Resolve the live Recovery UX P3 lifecycle dead-ends from issue #86 (rescoped) so
+every blocked governance state names an executable next action. Three confirmed
+user-facing dead-ends are fixed plus one narrative-parity gap, and two obsolete
+items are dropped:
+
+1. **Worktree branch mismatch has no rebind path.** A change bound to a worktree
+   whose actual git branch no longer matches the recorded `WorktreeBranch` emits
+   `dedicated_worktree_branch_mismatch`, whose remediation points to
+   `slipway repair` — but repair has no branch-rebind code, so the remediation is
+   hollow and the change is stranded. Fix: make the existing worktree-preflight
+   rebind primitive reachable for the branch-mismatch case and retarget the
+   recovery vocabulary to `slipway run` (which re-enters preflight and rebinds the
+   recorded branch to the worktree's actual branch).
+2. **`slipway repair` non-actionable findings.** The dual-active finding
+   ("multiple active changes require operator intervention") and the generic
+   drift fallback ("inspect the named artifact and rerun the owning Slipway
+   command after correction") name no executable command. Fix: dual-active names
+   the conflicting slugs plus `slipway status` / `slipway cancel --change` /
+   `slipway done --change`; the generic-drift default routes to `slipway run`
+   (reopen the earliest affected authority), consistent with the post-#99
+   recovery model.
+3. **abort → repair loop.** `slipway abort` sets `InterruptedExecutionAt`, and in
+   the broken-execution-state branch advises `slipway repair`, but only
+   `slipway run` clears that marker and repair never touches it — so
+   repair↔status can loop. Fix: abort's repair branch also names `slipway run` as
+   the step that clears the interrupted-execution marker and continues.
+4. **S2 scope guidance narrative parity (cosmetic).** The scope-contract recovery
+   guidance diagnostic is suppressed at S2_EXECUTE (shown only at S3/S4). The
+   executable next action at S2 is already adequate (per-blocker remediation +
+   the `scopeContractReopenTarget` advance gate from #102), so this is narrative
+   only: enable the same explanation at S2 for surface parity.
+
+## Complexity Assessment
+complex
+<!-- Rationale -->
+Touches lifecycle recovery routing and the public recovery vocabulary across
+several surfaces (worktree-preflight routing, repair findings, abort guidance,
+scope guidance). Each fix keeps blocked states fail-closed while making the next
+action executable; the worktree rebind reuses an existing primitive rather than
+adding a new git mutation. No new schema or data migration. Not critical because
+there is no fail-open risk: every change either reuses an existing fail-closed
+primitive or only rewrites a remediation string into an executable command.
+
+## Guardrail Domains
+`external_api_contracts` — intent-based classification. The change alters
+externally consumed Slipway CLI/JSON recovery behavior: the
+`dedicated_worktree_branch_mismatch` recovery `CommandTemplate`/remediation, the
+`slipway repair` dual-active and generic-drift finding strings + next actions,
+the `slipway abort` guidance text, and the S2 scope guidance surface. Public
+recovery JSON field shape (`primary_command`, `primary_action`,
+`recovery_class`, `steps[]`) MUST stay stable; intentional vocabulary changes
+need contract tests and docs/generated-surface updates. The worktree rebind only
+reconciles Slipway's recorded `WorktreeBranch` to the worktree's actual git HEAD
+(no `git checkout`/HEAD move, no working-tree mutation), and the preflight
+authenticity check still fail-closes against unregistered/non-dedicated
+worktrees, so it is not an irreversible/sensitive git operation.
+
+## In Scope
+- Worktree branch-mismatch rebind path: route the bound-but-mismatched worktree
+  through the existing worktree-preflight rebind (relax the `WorktreePath == ""`
+  precondition for the branch-mismatch case in `resolveS2Execute`,
+  `DeriveWorktreeBlockers`, and the advance/readiness gates), and retarget the
+  `dedicated_worktree_branch_mismatch` recovery vocabulary from `slipway repair`
+  to `slipway run`.
+- `slipway repair` actionability: dual-active finding names the conflicting slugs
+  and executable resolution commands; generic-drift `repairDriftNextAction`
+  default routes to `slipway run`.
+- `slipway abort` repair-branch guidance also names `slipway run` as the
+  interrupted-execution clearer.
+- S2 scope guidance narrative parity: emit the scope-contract recovery guidance
+  diagnostic at S2_EXECUTE as well (one-line gate relaxation).
+- Contract tests for each changed public surface; docs/generated-surface
+  alignment; regression replays for each dead-end.
+
+## Out of Scope
+- Issue #86 item 5 (reconcile docs with the restamp/recover/Tier surface):
+  obsolete — PR #99 removed that surface entirely; there is no such
+  reconciliation left to do.
+- Adding a `git checkout`/branch-switch operation (the rebind only reconciles
+  recorded metadata to the actual HEAD).
+- Issues #95 (premature execution-completeness advance), #92 (health/validate
+  assurance disagreement), #91 (mechanical seed substance gate), #88
+  (safety_baseline satisfy path / repair --focus sast), #80 (codebase-map
+  staleness), #75 (force-close) — separate efforts.
+- Dual-active *prevention* (stopping two changes from becoming active); this
+  change only makes the existing dual-active repair finding actionable.
+
+## Constraints
+- Public CLI/JSON recovery contract: preserve documented recovery object fields;
+  intentional vocabulary changes require contract tests + docs updates.
+- Worktree rebind reuses worktree-preflight as the sole writer of
+  `WorktreeBranch`; do not add a second branch-authority writer.
+- Blocked states stay fail-closed: every fix either reuses an existing
+  fail-closed primitive or only rewrites a remediation string to an executable
+  command; no force/bypass path is added.
+- Import layering: `progression` may import `state`/`model`; `model` stays a
+  leaf.
+- Verify against the repo's own loop: `go build/vet/test ./...`,
+  `go test ./internal/toolgen/...`, and current-worktree
+  `go run . init --refresh --tools all` with zero project-visible drift.
+- Self-dogfood through the current worktree binary; any node that requires
+  guessing or source-reading to proceed is a defect to fix in-repo.
+
+## Acceptance Signals
+- `go build ./...`, `go vet ./...`, `go test ./...` green; toolgen self-loop has
+  zero drift; `go run . validate --json` green from the current worktree.
+- A change bound to a worktree on a mismatched branch surfaces a recovery whose
+  `primary_command` is `slipway run`, and `slipway run` rebinds the recorded
+  branch to the worktree's actual branch and continues (no `slipway repair`
+  dead-end).
+- `slipway repair` with multiple active changes names the conflicting slugs and
+  an executable command (`slipway status` / `slipway cancel --change` /
+  `slipway done --change`); a generic drift finding's next action is
+  `slipway run`, never "inspect the named artifact and rerun".
+- After `slipway abort` in the broken-execution branch, the printed guidance
+  names `slipway run` as the step that clears the interrupted-execution marker;
+  abort→run resolves without a repair↔status loop.
+- The scope-contract recovery guidance diagnostic is present at S2_EXECUTE as
+  well as S3/S4.
+- Recovery JSON object field shape is unchanged; intentional vocabulary changes
+  are covered by contract tests; docs/generated surfaces match.
+
+## Open Questions
+<!-- None: the four dead-ends were mapped against current main (release 0.10.0)
+with exact code locations and minimal fixes confirmed; no blocking unknowns. -->
+
+## Deferred Ideas
+- Preventing dual-active states from arising (vs. making the repair finding
+  actionable) — separate hardening.
+- A dedicated `slipway worktree rebind` subcommand (the `slipway run` re-walk
+  covers the case without a new command surface).
+
+## Approved Summary
+Deliver the rescoped issue #86 as an `external_api_contracts` governed change:
+make every live lifecycle dead-end name an executable next action — worktree
+branch-mismatch rebinds via the existing preflight primitive routed by
+`slipway run`; `slipway repair` dual-active and generic-drift findings name
+executable commands; `slipway abort` points to `slipway run` to clear the
+interrupted-execution marker; and the S2 scope guidance gains narrative parity.
+The obsolete restamp/recover/Tier docs item is dropped (the surface no longer
+exists), and `git`-mutating rebind, dual-active prevention, and the other open
+issues are out of scope. No fail-open or force/bypass path is introduced; public
+recovery JSON shape is preserved with contract tests for the intentional
+vocabulary changes.
+
+Confirmed by user: 2026-06-06 (goal: resolve P3 issues #86/#80 to done-ready).

--- a/artifacts/changes/archived/resolve-the-live-recovery-ux-p3-lifecycle-dead-ends-from-iss/requirements.md
+++ b/artifacts/changes/archived/resolve-the-live-recovery-ux-p3-lifecycle-dead-ends-from-iss/requirements.md
@@ -1,0 +1,59 @@
+# Requirements
+## Project Context
+- Tech Stack: Go
+- Conventions: engine packages under internal/engine (read-only over model); cmd thin orchestrators; model is a leaf; one verdict-evidence YAML per skill under verification/.
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Requirements
+
+### Requirement: Worktree branch-mismatch reopens to an executable rebind
+REQ-001: When a governed change is bound to a worktree whose actual git branch no longer matches the recorded `WorktreeBranch`, the recovery surface MUST name `slipway run` as the primary command (not `slipway repair`), and `slipway run` MUST re-enter worktree-preflight and reconcile the recorded branch to the worktree's actual branch, with no `git checkout`/HEAD mutation and no second writer of `WorktreeBranch`.
+
+#### Scenario: Branch mismatch routes to slipway run and rebinds
+GIVEN an active change at S2_EXECUTE bound to a dedicated worktree whose recorded `WorktreeBranch` differs from the worktree's current git branch
+WHEN `slipway next`/`validate` is evaluated and then `slipway run` is invoked
+THEN the recovery `primary_command` is `slipway run`, the change re-enters worktree-preflight, and after rebinding the recorded `WorktreeBranch` equals the worktree's actual branch and the `dedicated_worktree_branch_mismatch` blocker is cleared.
+
+#### Scenario: Repair no longer claims to fix branch mismatch
+GIVEN a `dedicated_worktree_branch_mismatch` blocker
+WHEN the recovery remediation is rendered
+THEN it does not point to `slipway repair` (which has no branch-rebind code path).
+
+### Requirement: `slipway repair` findings name an executable next action
+REQ-002: `slipway repair` MUST NOT emit non-actionable findings. The dual-active finding MUST name the conflicting change slugs and an executable resolution command (`slipway status`, and `slipway cancel --change <slug>` / `slipway done --change <slug>`); the generic drift finding's next action MUST be `slipway run` (reopen the earliest affected authority), never "inspect the named artifact and rerun the owning Slipway command after correction".
+
+#### Scenario: Dual-active names slugs and commands
+GIVEN repair detects more than one active change
+WHEN the dual-active finding is rendered
+THEN it names the conflicting slugs and an executable command to resolve them, and does not emit the bare "multiple active changes require operator intervention" with a generic next action.
+
+#### Scenario: Generic drift routes to slipway run
+GIVEN a repair drift finding that matches no specific keyword case
+WHEN `repairDriftNextAction` computes the next action
+THEN it returns a `slipway run` instruction, not "inspect the named artifact and rerun".
+
+### Requirement: `slipway abort` names the interrupted-execution clearer
+REQ-003: After `slipway abort` sets `InterruptedExecutionAt`, the printed guidance — including the branch that mentions `slipway repair` — MUST name `slipway run` as the step that clears the interrupted-execution marker, so the operator cannot loop repair↔status without ever clearing it.
+
+#### Scenario: Abort repair branch names slipway run
+GIVEN `slipway abort` resolves its next action to the repair branch (broken execution state)
+WHEN the guidance text is printed
+THEN it instructs the operator to run `slipway repair` to restore integrity and then `slipway run` to clear the interrupted-execution marker and continue.
+
+### Requirement: Scope-contract recovery guidance has surface parity at S2
+REQ-004: The scope-contract recovery guidance diagnostic MUST be emitted at S2_EXECUTE as well as S3_REVIEW/S4_VERIFY, so an operator inspecting an S2 scope-contract failure sees the same explanation that S3/S4 already show. The executable next action at S2 is already covered by per-blocker remediation and the scope-contract advance-reopen gate; this requirement is surface/narrative parity.
+
+#### Scenario: S2 surfaces the scope guidance diagnostic
+GIVEN a change at S2_EXECUTE with a scope-contract blocker
+WHEN readiness diagnostics are computed
+THEN the scope-contract recovery guidance diagnostic is present, as it already is at S3/S4.
+
+### Requirement: Public recovery contract preserved and tested
+REQ-005: The public recovery JSON object field shape (`primary_command`, `primary_action`, `recovery_class`, `steps[]`) MUST remain stable. Each intentional vocabulary change (the branch-mismatch command, repair next actions, abort guidance) MUST be covered by a contract/regression test, and docs plus generated surfaces MUST agree with the resulting behavior after `go run . init --refresh --tools all`.
+
+#### Scenario: Recovery JSON shape unchanged with tested vocabulary
+GIVEN the changed recovery/repair/abort surfaces
+WHEN the recovery JSON and CLI text are rendered and the generated surfaces are refreshed
+THEN the documented recovery object fields are unchanged, the intentional vocabulary changes are asserted by tests, and `git diff --check` after the refresh shows zero project-visible drift.

--- a/artifacts/changes/archived/resolve-the-live-recovery-ux-p3-lifecycle-dead-ends-from-iss/research.md
+++ b/artifacts/changes/archived/resolve-the-live-recovery-ux-p3-lifecycle-dead-ends-from-iss/research.md
@@ -1,0 +1,101 @@
+# Research
+
+Investigation mapped each #86 dead-end against current `main` (release 0.10.0,
+which already contains PR #99 and PR #102). Exact code locations and minimal,
+fail-closed fixes were confirmed for each.
+
+## Alternatives Considered
+
+### Dead-end 1 — worktree branch-mismatch rebind
+- Detection: `internal/state/worktree.go` `ValidateWorktreeAuthenticityReasons`
+  appends `dedicated_worktree_branch_mismatch` (reason `internal/model/reason_code.go`).
+- Trap: `internal/engine/progression/skill_resolution.go` `resolveS2Execute` and
+  `internal/engine/progression/readiness.go` (~`DeriveWorktreeBlockers` fork) route
+  to worktree-preflight ONLY when `WorktreePath == ""`. A bound-but-mismatched
+  worktree falls to the `else` branch → permanent blocker, no rebind route.
+- Hollow remediation: `internal/model/recovery.go` maps
+  `dedicated_worktree_branch_mismatch` to `CommandTemplate: "slipway repair"`, but
+  `internal/state/repair.go` `RepairBoundWorktreeScopeMetadata` never reads/writes
+  `WorktreeBranch` and runs no git — repair cannot resolve it.
+- **Option A (SELECTED):** make the existing worktree-preflight rebind primitive
+  reachable for the branch-mismatch case (relax the `WorktreePath == ""`
+  precondition) and retarget the recovery vocabulary to `slipway run`.
+  worktree-preflight remains the sole writer of `WorktreeBranch`; `slipway run`
+  re-enters it and reconciles the recorded branch to the worktree's actual HEAD.
+- Option B (rejected): add a branch-rebind to `slipway repair`. Introduces a
+  second writer of the branch authority, fighting the single-binder invariant;
+  more code; keeps a non-`run` recovery path.
+
+### Dead-end 2 — repair non-actionable findings
+- Dual-active: `cmd/repair.go` emits "multiple active changes require operator
+  intervention" with the generic default next-action — even though the
+  conflicting slugs are already in hand (`activeChanges` / `unique` map). The
+  sibling `cmd/common.go` `wrapResolutionError` already shows the actionable form
+  (`--change <slug>` + `slipway status`).
+- Generic drift: `repairDriftNextAction` default returns "inspect the named
+  artifact and rerun the owning Slipway command after correction" — names no
+  command, although `governanceDigestRunNextAction` already produces the
+  actionable `slipway run` form for digest drift.
+- **SELECTED:** dual-active names the slugs + `slipway status` /
+  `slipway cancel --change` / `slipway done --change`; generic-drift default
+  routes to `slipway run` (reopen the earliest affected authority). Reuses
+  existing recovery vocabulary; `repairDriftFinding.NextAction` already carries
+  executable commands.
+
+### Dead-end 3 — abort→repair loop
+- `InterruptedExecutionAt` is SET at `cmd/abort.go` and CLEARED ONLY at
+  `cmd/run.go` (on a successful governed run, emitting a `resume.succeeded`
+  event). `slipway repair` never touches it (grep: zero hits in repair paths).
+- In the broken-execution branch, abort advises `slipway repair`; repair ignores
+  the marker; `slipway status` still shows it → repair↔status loop. The common
+  path already advises `run`/`run --resume` correctly via
+  `projectStatusExecutionAction`.
+- **Option (a) (SELECTED):** abort's `case "repair":` guidance also names
+  `slipway run` as the step that clears the interrupted-execution marker. One
+  string; keeps repair in the flow (it fixes the broken summary/checkpoint) but
+  names the legitimate clearer.
+- Option (b) (rejected): make repair clear the marker — wrong layer; the marker
+  is runtime execution state coupled to a successful `run` (forging a "resumed"
+  state without execution evidence violates evidence discipline).
+
+### Dead-end 4 — S2 scope guidance (narrative parity, cosmetic)
+- `internal/engine/progression/readiness.go` `scopeContractNeedsRecoveryGuidance`
+  returns false for S2_EXECUTE (only S3/S4 get the prose guidance diagnostic).
+- The executable next action at S2 is ALREADY adequate: per-blocker remediations
+  (`internal/model/recovery.go` scope reason codes, including `slipway run` for
+  changed-files-missing) plus the `scopeContractReopenTarget` advance gate from
+  PR #102 (`advance_governed.go` / `stale_evidence_recovery.go`) that reopens to
+  S2 on a scope-contract failure. The suppressed diagnostic is narrative only.
+- **SELECTED:** one-line gate relaxation so the diagnostic is emitted at S2 too,
+  for surface parity (the executable path is already covered, so this is
+  explanatory consistency, not a functional dead-end fix).
+
+## Unknowns
+- None blocking. All four dead-ends were located in current code with confirmed
+  fix shapes; the post-#99/#102 recovery model (`slipway run` as the mutating
+  recovery action) is the consistent target for the retargeted vocabulary.
+
+## Assumptions
+- worktree-preflight re-derivation overwrites a stale `WorktreeBranch` from fresh
+  preflight evidence (supported by `ApplyWorktreeMetadata` /
+  `PersistScopeWorktreeMetadata` being the binding writers).
+- `slipway cancel` and `slipway done` accept `--change <slug>` (confirmed:
+  `addChangeSelectorFlags`), so the dual-active guidance names real commands.
+- Public recovery JSON field shape (`primary_command`/`primary_action`/
+  `recovery_class`/`steps[]`) is a stable external contract; only vocabulary
+  values change.
+
+## Canonical References
+- `intent.md` (this bundle) — request and scope.
+- Dead-end 1: `internal/state/worktree.go`, `internal/engine/progression/skill_resolution.go`,
+  `internal/engine/progression/readiness.go`, `internal/engine/progression/validation.go`,
+  `internal/engine/progression/advance_governed.go`, `internal/model/recovery.go`,
+  `internal/model/reason_code.go`, `internal/state/repair.go`.
+- Dead-end 2: `cmd/repair.go` (dual-active block; `repairDriftNextAction`;
+  `governanceDigestRunNextAction`), `cmd/common.go` (`wrapResolutionError`).
+- Dead-end 3: `cmd/abort.go`, `cmd/run.go`, `cmd/status_view_build.go`
+  (`projectStatusExecutionAction`), `internal/state/health.go`.
+- Dead-end 4: `internal/engine/progression/readiness.go`
+  (`scopeContractNeedsRecoveryGuidance`), `internal/model/recovery.go` (scope
+  reason codes), `internal/engine/progression/stale_evidence_recovery.go`
+  (`scopeContractReopenTarget`, PR #102).

--- a/artifacts/changes/archived/resolve-the-live-recovery-ux-p3-lifecycle-dead-ends-from-iss/tasks.md
+++ b/artifacts/changes/archived/resolve-the-live-recovery-ux-p3-lifecycle-dead-ends-from-iss/tasks.md
@@ -1,0 +1,54 @@
+# Tasks
+## Project Context
+- Tech Stack: Go
+- Conventions: engine packages under internal/engine (read-only over model); cmd thin orchestrators; model is a leaf; one verdict-evidence YAML per skill under verification/.
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Task List
+
+- [x] `t-01` Worktree branch-mismatch rebind: route a bound-but-mismatched worktree through the existing worktree-preflight rebind by admitting the `dedicated_worktree_branch_mismatch` authenticity reason into `resolveS2Execute`, `DeriveWorktreeBlockers`, and the advance/readiness gates (relax the strict `WorktreePath == ""` precondition for that case only); retarget the `dedicated_worktree_branch_mismatch` recovery vocabulary from `slipway repair` to `slipway run`. worktree-preflight stays the sole `WorktreeBranch` writer; no git mutation.
+  - wave: 1
+  - depends_on: []
+  - target_files: [internal/state/worktree.go, internal/state/worktree_test.go, internal/engine/progression/advance_governed.go, internal/model/recovery.go, internal/model/recovery_test.go]
+  - task_kind: code
+  - covers: [REQ-001]
+  - evidence: verdict
+  - acceptance: A change bound to a worktree on a mismatched branch surfaces recovery `primary_command=slipway run`; advancing re-enters worktree-preflight and the recorded `WorktreeBranch` is reconciled to the worktree's actual branch with the mismatch blocker cleared; the recovery remediation no longer names `slipway repair`; preflight authenticity stays fail-closed for unregistered/non-dedicated worktrees.
+
+- [x] `t-02` `slipway repair` actionability: dual-active finding names the conflicting slugs and `slipway status` / `slipway cancel --change <slug>` / `slipway done --change <slug>`; `repairDriftNextAction` default routes to a `slipway run` reopen instruction instead of "inspect the named artifact and rerun the owning Slipway command after correction".
+  - wave: 1
+  - depends_on: []
+  - target_files: [cmd/repair.go, cmd/repair_test.go]
+  - task_kind: code
+  - covers: [REQ-002]
+  - evidence: verdict
+  - acceptance: Repair dual-active finding names the conflicting slugs plus an executable resolution command; the generic-drift default next action is a `slipway run` instruction; tests assert the executable commands and `NotContains` the old "inspect the named artifact and rerun" / bare "multiple active changes require operator intervention" dead-end strings.
+
+- [x] `t-03` `slipway abort` repair-branch guidance: the `case "repair":` arm also names `slipway run` as the step that clears the interrupted-execution marker and continues, so abort→repair→status cannot loop.
+  - wave: 1
+  - depends_on: []
+  - target_files: [cmd/abort.go, cmd/abort_test.go]
+  - task_kind: code
+  - covers: [REQ-003]
+  - evidence: verdict
+  - acceptance: After abort resolves to the repair branch, the printed guidance instructs `slipway repair` then `slipway run` to clear the interrupted-execution marker; a test asserts the repair-branch guidance contains `slipway run`; the common (resumable) path still advises `run`/`run --resume`.
+
+- [x] `t-04` S2 scope guidance parity + docs/generated alignment: in `scopeContractNeedsRecoveryGuidance` drop the `state != S3 && state != S4` early-return so the scope-contract recovery guidance diagnostic is emitted at S2_EXECUTE too; update any docs/generated surfaces that describe the changed recovery vocabulary (branch-mismatch command, repair next actions, abort guidance) so they match the new behavior.
+  - wave: 2
+  - depends_on: [t-01, t-02, t-03]
+  - target_files: [internal/engine/progression/readiness.go, internal/engine/progression/readiness_test.go, docs/commands.md, docs/operator-guide.md, internal/tmpl/templates, internal/toolgen]
+  - task_kind: code
+  - covers: [REQ-004, REQ-005]
+  - evidence: verdict
+  - acceptance: The scope-contract recovery guidance diagnostic is present at S2_EXECUTE (test-asserted) without changing the scope blockers/remediations; docs and generated surfaces describe the changed recovery vocabulary; `go run . init --refresh --tools all` leaves zero project-visible drift.
+
+- [x] `t-05` Proof stack and dead-end replays: `go build ./...`, `go vet ./...`, `go test ./...`, `go test ./internal/toolgen/...`, `go run . init --refresh --tools all` + `git diff --check` (zero drift), and `go run . validate --json` green from the current worktree; replay each dead-end (worktree branch-mismatch → `slipway run`; repair dual-active/generic-drift actionable; abort→run clears interrupted execution; S2 scope guidance present) and confirm recovery JSON object field shape is unchanged.
+  - wave: 3
+  - depends_on: [t-01, t-02, t-03, t-04]
+  - target_files: [internal/toolgen]
+  - task_kind: verification
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004, REQ-005]
+  - evidence: checklist
+  - acceptance: All proof commands pass under the current worktree binary; the four dead-end replays each name an executable next action with no dead-end string; the public recovery JSON field shape is unchanged and generated surfaces show zero drift.

--- a/cmd/abort.go
+++ b/cmd/abort.go
@@ -126,7 +126,7 @@ func makeAbortCmd() *cobra.Command {
 				}
 				switch nextAction {
 				case "repair":
-					writer.Writef("Run `slipway repair`, then inspect `slipway status` before retrying execution.\n")
+					writer.Writef("Run `slipway repair` to restore execution integrity, then `slipway run` to clear the interrupted-execution marker and continue.\n")
 				default:
 					writer.Writef("Use `slipway %s` to continue later, or `slipway status` to inspect blockers.\n", nextAction)
 				}

--- a/cmd/abort_test.go
+++ b/cmd/abort_test.go
@@ -145,6 +145,38 @@ func TestAbortClearsCheckpointAndPreservesActiveChange(t *testing.T) {
 	})
 }
 
+func TestAbortRepairBranchGuidanceNamesRun(t *testing.T) {
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+
+		slug := createGovernedRequest(t, root, "L2", "abort repair branch names run")
+		change, err := state.LoadChange(root, slug)
+		require.NoError(t, err)
+		change.CurrentState = model.StateS2Execute
+		change.PlanSubStep = model.PlanSubStepNone
+		require.NoError(t, state.SaveChange(root, change))
+
+		// Corrupt the execution summary so loadExecutionContext errors and abort
+		// resolves to the "repair" guidance branch (#86 dead-end 3).
+		summaryPath := state.ExecutionSummaryPathForRead(root, slug)
+		require.NoError(t, os.MkdirAll(filepath.Dir(summaryPath), 0o755))
+		require.NoError(t, os.WriteFile(summaryPath, []byte("not: [valid: yaml"), 0o644))
+
+		cmd := makeAbortCmd()
+		cmd.SetArgs([]string{"--change", slug})
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetErr(&buf)
+		require.NoError(t, cmd.Execute())
+
+		out := buf.String()
+		assert.Contains(t, out, "`slipway run`",
+			"repair-branch guidance must name slipway run as the interrupted-execution clearer")
+		assert.Contains(t, out, "`slipway repair`")
+	})
+}
+
 func TestAbortTextUsesRunWhenNoResumableWaveStateExists(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {

--- a/cmd/repair.go
+++ b/cmd/repair.go
@@ -214,9 +214,14 @@ func makeRepairCmd() *cobra.Command {
 						unique[ch.Slug] = struct{}{}
 					}
 					if len(unique) > 1 {
+						slugs := make([]string, 0, len(unique))
+						for slug := range unique {
+							slugs = append(slugs, slug)
+						}
+						slices.Sort(slugs)
 						summary.NonRepairableFindings = append(
 							summary.NonRepairableFindings,
-							"multiple active changes require operator intervention",
+							fmt.Sprintf("multiple active changes are active: %s", strings.Join(slugs, ", ")),
 						)
 					}
 				}
@@ -599,8 +604,10 @@ func repairDriftNextAction(reason, target string) string {
 		return "regenerate execution-summary.yaml from current wave-backed task evidence"
 	case strings.Contains(lower, "change authority"), strings.Contains(lower, "change.yaml"):
 		return "repair or replace the authoritative change.yaml before continuing"
+	case strings.Contains(lower, "multiple active changes"):
+		return "run `slipway status` to inspect, then resolve one with `slipway cancel --change <slug>` or `slipway done --change <slug>`"
 	default:
-		return "inspect the named artifact and rerun the owning Slipway command after correction"
+		return "run `slipway run` to reopen the earliest affected authority and re-run the owning stage"
 	}
 }
 

--- a/cmd/repair_test.go
+++ b/cmd/repair_test.go
@@ -502,7 +502,7 @@ func TestBuildUnrepairedDriftFindingsKeepsActionableTargets(t *testing.T) {
 
 	drift := buildUnrepairedDriftFindings([]string{
 		"bundle directory exists without change.yaml: orphan-dir",
-		"multiple active changes require operator intervention",
+		"multiple active changes are active: demo-a, demo-b",
 		"demo: execution summary unreadable: bad yaml",
 	})
 
@@ -513,15 +513,19 @@ func TestBuildUnrepairedDriftFindingsKeepsActionableTargets(t *testing.T) {
 		NextAction: "repair or replace the authoritative change.yaml before continuing",
 	})
 	assert.Contains(t, drift, repairDriftFinding{
-		Target:     "workspace",
-		Reason:     "multiple active changes require operator intervention",
-		NextAction: "inspect the named artifact and rerun the owning Slipway command after correction",
+		Target:     "demo-a, demo-b",
+		Reason:     "multiple active changes are active",
+		NextAction: "run `slipway status` to inspect, then resolve one with `slipway cancel --change <slug>` or `slipway done --change <slug>`",
 	})
 	assert.Contains(t, drift, repairDriftFinding{
 		Target:     "demo",
 		Reason:     "execution summary unreadable: bad yaml",
 		NextAction: "regenerate execution-summary.yaml from current wave-backed task evidence",
 	})
+	// Dead-end strings (#86) must not survive.
+	for _, f := range drift {
+		assert.NotEqual(t, "inspect the named artifact and rerun the owning Slipway command after correction", f.NextAction)
+	}
 }
 
 func TestRepairMaterializesWavePlanRecoversWaveRunsAndClearsStaleCheckpoint(t *testing.T) {
@@ -1209,6 +1213,22 @@ func TestRepairDriftNextActionDigestGuidanceUsesRun(t *testing.T) {
 			assert.NotContains(t, got, "restamp")
 		})
 	}
+}
+
+func TestRepairDriftNextActionGenericAndDualActive(t *testing.T) {
+	t.Parallel()
+
+	// #86: a generic drift finding routes to `slipway run`, not the
+	// "inspect the named artifact and rerun" dead-end.
+	generic := repairDriftNextAction("some unclassified drift", "artifacts/changes/demo")
+	assert.Contains(t, generic, "slipway run")
+	assert.NotContains(t, generic, "inspect the named artifact")
+
+	// #86: the dual-active finding names executable resolution commands.
+	dual := repairDriftNextAction("multiple active changes are active", "demo-a, demo-b")
+	assert.Contains(t, dual, "slipway status")
+	assert.Contains(t, dual, "slipway cancel --change")
+	assert.Contains(t, dual, "slipway done --change")
 }
 
 func TestRepairPathAuthorityUsesLinkedWorktreeInvocationWorkspace(t *testing.T) {

--- a/internal/engine/progression/advance_governed.go
+++ b/internal/engine/progression/advance_governed.go
@@ -70,6 +70,23 @@ func AdvanceGoverned(root, slug string, opts ...AdvanceOptions) (summary Advance
 		return advanceIntake(root, &change, fromState)
 	}
 
+	// 1b. Reconcile a bound worktree whose recorded branch drifted from its actual
+	// git branch (no git mutation) so a branch mismatch resolves via `slipway run`
+	// instead of a hollow `slipway repair` dead-end. Only a pure branch mismatch on
+	// an otherwise-valid dedicated worktree is reconciled; every other authenticity
+	// failure stays fail-closed in the bundle/worktree gates below.
+	if fromState == model.StateS2Execute && strings.TrimSpace(change.WorktreePath) != "" {
+		reconciled, err := state.ReconcileWorktreeBranchBinding(root, &change)
+		if err != nil {
+			return AdvanceSummary{}, err
+		}
+		if reconciled {
+			if err := state.SaveChange(root, change); err != nil {
+				return AdvanceSummary{}, err
+			}
+		}
+	}
+
 	// 2. Bundle precondition check.
 	// Skip at S1_PLAN/research with NeedsDiscovery — research runs before
 	// the full bundle is populated.

--- a/internal/engine/progression/readiness.go
+++ b/internal/engine/progression/readiness.go
@@ -285,7 +285,7 @@ func evaluateGovernanceReadinessBaseWithReaders(
 			readiness.ScopeContract = &cloned
 			readiness.Blockers = append(readiness.Blockers, scopeReport.Blockers...)
 			readiness.Diagnostics = append(readiness.Diagnostics, scopeReport.Diagnostics...)
-			if scopeContractNeedsRecoveryGuidance(effectiveState, scopeReport) {
+			if scopeContractNeedsRecoveryGuidance(scopeReport) {
 				readiness.Diagnostics = append(readiness.Diagnostics, scopeContractRecoveryGuidanceDiagnostic)
 			}
 		}
@@ -419,10 +419,13 @@ func wavePreviewHasReplacementBlockers(blockers []model.ReasonCode) bool {
 	return false
 }
 
-func scopeContractNeedsRecoveryGuidance(state model.WorkflowState, report scopecontract.Report) bool {
-	if state != model.StateS3Review && state != model.StateS4Verify {
-		return false
-	}
+// scopeContractNeedsRecoveryGuidance reports whether the scope-contract recovery
+// guidance diagnostic should be surfaced. It is emitted whenever the contract has
+// blockers, at any lifecycle state (S2_EXECUTE as well as S3_REVIEW/S4_VERIFY) so
+// the explanation has surface parity. The executable next action at S2 is already
+// carried by per-blocker remediation and the scope-contract advance-reopen gate;
+// this diagnostic is the narrative complement.
+func scopeContractNeedsRecoveryGuidance(report scopecontract.Report) bool {
 	return len(report.Blockers) > 0
 }
 

--- a/internal/engine/progression/readiness_test.go
+++ b/internal/engine/progression/readiness_test.go
@@ -8,11 +8,27 @@ import (
 
 	"github.com/signalridge/slipway/internal/bootstrap"
 	"github.com/signalridge/slipway/internal/engine/governance"
+	"github.com/signalridge/slipway/internal/engine/scopecontract"
 	"github.com/signalridge/slipway/internal/model"
 	"github.com/signalridge/slipway/internal/state"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestScopeContractRecoveryGuidanceHasSurfaceParity pins #86 dead-end (4): the
+// scope-contract recovery guidance diagnostic is emitted whenever the contract
+// has blockers, at any lifecycle state (S2_EXECUTE as well as S3/S4) — no
+// state-gated suppression.
+func TestScopeContractRecoveryGuidanceHasSurfaceParity(t *testing.T) {
+	t.Parallel()
+
+	withBlockers := scopecontract.Report{Blockers: []model.ReasonCode{model.NewReasonCode("scope_contract_drift", "")}}
+	assert.True(t, scopeContractNeedsRecoveryGuidance(withBlockers),
+		"scope guidance must surface whenever there are blockers, including at S2_EXECUTE")
+
+	clean := scopecontract.Report{}
+	assert.False(t, scopeContractNeedsRecoveryGuidance(clean))
+}
 
 func TestEvaluateArtifactReadinessWithContext_IgnoresDependenciesOutsideEligibleLevel(t *testing.T) {
 	t.Parallel()

--- a/internal/model/recovery.go
+++ b/internal/model/recovery.go
@@ -127,9 +127,9 @@ var blockerRemediations = map[string]blockerRemediation{
 		Priority:        15,
 	},
 	"dedicated_worktree_branch_mismatch": {
-		Remediation:     "Repair the dedicated worktree binding so the recorded branch matches the bound worktree.",
-		CommandTemplate: "slipway repair",
-		Class:           RecoveryClassSatisfyControl,
+		Remediation:     "Run `slipway run` to reconcile the recorded branch to the bound worktree's actual branch and continue.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRerunSkill,
 	},
 	"dedicated_worktree_metadata_required": {
 		Remediation:     "Record or repair dedicated worktree metadata before continuing.",

--- a/internal/model/recovery_test.go
+++ b/internal/model/recovery_test.go
@@ -303,6 +303,20 @@ func TestBuildRecoveryNilOnCleanState(t *testing.T) {
 	assert.Nil(t, BuildRecovery(nil))
 }
 
+func TestBuildRecoveryWorktreeBranchMismatchRoutesToRun(t *testing.T) {
+	t.Parallel()
+
+	// #86: a bound-worktree branch mismatch must route to `slipway run` (which
+	// reconciles the recorded branch), not the hollow `slipway repair` dead-end.
+	got := BuildRecovery([]ReasonCode{
+		NewReasonCode("dedicated_worktree_branch_mismatch", ""),
+	})
+	require.NotNil(t, got)
+	assert.Equal(t, "slipway run", got.PrimaryCommand)
+	assert.NotContains(t, got.PrimaryAction, "slipway repair")
+	assert.Contains(t, got.PrimaryAction, "slipway run")
+}
+
 func TestBuildRecoverySelectsPrimaryByStagePriority(t *testing.T) {
 	t.Parallel()
 

--- a/internal/state/worktree.go
+++ b/internal/state/worktree.go
@@ -373,6 +373,63 @@ func ValidateDedicatedWorktreeAuthenticityReasons(repoRoot, worktreePath, expect
 	return nil, nil
 }
 
+// resolveWorktreeActualBranch returns the git branch the bound worktree is
+// actually on (the same value ValidateWorktreeAuthenticityReasons compares
+// against). It performs no mutation.
+func resolveWorktreeActualBranch(worktreePath string) (string, error) {
+	normalizedPath, err := NormalizePath(worktreePath)
+	if err != nil {
+		return "", err
+	}
+	if actualBranch, ok := gitBranchFromMetadata(normalizedPath); ok {
+		return strings.TrimSpace(actualBranch), nil
+	}
+	cmd := exec.Command("git", "-C", normalizedPath, "rev-parse", "--abbrev-ref", "HEAD")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("resolve worktree branch: %w (%s)", err, strings.TrimSpace(string(out)))
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// ReconcileWorktreeBranchBinding realigns a bound change's recorded
+// WorktreeBranch to the worktree's actual git branch when the ONLY authenticity
+// problem is a branch mismatch on an otherwise-valid dedicated worktree. It is a
+// metadata reconciliation — no `git checkout`/HEAD move — routed through the
+// canonical PersistScopeWorktreeMetadata setter, so worktree-preflight remains
+// the initial binder and this only realigns an existing binding to reality.
+//
+// It returns (false, nil) and leaves the change untouched for any other
+// condition (unbound, path invalid/unregistered, non-dedicated, or no mismatch),
+// preserving the worktree gate's fail-closed behavior for those cases.
+func ReconcileWorktreeBranchBinding(repoRoot string, change *model.Change) (bool, error) {
+	if change == nil {
+		return false, nil
+	}
+	worktreePath := strings.TrimSpace(change.WorktreePath)
+	if worktreePath == "" || strings.TrimSpace(change.WorktreeBranch) == "" {
+		return false, nil
+	}
+	reasons, err := ValidateDedicatedWorktreeAuthenticityReasons(repoRoot, worktreePath, change.WorktreeBranch)
+	if err != nil {
+		return false, err
+	}
+	if len(reasons) != 1 || strings.TrimSpace(reasons[0].Code) != WorktreeReasonBranchMismatch {
+		return false, nil
+	}
+	actualBranch, err := resolveWorktreeActualBranch(worktreePath)
+	if err != nil {
+		return false, err
+	}
+	if actualBranch == "" || actualBranch == strings.TrimSpace(change.WorktreeBranch) {
+		return false, nil
+	}
+	if err := PersistScopeWorktreeMetadata(change, change.WorktreePath, actualBranch); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 func reasonCodesFromWorktreeReasons(reasons []string) []model.ReasonCode {
 	if len(reasons) == 0 {
 		return nil

--- a/internal/state/worktree_test.go
+++ b/internal/state/worktree_test.go
@@ -210,6 +210,40 @@ func TestListGitWorktreesCachedWithListerDoesNotCacheStaleResultWhenProbeChanges
 	assert.Equal(t, 2, calls, "probe changes during listing must prevent caching stale worktree sets")
 }
 
+func TestReconcileWorktreeBranchBindingRealignsBranchMismatch(t *testing.T) {
+	repoRoot, worktreePath := setupRepoWithWorktree(t)
+
+	// The worktree is actually on "feature"; record a mismatched branch.
+	change := model.NewChange("rebind-demo")
+	change.WorktreePath = worktreePath
+	change.WorktreeBranch = "main"
+
+	reconciled, err := ReconcileWorktreeBranchBinding(repoRoot, &change)
+	require.NoError(t, err)
+	assert.True(t, reconciled, "a pure branch mismatch on a dedicated worktree must reconcile")
+	assert.Equal(t, "feature", change.WorktreeBranch, "recorded branch realigned to the worktree's actual branch")
+
+	// Now that the binding matches reality, a second reconcile is a no-op.
+	reconciledAgain, err := ReconcileWorktreeBranchBinding(repoRoot, &change)
+	require.NoError(t, err)
+	assert.False(t, reconciledAgain)
+}
+
+func TestReconcileWorktreeBranchBindingLeavesNonBranchMismatchAlone(t *testing.T) {
+	repoRoot, _ := setupRepoWithWorktree(t)
+
+	// An invalid/unregistered worktree path is NOT a pure branch mismatch, so
+	// reconcile must fail closed and leave the recorded branch untouched.
+	change := model.NewChange("rebind-noop")
+	change.WorktreePath = filepath.Join(repoRoot, "missing")
+	change.WorktreeBranch = "feature"
+
+	reconciled, err := ReconcileWorktreeBranchBinding(repoRoot, &change)
+	require.NoError(t, err)
+	assert.False(t, reconciled)
+	assert.Equal(t, "feature", change.WorktreeBranch)
+}
+
 func setupRepoWithWorktree(t *testing.T) (repoRoot string, worktreePath string) {
 	t.Helper()
 	repoRoot = t.TempDir()


### PR DESCRIPTION
## Summary
Resolves the live Recovery UX P3 lifecycle dead-ends from #86 (rescoped) so every blocked governance state names an **executable** next action. No fail-open or force/bypass path is introduced; the public recovery JSON object field shape (`primary_command`/`primary_action`/`recovery_class`/`steps[]`) is preserved.

## Fixes
- **Worktree branch mismatch → `slipway run`.** A change bound to a worktree whose recorded branch drifted from its actual git HEAD now reconciles via `ReconcileWorktreeBranchBinding` (routed through the canonical `PersistScopeWorktreeMetadata` setter — no `git checkout`, no second branch-authority writer, **fail-closed** for every other authenticity failure). The recovery vocabulary retargets from the hollow `slipway repair` to `slipway run`.
- **`slipway repair` actionability.** The dual-active finding names the conflicting slugs plus `slipway status` / `slipway cancel --change` / `slipway done --change`; the generic-drift default routes to `slipway run` instead of "inspect the named artifact and rerun".
- **`slipway abort` loop.** The repair-branch guidance also names `slipway run` as the step that clears the interrupted-execution marker, so abort→repair→status cannot loop.
- **S2 scope guidance parity.** The scope-contract recovery guidance diagnostic now surfaces at S2_EXECUTE too (the executable next action was already covered by per-blocker remediation + the #102 advance-reopen gate).

## Dropped (obsolete)
- #86 item 5 (reconcile docs with the restamp/recover/Tier surface): PR #99 removed that surface entirely.

## Out of scope
- Adding a `git checkout`/branch-switch (rebind only reconciles recorded metadata to the actual HEAD).
- Dual-active *prevention* (this only makes the existing dual-active repair finding actionable).
- #95/#92/#91/#88/#80/#75 — separate efforts.

## Verification
- `go build/vet/test ./...` green; `golangci-lint run` → 0 issues.
- `go run . init --refresh --tools all` + `git diff --check` → zero project-visible drift (no generated surface references the changed vocabulary).
- Each dead-end has a focused regression: `TestReconcileWorktreeBranchBinding*`, `TestBuildRecoveryWorktreeBranchMismatchRoutesToRun`, `TestBuildUnrepairedDriftFindingsKeepsActionableTargets`, `TestRepairDriftNextActionGenericAndDualActive`, `TestAbortRepairBranchGuidanceNamesRun`, `TestScopeContractRecoveryGuidanceHasSurfaceParity`.
- Driven through the full Slipway governed flow to done-ready (per-change `validate --json` fresh, gates approved).

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)