### PR TITLE
fix(governance): stage-aware assurance traceability; doctor raises no incident before review (#92)

### DIFF
--- a/artifacts/changes/archived/fix-health-governance-falsely-reporting-missing-final-assura/change.yaml
+++ b/artifacts/changes/archived/fix-health-governance-falsely-reporting-missing-final-assura/change.yaml
@@ -1,0 +1,31 @@
+version: 1
+slug: fix-health-governance-falsely-reporting-missing-final-assura
+description: 'Fix health --governance falsely reporting missing final assurance coverage verdicts as a blocking traceability incident during S2 execution (issue #92): make the assurance-coverage traceability gap stage-aware so it is non-blocking before review/verify and only fails closed at closeout, aligning health with validate/next readiness surfaces.'
+status: done
+current_state: DONE
+complexity_level: simple
+base_ref: HEAD
+created_at: 2026-06-06T14:00:25.313346Z
+quality_mode: standard
+workflow_preset: light
+worktree_branch: feat/fix-health-governance-falsely-reporting-missing-final-assura
+artifact_schema: core
+artifacts:
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: 7d978b6675e1712f74a7722bd63cbf1925f5264372a6a11ffe41eb312e3cfed9
+        updated_at: 2026-06-06T15:53:38.699281487Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: 82567c428141395da411624e89da47d843c6a620686b2ba4c55e76e79e22fa25
+        updated_at: 2026-06-06T15:52:53.314051494Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: e7252f5cc3b6cf8ca2a0c3ea03ff455632d3988e7aef7273ca40ae05061c19d3
+        updated_at: 2026-06-06T15:53:11.911118706Z

--- a/artifacts/changes/archived/fix-health-governance-falsely-reporting-missing-final-assura/intent.md
+++ b/artifacts/changes/archived/fix-health-governance-falsely-reporting-missing-final-assura/intent.md
@@ -1,0 +1,37 @@
+# Intent
+
+## Summary
+Fix health --governance falsely reporting missing final assurance coverage verdicts as a blocking traceability incident during S2 execution (issue #92): make the assurance-coverage traceability gap stage-aware so it is non-blocking before review/verify and only fails closed at closeout, aligning health with validate/next readiness surfaces.
+## Complexity Assessment
+simple
+<!-- Rationale: provide justification for the assessed complexity level -->
+Single, localized classification fix in the governance traceability evaluator plus its one call site, guarded by unit tests. No new commands and no schema changes; the only additional surface is the doctor-synthesis rendering in `cmd/health.go`, which mirrors the same gap classification (an advisory traceability check raises no doctor incident). Root cause is already understood; the only design decision (how to classify the gap before S3) is resolved.
+
+## In Scope
+- `internal/engine/governance/traceability.go`: thread the change's lifecycle state/phase into `TraceabilityInput`, and make the assurance-coverage gaps (`requirement missing assurance coverage verdict` and `assurance verifies no requirement IDs`) **non-blocking (WARN-level)** while the change is before `S3_REVIEW`; keep them **blocking** at/after `S3_REVIEW`.
+- `internal/engine/governance/health.go`: pass `change.CurrentState` into `TraceabilityInput` at the `deriveGovernanceControls` call site so the evaluator can apply the stage rule.
+- `cmd/health.go`: in `governanceDoctorActions`, stop promoting a `traceability_coherence` check whose gaps are all non-blocking into a `governance_traceability_coherence` doctor action, so `--doctor` raises no non-repairable incident before review; a blocking (`FAIL`) check still surfaces unchanged.
+- Unit tests proving: at `S2_EXECUTE` incomplete assurance coverage yields `traceability_coherence` = WARN (governance not forced unhealthy by this gap) and no doctor action; at `S3_REVIEW`/`S4_VERIFY`/`DONE` it yields FAIL (still fails closed) and the doctor action returns.
+
+## Out of Scope
+- No change to `validate` / `slipway next` behavior — they already correctly route to `wave-orchestration` at S2; this change makes `health` agree, not the reverse.
+- No change to other traceability gap types (requirement→intent, task→requirement, decision→requirement, blocking open questions) — those remain blocking as today.
+- Issue #91 (mechanical requirements/tasks seeding) — separate governed change.
+
+## Constraints
+- Must remain fail-closed at `S3_REVIEW`, `S4_VERIFY`, and `DONE`: a change cannot reach `done` with missing assurance coverage verdicts.
+- Public health JSON shape stays stable (status values remain OK/WARN/FAIL; gap records unchanged in shape).
+- Smallest clean design: no new lifecycle plumbing beyond passing the already-available `CurrentState`.
+
+## Acceptance Signals
+- A change at `S2_EXECUTE` with incomplete per-requirement assurance coverage: `slipway health --governance --json` reports `traceability_coherence` status `WARN` (not `FAIL`), `governance.healthy` is not driven false by this gap alone, and `--doctor` raises no non-repairable incident for it.
+- The same change at `S3_REVIEW` with incomplete assurance coverage: `traceability_coherence` is `FAIL` (fails closed before closeout).
+- `slipway validate --json` and `slipway next --json` outputs are unchanged for the S2 case; all three readiness surfaces agree the next action is `wave-orchestration`.
+- New/updated Go unit tests pass and `go test ./...` is green.
+
+## Approved Summary
+Make the assurance-coverage traceability gap stage-aware. Before `S3_REVIEW`, a requirement lacking an assurance coverage verdict (or an assurance file that verifies no requirement IDs) is reported as a non-blocking WARN gap in `traceability_coherence`, so `health --governance` no longer raises a false blocking/incident state that contradicts `validate`/`next` (which correctly send the user to `wave-orchestration`). At and after `S3_REVIEW` the same gaps are blocking, preserving fail-closed behavior at closeout. Scope is limited to `traceability.go` + the `health.go` call site plus tests; `validate`/`next` and all other gap types are untouched; #91 is excluded. Primary acceptance signal: S2 → `traceability_coherence` WARN, S3+ → FAIL.
+
+Confirmed by user 2026-06-06 (selected "S3 前降级为非阻塞 WARN (推荐)" approach, which also confirmed this scope).
+
+Scope update 2026-06-07: review found the original scope (evaluator + health call site) did not fully satisfy the already-approved `--doctor` acceptance signal, because `cmd/health.go` `governanceDoctorActions` still promoted the now-advisory `traceability_coherence` WARN into a non-repairable doctor action — re-creating the #92 contradiction at a lower severity. Scope expanded to include the doctor-synthesis surface (`cmd/health.go` + `cmd/health_test.go`) and a first-class requirement (REQ-004). User authorized completing this through a full governed re-walk.

--- a/artifacts/changes/archived/fix-health-governance-falsely-reporting-missing-final-assura/requirements.md
+++ b/artifacts/changes/archived/fix-health-governance-falsely-reporting-missing-final-assura/requirements.md
@@ -1,0 +1,88 @@
+# Requirements
+## Project Context
+- Tech Stack: Go
+- Conventions: cmd/* CLI over internal/engine/* kernel; generated skills/docs via toolgen; table-driven tests
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Requirements
+
+### Requirement: Assurance-coverage traceability gaps are stage-aware before review (#92)
+REQ-001: Before `S3_REVIEW` (i.e. at `S0_INTAKE`, `S1_PLAN`, or `S2_EXECUTE`), the
+traceability evaluator MUST classify the per-requirement assurance gaps
+(`requirement missing assurance coverage verdict` and `assurance verifies no
+requirement IDs`) as **non-blocking** so that `health --governance` reports
+`traceability_coherence` as `WARN` (not `FAIL`) and `governance.healthy` is not
+driven false by these gaps alone. The lifecycle state MUST flow into the
+evaluator from the owning call site rather than being inferred; when the state is
+unknown/empty the gaps MUST stay blocking (fail-closed default). No other
+traceability gap type changes classification.
+
+#### Scenario: S2 execution with incomplete assurance coverage is a warning
+GIVEN a change at `S2_EXECUTE` whose requirements include REQ IDs not yet covered
+by an assurance coverage verdict
+WHEN governance health is computed for that change
+THEN `traceability_coherence` is `WARN`, the assurance gaps are present but
+non-blocking, and the overall report is not marked unhealthy by those gaps.
+
+#### Scenario: Unknown lifecycle state stays fail-closed
+GIVEN `EvaluateTraceability` is called without a lifecycle state (empty/unknown)
+and assurance coverage is incomplete
+WHEN traceability is evaluated
+THEN the assurance gaps remain blocking and the status is `FAIL`.
+
+### Requirement: Assurance coverage still fails closed at review and closeout (#92)
+REQ-002: At `S3_REVIEW`, `S4_VERIFY`, and `DONE`, the same assurance-coverage
+gaps MUST remain blocking, so `traceability_coherence` is `FAIL` and a change
+cannot reach `done` while any requirement lacks an assurance coverage verdict.
+A change whose assurance covers every requirement MUST produce no assurance gap
+at any state.
+
+#### Scenario: S3 review with incomplete assurance coverage blocks
+GIVEN a change at `S3_REVIEW` whose requirements include REQ IDs not covered by an
+assurance coverage verdict
+WHEN traceability is evaluated
+THEN the assurance gaps are blocking and the status is `FAIL`.
+
+#### Scenario: Complete assurance coverage is OK regardless of state
+GIVEN a change whose assurance verifies every requirement ID
+WHEN traceability is evaluated at `S2_EXECUTE` or at `S3_REVIEW`
+THEN no assurance gap is produced and the status is `OK`.
+
+### Requirement: Readiness surfaces agree and the suite stays green (#92)
+REQ-003: The fix MUST be limited to the governance traceability evaluator, its
+health call site, and the doctor-synthesis surface that renders governance
+health checks, plus tests; `slipway validate` / `slipway next` behavior is
+unchanged (they already route an S2 change to `wave-orchestration`), so all three
+readiness surfaces agree on the next action at S2. `go build ./...`,
+`go vet ./...`, and `go test ./...` MUST pass, and no generated skill/command/doc
+surface changes (no toolgen drift introduced).
+
+#### Scenario: Build, vet, and tests pass with no surface drift
+GIVEN the change is implemented
+WHEN `go build ./... && go vet ./... && go test ./...` runs
+THEN all pass, and `validate`/`next` outputs for an S2 change are unchanged
+(next action remains `wave-orchestration`).
+
+### Requirement: Doctor surface raises no non-repairable incident for advisory traceability (#92)
+REQ-004: The `health --governance --doctor` surface MUST treat a
+`traceability_coherence` check whose gaps are all non-blocking (advisory, e.g.
+pre-review assurance coverage verdicts) as carrying no actionable repair: the
+doctor view MUST NOT emit a `governance_traceability_coherence` action for it, so
+`--doctor` raises no non-repairable incident that contradicts `validate`/`next`.
+When the same check is blocking (`FAIL`, i.e. at/after `S3_REVIEW`), the doctor
+view MUST still emit the `governance_traceability_coherence` action. No other
+governance check's doctor behavior changes.
+
+#### Scenario: S2 advisory traceability raises no doctor action
+GIVEN a change at `S2_EXECUTE` with incomplete per-requirement assurance coverage
+WHEN `slipway health --governance --json --doctor` runs
+THEN `traceability_coherence` is `WARN` and the doctor view contains no
+`governance_traceability_coherence` action.
+
+#### Scenario: S3 blocking traceability still raises a doctor action
+GIVEN a change at `S3_REVIEW` with incomplete per-requirement assurance coverage
+WHEN `slipway health --governance --json --doctor` runs
+THEN `traceability_coherence` is `FAIL` and the doctor view contains a
+`governance_traceability_coherence` action.

--- a/artifacts/changes/archived/fix-health-governance-falsely-reporting-missing-final-assura/tasks.md
+++ b/artifacts/changes/archived/fix-health-governance-falsely-reporting-missing-final-assura/tasks.md
@@ -1,0 +1,54 @@
+# Tasks
+## Project Context
+- Tech Stack: Go
+- Conventions: cmd/* CLI over internal/engine/* kernel; generated skills/docs via toolgen; table-driven tests
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Task List
+
+- [x] `t-01` (#92) Make assurance-coverage traceability gaps stage-aware. In
+  `internal/engine/governance/traceability.go` add a `LifecycleState
+  model.WorkflowState` field to `TraceabilityInput`, and in `EvaluateTraceability`
+  compute `assuranceBlocking := !assuranceVerdictsExpectedLater(input.LifecycleState)`
+  where a small helper returns true for `S0_INTAKE`/`S1_PLAN`/`S2_EXECUTE` (before
+  review) and false otherwise (including empty/unknown → fail-closed). Apply that
+  `Blocking` value to BOTH assurance gaps (`assurance verifies no requirement IDs`
+  and `requirement missing assurance coverage verdict`); leave every other gap
+  type unchanged. In `internal/engine/governance/health.go` pass
+  `change.CurrentState` into the `TraceabilityInput` at the `deriveGovernanceControls`
+  call site. Test-first: extend `internal/engine/governance/traceability_test.go`
+  to cover S2 (non-blocking → WARN), unknown-state (blocking → FAIL), S3/S4/DONE
+  (blocking → FAIL), and complete-coverage (OK at S2 and S3); update the existing
+  `TestTraceabilityAssuranceMustCoverEveryRequirement` /
+  `TestTraceabilityAssuranceNoREQIDs` to assert the fail-closed default.
+  Then complete the same #92 behavior on the doctor-synthesis surface: in
+  `cmd/health.go`, `governanceDoctorActions` MUST NOT promote a
+  `traceability_coherence` check whose gaps are all non-blocking into a doctor
+  action (add a `traceabilityCheckHasBlockingGap` guard); a blocking (`FAIL`)
+  check still surfaces its action unchanged (REQ-004).
+  - wave: 1
+  - depends_on: []
+  - target_files: ["internal/engine/governance/traceability.go", "internal/engine/governance/traceability_test.go", "internal/engine/governance/health.go", "cmd/health.go"]
+  - task_kind: code
+  - covers: [REQ-001, REQ-002, REQ-004]
+
+- [x] `t-02` (#92) Prove the health surface and lock the suite. Add a
+  governance-health test in `internal/engine/governance/health_test.go` that
+  builds a snapshot for a change at `S2_EXECUTE` with incomplete per-requirement
+  assurance coverage and asserts `traceability_coherence` is `WARN` and the report
+  is not unhealthy from that gap, plus a companion at `S3_REVIEW` asserting `FAIL`.
+  Then add command-level doctor regressions in `cmd/health_test.go`: a
+  deterministic unit test over `governanceDoctorActions` (non-blocking
+  traceability check → no action; blocking → action present) plus an end-to-end
+  `health --governance --json --doctor` test asserting S2 → WARN with no
+  `governance_traceability_coherence` action and S3 → FAIL with the action
+  present (REQ-004). Then run `go build ./... && go vet ./... && go test ./...`
+  green and confirm no toolgen/generated-surface drift (no generated
+  skill/command/doc surface changes).
+  - wave: 2
+  - depends_on: [t-01]
+  - target_files: ["internal/engine/governance/health_test.go", "cmd/health_test.go"]
+  - task_kind: code
+  - covers: [REQ-003]

--- a/cmd/health.go
+++ b/cmd/health.go
@@ -656,6 +656,17 @@ func governanceDoctorActions(report *governance.GovernanceHealthReport) []doctor
 			continue
 		}
 
+		// A traceability_coherence check that carries only non-blocking gaps is
+		// advisory, not an incident: e.g. per-requirement assurance coverage
+		// verdicts that are authored later during review (#92). It needs no
+		// repair now and has no command to offer, so surfacing it as a
+		// non-repairable doctor action would re-create the false "blocking
+		// incident" friction that contradicts validate/next. FAIL traceability
+		// (at least one blocking gap) still surfaces unchanged.
+		if check.Name == "traceability_coherence" && !traceabilityCheckHasBlockingGap(check) {
+			continue
+		}
+
 		action := doctorAction{
 			Priority:   governanceDoctorPriority(check.Status),
 			Category:   "governance_" + check.Name,
@@ -670,6 +681,19 @@ func governanceDoctorActions(report *governance.GovernanceHealthReport) []doctor
 		actions = append(actions, action)
 	}
 	return actions
+}
+
+// traceabilityCheckHasBlockingGap reports whether a traceability_coherence
+// check carries at least one blocking gap. A WARN check with only advisory
+// gaps (e.g. pre-review assurance coverage verdicts, #92) has none, so it must
+// not be promoted into a non-repairable doctor action.
+func traceabilityCheckHasBlockingGap(check governance.GovernanceHealthCheck) bool {
+	for _, gap := range check.TraceabilityGaps {
+		if gap.Blocking {
+			return true
+		}
+	}
+	return false
 }
 
 func governanceDoctorPriority(status string) int {

--- a/cmd/health.go
+++ b/cmd/health.go
@@ -656,14 +656,16 @@ func governanceDoctorActions(report *governance.GovernanceHealthReport) []doctor
 			continue
 		}
 
-		// A traceability_coherence check that carries only non-blocking gaps is
+		// A traceability_coherence check whose gaps are ALL non-blocking is
 		// advisory, not an incident: e.g. per-requirement assurance coverage
 		// verdicts that are authored later during review (#92). It needs no
 		// repair now and has no command to offer, so surfacing it as a
 		// non-repairable doctor action would re-create the false "blocking
-		// incident" friction that contradicts validate/next. FAIL traceability
-		// (at least one blocking gap) still surfaces unchanged.
-		if check.Name == "traceability_coherence" && !traceabilityCheckHasBlockingGap(check) {
+		// incident" friction that contradicts validate/next. A FAIL check (at
+		// least one blocking gap) and a gapless WARN (e.g. no-snapshot or
+		// unreadable-snapshot "data unavailable" warnings) still surface
+		// unchanged.
+		if check.Name == "traceability_coherence" && traceabilityCheckHasOnlyAdvisoryGaps(check) {
 			continue
 		}
 
@@ -683,17 +685,22 @@ func governanceDoctorActions(report *governance.GovernanceHealthReport) []doctor
 	return actions
 }
 
-// traceabilityCheckHasBlockingGap reports whether a traceability_coherence
-// check carries at least one blocking gap. A WARN check with only advisory
-// gaps (e.g. pre-review assurance coverage verdicts, #92) has none, so it must
-// not be promoted into a non-repairable doctor action.
-func traceabilityCheckHasBlockingGap(check governance.GovernanceHealthCheck) bool {
+// traceabilityCheckHasOnlyAdvisoryGaps reports whether a traceability_coherence
+// check carries at least one gap and every gap is non-blocking (advisory, e.g.
+// pre-review assurance coverage verdicts, #92). It is false for a check with a
+// blocking gap (FAIL) and false for a check with NO gaps at all — a gapless
+// traceability WARN signals missing or unreadable governance data, not an
+// advisory gap, so it must still surface as a doctor action.
+func traceabilityCheckHasOnlyAdvisoryGaps(check governance.GovernanceHealthCheck) bool {
+	if len(check.TraceabilityGaps) == 0 {
+		return false
+	}
 	for _, gap := range check.TraceabilityGaps {
 		if gap.Blocking {
-			return true
+			return false
 		}
 	}
-	return false
+	return true
 }
 
 func governanceDoctorPriority(status string) int {

--- a/cmd/health_test.go
+++ b/cmd/health_test.go
@@ -1570,3 +1570,147 @@ func TestClassifyGlobalHealthImpactBySeverity(t *testing.T) {
 	assert.False(t, findings[2].ActiveChangeBlocking)
 	assert.Equal(t, "non_blocking_for_active_change", findings[2].ActiveChangeImpact)
 }
+
+// TestGovernanceDoctorActionsSuppressNonBlockingTraceabilityWarning pins the
+// doctor-synthesis contract for issue #92: a traceability_coherence check whose
+// gaps are all non-blocking (advisory, e.g. pre-review assurance coverage) must
+// NOT become a doctor action, while a check with a blocking gap still does.
+func TestGovernanceDoctorActionsSuppressNonBlockingTraceabilityWarning(t *testing.T) {
+	t.Parallel()
+
+	const assuranceIssue = "requirement missing assurance coverage verdict"
+
+	advisory := &governance.GovernanceHealthReport{
+		Slug: "stage-aware",
+		Checks: []governance.GovernanceHealthCheck{{
+			Name:    "traceability_coherence",
+			Status:  "WARN",
+			Message: "1 traceability warnings",
+			TraceabilityGaps: []model.TraceabilityGap{{
+				ID:       "REQ-002",
+				Type:     "assurance",
+				Issue:    assuranceIssue,
+				Blocking: false,
+			}},
+		}},
+	}
+	for _, action := range governanceDoctorActions(advisory) {
+		assert.NotEqual(t, "governance_traceability_coherence", action.Category,
+			"a non-blocking traceability warning must not become a doctor action (#92)")
+	}
+
+	blocking := &governance.GovernanceHealthReport{
+		Slug: "stage-aware",
+		Checks: []governance.GovernanceHealthCheck{{
+			Name:    "traceability_coherence",
+			Status:  "FAIL",
+			Message: "1 blocking traceability gaps",
+			TraceabilityGaps: []model.TraceabilityGap{{
+				ID:       "REQ-002",
+				Type:     "assurance",
+				Issue:    assuranceIssue,
+				Blocking: true,
+			}},
+		}},
+	}
+	found := false
+	for _, action := range governanceDoctorActions(blocking) {
+		if action.Category == "governance_traceability_coherence" {
+			found = true
+			assert.False(t, action.Repairable)
+		}
+	}
+	assert.True(t, found, "a blocking traceability gap must still surface as a doctor action")
+}
+
+// TestHealthCommandDoctorTracksAssuranceCoverageBlockingState is the end-to-end
+// regression for #92: at S2_EXECUTE incomplete assurance coverage is an advisory
+// WARN with no doctor action, while at S3_REVIEW the same gap fails closed and
+// surfaces a doctor action. The bundle is authored so the assurance gap is the
+// only traceability gap, so the WARN/FAIL difference is attributable to the
+// stage-aware rule alone.
+func TestHealthCommandDoctorTracksAssuranceCoverageBlockingState(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name       string
+		state      model.WorkflowState
+		wantStatus string
+		wantAction bool
+	}{
+		{"S2 assurance pending is advisory", model.StateS2Execute, "WARN", false},
+		{"S3 assurance pending blocks", model.StateS3Review, "FAIL", true},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			withCommandWorkspace(t, root, func() {
+				initTestWorkspace(t, root)
+
+				slug := createGovernedRequest(t, root, "L2", "assurance stage-aware doctor")
+				change, err := state.LoadChange(root, slug)
+				require.NoError(t, err)
+				change.CurrentState = tc.state
+				change.ArtifactSchema = model.ArtifactSchemaExpanded
+				require.NoError(t, state.SaveChange(root, change))
+
+				bundleDir := filepath.Join(root, "artifacts", "changes", slug)
+				require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "intent.md"), []byte(`# Intent
+INT-001: stabilize the surface
+## Open Questions
+(none)
+`), 0o644))
+				require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "requirements.md"), []byte(`# Requirements
+### Requirement: First
+REQ-001: First requirement. Traces to INT-001.
+### Requirement: Second
+REQ-002: Second requirement. Traces to INT-001.
+`), 0o644))
+				require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "tasks.md"), []byte(`# Tasks
+- [ ] `+"`t-01`"+` do the work
+  covers: [REQ-001, REQ-002]
+`), 0o644))
+				require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "assurance.md"), []byte(`# Assurance
+## Requirement Coverage
+REQ-001: verified via tests
+`), 0o644))
+
+				// Persist a snapshot at the change's current state so the health
+				// command has authoritative governance state to report even if
+				// it skips recompute for the (non-dedicated) worktree binding.
+				_, err = governance.RecomputeGovernanceSnapshot(root, change, bundleDir)
+				require.NoError(t, err)
+
+				var out bytes.Buffer
+				cmd := commandForRoot(t, root, makeHealthCmd())
+				cmd.SetArgs([]string{"--json", "--governance", "--doctor", "--change", slug})
+				cmd.SetOut(&out)
+				require.NoError(t, cmd.Execute())
+
+				var view healthView
+				require.NoError(t, json.Unmarshal(out.Bytes(), &view))
+				require.NotNil(t, view.Governance)
+				require.NotNil(t, view.Doctor)
+
+				var traceStatus string
+				for _, c := range view.Governance.Checks {
+					if c.Name == "traceability_coherence" {
+						traceStatus = c.Status
+					}
+				}
+				assert.Equal(t, tc.wantStatus, traceStatus,
+					"assurance coverage gap should be the only traceability gap")
+
+				hasTraceAction := false
+				for _, action := range view.Doctor.Actions {
+					if action.Category == "governance_traceability_coherence" {
+						hasTraceAction = true
+					}
+				}
+				assert.Equal(t, tc.wantAction, hasTraceAction,
+					"doctor traceability action presence must track blocking state (#92)")
+			})
+		})
+	}
+}

--- a/cmd/health_test.go
+++ b/cmd/health_test.go
@@ -941,6 +941,54 @@ func TestHealthCommandGovernanceReportsUnreadableSnapshotInsteadOfFailing(t *tes
 	})
 }
 
+// TestHealthCommandDoctorSurfacesGaplessTraceabilityWarning is the end-to-end
+// regression for the over-broad #92 doctor suppression: an unreadable governance
+// snapshot yields a gapless traceability_coherence WARN ("data unavailable"),
+// which must still surface as a doctor action. Only traceability checks that
+// carry advisory (non-blocking) gaps are suppressed.
+func TestHealthCommandDoctorSurfacesGaplessTraceabilityWarning(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+
+		slug := createGovernedRequest(t, root, "L2", "health doctor gapless traceability")
+		snapshotPath := governance.SnapshotPath(root, slug)
+		require.NoError(t, os.MkdirAll(filepath.Dir(snapshotPath), 0o755))
+		require.NoError(t, os.WriteFile(snapshotPath, []byte("version: ["), 0o644))
+
+		var out bytes.Buffer
+		cmd := commandForRoot(t, root, makeHealthCmd())
+		cmd.SetArgs([]string{"--json", "--governance", "--doctor", "--change", slug})
+		cmd.SetOut(&out)
+		require.NoError(t, cmd.Execute())
+
+		var view healthView
+		require.NoError(t, json.Unmarshal(out.Bytes(), &view))
+		require.NotNil(t, view.Governance)
+		require.NotNil(t, view.Doctor)
+
+		var traceFound bool
+		for _, check := range view.Governance.Checks {
+			if check.Name == "traceability_coherence" {
+				traceFound = true
+				assert.Equal(t, "WARN", check.Status)
+				assert.Empty(t, check.TraceabilityGaps, "data-unavailable WARN carries no gaps")
+			}
+		}
+		require.True(t, traceFound, "expected a traceability_coherence check")
+
+		hasTraceAction := false
+		for _, action := range view.Doctor.Actions {
+			if action.Category == "governance_traceability_coherence" {
+				hasTraceAction = true
+			}
+		}
+		assert.True(t, hasTraceAction,
+			"a gapless traceability WARN (unreadable snapshot) must still surface as a doctor action")
+	})
+}
+
 func TestHealthCommandGovernanceObservationsStillRenderWhenSnapshotUnreadable(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
@@ -1621,6 +1669,27 @@ func TestGovernanceDoctorActionsSuppressNonBlockingTraceabilityWarning(t *testin
 		}
 	}
 	assert.True(t, found, "a blocking traceability gap must still surface as a doctor action")
+
+	// Regression: a gapless traceability_coherence WARN (e.g. no-snapshot or
+	// unreadable-snapshot "data unavailable") is NOT an advisory gap and must
+	// still surface as a doctor action. The suppression is scoped to checks
+	// that actually carry advisory gaps, not to every non-blocking WARN.
+	gapless := &governance.GovernanceHealthReport{
+		Slug: "stage-aware",
+		Checks: []governance.GovernanceHealthCheck{{
+			Name:    "traceability_coherence",
+			Status:  "WARN",
+			Message: "governance_audit_data_unavailable: parse governance snapshot",
+		}},
+	}
+	foundGapless := false
+	for _, action := range governanceDoctorActions(gapless) {
+		if action.Category == "governance_traceability_coherence" {
+			foundGapless = true
+		}
+	}
+	assert.True(t, foundGapless,
+		"a gapless traceability WARN (missing/unreadable governance data) must still surface as a doctor action")
 }
 
 // TestHealthCommandDoctorTracksAssuranceCoverageBlockingState is the end-to-end

--- a/internal/engine/governance/health.go
+++ b/internal/engine/governance/health.go
@@ -458,9 +458,10 @@ func deriveGovernanceControls(
 	existingControls []model.ControlActivation,
 ) (control.DeriveControlsResult, model.TraceabilitySummary, error) {
 	traceability := EvaluateTraceability(TraceabilityInput{
-		BundleDir:  bundleDir,
-		Slug:       change.Slug,
-		SchemaName: change.ArtifactSchema,
+		BundleDir:      bundleDir,
+		Slug:           change.Slug,
+		SchemaName:     change.ArtifactSchema,
+		LifecycleState: change.CurrentState,
 	})
 
 	presetPolicy, err := ResolvePresetPolicy(root, change)

--- a/internal/engine/governance/health_test.go
+++ b/internal/engine/governance/health_test.go
@@ -842,3 +842,97 @@ func writePlanningTasksChecklist(t *testing.T, bundleDir, content string) {
 	require.NoError(t, os.MkdirAll(bundleDir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "tasks.md"), []byte(content), 0o644))
 }
+
+// TestTraceabilityCoherenceHealthIsStageAware proves that health.go threads the
+// change's lifecycle state into traceability evaluation, so an incomplete
+// per-requirement assurance coverage is a non-blocking WARN during S2 execution
+// (issue #92) but still fails closed at S3 review. Uses the standard preset so
+// the light-preset audit-gap downgrade does not mask the distinction.
+func TestTraceabilityCoherenceHealthIsStageAware(t *testing.T) {
+	t.Parallel()
+
+	writeBundle := func(t *testing.T) (root, slug, bundleDir string) {
+		t.Helper()
+		root = t.TempDir()
+		slug = "stage-aware-health"
+		bundleDir = filepath.Join(root, "artifacts", "changes", slug)
+		require.NoError(t, os.MkdirAll(bundleDir, 0o755))
+		writeFile(t, filepath.Join(bundleDir, "intent.md"), `INT-001: Intent`)
+		writeFile(t, resolveTestArtifact(bundleDir, slug), `# Requirements
+### Requirement: Something
+REQ-001: Something. INT-001
+### Requirement: Something Else
+REQ-002: Something else. INT-001
+`)
+		writeFile(t, filepath.Join(bundleDir, "tasks.md"), `# Tasks
+- [ ] `+"`t-01`"+` first task
+  covers: [REQ-001, REQ-002]
+`)
+		writeFile(t, filepath.Join(bundleDir, "assurance.md"), `# Assurance
+## Requirement Coverage
+REQ-001: verified via tests
+`)
+		return root, slug, bundleDir
+	}
+
+	traceCheck := func(t *testing.T, report GovernanceHealthReport) GovernanceHealthCheck {
+		t.Helper()
+		for _, c := range report.Checks {
+			if c.Name == "traceability_coherence" {
+				return c
+			}
+		}
+		t.Fatal("traceability_coherence check not found")
+		return GovernanceHealthCheck{}
+	}
+
+	const assuranceIssue = "requirement missing assurance coverage verdict"
+
+	t.Run("S2_EXECUTE reports WARN, not a blocking incident", func(t *testing.T) {
+		t.Parallel()
+		root, slug, bundleDir := writeBundle(t)
+		change := model.Change{
+			Slug:           slug,
+			CurrentState:   model.StateS2Execute,
+			WorkflowPreset: model.WorkflowPresetStandard,
+			ArtifactSchema: model.ArtifactSchemaExpanded,
+		}
+		snap, err := PreviewGovernanceSnapshot(root, change, bundleDir)
+		require.NoError(t, err)
+		report := CollectGovernanceHealthWithSnapshot(root, change, snap)
+
+		check := traceCheck(t, report)
+		assert.Equal(t, "WARN", check.Status)
+		// The gap is still reported, but as advisory — it must not be the thing
+		// that drives governance unhealthy. Other bare-tempdir checks (e.g.
+		// worktree_binding) may FAIL for reasons unrelated to #92, so assert the
+		// assurance gap specifically does not produce a traceability FAIL rather
+		// than asserting the whole report is healthy.
+		assert.True(t, hasGapIssue(check.TraceabilityGaps, assuranceIssue), "assurance gap should still be reported")
+		assert.False(t, hasBlockingGapIssue(check.TraceabilityGaps, assuranceIssue), "assurance gap must be non-blocking before review")
+		for _, c := range report.Checks {
+			if c.Status == "FAIL" {
+				assert.NotEqual(t, "traceability_coherence", c.Name,
+					"incomplete assurance coverage must not drive traceability FAIL at S2")
+			}
+		}
+	})
+
+	t.Run("S3_REVIEW fails closed", func(t *testing.T) {
+		t.Parallel()
+		root, slug, bundleDir := writeBundle(t)
+		change := model.Change{
+			Slug:           slug,
+			CurrentState:   model.StateS3Review,
+			WorkflowPreset: model.WorkflowPresetStandard,
+			ArtifactSchema: model.ArtifactSchemaExpanded,
+		}
+		snap, err := PreviewGovernanceSnapshot(root, change, bundleDir)
+		require.NoError(t, err)
+		report := CollectGovernanceHealthWithSnapshot(root, change, snap)
+
+		check := traceCheck(t, report)
+		assert.Equal(t, "FAIL", check.Status)
+		assert.True(t, hasBlockingGapIssue(check.TraceabilityGaps, assuranceIssue), "assurance gap must fail closed at review")
+	})
+}

--- a/internal/engine/governance/traceability.go
+++ b/internal/engine/governance/traceability.go
@@ -27,9 +27,31 @@ type TraceabilityInput struct {
 	BundleDir  string
 	Slug       string
 	SchemaName model.ArtifactSchemaName
+	// LifecycleState is the change's current workflow state. It makes
+	// closeout-time checks (per-requirement assurance coverage verdicts)
+	// stage-aware: before S3_REVIEW those gaps are advisory because the
+	// assurance verdicts are authored during review/verify, while at and after
+	// S3_REVIEW they remain blocking. An empty/unknown state stays fail-closed
+	// (blocking).
+	LifecycleState model.WorkflowState
 	// ArtifactNames maps logical names (e.g., "intent.md") to their resolved paths.
 	// When nil, default artifact resolution is used.
 	ArtifactResolver func(artifactName string) string
+}
+
+// assuranceVerdictsExpectedLater reports whether the change is still before the
+// review phase, where per-requirement assurance coverage verdicts have not yet
+// been authored. For those states, a missing assurance verdict is expected and
+// must not be a blocking traceability incident. Any other state — including an
+// empty/unknown state — is treated as at/after review, keeping the assurance
+// gaps fail-closed.
+func assuranceVerdictsExpectedLater(state model.WorkflowState) bool {
+	switch state {
+	case model.StateS0Intake, model.StateS1Plan, model.StateS2Execute:
+		return true
+	default:
+		return false
+	}
 }
 
 // EvaluateTraceability derives a traceability summary by scanning artifact content.
@@ -209,13 +231,17 @@ func EvaluateTraceability(input TraceabilityInput) model.TraceabilitySummary {
 	}
 
 	// Check: assurance must include per-requirement coverage verdicts.
+	// These verdicts are authored during review/verify, so before S3_REVIEW a
+	// missing verdict is expected and reported as a non-blocking warning; at and
+	// after review (and for an unknown state) it fails closed.
+	assuranceBlocking := !assuranceVerdictsExpectedLater(input.LifecycleState)
 	if strings.TrimSpace(assuranceContent) != "" && len(requireIDs) > 0 {
 		if len(assuranceREQs) == 0 {
 			gaps = append(gaps, model.TraceabilityGap{
 				ID:       "assurance",
 				Type:     "assurance",
 				Issue:    "assurance verifies no requirement IDs",
-				Blocking: true,
+				Blocking: assuranceBlocking,
 			})
 		} else {
 			assuredREQs := map[string]bool{}
@@ -236,7 +262,7 @@ func EvaluateTraceability(input TraceabilityInput) model.TraceabilitySummary {
 					ID:       fullReqID,
 					Type:     "assurance",
 					Issue:    "requirement missing assurance coverage verdict",
-					Blocking: true,
+					Blocking: assuranceBlocking,
 				})
 			}
 		}

--- a/internal/engine/governance/traceability_test.go
+++ b/internal/engine/governance/traceability_test.go
@@ -444,6 +444,174 @@ REQ-001: verified via tests
 	assert.Contains(t, gapIDs, "REQ-002")
 }
 
+func hasGapIssue(gaps []model.TraceabilityGap, issue string) bool {
+	for _, g := range gaps {
+		if g.Issue == issue {
+			return true
+		}
+	}
+	return false
+}
+
+func hasBlockingGapIssue(gaps []model.TraceabilityGap, issue string) bool {
+	for _, g := range gaps {
+		if g.Issue == issue && g.Blocking {
+			return true
+		}
+	}
+	return false
+}
+
+// writeAssuranceGapBundle writes a bundle whose assurance covers REQ-001 but not
+// REQ-002, producing a "requirement missing assurance coverage verdict" gap.
+func writeAssuranceGapBundle(t *testing.T) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	slug := "assurance-stage"
+	writeFile(t, filepath.Join(dir, "intent.md"), `INT-001: Intent`)
+	writeFile(t, resolveTestArtifact(dir, slug), `# Requirements
+### Requirement: Something
+REQ-001: Something. INT-001
+### Requirement: Something Else
+REQ-002: Something else. INT-001
+`)
+	writeFile(t, filepath.Join(dir, "tasks.md"), `# Tasks
+- [ ] `+"`t-01`"+` first task
+  covers: [REQ-001, REQ-002]
+`)
+	writeFile(t, filepath.Join(dir, "assurance.md"), `# Assurance
+## Requirement Coverage
+REQ-001: verified via tests
+`)
+	return dir, slug
+}
+
+func TestTraceabilityAssuranceCoverageGapIsStageAware(t *testing.T) {
+	t.Parallel()
+
+	const issue = "requirement missing assurance coverage verdict"
+
+	for _, state := range []model.WorkflowState{model.StateS0Intake, model.StateS1Plan, model.StateS2Execute} {
+		state := state
+		t.Run("non-blocking before review/"+string(state), func(t *testing.T) {
+			t.Parallel()
+			dir, slug := writeAssuranceGapBundle(t)
+			result := EvaluateTraceability(TraceabilityInput{
+				BundleDir:      dir,
+				Slug:           slug,
+				LifecycleState: state,
+			})
+			assert.Equal(t, model.TraceabilityStatusWarning, result.Status)
+			assert.True(t, hasGapIssue(result.Gaps, issue), "gap should still be reported")
+			assert.False(t, hasBlockingGapIssue(result.Gaps, issue), "gap should be non-blocking before review")
+		})
+	}
+
+	for _, state := range []model.WorkflowState{model.StateS3Review, model.StateS4Verify, model.StateDone} {
+		state := state
+		t.Run("blocking at or after review/"+string(state), func(t *testing.T) {
+			t.Parallel()
+			dir, slug := writeAssuranceGapBundle(t)
+			result := EvaluateTraceability(TraceabilityInput{
+				BundleDir:      dir,
+				Slug:           slug,
+				LifecycleState: state,
+			})
+			assert.Equal(t, model.TraceabilityStatusFail, result.Status)
+			assert.True(t, hasBlockingGapIssue(result.Gaps, issue), "gap must fail closed at/after review")
+		})
+	}
+
+	t.Run("unknown state stays fail-closed", func(t *testing.T) {
+		t.Parallel()
+		dir, slug := writeAssuranceGapBundle(t)
+		result := EvaluateTraceability(TraceabilityInput{BundleDir: dir, Slug: slug})
+		assert.Equal(t, model.TraceabilityStatusFail, result.Status)
+		assert.True(t, hasBlockingGapIssue(result.Gaps, issue), "unknown lifecycle state must fail closed")
+	})
+}
+
+func TestTraceabilityAssuranceNoREQIDsIsStageAware(t *testing.T) {
+	t.Parallel()
+
+	const issue = "assurance verifies no requirement IDs"
+	writeBundle := func(t *testing.T) (string, string) {
+		t.Helper()
+		dir := t.TempDir()
+		slug := "assurance-no-ids"
+		writeFile(t, filepath.Join(dir, "intent.md"), `INT-001: Intent`)
+		writeFile(t, resolveTestArtifact(dir, slug), `# Requirements
+### Requirement: Something
+REQ-001: Something. INT-001
+`)
+		writeFile(t, filepath.Join(dir, "assurance.md"), `# Assurance
+All tests pass.
+`)
+		return dir, slug
+	}
+
+	t.Run("non-blocking at S2_EXECUTE", func(t *testing.T) {
+		t.Parallel()
+		dir, slug := writeBundle(t)
+		result := EvaluateTraceability(TraceabilityInput{
+			BundleDir:      dir,
+			Slug:           slug,
+			LifecycleState: model.StateS2Execute,
+		})
+		assert.Equal(t, model.TraceabilityStatusWarning, result.Status)
+		assert.True(t, hasGapIssue(result.Gaps, issue))
+		assert.False(t, hasBlockingGapIssue(result.Gaps, issue))
+	})
+
+	t.Run("blocking at S3_REVIEW", func(t *testing.T) {
+		t.Parallel()
+		dir, slug := writeBundle(t)
+		result := EvaluateTraceability(TraceabilityInput{
+			BundleDir:      dir,
+			Slug:           slug,
+			LifecycleState: model.StateS3Review,
+		})
+		assert.Equal(t, model.TraceabilityStatusFail, result.Status)
+		assert.True(t, hasBlockingGapIssue(result.Gaps, issue))
+	})
+}
+
+func TestTraceabilityAssuranceCompleteCoverageOKAcrossStates(t *testing.T) {
+	t.Parallel()
+
+	for _, state := range []model.WorkflowState{model.StateS2Execute, model.StateS3Review} {
+		state := state
+		t.Run(string(state), func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			slug := "assurance-complete"
+			writeFile(t, filepath.Join(dir, "intent.md"), `INT-001: Intent`)
+			writeFile(t, resolveTestArtifact(dir, slug), `# Requirements
+### Requirement: Something
+REQ-001: Something. INT-001
+### Requirement: Something Else
+REQ-002: Something else. INT-001
+`)
+			writeFile(t, filepath.Join(dir, "tasks.md"), `# Tasks
+- [ ] `+"`t-01`"+` first task
+  covers: [REQ-001, REQ-002]
+`)
+			writeFile(t, filepath.Join(dir, "assurance.md"), `# Assurance
+## Requirement Coverage
+REQ-001: verified via tests
+REQ-002: verified via tests
+`)
+			result := EvaluateTraceability(TraceabilityInput{
+				BundleDir:      dir,
+				Slug:           slug,
+				LifecycleState: state,
+			})
+			assert.Equal(t, model.TraceabilityStatusOK, result.Status)
+			assert.False(t, hasGapIssue(result.Gaps, "requirement missing assurance coverage verdict"))
+		})
+	}
+}
+
 func TestTraceabilityBlockingOpenQuestions(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()


### PR DESCRIPTION
## Problem (#92)

Before `S3_REVIEW`, per-requirement assurance coverage verdicts have not been authored yet (they are written during review/verify). The traceability evaluator still classified the missing-verdict gaps as **blocking**, so for an S2 change:

- `slipway health --governance --json` reported `traceability_coherence: FAIL` with N blocking `assurance` gaps,
- `slipway health --governance --json --doctor` raised a non-repairable incident,

which **contradicted** `validate`/`next`, both of which correctly route the same S2 change to `wave-orchestration`. The user was forced to choose between two conflicting remediation paths.

## Fix

Make the assurance-coverage traceability gaps **stage-aware**:

- **Evaluator** (`internal/engine/governance/traceability.go`): add `LifecycleState` to `TraceabilityInput`; `assuranceVerdictsExpectedLater` returns true for `S0_INTAKE`/`S1_PLAN`/`S2_EXECUTE` (gaps non-blocking → WARN) and false otherwise, including unknown/empty (fail-closed → FAIL). Applies to both assurance gaps (`requirement missing assurance coverage verdict`, `assurance verifies no requirement IDs`); no other gap type changes.
- **Health call site** (`internal/engine/governance/health.go`): thread `change.CurrentState` into the evaluator.
- **Doctor synthesis** (`cmd/health.go`): `governanceDoctorActions` no longer promotes a `traceability_coherence` check **whose gaps are all non-blocking** into a `governance_traceability_coherence` action (via `traceabilityCheckHasOnlyAdvisoryGaps`), so `--doctor` raises no non-repairable incident before review. A blocking (`FAIL`) check **and a gapless WARN** (e.g. no-snapshot / unreadable-snapshot `governance_audit_data_unavailable`) both still surface unchanged.

Fail-closed is preserved at `S3_REVIEW`/`S4_VERIFY`/`DONE`: a change cannot reach `done` while any requirement lacks an assurance coverage verdict. `validate`/`next` behavior is unchanged (`EvaluateTraceability` has a single non-test caller).

### Review follow-up (commit 2)

A first pass suppressed on `!hasBlockingGap`, which is also true for a **gapless** traceability WARN — wrongly hiding the no-snapshot / unreadable-snapshot data-unavailable warnings from `--doctor`, beyond the advisory case REQ-004 scopes. The predicate is now `traceabilityCheckHasOnlyAdvisoryGaps`: suppress only when the check carries **≥1 gap and every gap is non-blocking**. FAIL checks and gapless WARNs surface unchanged.

## Tests

- Stage-aware evaluator tables (S0/S1/S2 non-blocking, S3/S4/DONE blocking, unknown fail-closed, complete coverage OK) over both assurance issue strings.
- Engine health test: S2 → WARN (gap present-but-non-blocking, not a FAIL driver) / S3 → FAIL.
- Deterministic `governanceDoctorActions` unit test: WARN-with-advisory-gap → no action; FAIL → action; **gapless WARN → action still present**.
- End-to-end `health --governance --json --doctor` regressions: S2 → WARN with no doctor action; S3 → FAIL with action present; **unreadable snapshot → gapless WARN still surfaces a doctor action**.
- `go build ./... && go vet ./... && go test ./...` green.

## Governance

Driven through a full governed Slipway re-walk (S0 intake → S1 plan-audit → S2 wave-orchestration → S3 spec-compliance + code-quality review → S4 goal-verification → G_ship → done). Scope was expanded mid-flow to the doctor-synthesis surface and recorded as a first-class requirement (REQ-004); all evidence was produced through each owning stage's public flow. The commit-2 follow-up is a bounded correctness fix that **restores** REQ-004's "no other doctor behavior changes" guarantee.

Closes #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)