### PR TITLE
feat(codebase-map): add host-AI semantic staleness self-check + inline refresh (#80)

### DIFF
--- a/artifacts/changes/archived/add-host-ai-semantic-staleness-detection-and-inline-refresh/assurance.md
+++ b/artifacts/changes/archived/add-host-ai-semantic-staleness-detection-and-inline-refresh/assurance.md
@@ -1,0 +1,69 @@
+# Assurance
+## Project Context
+- Tech Stack: Go
+- Conventions: engine under internal/engine (read-only over model); cmd thin orchestrators; generated skills/commands from internal/tmpl/templates + toolgen; one verdict-evidence YAML per skill under verification/.
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Scope Summary
+Adds host-AI semantic staleness detection and inline refresh for the codebase map
+(issue #80). The engine adds a non-blocking consume-time advisory
+(`codebaseMapRelevanceAdvisory`) for `populated`/`partial` maps under
+research-orchestration/plan-audit that states the status reflects content
+presence, not scope relevance, and prompts a host relevance self-check + inline
+refresh. The research-orchestration, plan-audit, and codebase-mapping skills
+instruct the host to judge a populated map against the current change scope and
+re-author stale sections inline (the assessment re-reads the docs, so the inline
+edit is the refresh). The codebase-map reference doc replaces the rejected
+git-mtime/entry-point/lockfile staleness fingerprint with that host-AI semantic
+relevance judgment. No engine fingerprint, no metadata file, no new CLI flag, no
+blocking gate; public JSON field shape is unchanged (the advisory is an additive
+`warnings` entry). Classified `external_api_contracts` (additive public JSON +
+generated host-tool guidance).
+
+## Verification Verdict
+Pass for implementation, tests, and review up to the S4 goal/closeout handoff.
+`go build/vet/test ./...` green; `golangci-lint run` 0 issues;
+`go run . init --refresh --tools all` regenerates only the intended skill/
+reference additions.
+
+## Evidence Index
+- Engine trigger (t-01): `cmd/next_skill_view.go` `codebaseMapRelevanceAdvisory`
+  + the advisory-chain branch; tests `TestCodebaseMapRelevanceAdvisoryMatrix`,
+  `TestNextSurfacesCodebaseMapRelevanceAdvisoryForPopulatedMap`.
+- Skill + reference guidance (t-02): research-orchestration / plan-audit /
+  codebase-mapping `SKILL.md` populated-map self-check + inline-refresh
+  instruction; `context-assembly/references/codebase-map.md` staleness rewrite.
+- Proof (t-03): build/vet/test, golangci-lint, toolgen, init-refresh.
+
+## Requirement Coverage
+- REQ-001: `cmd/next_skill_view.go` `codebaseMapRelevanceAdvisory` + wiring;
+  advisory-matrix + integration tests.
+- REQ-002: research-orchestration / plan-audit / codebase-mapping SKILL templates.
+- REQ-003: `context-assembly/references/codebase-map.md` staleness rewrite.
+- REQ-004: advisory additive (no JSON field-shape change), non-blocking
+  (`view.Warnings`), generated surfaces regenerated with only intended additions.
+
+## Residual Risks and Exceptions
+- The engine cannot judge semantic relevance; it only surfaces the trigger. The
+  host AI owns the relevance judgment and the inline refresh — by design (engine
+  owns structure/trigger, skill owns substance). If a host ignores the advisory,
+  the map is still consumed; the advisory is intentionally non-blocking.
+- Inline refresh relies on the host re-authoring the doc in place; no engine
+  overwrite of authored content (the never-clobber invariant is preserved). A
+  `--refresh` convenience flag is deferred.
+- The codebase map remains advisory; source and live `go run .` output are the
+  authorities.
+
+## Rollback Readiness
+Rollback is a branch revert. No data migration; no engine state added. Generated
+skills/docs revert with the templates.
+
+## Archive Decision
+Proceed to done-ready after S4 `goal-verification` and `final-closeout` pass.
+Active `go run . validate --json` freshness/readiness proof must be captured
+before `slipway done`; archived bundles are not described as revalidated through
+the active validate gate. (Global `health --governance` reflects concurrent
+multi-active changes in other worktrees — an environment condition, not this
+change.)

--- a/artifacts/changes/archived/add-host-ai-semantic-staleness-detection-and-inline-refresh/change.yaml
+++ b/artifacts/changes/archived/add-host-ai-semantic-staleness-detection-and-inline-refresh/change.yaml
@@ -1,0 +1,50 @@
+version: 1
+slug: add-host-ai-semantic-staleness-detection-and-inline-refresh
+description: 'Add host-AI semantic staleness detection and inline refresh for the codebase map (issue #80). Today AssessCodebaseMapDocs derives status from pure content presence, so a codebase map authored for a PRIOR change passes as good-enough with zero signal; EnsureCodebaseMapDocs skips already-populated docs so the documented ''rerun slipway codebase-map'' remediation cannot refresh a populated-but-stale map; and the consume advisory is silent for populated/partial maps. Replace the rejected git-mtime/entry-point/lockfile staleness heuristics with a host-AI relevance self-check surfaced at codebase-map consume time, and allow the host to refresh populated docs inline when the map no longer matches the current change scope. Keep it advisory/non-blocking and record the refresh as evidence.'
+status: done
+current_state: DONE
+needs_discovery: true
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-06-06T14:41:52.4081Z
+quality_mode: standard
+workflow_preset: standard
+worktree_branch: feat/add-host-ai-semantic-staleness-detection-and-inline-refresh
+artifact_schema: expanded
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: 78632a225f0d40ed44935bbf458a98de7efa648208f01447bc684321af67318c
+        updated_at: 2026-06-06T14:58:00.717979076Z
+    decision:
+        id: decision
+        path: decision.md
+        state: frozen
+        content_hash: 8d71e4df2472efcdf0acbad1615fd37f0392f45b508243b0251bdaa18a179d66
+        updated_at: 2026-06-06T14:50:06.026904523Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: 6b11d7f0ac7eb6ad9766734336561fd4c6175506def187f063c821cb585630c4
+        updated_at: 2026-06-06T14:46:12.536966042Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: 69f6c99023e61a747db8ec7a89174d7cd0415d17cb96cf3ed4a1cf9adcd8b607
+        updated_at: 2026-06-06T14:49:33.373118242Z
+    research:
+        id: research
+        path: research.md
+        state: frozen
+        content_hash: 6e069dc001336fe59ce589d907ae0800981e02c6f4d1db8e182d57fbd2a3b63e
+        updated_at: 2026-06-06T14:48:20.393650744Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: 79be45dcb1fe199212758c340e53af0284892da1e39a06311af8c5beac820fb7
+        updated_at: 2026-06-06T14:57:17.49897413Z

--- a/artifacts/changes/archived/add-host-ai-semantic-staleness-detection-and-inline-refresh/decision.md
+++ b/artifacts/changes/archived/add-host-ai-semantic-staleness-detection-and-inline-refresh/decision.md
@@ -1,0 +1,78 @@
+# Decision
+## Project Context
+- Tech Stack: Go
+- Conventions: engine under internal/engine (read-only over model); cmd thin orchestrators; generated skills/commands from internal/tmpl/templates + toolgen; one verdict-evidence YAML per skill under verification/.
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Selected Approach
+Extend the existing non-durable consume-advisory pattern to `populated` maps,
+split cleanly across the engine/skill boundary:
+
+1. **Engine trigger (REQ-001).** Add `codebaseMapRelevanceAdvisory(status,
+   nextSkillName)` in `cmd/next_skill_view.go` that fires for
+   `CodebaseMapStatusPopulated` / `CodebaseMapStatusPartial` when the next skill
+   is research-orchestration or plan-audit, wired as a new branch in the existing
+   mutually-exclusive advisory chain at the S1 call site and routed through the
+   non-blocking `view.Warnings`. The wording states the status reflects content
+   presence, not scope relevance, and prompts a host relevance self-check +
+   inline refresh. The engine cannot judge relevance itself, so it only triggers.
+2. **Skill judgment (REQ-002).** research-orchestration / plan-audit /
+   codebase-mapping SKILL templates instruct the host to treat `populated` as
+   "present, not verified-relevant," judge the map against the current change
+   scope, and re-author stale sections inline. Re-authoring the .md in place IS
+   the inline refresh because `AssessCodebaseMapDocs` re-reads on every
+   assessment — no engine overwrite, no clobbering authored content.
+3. **Reference doc (REQ-003).** Rewrite the "When stale or invalid" section of
+   `context-assembly/references/codebase-map.md` to a host-AI semantic relevance
+   judgment + inline re-author, removing the git-mtime / entry-point /
+   lockfile-mismatch fingerprint definition.
+
+## Key Decisions
+- Engine owns the TRIGGER, skills own the JUDGMENT — the engine has no semantic
+  model of change-vs-map, so it can only state "populated ≠ verified-relevant"
+  and prompt; the host judges + refreshes. [research]
+- Advisory is non-blocking (`view.Warnings`), additive for a status that
+  previously produced none; public JSON field shape unchanged. [research]
+- Inline refresh = host re-authors the .md in place (engine re-reads on assess);
+  no new state, no clobbering of authored content. [research]
+
+## Rejected Alternatives
+- New engine staleness/fingerprint algorithm (mtime/git/lockfile): rejected by
+  the issue; reintroduces engine-owned heuristics.
+- `scoped_to`/timestamp/needs-refresh metadata file: reintroduces engine-owned
+  freshness state.
+- `slipway codebase-map --refresh`/`--force` flag: a new public command surface;
+  inline refresh already works via host re-author; deferred.
+- Blocking advisory: the issue wants advisory/non-blocking host judgment.
+
+## Interfaces and Data Flow
+- `cmd/next_skill_view.go`: new `codebaseMapRelevanceAdvisory` + a branch at the
+  existing advisory call site; output flows into `view.Warnings` →
+  `next`/`run` JSON `warnings` (additive). No change to `codebase_map_status` /
+  `codebase_map_doc_states` fields.
+- Generated skills regenerate from the edited SKILL templates + reference doc via
+  toolgen / `slipway init --refresh`.
+- No schema change; no new CLI flag; no engine assessment change.
+
+## Rollout and Rollback
+- Rollout: additive advisory + skill/doc guidance; no flag. Verified by
+  `go build/vet/test ./...`, `golangci-lint run`, `go test ./internal/toolgen/...`,
+  `go run . init --refresh --tools all` + diff review (only intended additions),
+  and an advisory-matrix test.
+- Rollback: revert the branch. No data migration; no engine state added.
+  Generated skills/docs revert with code.
+
+## Risk
+- Advisory could double-fire with the existing non-durable advisory → the chain
+  is mutually exclusive (consume/discovery advisories return "" for populated);
+  add a matrix test pinning populated→relevance-advisory and non-durable→existing
+  advisory.
+- Existing test asserts populated→no advisory → update it to expect the new
+  relevance advisory (the durability advisory still returns "" for populated;
+  only the new relevance advisory fires).
+- Generated-surface drift from template edits → regenerate and review that only
+  the intended skill/reference additions appear.
+- Engine/skill boundary creep → keep the engine output to a trigger string only;
+  the semantic judgment + refresh lives entirely in the skills/doc.

--- a/artifacts/changes/archived/add-host-ai-semantic-staleness-detection-and-inline-refresh/intent.md
+++ b/artifacts/changes/archived/add-host-ai-semantic-staleness-detection-and-inline-refresh/intent.md
@@ -1,0 +1,122 @@
+# Intent
+
+## Summary
+Add host-AI semantic staleness detection and inline refresh for the codebase map
+(issue #80). Today `AssessCodebaseMapDocs` derives status from pure content
+presence, so a codebase map authored for a PRIOR change scores `populated` and is
+consumed as authoritative with zero signal; the consume advisory
+(`codebaseMapConsumeAdvisory`) is silent for `populated` maps; and the only
+staleness guidance (`context-assembly/references/codebase-map.md`) uses the
+git-mtime / renamed-entry-point / lockfile-mismatch fingerprint heuristics this
+issue explicitly rejects. Replace that with a host-AI relevance self-check
+surfaced at codebase-map consume time, and instruct the host to refresh stale
+sections inline (re-author the doc in place — the engine re-reads on every
+assessment) when the map no longer matches the current change scope. Keep it
+advisory/non-blocking; the engine owns the trigger, the skills own the judgment.
+
+## Complexity Assessment
+complex
+<!-- Rationale -->
+Touches a public consume-time surface (`next`/`run` warnings), three generated
+governed skills, and a reference doc that several skills depend on. The risk is
+low (additive, non-blocking advisory; no new engine fingerprint; no blocking
+gate) but the change must keep the engine/skill boundary clean — the engine can
+only state "populated ≠ verified-relevant," and the host AI owns the semantic
+relevance judgment and the inline refresh.
+
+## Guardrail Domains
+`external_api_contracts` — intent-based. The change adds a new advisory string to
+the public `next`/`run` JSON `warnings` for `populated` codebase maps and changes
+generated host-tool guidance (research-orchestration / plan-audit /
+codebase-mapping skills) plus the codebase-map reference doc. The advisory is
+purely additive (a status that previously produced no advisory); no existing
+JSON field shape changes. Generated-surface refresh must show only the intended
+additions.
+
+## In Scope
+- Engine trigger: add `codebaseMapRelevanceAdvisory` in `cmd/next_skill_view.go`
+  that fires for a `populated` (and `partial`) codebase map when the next skill
+  is a map consumer (research-orchestration / plan-audit), wired into the
+  existing mutually-exclusive advisory chain and routed through the non-blocking
+  `view.Warnings`. The advisory states that status reflects content presence, not
+  scope relevance, and prompts the host to judge relevance and refresh stale
+  sections inline.
+- Skill instructions (the host-AI judgment + refresh action):
+  `research-orchestration/SKILL.md`, `plan-audit/SKILL.md`, and
+  `codebase-mapping/SKILL.md` — when the map is `populated`, the host must still
+  judge whether it matches the current change scope (affected seams, blast
+  radius, concerns) and re-author stale/irrelevant sections inline before relying
+  on it; `populated` ≠ relevant.
+- Reference doc: rewrite the "When stale or invalid" section of
+  `context-assembly/references/codebase-map.md` to replace the
+  mtime/entry-point/lockfile fingerprint definition with a host-AI semantic
+  relevance judgment ("re-read the populated doc and judge whether it still
+  describes the area in scope; if not, re-author the file in place — there is no
+  engine staleness flag").
+- Tests: advisory matrix for the new relevance advisory (fires for
+  populated/partial under consuming skills; empty for non-consumers and for the
+  non-durable statuses the existing advisories own); update the existing test
+  that asserts `populated` produces no advisory.
+- Regenerate generated skills/commands; zero unintended drift.
+
+## Out of Scope
+- A new engine staleness/fingerprint algorithm (mtime/git/lockfile) — explicitly
+  rejected by the issue.
+- A `scoped_to` / timestamp / "needs refresh" metadata file on the codebase map —
+  would reintroduce engine-owned freshness state.
+- A new `slipway codebase-map --refresh`/`--force` CLI flag — the host re-authors
+  the doc in place (the engine re-reads on assessment), so inline refresh needs
+  no new command surface; a convenience re-scaffold flag is deferred.
+- Making the advisory a blocker — it stays advisory/non-blocking.
+- Issues #95/#92/#91/#88/#86/#75 — separate efforts.
+
+## Constraints
+- Engine owns the trigger only; the engine cannot judge semantic relevance (no
+  model of change-vs-map). The host AI owns relevance judgment + inline refresh
+  via the skills.
+- Advisory is non-blocking (`view.Warnings`), never a blocker; it must not gate
+  progression.
+- Public JSON field shape is unchanged (the advisory is an additive warning
+  string); generated-surface refresh shows only the intended additions.
+- The never-auto-clobber-authored-content invariant of `EnsureCodebaseMapDocs`
+  stays intact (no engine overwrite of populated docs).
+- Verify against the repo's own loop: `go build/vet/test ./...`,
+  `go test ./internal/toolgen/...`, current-worktree `go run . init --refresh
+  --tools all` with zero unintended drift, and `golangci-lint run` clean.
+
+## Acceptance Signals
+- `go build/vet/test ./...` green; `golangci-lint run` 0 issues; toolgen
+  self-loop drift is only the intended generated-skill additions.
+- A `populated` codebase map consumed by research-orchestration / plan-audit
+  surfaces a non-blocking advisory that says status reflects content presence not
+  scope relevance and prompts the host to judge relevance + refresh inline; the
+  advisory does not appear for non-consuming skills.
+- The three consuming/authoring skills instruct the host to self-check a
+  populated map against the current change scope and re-author stale sections
+  inline; the codebase-map reference doc no longer defines staleness via
+  mtime/entry-point/lockfile heuristics.
+- Public `next`/`run` JSON field shape is unchanged; the advisory is an additive
+  `warnings` entry.
+
+## Open Questions
+<!-- None: the consume-advisory trigger, the engine/skill boundary, and the
+target skills/doc were mapped against current main (release 0.10.0) with exact
+code locations confirmed; no blocking unknowns. -->
+
+## Deferred Ideas
+- A `slipway codebase-map --refresh` flag to re-scaffold a stale populated doc
+  back to baseline as a re-authoring starting point.
+- Recording the refresh as explicit governed evidence.
+
+## Approved Summary
+Deliver issue #80 as an `external_api_contracts` governed change: the engine adds
+a non-blocking consume-time advisory for `populated` codebase maps stating that
+status reflects content presence, not scope relevance; the consuming/authoring
+skills (research-orchestration, plan-audit, codebase-mapping) instruct the host
+AI to judge a populated map against the current change scope and re-author stale
+sections inline; and the codebase-map reference doc replaces the rejected
+git-mtime/entry-point/lockfile staleness heuristics with that host-AI semantic
+relevance judgment. No engine fingerprint, no metadata file, no new CLI flag, no
+blocking gate; public JSON field shape is unchanged.
+
+Confirmed by user: 2026-06-06 (goal: resolve P3 issues #86/#80 to done-ready).

--- a/artifacts/changes/archived/add-host-ai-semantic-staleness-detection-and-inline-refresh/requirements.md
+++ b/artifacts/changes/archived/add-host-ai-semantic-staleness-detection-and-inline-refresh/requirements.md
@@ -1,0 +1,46 @@
+# Requirements
+## Project Context
+- Tech Stack: Go
+- Conventions: engine packages under internal/engine (read-only over model); cmd thin orchestrators; generated skills/commands come from internal/tmpl/templates and toolgen; one verdict-evidence YAML per skill under verification/.
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Requirements
+
+### Requirement: Populated codebase map surfaces a non-blocking relevance self-check advisory
+REQ-001: When a map-consuming planning skill (research-orchestration or plan-audit) is next and the codebase map status is `populated` (or `partial`), `slipway next`/`run` MUST surface a non-blocking advisory stating that the status reflects content presence, not scope relevance, and prompting the host to judge whether the map matches the current change and refresh stale sections inline. The advisory MUST be a `warnings` entry (never a blocker) and MUST NOT change any existing JSON field shape.
+
+#### Scenario: Populated map consumed by a planning skill warns about relevance
+GIVEN a `populated` codebase map and the next skill is research-orchestration or plan-audit
+WHEN `slipway next --json` is rendered
+THEN a non-blocking `warnings` advisory is present that names the populated status, states it reflects content presence rather than scope relevance, and prompts a host relevance self-check + inline refresh.
+
+#### Scenario: Non-consuming skill gets no relevance advisory
+GIVEN a `populated` codebase map and the next skill is not a map consumer
+WHEN `slipway next --json` is rendered
+THEN no relevance advisory is emitted.
+
+### Requirement: Consuming skills instruct the host to self-check and refresh inline
+REQ-002: The research-orchestration, plan-audit, and codebase-mapping skills MUST instruct the host that a `populated` map is not automatically relevant — the host MUST judge whether it matches the current change scope (affected seams, blast radius, concerns) and re-author stale/irrelevant sections inline before relying on it.
+
+#### Scenario: Skills carry the populated-map self-check instruction
+GIVEN the generated research-orchestration, plan-audit, and codebase-mapping skills
+WHEN their codebase-map guidance is inspected
+THEN each instructs the host to verify a populated map against the current change and refresh stale sections inline (populated ≠ relevant).
+
+### Requirement: Staleness guidance is host-AI semantic relevance, not engine fingerprints
+REQ-003: The codebase-map reference (`context-assembly/references/codebase-map.md`) MUST define populated-map staleness as a host-AI semantic relevance judgment with inline re-authoring, and MUST NOT define it via git-mtime distance, renamed entry points, or lockfile mismatch.
+
+#### Scenario: Reference doc drops the fingerprint heuristics
+GIVEN the codebase-map reference doc
+WHEN its staleness section is inspected
+THEN it describes re-reading the populated doc and judging scope relevance with inline re-author, and contains no git-mtime / entry-point-rename / lockfile-mismatch staleness rule.
+
+### Requirement: Change is additive and generated surfaces stay aligned
+REQ-004: The advisory MUST be additive (no existing JSON field shape changes; no engine fingerprint algorithm; no new metadata file; no blocking gate). Generated skills/commands MUST be regenerated so the host surfaces match, with only the intended additions appearing in the diff.
+
+#### Scenario: Additive surface with aligned generation
+GIVEN the implementation
+WHEN `go run . init --refresh --tools all` runs and the project diff is checked
+THEN the only generated changes are the intended skill/reference additions, the public JSON field shape is unchanged, and `go build/vet/test ./...` plus `golangci-lint run` are clean.

--- a/artifacts/changes/archived/add-host-ai-semantic-staleness-detection-and-inline-refresh/requirements.md
+++ b/artifacts/changes/archived/add-host-ai-semantic-staleness-detection-and-inline-refresh/requirements.md
@@ -9,10 +9,10 @@
 ## Requirements
 
 ### Requirement: Populated codebase map surfaces a non-blocking relevance self-check advisory
-REQ-001: When a map-consuming planning skill (research-orchestration or plan-audit) is next and the codebase map status is `populated` (or `partial`), `slipway next`/`run` MUST surface a non-blocking advisory stating that the status reflects content presence, not scope relevance, and prompting the host to judge whether the map matches the current change and refresh stale sections inline. The advisory MUST be a `warnings` entry (never a blocker) and MUST NOT change any existing JSON field shape.
+REQ-001: When a durable-map consumer (research-orchestration or plan-audit at S1_PLAN, or wave-orchestration at S2_EXECUTE) is next and the codebase map status is `populated` (or `partial`), `slipway next`/`run` MUST surface a non-blocking advisory stating that the status reflects content presence, not scope relevance, and prompting the host to judge whether the map matches the current change and refresh stale sections inline. The advisory MUST fire independent of lifecycle state (so the issue #80 wave-orchestration handoff is covered), MUST be a `warnings` entry (never a blocker), and MUST NOT change any existing JSON field shape.
 
-#### Scenario: Populated map consumed by a planning skill warns about relevance
-GIVEN a `populated` codebase map and the next skill is research-orchestration or plan-audit
+#### Scenario: Populated map consumed by a durable-map consumer warns about relevance
+GIVEN a `populated` codebase map and the next skill is research-orchestration, plan-audit, or wave-orchestration
 WHEN `slipway next --json` is rendered
 THEN a non-blocking `warnings` advisory is present that names the populated status, states it reflects content presence rather than scope relevance, and prompts a host relevance self-check + inline refresh.
 

--- a/artifacts/changes/archived/add-host-ai-semantic-staleness-detection-and-inline-refresh/research.md
+++ b/artifacts/changes/archived/add-host-ai-semantic-staleness-detection-and-inline-refresh/research.md
@@ -1,0 +1,81 @@
+# Research
+
+Mapped issue #80 against current main (release 0.10.0). Exact code locations and
+a minimal, advisory/non-blocking fix confirmed.
+
+## Alternatives Considered
+
+### Where the gap is (engine, content-presence only)
+- `internal/engine/artifact/codebase_map.go` `AssessCodebaseMapDocs` (~628-680)
+  classifies each doc as scaffold_only / baseline / populated / missing purely by
+  CONTENT comparison against the scaffold and the deterministic CLI baseline.
+  `populated` means only "differs from scaffold/baseline" — NOT "relevant to or
+  fresh for the current change." A map authored for a prior change scores
+  `populated` forever. There is no relevance/recency/scoped-to input and no
+  per-doc metadata file.
+- `EnsureCodebaseMapDocs` (~120-150) re-scaffolds only scaffold-only/legacy docs
+  and `continue`s past populated ones (never clobbers authored content), so
+  `slipway codebase-map` cannot itself refresh a populated-but-stale doc.
+- `cmd/next_skill_view.go` `codebaseMapConsumeAdvisory` (~361-376) emits an
+  advisory ONLY for scaffold_only/baseline maps under research-orchestration /
+  plan-audit; for `populated`/`partial` it returns "" (no advisory). The doc
+  comment (~355-360) and tests pin this. So a populated prior-change map consumes
+  silently.
+- The only populated-map staleness guidance,
+  `internal/tmpl/templates/skills/context-assembly/references/codebase-map.md`
+  (~62-77), defines staleness via git-mtime distance, renamed entry points, and
+  lockfile mismatch — the engine-fingerprint heuristics #80 rejects — and is a
+  reference doc, not surfaced at consume time.
+
+### Selected direction (advisory trigger + host-AI judgment)
+The architecture already does the right thing for non-durable maps; extend the
+SAME pattern to `populated`, split cleanly by the engine/skill boundary:
+- ENGINE owns the TRIGGER: add `codebaseMapRelevanceAdvisory` in
+  `cmd/next_skill_view.go` that fires for `populated` (and `partial`) maps under
+  the map-consuming skills, routed through the non-blocking `view.Warnings`. The
+  engine can only state "status reflects content presence, not scope relevance"
+  — it has no model to judge relevance itself.
+- SKILLS own the JUDGMENT + REFRESH: research-orchestration / plan-audit /
+  codebase-mapping SKILL templates instruct the host to judge a populated map
+  against the current change scope and re-author stale sections inline (the
+  engine re-reads on every assessment, so re-authoring the .md in place IS the
+  inline refresh — no new state, no clobbering).
+- DOC: rewrite the reference's staleness section to a host-AI semantic relevance
+  judgment + inline re-author, replacing the mtime/lockfile fingerprint.
+
+### Rejected alternatives
+- A new engine staleness/fingerprint algorithm (mtime/git/lockfile): explicitly
+  rejected by the issue; reintroduces engine-owned freshness heuristics.
+- A `scoped_to`/timestamp/needs-refresh metadata file: reintroduces engine-owned
+  freshness state; heavier than needed.
+- A `slipway codebase-map --refresh`/`--force` flag: a new public command surface;
+  inline refresh is already achievable by the host re-authoring the .md in place,
+  so the flag is deferred, not required.
+- Making the advisory blocking: the issue wants advisory/non-blocking host
+  judgment.
+
+## Unknowns
+- None blocking. The trigger function, its call site, the consuming skills, the
+  reference doc, and the existing tests were all located with exact line refs.
+
+## Assumptions
+- `view.Warnings` is the correct non-blocking surface (it is a plain []string in
+  the next/run JSON and human output, never a blocker — confirmed).
+- `AssessCodebaseMapDocs` re-reads doc content on every assessment, so a
+  host-re-authored populated doc is immediately re-classified with no state to
+  invalidate (confirmed — no metadata cache).
+- The advisory chain at the call site is mutually exclusive (consume/discovery
+  advisories return "" for populated), so a new populated-case branch will not
+  double-fire.
+
+## Canonical References
+- Engine trigger: `cmd/next_skill_view.go` (`codebaseMapConsumeAdvisory` ~361-376,
+  call site ~298-302), `cmd/next_context_build.go` (~25-37, 77),
+  `internal/engine/artifact/codebase_map.go` (`AssessCodebaseMapDocs` ~628-680).
+- Public JSON: `cmd/next.go` (codebase_map_status/doc_states ~157-158),
+  `cmd/next_handoff.go` (~52-53).
+- Skills: `internal/tmpl/templates/skills/research-orchestration/SKILL.md` (~61-81),
+  `plan-audit/SKILL.md` (~21-44), `codebase-mapping/SKILL.md` (~42-45,74-78),
+  `context-assembly/references/codebase-map.md` (~62-77).
+- Tests: `cmd/next_skill_capability_hints_test.go` (~27-51, 290-294),
+  `internal/tmpl/templates_test.go` (~190-214).

--- a/artifacts/changes/archived/add-host-ai-semantic-staleness-detection-and-inline-refresh/tasks.md
+++ b/artifacts/changes/archived/add-host-ai-semantic-staleness-detection-and-inline-refresh/tasks.md
@@ -8,7 +8,7 @@
 
 ## Task List
 
-- [x] `t-01` Engine relevance-advisory trigger: add `codebaseMapRelevanceAdvisory(status, nextSkillName)` in `cmd/next_skill_view.go` that fires for `CodebaseMapStatusPopulated`/`CodebaseMapStatusPartial` under research-orchestration/plan-audit, wired as a branch in the existing mutually-exclusive advisory chain and routed through non-blocking `view.Warnings`; the wording states status reflects content presence not scope relevance and prompts a host relevance self-check + inline refresh.
+- [x] `t-01` Engine relevance-advisory trigger: add `codebaseMapRelevanceAdvisory(status, nextSkillName)` in `cmd/next_skill_view.go` that fires for `CodebaseMapStatusPopulated`/`CodebaseMapStatusPartial` under all durable-map consumers (research-orchestration, plan-audit, AND wave-orchestration), surfaced independent of lifecycle state (not gated to S1_PLAN) so the issue #80 wave-orchestration handoff is covered, and routed through non-blocking `view.Warnings`; the wording states status reflects content presence not scope relevance and prompts a host relevance self-check + inline refresh.
   - wave: 1
   - depends_on: []
   - target_files: [cmd/next_skill_view.go, cmd/next_skill_capability_hints_test.go]
@@ -20,11 +20,11 @@
 - [x] `t-02` Skill + reference-doc guidance: instruct the host to treat a `populated` map as present-not-verified-relevant, judge it against the current change scope, and re-author stale sections inline; rewrite the codebase-map reference staleness section to that host-AI semantic relevance judgment, removing the git-mtime/entry-point/lockfile fingerprint heuristics.
   - wave: 1
   - depends_on: []
-  - target_files: [internal/tmpl/templates/skills/research-orchestration/SKILL.md, internal/tmpl/templates/skills/plan-audit/SKILL.md, internal/tmpl/templates/skills/codebase-mapping/SKILL.md, internal/tmpl/templates/skills/context-assembly/references/codebase-map.md]
+  - target_files: [internal/tmpl/templates/skills/research-orchestration/SKILL.md, internal/tmpl/templates/skills/plan-audit/SKILL.md, internal/tmpl/templates/skills/codebase-mapping/SKILL.md, internal/tmpl/templates/skills/wave-orchestration/SKILL.md.tmpl, internal/tmpl/templates/skills/context-assembly/references/codebase-map.md]
   - task_kind: code
   - covers: [REQ-002, REQ-003]
   - evidence: verdict
-  - acceptance: research-orchestration, plan-audit, and codebase-mapping skills instruct the populated-map self-check + inline refresh; the reference doc defines staleness as host-AI semantic relevance with inline re-author and contains no mtime/entry-point/lockfile staleness rule.
+  - acceptance: research-orchestration, plan-audit, codebase-mapping, AND wave-orchestration skills instruct the populated-map self-check + inline refresh; plan-audit no longer says `partial` gets no whole-map advisory; the reference doc defines staleness as host-AI semantic relevance with inline re-author, routes `slipway codebase-map` only to missing/scaffold/baseline scaffolding (not the stale-populated no-op), and contains no mtime/entry-point/lockfile staleness rule.
 
 - [x] `t-03` Proof + generated-surface alignment: `go build ./...`, `go vet ./...`, `go test ./...`, `go test ./internal/toolgen/...`, `golangci-lint run`, and `go run . init --refresh --tools all` followed by a diff review confirming only the intended skill/reference additions; confirm the advisory is additive (public JSON field shape unchanged) and non-blocking.
   - wave: 2

--- a/artifacts/changes/archived/add-host-ai-semantic-staleness-detection-and-inline-refresh/tasks.md
+++ b/artifacts/changes/archived/add-host-ai-semantic-staleness-detection-and-inline-refresh/tasks.md
@@ -1,0 +1,36 @@
+# Tasks
+## Project Context
+- Tech Stack: Go
+- Conventions: engine under internal/engine (read-only over model); cmd thin orchestrators; generated skills/commands from internal/tmpl/templates + toolgen; one verdict-evidence YAML per skill under verification/.
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Task List
+
+- [x] `t-01` Engine relevance-advisory trigger: add `codebaseMapRelevanceAdvisory(status, nextSkillName)` in `cmd/next_skill_view.go` that fires for `CodebaseMapStatusPopulated`/`CodebaseMapStatusPartial` under research-orchestration/plan-audit, wired as a branch in the existing mutually-exclusive advisory chain and routed through non-blocking `view.Warnings`; the wording states status reflects content presence not scope relevance and prompts a host relevance self-check + inline refresh.
+  - wave: 1
+  - depends_on: []
+  - target_files: [cmd/next_skill_view.go, cmd/next_skill_capability_hints_test.go]
+  - task_kind: code
+  - covers: [REQ-001]
+  - evidence: verdict
+  - acceptance: A populated/partial map under a consuming skill surfaces a non-blocking `warnings` relevance advisory (not a blocker); non-consuming skills get none; the advisory and the existing non-durable advisory do not double-fire; public JSON field shape is unchanged; an advisory-matrix test pins the behavior and the prior populated->empty assertion is updated.
+
+- [x] `t-02` Skill + reference-doc guidance: instruct the host to treat a `populated` map as present-not-verified-relevant, judge it against the current change scope, and re-author stale sections inline; rewrite the codebase-map reference staleness section to that host-AI semantic relevance judgment, removing the git-mtime/entry-point/lockfile fingerprint heuristics.
+  - wave: 1
+  - depends_on: []
+  - target_files: [internal/tmpl/templates/skills/research-orchestration/SKILL.md, internal/tmpl/templates/skills/plan-audit/SKILL.md, internal/tmpl/templates/skills/codebase-mapping/SKILL.md, internal/tmpl/templates/skills/context-assembly/references/codebase-map.md]
+  - task_kind: code
+  - covers: [REQ-002, REQ-003]
+  - evidence: verdict
+  - acceptance: research-orchestration, plan-audit, and codebase-mapping skills instruct the populated-map self-check + inline refresh; the reference doc defines staleness as host-AI semantic relevance with inline re-author and contains no mtime/entry-point/lockfile staleness rule.
+
+- [x] `t-03` Proof + generated-surface alignment: `go build ./...`, `go vet ./...`, `go test ./...`, `go test ./internal/toolgen/...`, `golangci-lint run`, and `go run . init --refresh --tools all` followed by a diff review confirming only the intended skill/reference additions; confirm the advisory is additive (public JSON field shape unchanged) and non-blocking.
+  - wave: 2
+  - depends_on: [t-01, t-02]
+  - target_files: [internal/toolgen]
+  - task_kind: verification
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004]
+  - evidence: checklist
+  - acceptance: All proof commands pass under the current worktree binary; the generated skills/reference reflect only the intended additions; the relevance advisory surfaces non-blocking for populated/partial maps under consuming skills; the public JSON field shape is unchanged.

--- a/cmd/next_skill_capability_hints_test.go
+++ b/cmd/next_skill_capability_hints_test.go
@@ -50,6 +50,31 @@ func TestCodebaseMapConsumeAdvisoryMatrix(t *testing.T) {
 	assert.NotContains(t, advisory, "No durable codebase-map documents found")
 }
 
+// TestCodebaseMapRelevanceAdvisoryMatrix pins #80: the relevance advisory fires
+// for durable (populated/partial) maps consumed by research-orchestration or
+// plan-audit, is absent for non-consuming skills, and does not fire for the
+// non-durable statuses owned by the consume advisory.
+func TestCodebaseMapRelevanceAdvisoryMatrix(t *testing.T) {
+	t.Parallel()
+	for _, skillName := range []string{progression.SkillResearchOrchestration, progression.SkillPlanAudit} {
+		for _, status := range []string{artifact.CodebaseMapStatusPopulated, artifact.CodebaseMapStatusPartial} {
+			adv := codebaseMapRelevanceAdvisory(status, skillName)
+			assert.NotEmpty(t, adv, "%s consumed by %s should surface a relevance advisory", status, skillName)
+			assert.Contains(t, adv, "reflects content presence, not scope relevance")
+			assert.Contains(t, adv, "does not block progression")
+		}
+		// Non-durable statuses belong to the consume advisory, not this one.
+		assert.Empty(t, codebaseMapRelevanceAdvisory(artifact.CodebaseMapStatusScaffoldOnly, skillName))
+		assert.Empty(t, codebaseMapRelevanceAdvisory(artifact.CodebaseMapStatusBaseline, skillName))
+		assert.Empty(t, codebaseMapRelevanceAdvisory(artifact.CodebaseMapStatusMissing, skillName))
+	}
+	// Non-consuming skills never receive the relevance advisory.
+	for _, skillName := range []string{progression.SkillWaveOrchestration, progression.SkillIntakeClarification, ""} {
+		assert.Empty(t, codebaseMapRelevanceAdvisory(artifact.CodebaseMapStatusPopulated, skillName))
+		assert.Empty(t, codebaseMapRelevanceAdvisory(artifact.CodebaseMapStatusPartial, skillName))
+	}
+}
+
 // TestCodebaseMapStatusHasNoDurableDocs pins the empty-map technique-hint set:
 // it fires for missing/scaffold_only and not for baseline/partial/populated.
 func TestCodebaseMapStatusHasNoDurableDocs(t *testing.T) {
@@ -277,21 +302,31 @@ func TestRunSurfacesBaselineCodebaseMapStatusAndAdvisory(t *testing.T) {
 	})
 }
 
-// TestNextOmitsCodebaseMapAdvisoryForPopulatedMap is the negative path: a
-// populated map consumed by research-orchestration must NOT add the advisory.
-func TestNextOmitsCodebaseMapAdvisoryForPopulatedMap(t *testing.T) {
+// TestNextSurfacesCodebaseMapRelevanceAdvisoryForPopulatedMap is the #80 path: a
+// populated map consumed by research-orchestration surfaces a non-blocking
+// relevance advisory (status reflects content presence, not scope relevance).
+func TestNextSurfacesCodebaseMapRelevanceAdvisoryForPopulatedMap(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {
 		require.NoError(t, bootstrap.InitWorkspace(root, []string{"codex"}, false))
-		createGovernedRequest(t, root, "L2", "advisory absent for populated map")
+		createGovernedRequest(t, root, "L2", "relevance advisory for populated map")
 		writePopulatedCodebaseMapDocs(t, root)
 
 		var view nextView
 		decodeNextJSON(t, []string{"--json", "--diagnostics"}, &view)
 		require.NotNil(t, view.NextSkill)
 		require.Equal(t, "research-orchestration", view.NextSkill.Name)
-		assert.False(t, warningsContainCodebaseMapAdvisory(view.Warnings),
-			"populated map must not surface a codebase_map_advisory warning; got %v", view.Warnings)
+		assert.True(t, warningsContainCodebaseMapAdvisory(view.Warnings),
+			"populated map must surface a codebase_map_advisory relevance warning; got %v", view.Warnings)
+		found := false
+		for _, w := range view.Warnings {
+			if strings.Contains(w, "reflects content presence, not scope relevance") {
+				found = true
+			}
+		}
+		assert.True(t, found,
+			"populated map advisory must be the relevance framing; got %v", view.Warnings)
+		// The advisory stays non-blocking and the empty-map technique hint is absent.
 		assert.False(t, hasNoDurableCodebaseMapHint(view),
 			"populated map must not surface the empty-map technique hint")
 	})

--- a/cmd/next_skill_capability_hints_test.go
+++ b/cmd/next_skill_capability_hints_test.go
@@ -56,7 +56,13 @@ func TestCodebaseMapConsumeAdvisoryMatrix(t *testing.T) {
 // non-durable statuses owned by the consume advisory.
 func TestCodebaseMapRelevanceAdvisoryMatrix(t *testing.T) {
 	t.Parallel()
-	for _, skillName := range []string{progression.SkillResearchOrchestration, progression.SkillPlanAudit} {
+	// All durable-map consumers — including wave-orchestration (S2), the exact
+	// handoff issue #80 reproduces — receive the relevance advisory.
+	for _, skillName := range []string{
+		progression.SkillResearchOrchestration,
+		progression.SkillPlanAudit,
+		progression.SkillWaveOrchestration,
+	} {
 		for _, status := range []string{artifact.CodebaseMapStatusPopulated, artifact.CodebaseMapStatusPartial} {
 			adv := codebaseMapRelevanceAdvisory(status, skillName)
 			assert.NotEmpty(t, adv, "%s consumed by %s should surface a relevance advisory", status, skillName)
@@ -69,7 +75,7 @@ func TestCodebaseMapRelevanceAdvisoryMatrix(t *testing.T) {
 		assert.Empty(t, codebaseMapRelevanceAdvisory(artifact.CodebaseMapStatusMissing, skillName))
 	}
 	// Non-consuming skills never receive the relevance advisory.
-	for _, skillName := range []string{progression.SkillWaveOrchestration, progression.SkillIntakeClarification, ""} {
+	for _, skillName := range []string{progression.SkillIntakeClarification, progression.SkillGoalVerification, ""} {
 		assert.Empty(t, codebaseMapRelevanceAdvisory(artifact.CodebaseMapStatusPopulated, skillName))
 		assert.Empty(t, codebaseMapRelevanceAdvisory(artifact.CodebaseMapStatusPartial, skillName))
 	}
@@ -329,6 +335,41 @@ func TestNextSurfacesCodebaseMapRelevanceAdvisoryForPopulatedMap(t *testing.T) {
 		// The advisory stays non-blocking and the empty-map technique hint is absent.
 		assert.False(t, hasNoDurableCodebaseMapHint(view),
 			"populated map must not surface the empty-map technique hint")
+	})
+}
+
+// TestNextSurfacesCodebaseMapRelevanceAdvisoryForWaveOrchestration is the exact
+// issue #80 live reproduction: at S2_EXECUTE the next skill is wave-orchestration
+// and a populated (stale prior-change) map must still surface the non-blocking
+// relevance advisory — the advisory is not gated to S1 planning skills.
+func TestNextSurfacesCodebaseMapRelevanceAdvisoryForWaveOrchestration(t *testing.T) {
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		require.NoError(t, bootstrap.InitWorkspace(root, []string{"codex"}, false))
+		slug := createGovernedRequest(t, root, "L2", "relevance advisory at wave-orchestration")
+		writePopulatedCodebaseMapDocs(t, root)
+
+		change, err := state.LoadChange(root, slug)
+		require.NoError(t, err)
+		change.CurrentState = model.StateS2Execute
+		change.PlanSubStep = model.PlanSubStepNone
+		change.NeedsDiscovery = false
+		require.NoError(t, state.SaveChange(root, change))
+
+		var view nextView
+		decodeNextJSON(t, []string{"--json", "--diagnostics"}, &view)
+		require.NotNil(t, view.NextSkill)
+		require.Equal(t, "wave-orchestration", view.NextSkill.Name)
+		assert.True(t, warningsContainCodebaseMapAdvisory(view.Warnings),
+			"populated map consumed at wave-orchestration (S2) must surface the relevance advisory; got %v", view.Warnings)
+		found := false
+		for _, w := range view.Warnings {
+			if strings.Contains(w, "reflects content presence, not scope relevance") {
+				found = true
+			}
+		}
+		assert.True(t, found,
+			"wave-orchestration advisory must be the relevance framing; got %v", view.Warnings)
 	})
 }
 

--- a/cmd/next_skill_view.go
+++ b/cmd/next_skill_view.go
@@ -299,7 +299,17 @@ func assembleSkillViewWithOptions(
 			view.Warnings = append(view.Warnings, advisory)
 		} else if advisory := codebaseMapDiscoveryAdvisory(mapStatus, nextSkillName, governedChange.NeedsDiscovery); advisory != "" {
 			view.Warnings = append(view.Warnings, advisory)
-		} else if advisory := codebaseMapRelevanceAdvisory(mapStatus, nextSkillName); advisory != "" {
+		}
+	}
+
+	// Codebase-map relevance self-check (#80): a populated/partial map reflects
+	// content presence, not scope relevance, and can be consumed stale at any
+	// durable-map consumer — including wave-orchestration at S2_EXECUTE, the exact
+	// handoff issue #80 reproduces — so this fires independent of lifecycle state.
+	// It is disjoint by status from the S1 consume/discovery advisories above
+	// (those own scaffold_only/baseline/missing), so it never double-fires.
+	if governedChange != nil {
+		if advisory := codebaseMapRelevanceAdvisory(view.InputContext.CodebaseMapStatus, nextSkillName); advisory != "" {
 			view.Warnings = append(view.Warnings, advisory)
 		}
 	}
@@ -377,19 +387,22 @@ func codebaseMapConsumeAdvisory(status, nextSkillName string) string {
 	}
 }
 
-// codebaseMapRelevanceAdvisory returns a non-blocking consume-time advisory when
-// a map-consuming planning skill (research-orchestration or plan-audit) is next
-// and the codebase map is durable (populated or partial). The map status reflects
-// content presence, not scope relevance — a map authored for a prior change still
-// reads `populated` — so Slipway cannot tell whether the map matches THIS change.
-// The engine only surfaces the trigger; the host AI owns the semantic relevance
-// judgment and the inline refresh (re-author the relevant docs in artifacts/codebase
-// in place; the assessment re-reads them on every run). It complements the
-// non-durable consume advisory, which owns scaffold_only/baseline, so at most one
-// codebase_map_advisory fires.
+// codebaseMapRelevanceAdvisory returns a non-blocking advisory when a durable-map
+// consumer is next and the codebase map is durable (populated or partial). The
+// consumers are research-orchestration and plan-audit (S1_PLAN) and
+// wave-orchestration (S2_EXECUTE) — the same set the codebase-mapping skill names
+// as SHOULD-consume — so the advisory fires at the exact handoff issue #80
+// reproduces: a stale populated map consumed at wave-orchestration. The map status
+// reflects content presence, not scope relevance — a map authored for a prior
+// change still reads `populated` — so Slipway cannot tell whether the map matches
+// THIS change. The engine only surfaces the trigger; the host AI owns the semantic
+// relevance judgment and the inline refresh (re-author the relevant docs in
+// artifacts/codebase in place; the assessment re-reads them on every run). It is
+// disjoint by status from the non-durable consume advisory (scaffold_only/baseline),
+// so at most one codebase_map_advisory fires.
 func codebaseMapRelevanceAdvisory(status, nextSkillName string) string {
 	switch nextSkillName {
-	case progression.SkillResearchOrchestration, progression.SkillPlanAudit:
+	case progression.SkillResearchOrchestration, progression.SkillPlanAudit, progression.SkillWaveOrchestration:
 	default:
 		return ""
 	}

--- a/cmd/next_skill_view.go
+++ b/cmd/next_skill_view.go
@@ -299,6 +299,8 @@ func assembleSkillViewWithOptions(
 			view.Warnings = append(view.Warnings, advisory)
 		} else if advisory := codebaseMapDiscoveryAdvisory(mapStatus, nextSkillName, governedChange.NeedsDiscovery); advisory != "" {
 			view.Warnings = append(view.Warnings, advisory)
+		} else if advisory := codebaseMapRelevanceAdvisory(mapStatus, nextSkillName); advisory != "" {
+			view.Warnings = append(view.Warnings, advisory)
 		}
 	}
 
@@ -368,6 +370,33 @@ func codebaseMapConsumeAdvisory(status, nextSkillName string) string {
 	case artifact.CodebaseMapStatusScaffoldOnly, artifact.CodebaseMapStatusBaseline:
 		return fmt.Sprintf(
 			"codebase_map_advisory: %s is consuming a non-durable codebase map (status: %s); refine artifacts/codebase with source-backed findings before relying on it as reviewed context, or inspect input_context.codebase_map_doc_states for per-doc gaps.",
+			nextSkillName, status,
+		)
+	default:
+		return ""
+	}
+}
+
+// codebaseMapRelevanceAdvisory returns a non-blocking consume-time advisory when
+// a map-consuming planning skill (research-orchestration or plan-audit) is next
+// and the codebase map is durable (populated or partial). The map status reflects
+// content presence, not scope relevance — a map authored for a prior change still
+// reads `populated` — so Slipway cannot tell whether the map matches THIS change.
+// The engine only surfaces the trigger; the host AI owns the semantic relevance
+// judgment and the inline refresh (re-author the relevant docs in artifacts/codebase
+// in place; the assessment re-reads them on every run). It complements the
+// non-durable consume advisory, which owns scaffold_only/baseline, so at most one
+// codebase_map_advisory fires.
+func codebaseMapRelevanceAdvisory(status, nextSkillName string) string {
+	switch nextSkillName {
+	case progression.SkillResearchOrchestration, progression.SkillPlanAudit:
+	default:
+		return ""
+	}
+	switch status {
+	case artifact.CodebaseMapStatusPopulated, artifact.CodebaseMapStatusPartial:
+		return fmt.Sprintf(
+			"codebase_map_advisory: %s is consuming a codebase map whose status (%s) reflects content presence, not scope relevance — it may have been authored for a prior change. Judge whether its affected seams, blast radius, and concerns match THIS change's scope, and re-author any stale sections in artifacts/codebase inline before relying on it. Advisory only — this does not block progression.",
 			nextSkillName, status,
 		)
 	default:

--- a/internal/tmpl/templates/skills/codebase-mapping/SKILL.md
+++ b/internal/tmpl/templates/skills/codebase-mapping/SKILL.md
@@ -42,7 +42,12 @@ to be reviewed and shared, not hidden as local-only state. `next`/`run` surface
 `input_context.codebase_map_status` (and per-doc
 `input_context.codebase_map_doc_states`) so downstream hosts can tell whether the
 map is durable; a `scaffold_only` or `baseline` status means the map is
-non-durable and should be refined before it is consumed as reviewed context.
+non-durable and should be refined before it is consumed as reviewed context. A
+`populated` status only means the documents differ from the scaffold/baseline —
+not that they describe the current change. When a populated map predates the
+change in scope, re-author the change-relevant documents in place rather than
+treating presence as freshness; the assessment re-reads them, so the inline edit
+is the refresh.
 
 ## Process
 

--- a/internal/tmpl/templates/skills/context-assembly/references/codebase-map.md
+++ b/internal/tmpl/templates/skills/context-assembly/references/codebase-map.md
@@ -61,16 +61,26 @@ extra top-level files expecting downstream consumers to discover them.
 
 ## When stale or invalid
 
-Treat the map as stale (rerun required) when:
+Staleness is a host-AI semantic relevance judgment, not an engine fingerprint.
+The `codebase_map_status` only reports content presence (`populated`,
+`baseline`, `scaffold_only`, `missing`) — it cannot tell whether a populated map
+was authored for *this* change. So when you consume a `populated` (or `partial`)
+map, judge its relevance yourself:
 
-- The last-modified timestamp on any document is older than the most
-  recent significant change to the relevant code area (git mtime on the
-  matching directory > doc mtime).
-- The entry points named in `STRUCTURE.md` no longer exist or have been
-  renamed.
-- The dependencies named in `STACK.md` do not match the lockfile.
-- A file is empty or contains only the scaffold template (starts with a
-  heading and has bullets with no content).
+- Re-read the populated documents and ask whether their affected seams, blast
+  radius, module boundaries, and concerns still describe the area **this** change
+  touches. A map authored for a prior, unrelated change reads `populated` but is
+  not relevant.
+- If a section no longer matches the current scope, **re-author it in place** in
+  `artifacts/codebase/<DOC>.md`. The assessment re-reads the files on every run,
+  so an inline edit is the refresh — there is no engine staleness flag to clear
+  and no command that overwrites your authored content.
+- A file that is empty or holds only the scaffold template is non-durable
+  (`scaffold_only`), not stale — fill it from source.
+
+Do not rely on file mtimes, entry-point renames, or lockfile drift as staleness
+signals: those are mechanical proxies that miss the real question — does the map
+describe the change in front of you?
 
 Partial output — one or two docs filled, the rest empty — is not stale, it
 is unfinished. Complete the set before handing off to a planning or review

--- a/internal/tmpl/templates/skills/context-assembly/references/codebase-map.md
+++ b/internal/tmpl/templates/skills/context-assembly/references/codebase-map.md
@@ -44,10 +44,13 @@ extra top-level files expecting downstream consumers to discover them.
 ## Assembly procedure (method-first)
 
 1. Restate the intake question in one sentence before reading anything.
-2. Invoke `slipway codebase-map` if the artifact directory is missing,
-   scaffold-only, or stale. The command is idempotent; reruns populate missing
+2. Invoke `slipway codebase-map` only to **scaffold** a missing, scaffold-only,
+   or baseline document set. The command is idempotent; reruns populate missing
    or scaffold-only files with deterministic baseline repository facts and do
-   not overwrite hand-authored substantive content.
+   not overwrite hand-authored substantive content — so it cannot refresh a
+   `populated` document. For a `populated`/`partial` map that no longer matches
+   the current change (semantically stale), do not rerun the command; re-author
+   the affected documents inline instead (see "When stale or invalid").
    - `status: baseline` means the documents contain CLI-detected facts only.
      Treat them as a starting point awaiting authored verification, not as
      completed brownfield analysis.

--- a/internal/tmpl/templates/skills/plan-audit/SKILL.md
+++ b/internal/tmpl/templates/skills/plan-audit/SKILL.md
@@ -38,17 +38,17 @@ Before auditing task targets against the map, check
 means the documents are **non-durable** (template placeholders or CLI-detected
 facts only); do not audit against them as if they were reviewed context. Record
 the consume-time codebase-map advisory that `next`/`run` emits as an advisory
-gap rather than treating the map as complete brownfield analysis. A `partial`
-map gets no whole-map advisory, so inspect
+gap rather than treating the map as complete brownfield analysis.
+
+A `populated` or `partial` status reflects content presence, not scope
+relevance — a map authored for a prior change still reads `populated`. When
+`next`/`run` emits the codebase-map relevance advisory (it fires for `populated`
+and `partial`), judge whether the map matches this change's scope (affected
+seams, blast radius, concerns) before auditing task targets against it, and
+re-author stale sections in `artifacts/codebase` inline if it does not.
+Populated is not the same as relevant. For a `partial` map, also inspect
 `input_context.codebase_map_doc_states` and treat any per-doc `scaffold_only`,
 `baseline`, or `missing` entry as non-durable for that document.
-
-A `populated` status reflects content presence, not scope relevance — a map
-authored for a prior change still reads `populated`. When `next`/`run` emits the
-codebase-map relevance advisory, judge whether the map matches this change's
-scope (affected seams, blast radius, concerns) before auditing task targets
-against it, and re-author stale sections in `artifacts/codebase` inline if it
-does not. Populated is not the same as relevant.
 
 Use `slipway-coding-discipline` as the execution-shape bar: plans should stay
 simple, goal-scoped, and sliced for surgical implementation.

--- a/internal/tmpl/templates/skills/plan-audit/SKILL.md
+++ b/internal/tmpl/templates/skills/plan-audit/SKILL.md
@@ -43,6 +43,13 @@ map gets no whole-map advisory, so inspect
 `input_context.codebase_map_doc_states` and treat any per-doc `scaffold_only`,
 `baseline`, or `missing` entry as non-durable for that document.
 
+A `populated` status reflects content presence, not scope relevance — a map
+authored for a prior change still reads `populated`. When `next`/`run` emits the
+codebase-map relevance advisory, judge whether the map matches this change's
+scope (affected seams, blast radius, concerns) before auditing task targets
+against it, and re-author stale sections in `artifacts/codebase` inline if it
+does not. Populated is not the same as relevant.
+
 Use `slipway-coding-discipline` as the execution-shape bar: plans should stay
 simple, goal-scoped, and sliced for surgical implementation.
 

--- a/internal/tmpl/templates/skills/research-orchestration/SKILL.md
+++ b/internal/tmpl/templates/skills/research-orchestration/SKILL.md
@@ -72,9 +72,17 @@ codebase-map advisory for a non-durable map, record it as a research finding and
 refine the documents (file:line citations, module boundaries, change-specific
 risks) before depending on them.
 
-A `partial` map carries no whole-map advisory, so inspect
-`input_context.codebase_map_doc_states` and treat any per-doc `scaffold_only`,
-`baseline`, or `missing` entry as non-durable for that document.
+A `populated` status means only that the documents differ from the scaffold and
+the CLI baseline — it reflects content **presence, not scope relevance**. A map
+authored for a prior change still reads `populated`. When `next`/`run` surfaces a
+codebase-map relevance advisory, judge whether the map's affected seams, blast
+radius, and concerns match **this** change's scope; re-author any stale or
+out-of-scope sections in `input_context.codebase_map_dir` inline (the assessment
+re-reads them on every run) before relying on the map as reviewed context.
+Populated is not the same as relevant.
+
+Inspect `input_context.codebase_map_doc_states` and treat any per-doc
+`scaffold_only`, `baseline`, or `missing` entry as non-durable for that document.
 
 If the durable codebase map is missing or stale, run the
 `slipway-codebase-mapping` technique skill first and write the documents into

--- a/internal/tmpl/templates/skills/wave-orchestration/SKILL.md.tmpl
+++ b/internal/tmpl/templates/skills/wave-orchestration/SKILL.md.tmpl
@@ -31,6 +31,14 @@ If durable codebase mapping exists at `input_context.codebase_map_dir`, read:
 Use them to align execution with directory conventions, test infrastructure,
 and known risk hotspots.
 
+`input_context.codebase_map_status` reflects content **presence, not scope
+relevance** — a map authored for a prior change still reads `populated`. When
+`next`/`run` surfaces a codebase-map relevance advisory, judge whether the map
+matches **this** change's scope before relying on it for execution targeting, and
+re-author any stale sections in `artifacts/codebase` inline (the assessment
+re-reads them) rather than executing against a stale map. Populated is not the
+same as relevant; this is advisory and never blocks execution.
+
 If `input_context.resume_checkpoint` is present, skip `completed_task_ids` only
 when `freshness` is `fresh`; stale checkpoints require rerunning everything.
 Carry `checkpoint_type` and any `user_response_payload` into evidence.

--- a/internal/tmpl/templates_test.go
+++ b/internal/tmpl/templates_test.go
@@ -78,6 +78,57 @@ func TestPlanAuditTemplateDoesNotReintroduceLightPresetVerificationBlocker(t *te
 	assert.NotContains(t, content, "Every task needs explicit per-task verification fields before execution begins.")
 }
 
+// TestCodebaseMapRelevanceGuidanceInSkills pins issue #80: the durable-map
+// consumer skills carry the populated/partial relevance self-check, the stale
+// "no whole-map advisory" prose is gone, and the reference defines staleness as a
+// host-AI semantic relevance judgment rather than the rejected git-mtime/lockfile
+// fingerprint heuristics. Guards against a future `init --refresh` regressing it.
+func TestCodebaseMapRelevanceGuidanceInSkills(t *testing.T) {
+	t.Parallel()
+
+	// Collapse line-wrapping whitespace so multi-word phrases match regardless of
+	// where the 79-column prose wrap falls.
+	norm := func(s string) string { return strings.Join(strings.Fields(s), " ") }
+
+	for _, path := range []string{
+		"skills/research-orchestration/SKILL.md",
+		"skills/plan-audit/SKILL.md",
+	} {
+		content, err := Content(path)
+		require.NoError(t, err, path)
+		flat := norm(content)
+		assert.Contains(t, flat, "not scope relevance", path)
+		assert.Contains(t, flat, "Populated is not the same as relevant", path)
+		assert.NotContains(t, flat, "no whole-map advisory", path)
+	}
+
+	// wave-orchestration (rendered) is a durable-map consumer and must carry the
+	// relevance self-check — the exact handoff issue #80 reproduces.
+	wave, err := Render("skills/wave-orchestration/SKILL.md.tmpl", map[string]string{
+		"ToolID":      "claude",
+		"Trigger":     "/slipway:wave-orchestration",
+		"Description": "test",
+	})
+	require.NoError(t, err)
+	flatWave := norm(wave)
+	assert.Contains(t, flatWave, "not scope relevance")
+	assert.Contains(t, flatWave, "Populated is not the same as relevant")
+
+	mapping, err := Content("skills/codebase-mapping/SKILL.md")
+	require.NoError(t, err)
+	assert.Contains(t, norm(mapping), "re-author the change-relevant documents in place")
+
+	// The reference defines staleness as host-AI semantic relevance, not the
+	// rejected fingerprint heuristics, and no longer routes stale populated docs
+	// to the `slipway codebase-map` no-op.
+	ref, err := Content("skills/context-assembly/references/codebase-map.md")
+	require.NoError(t, err)
+	flatRef := norm(ref)
+	assert.Contains(t, flatRef, "host-AI semantic relevance judgment")
+	assert.NotContains(t, flatRef, "git mtime on the matching directory")
+	assert.NotContains(t, flatRef, "do not match the lockfile")
+}
+
 func TestFinalCloseoutTemplateRequiresAssuranceAttestationOnStandardStrict(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
A codebase map authored for a **prior** change scores `populated` and is consumed as authoritative with zero signal — `AssessCodebaseMapDocs` reports content **presence, not scope relevance** — and the only staleness guidance used the git-mtime / entry-point-rename / lockfile-mismatch fingerprint heuristics this issue rejects. This adds a host-AI semantic relevance self-check at consume time plus inline refresh, keeping it advisory/non-blocking.

## Changes
- **Engine trigger.** New `codebaseMapRelevanceAdvisory` (`cmd/next_skill_view.go`) fires for `populated`/`partial` maps consumed by research-orchestration / plan-audit, wired into the existing mutually-exclusive advisory chain and routed through the **non-blocking** `view.Warnings`. It states the status reflects content presence, not scope relevance, and prompts a host relevance self-check + inline refresh. The engine only surfaces the trigger — it has no model to judge relevance itself.
- **Skill judgment.** research-orchestration, plan-audit, and codebase-mapping skills instruct the host to judge a populated map against **this** change's scope (affected seams, blast radius, concerns) and re-author stale sections in `artifacts/codebase` inline. The assessment re-reads the docs on every run, so the inline edit **is** the refresh — no engine overwrite of authored content.
- **Reference doc.** Rewrite the codebase-map staleness section to a host-AI semantic relevance judgment + inline re-author, removing the mtime/entry-point/lockfile fingerprint.

## Design boundary
The engine owns the **trigger** ("populated ≠ verified-relevant"); the host AI owns the **semantic judgment + refresh** (per the repo's engine-owns-structure / skill-owns-substance principle). No engine fingerprint algorithm, no `scoped_to`/timestamp metadata file, no new CLI flag, no blocking gate.

## Out of scope
- A `slipway codebase-map --refresh`/`--force` flag (inline refresh already works via host re-author; deferred).
- #95/#92/#91/#88/#86/#75 — separate efforts.

## Verification
- `go build/vet/test ./...` green; `golangci-lint run` → 0 issues; `go test ./internal/toolgen/...` green.
- `go run . init --refresh --tools all` + `git diff --check` → only the intended 2 cmd + 4 skill/reference changes; public JSON field shape unchanged.
- Regressions: `TestCodebaseMapRelevanceAdvisoryMatrix` (fire/empty matrix) and `TestNextSurfacesCodebaseMapRelevanceAdvisoryForPopulatedMap` (integration: relevance warning present, non-blocking).
- Driven through the full Slipway governed flow to done-ready (per-change `validate --json` fresh, gates approved).

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)