### PR TITLE
fix(governance): skill-authored requirements/tasks + substance gates (#91)

### DIFF
--- a/artifacts/changes/archived/make-requirements-md-tasks-md-skill-authored-not-mechanicall/change.yaml
+++ b/artifacts/changes/archived/make-requirements-md-tasks-md-skill-authored-not-mechanicall/change.yaml
@@ -1,0 +1,31 @@
+version: 1
+slug: make-requirements-md-tasks-md-skill-authored-not-mechanicall
+description: 'Make requirements.md/tasks.md skill-authored, not mechanically seeded with fake content that passes structure-only validation (issue #91): the engine yields an obviously-not-real scaffold instead of fabricated tautology requirements/tasks, and governance validates substance (MUST/SHALL in the requirement body, a concrete non-tautological scenario, placeholder rejection) so a mechanical scaffold cannot reach done. Engine owns structure; skill owns substance.'
+status: done
+current_state: DONE
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-06-06T14:35:52.567514Z
+quality_mode: standard
+workflow_preset: light
+worktree_branch: feat/make-requirements-md-tasks-md-skill-authored-not-mechanicall
+artifact_schema: core
+artifacts:
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: 52f520b56121eff344c59aff0fcc91f82d29687e9658926247e349c8cfe95907
+        updated_at: 2026-06-06T18:16:05.506282989Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: ee9aecbc69f539c75cdff0ffae90416bca4c38e1254cdde0a0eaf658b437f46e
+        updated_at: 2026-06-06T18:13:52.534408063Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: 37e4cb4b366409b397e27f001ff745714004c21d0bbd0e9109ec005ab47bb808
+        updated_at: 2026-06-06T18:19:59.028570064Z

--- a/artifacts/changes/archived/make-requirements-md-tasks-md-skill-authored-not-mechanicall/intent.md
+++ b/artifacts/changes/archived/make-requirements-md-tasks-md-skill-authored-not-mechanicall/intent.md
@@ -1,0 +1,50 @@
+# Intent
+
+## Summary
+Make requirements.md/tasks.md skill-authored, not mechanically seeded with fake content that passes structure-only validation (issue #91): the engine yields an obviously-not-real scaffold instead of fabricated tautology requirements/tasks, and governance validates substance (MUST/SHALL in the requirement body, a concrete non-tautological scenario, placeholder rejection) so a mechanical scaffold cannot reach done. Engine owns structure; skill owns substance.
+## Complexity Assessment
+complex
+<!-- Rationale: provide justification for the assessed complexity level -->
+Spans engine artifact authoring (seed functions + templates), two governance validators (requirements + tasks substance), a runtime placeholder gate, and a new public CLI surface (`slipway instructions`) with generated-surface regeneration. It changes external governance contracts and must fail closed, so it is complex rather than simple.
+
+## Guardrail Domains
+<!-- none detected -->
+None. This is governance/authoring correctness, not auth/credentials/PII/financial/schema-migration/irreversible work. (Public CLI/JSON behavior still reviewed as an external contract.)
+
+## In Scope
+Broader scope (A + C + tasks gate + runtime application + instructions surface), confirmed with the user:
+- **A — engine yields structure, not fabricated substance** (`internal/engine/artifact/manager.go`, `internal/tmpl/templates/artifacts/requirements.md`, `internal/tmpl/templates/artifacts/tasks.md`): the default `seedRequirements`/`appendRequirementBlock` and `seedTasks` output becomes an *obviously-not-real* honest placeholder scaffold (headings + HTML-comment guidance + explicit "replace with…" prose that embeds the quality bar), matching the honesty of `seedDecision`/`seedResearch`. Fabricated tautology requirement sentences and the tautology `GIVEN/WHEN/THEN` are removed. The `--from-doc` path may still derive requirement/task *titles* from the user-provided doc, but must not fabricate normative bodies or tautology scenarios.
+- **C — substance gate (requirements)**: add a requirements-specific `LooksLikeRequirementsPlaceholder` (`requirements.go`) matching only the requirements seed markers + anchored tautology lines (not the generic decision/research sentinels, so authored prose containing a generic phrase is not false-flagged); extend `EvaluateRequirementsContract` (`internal/engine/artifact/requirements_contract.go`) so each `REQ-*` body line contains an RFC-2119 strong-obligation keyword (`MUST`/`SHALL`/`REQUIRED`), each requirement has ≥1 concrete (non-tautology, non-placeholder) `#### Scenario` complete within a single scenario, and placeholder content is rejected.
+- **C — substance gate (tasks)**: add a tasks substance validator that rejects placeholder tasks (`pending task objective` / `pending verification objective`) and requires real objectives; wire it into the same gate path `validate`/plan-audit uses for `requirements_contract`.
+- **runtime scoping** (`internal/engine/governance/runtime_actions.go`): keep the `artifactSectionHasSubstantiveContent` placeholder helper scoped to `decision.md` (its only invoked artifacts are `decision.md`/`assurance.md`). Placeholder `requirements.md`/`tasks.md` rejection is owned by the progression substance gate + the validate contracts, so generalizing this runtime helper would be dead, unreachable code.
+- **instructions surface**: add `slipway instructions <artifact>` (openspec-style) returning the artifact template + authoring guidance (text + `--json`), so an authoring skill can read the template and quality bar before writing. Register the command, its capability/command surface, and regenerate generated command references/skills/docs with zero toolgen drift.
+- Tests for every behavior; `go build ./... && go vet ./... && go test ./...` green; toolgen self-loop zero drift.
+
+## Out of Scope
+- Routing authorship to skills is already the de-facto behavior (skills author requirements/tasks; with this change the engine stops fabricating). No new skill→artifact routing wiring beyond the honest scaffold + instructions surface.
+- The markdown format itself stays (`### Requirement:` / `#### Scenario:` / `- [ ] \`t-NN\``); we change content honesty + validation, not the schema shape.
+- Issue #92 (separate, already done-ready).
+
+## Constraints
+- Fail closed: the substance gate must reject mechanical/placeholder content; it must not introduce a bypass/force path. Unknown/edge inputs default to rejection only when clearly placeholder, not on legitimately-authored content (avoid false positives that block real work).
+- The new gate must not retroactively break legitimately-authored bundles (real MUST/SHALL + concrete scenarios pass).
+- Keep generated surfaces aligned (zero drift) — code, skills, command refs, docs are one product surface.
+
+## Acceptance Signals
+- A mechanical/placeholder `requirements.md` (engine default scaffold, unedited) makes `EvaluateRequirementsContract` return `invalid` and cannot reach `done`; a real authored one returns `valid`.
+- `LooksLikeRequirementsPlaceholder` returns true for the requirements seed/tautology sentinels but NOT for generic decision/research sentinels in authored prose; placeholder `requirements.md`/`tasks.md` is rejected by the progression substance gate + the validate contracts; the runtime helper stays scoped to `decision.md`.
+- A placeholder `tasks.md` is rejected by the tasks substance validator; a real one passes.
+- The engine's default `seedRequirements`/`seedTasks` output is detected as placeholder (obviously-not-real), proving the engine no longer fabricates plausible substance.
+- `slipway instructions requirements` / `slipway instructions tasks` return the template + authoring guidance (text and `--json`).
+- Toolgen self-loop reports zero drift; `go build ./... && go vet ./... && go test ./...` pass.
+
+## Open Questions
+- [x] None — needs_discovery=false; root cause and fix surfaces already confirmed by reading current code (manager.go seed funcs + templates, requirements_contract.go, runtime_actions.go).
+
+## Deferred Ideas
+- Quantitative ambiguity scoring (gsd-style) for requirements — out of scope; a future enhancement.
+
+## Approved Summary
+Engine owns structure, skill owns substance. (A) The engine's default requirements.md/tasks.md scaffold becomes obviously-not-real honest placeholders instead of fabricated tautology requirements/tasks. (C) A substance gate rejects mechanical/placeholder content: a requirements-specific placeholder matcher, a `EvaluateRequirementsContract` content check (RFC-2119 MUST/SHALL/REQUIRED-in-body + concrete single-scenario + placeholder rejection), and a tasks substance validator; the runtime placeholder helper stays scoped to decision.md (requirements/tasks substance is owned by the progression gate + validate contracts). A new `slipway instructions <artifact>` surface serves the template + guidance to authoring skills. All generated surfaces regenerated with zero drift; full build/vet/test green. Net: a 100% mechanical scaffold cannot pass validation or reach done.
+
+Confirmed by user 2026-06-06 (selected the broader "A+C + tasks gate + runtime application + instructions surface" scope).

--- a/artifacts/changes/archived/make-requirements-md-tasks-md-skill-authored-not-mechanicall/requirements.md
+++ b/artifacts/changes/archived/make-requirements-md-tasks-md-skill-authored-not-mechanicall/requirements.md
@@ -1,0 +1,127 @@
+# Requirements
+## Project Context
+- Tech Stack: Go
+- Conventions: cmd/* CLI over internal/engine/* kernel; generated skills/docs via toolgen; table-driven tests
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Requirements
+
+### Requirement: Engine yields an obviously-not-real scaffold, not fabricated substance (#91)
+REQ-001: The engine's default `requirements.md` and `tasks.md` seed (no `--from-doc`)
+MUST NOT fabricate plausible normative requirements or tautological scenarios.
+`seedRequirements`/`appendRequirementBlock` and `seedTasks` MUST emit an
+obviously-not-real honest placeholder scaffold (headings plus guidance prose that
+embeds the quality bar and explicit "replace with…" instructions), matching the
+honesty of `seedDecision`/`seedResearch`. The default-seeded content MUST be
+detected by `LooksLikeTemplatePlaceholder`. The `--from-doc` path MAY still derive
+requirement/task titles from the user document but MUST NOT fabricate normative
+bodies or tautology scenarios.
+
+#### Scenario: Default seed is detectably non-substantive
+GIVEN a change with no `--from-doc` source
+WHEN the engine seeds `requirements.md` and `tasks.md`
+THEN the seeded requirement body and scenario contain honest placeholder prose
+that `LooksLikeTemplatePlaceholder` reports as a placeholder, and the prior
+fabricated GIVEN/THEN tautology scaffold lines are no longer emitted.
+
+### Requirement: Placeholder detection covers requirements tautologies (#91)
+REQ-002: `LooksLikeTemplatePlaceholder` MUST return true for the requirements
+scaffold sentinels — the legacy GIVEN/WHEN/THEN tautology scenario lines, the
+honest-seed requirement and scenario placeholder markers, the placeholder
+verification-objective marker, and the requirements fallback marker — in addition
+to the existing decision/research/task sentinels. (The exact sentinel strings are
+pinned in the artifact-package tests; this file paraphrases them to avoid
+self-flagging.)
+
+#### Scenario: Requirements tautology strings are recognized
+GIVEN text containing a requirements scaffold tautology sentinel
+WHEN `LooksLikeTemplatePlaceholder` evaluates it
+THEN it returns true.
+
+### Requirement: requirements.md must pass a substance gate, not only structure (#91)
+REQ-003: `EvaluateRequirementsContract` MUST, beyond the existing structure checks,
+return `invalid` when the requirements lack substance: each `REQ-*` body line MUST
+contain an RFC-2119 strong-obligation keyword (`MUST`, `SHALL`, or the equivalent
+`REQUIRED`); each requirement block MUST have at least one concrete `#### Scenario`
+whose body is neither a tautology sentinel nor a requirements placeholder hit; and
+overall placeholder-only content MUST be rejected. Placeholder detection MUST be
+requirements-specific so legitimately-authored prose that merely contains a generic
+sentinel substring (e.g. "pending investigation") is NOT rejected. Legitimately-authored
+requirements (real `MUST`/`SHALL`/`REQUIRED` bodies and concrete scenarios) MUST still
+return `valid`.
+
+#### Scenario: Mechanical requirements are rejected
+GIVEN a `requirements.md` consisting only of the engine's default placeholder
+scaffold (or a requirement whose body has no MUST/SHALL, or only a tautology
+scenario)
+WHEN `EvaluateRequirementsContract` evaluates it
+THEN the result is `invalid` with a message naming the missing substance.
+
+#### Scenario: Authored requirements pass
+GIVEN a `requirements.md` whose every `REQ-*` body contains MUST/SHALL and has a
+concrete, non-tautology scenario
+WHEN `EvaluateRequirementsContract` evaluates it
+THEN the result is `valid`.
+
+### Requirement: tasks.md must pass a substance gate (#91)
+REQ-004: A tasks substance validator MUST reject a `tasks.md` whose task objectives
+are the engine's seeded placeholder markers (the seeded task/verification objective
+markers) or otherwise non-substantive, and MUST be wired into the same governed validation
+path (`slipway validate` / plan-audit) that consumes the requirements contract.
+A real authored task list MUST pass.
+
+#### Scenario: Placeholder tasks are rejected
+GIVEN a `tasks.md` whose only task is the engine placeholder objective
+WHEN governed validation evaluates the bundle
+THEN the tasks substance check reports the bundle invalid with an actionable
+message.
+
+#### Scenario: Authored tasks pass
+GIVEN a `tasks.md` with real task objectives, target files, and covers mapping
+WHEN governed validation evaluates the bundle
+THEN the tasks substance check passes.
+
+### Requirement: Placeholder requirements/tasks are rejected by the governed validation path (#91)
+REQ-005: A placeholder/seed `requirements.md` or `tasks.md` MUST NOT be counted as
+substantive: the progression substance gate (hard, from plan-audit onward) and the
+`slipway validate` requirements/tasks contracts MUST reject it. The runtime
+substantive-content helper (`artifactSectionHasSubstantiveContent` in
+`internal/engine/governance/runtime_actions.go`) MUST stay scoped to `decision.md`
+(its only invoked artifacts are `decision.md`/`assurance.md`); it MUST NOT carry a
+dead generalization to `requirements.md`/`tasks.md`, whose substance is owned by the
+governed validation path above.
+
+#### Scenario: Placeholder requirements/tasks cannot pass governed validation
+GIVEN a `requirements.md` or `tasks.md` whose body is placeholder scaffold prose
+WHEN governed validation evaluates the bundle at or past plan-audit
+THEN it is reported invalid and cannot reach done, while the runtime helper carries
+no requirements/tasks placeholder branch.
+
+### Requirement: A public instructions surface serves template + guidance (#91)
+REQ-006: `slipway instructions <artifact>` MUST return the artifact template plus
+authoring guidance (the quality bar) for a named governed artifact (at least
+`requirements` and `tasks`), in both human text and `--json`, so an authoring
+skill can read the template and substance bar before writing. An unknown artifact
+name MUST produce an actionable error.
+
+#### Scenario: instructions returns template and guidance
+GIVEN `slipway instructions requirements` (and `--json`)
+WHEN the command runs
+THEN it outputs the requirements template and authoring guidance, exit 0.
+
+#### Scenario: unknown artifact errors
+GIVEN `slipway instructions not-an-artifact`
+WHEN the command runs
+THEN it exits non-zero with a message naming the valid artifact names.
+
+### Requirement: Generated surfaces stay aligned with zero drift (#91)
+REQ-007: After the source and surface changes, all generated skills, command
+references, and docs MUST be regenerated so the toolgen self-loop reports zero
+drift, and `go build ./... && go vet ./... && go test ./...` MUST pass.
+
+#### Scenario: Toolgen self-loop is clean
+GIVEN the change is implemented
+WHEN toolgen regeneration and the drift check run
+THEN there is zero drift and build, vet, and test all pass.

--- a/artifacts/changes/archived/make-requirements-md-tasks-md-skill-authored-not-mechanicall/tasks.md
+++ b/artifacts/changes/archived/make-requirements-md-tasks-md-skill-authored-not-mechanicall/tasks.md
@@ -1,0 +1,97 @@
+# Tasks
+## Project Context
+- Tech Stack: Go
+- Conventions: cmd/* CLI over internal/engine/* kernel; generated skills/docs via toolgen; table-driven tests
+- Test Command: go test ./...
+- Build Command: go build ./...
+- Languages: Go
+
+## Task List
+
+- [x] `t-01` (#91) Make the engine's default requirements/tasks seed an
+  obviously-not-real honest placeholder. In `internal/engine/artifact/manager.go`
+  rewrite `appendRequirementBlock` (and `seedRequirements`/`seededRequirementsContent`
+  default path) and `seedTasks` so the default scaffold emits headings plus honest
+  guidance prose ("replace with…", quality bar) instead of a fabricated
+  `REQ-001: The system MUST <request>` and the tautology GIVEN/WHEN/THEN; keep the
+  `--from-doc` title derivation but drop fabricated normative bodies/tautology
+  scenarios. Keep templates `internal/tmpl/templates/artifacts/requirements.md` and
+  `tasks.md` rendering the seeded content (adjust if needed so the rendered default
+  is detectably placeholder). Test-first: `manager_test.go` (or the existing seed
+  tests) assert the default-seeded requirements/tasks are `LooksLikeTemplatePlaceholder`
+  and no longer contain the old tautology strings.
+  - wave: 1
+  - depends_on: []
+  - target_files: ["internal/engine/artifact/manager.go", "internal/tmpl/templates/artifacts/requirements.md", "internal/tmpl/templates/artifacts/tasks.md", "internal/engine/artifact/manager_test.go"]
+  - task_kind: code
+  - covers: [REQ-001]
+
+- [x] `t-02` (#91) Add requirements substance detection + gate. In
+  `internal/engine/artifact/manager.go` extend `LooksLikeTemplatePlaceholder` with
+  the requirements scaffold sentinels (the legacy GIVEN/WHEN/THEN tautology lines,
+  the honest-seed requirement/scenario placeholder markers, the placeholder
+  verification-objective marker, and the requirements fallback marker; exact
+  strings pinned in artifact-package tests). In
+  `internal/engine/artifact/requirements_contract.go` extend
+  `EvaluateRequirementsContract` so each REQ-* body contains MUST/SHALL, each
+  requirement has >=1 concrete non-tautology/non-placeholder scenario, and
+  placeholder-only content is rejected (invalid with an actionable message);
+  authored content stays valid. Test-first: `requirements_contract_test.go` (reject
+  mechanical/no-MUST/tautology-only; accept authored) and a placeholder-sentinel
+  test.
+  - wave: 2
+  - depends_on: [t-01]
+  - target_files: ["internal/engine/artifact/manager.go", "internal/engine/artifact/requirements.go", "internal/engine/artifact/requirements_contract.go", "internal/engine/artifact/requirements_contract_test.go", "internal/engine/artifact/manager_test.go"]
+  - task_kind: code
+  - covers: [REQ-002, REQ-003]
+
+- [x] `t-03` (#91) Add a tasks substance validator and wire it into the governed
+  validation path. Add `EvaluateTasksContract` (new
+  `internal/engine/artifact/tasks_contract.go`) rejecting placeholder task
+  objectives (the engine's seeded task/verification objective markers) and
+  non-substantive task lists; invoke it from the same gate path that consumes
+  `EvaluateRequirementsContract` (locate via `validate`/plan-audit artifact-gate
+  wiring) so `slipway validate` fails a placeholder tasks.md. Test-first:
+  `tasks_contract_test.go` (reject placeholder, accept authored) and the
+  validate-gate test that exercises the wiring.
+  - wave: 3
+  - depends_on: [t-02]
+  - target_files: ["internal/engine/artifact/tasks_contract.go", "internal/engine/artifact/tasks_contract_test.go", "internal/engine/progression/validation.go", "internal/engine/progression/validation_test.go", "internal/model/reason_code.go", "internal/model/recovery.go", "cmd/validate.go", "cmd/validate_requirements_contract_test.go", "cmd/cli_e2e_test.go", "cmd/governance_gate_consistency_test.go", "cmd/progression_next_test.go", "cmd/review_test.go", "cmd/lifecycle_commands_test.go"]
+  - task_kind: code
+  - covers: [REQ-004]
+
+- [x] `t-04` (#91) Keep the runtime placeholder helper scoped to decision.md; do
+  NOT generalize it to `requirements.md`/`tasks.md`. `artifactSectionHasSubstantiveContent`
+  in `internal/engine/governance/runtime_actions.go` is only invoked for
+  `decision.md`/`assurance.md` (via `hasRollbackDocumentation`), so a
+  requirements/tasks branch would be dead, unreachable code; their substance is
+  owned by the progression substance gate + the validate contracts (REQ-003/REQ-004).
+  Document the deliberate scoping in `runtime_actions.go`.
+  - wave: 1
+  - depends_on: []
+  - target_files: ["internal/engine/governance/runtime_actions.go"]
+  - task_kind: code
+  - covers: [REQ-005]
+
+- [x] `t-05` (#91) Add the `slipway instructions <artifact>` command. New
+  `cmd/instructions.go` returning the named artifact's template + authoring guidance
+  (text and `--json`), with an actionable error for unknown names; register it in
+  the command tree and the command registry/capability surface used by toolgen.
+  Test-first: `cmd/instructions_test.go` (requirements/tasks return template +
+  guidance, text and json; unknown name errors).
+  - wave: 2
+  - depends_on: []
+  - target_files: ["cmd/instructions.go", "cmd/instructions_test.go", "cmd/root.go", "cmd/root_help_test.go"]
+  - task_kind: code
+  - covers: [REQ-006]
+
+- [x] `t-06` (#91) Regenerate all generated surfaces and lock the suite. Run the
+  toolgen self-loop to regenerate generated skills, command references, and docs
+  (covering the new `instructions` command surface and any seed/guidance text that
+  flows into generated skills) and confirm zero drift; then run
+  `go build ./... && go vet ./... && go test ./...` green.
+  - wave: 4
+  - depends_on: [t-01, t-02, t-03, t-04, t-05]
+  - target_files: ["internal/toolgen/toolgen.go", "internal/toolgen/toolgen_test.go", "docs/commands.md", "internal/tmpl/templates/skills/plan-audit/SKILL.md"]
+  - task_kind: doc
+  - covers: [REQ-007]

--- a/cmd/cli_e2e_test.go
+++ b/cmd/cli_e2e_test.go
@@ -334,8 +334,12 @@ func TestCLIEndToEndValidateIncludesRequirementsContract(t *testing.T) {
 		require.NoError(t, err)
 
 		// Write requirements.md flat in bundle.
-		reqContent := "# Requirements\n\n### Requirement: Token Auth\nREQ-001: The system MUST support token-based authentication.\n"
+		reqContent := "# Requirements\n\n### Requirement: Token Auth\nREQ-001: The system MUST support token-based authentication.\n\n#### Scenario: Token authenticates a request\nGIVEN a valid token\nWHEN a request presents it\nTHEN the request is authenticated.\n"
 		require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "requirements.md"), []byte(reqContent), 0o644))
+
+		// Write a substantive tasks.md so the tasks_contract surfaces as valid.
+		tasksContent := "# Tasks\n\n## Task List\n\n- [ ] `t-01` Implement token-based authentication for protected routes\n  - wave: 1\n  - target_files: [\"cmd/root.go\"]\n  - covers: [REQ-001]\n"
+		require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "tasks.md"), []byte(tasksContent), 0o644))
 
 		stdout, stderr, err := runRootCommandIn(root, []string{"validate", "--json", "--change", slug})
 		require.NoError(t, err)
@@ -347,6 +351,9 @@ func TestCLIEndToEndValidateIncludesRequirementsContract(t *testing.T) {
 		assert.Equal(t, slug, view.Slug)
 		assert.Equal(t, "valid", view.RequirementsContract.Status)
 		assert.Contains(t, view.RequirementsContract.Message, "validated")
+		require.NotNil(t, view.TasksContract)
+		assert.Equal(t, "valid", view.TasksContract.Status)
+		assert.Contains(t, view.TasksContract.Message, "validated")
 
 		// Verify no published directory is created.
 		_, err = os.Stat(filepath.Join(root, "artifacts", "requirements", slug))
@@ -416,7 +423,7 @@ func TestCLIEndToEndSuccessfulReviewPassAtS7(t *testing.T) {
 		bundlePath := filepath.Join(root, "artifacts", "changes", slug)
 		specPath := artifact.ResolveArtifactPath(bundlePath, slug, "requirements.md")
 		require.NoError(t, os.MkdirAll(filepath.Dir(specPath), 0o755))
-		require.NoError(t, os.WriteFile(specPath, []byte("## Requirements\n\n### Requirement: ReviewE2E\n\nREQ-001: The system MUST support review from the CLI.\n"), 0o644))
+		require.NoError(t, os.WriteFile(specPath, []byte("## Requirements\n\n### Requirement: ReviewE2E\n\nREQ-001: The system MUST support review from the CLI.\n\n#### Scenario: Review runs from the CLI\nGIVEN a governed change ready for review\nWHEN the reviewer runs the CLI review command\nTHEN the review result is produced.\n"), 0o644))
 
 		// Write tasks.md covering that requirement.
 		require.NoError(t, os.WriteFile(filepath.Join(bundlePath, "tasks.md"), []byte("# Tasks\n\n- [ ] `t-01` implement review e2e\n  - wave: 1\n  - depends_on: []\n  - target_files: [\"cmd/review.go\"]\n  - task_kind: code\n  - covers: [REQ-001]\n"), 0o644))
@@ -492,7 +499,7 @@ func TestCLIEndToEndValidateRequirementsContractAfterRequestNext(t *testing.T) {
 		require.NoError(t, err)
 		bundleDir, err := state.GovernedBundleDir(root, change)
 		require.NoError(t, err)
-		reqContent := "# Requirements\n\n## Requirements\n\n### Requirement: Token Rotation\nREQ-001: The system MUST rotate tokens on schedule.\n"
+		reqContent := "# Requirements\n\n## Requirements\n\n### Requirement: Token Rotation\nREQ-001: The system MUST rotate tokens on schedule.\n\n#### Scenario: Tokens rotate on schedule\nGIVEN a token nearing expiry\nWHEN the rotation schedule runs\nTHEN a fresh token is issued.\n"
 		require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "requirements.md"), []byte(reqContent), 0o644))
 
 		validateOut := bytes.NewBuffer(nil)

--- a/cmd/governance_gate_consistency_test.go
+++ b/cmd/governance_gate_consistency_test.go
@@ -46,7 +46,12 @@ INT-001: validate gate status reuse
 `)))
 	require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "requirements.md", []byte(`# Requirements
 ### Requirement: StableGateStatus
-REQ-001: Planning gate evidence must remain visible after execution.
+REQ-001: Planning gate evidence MUST remain visible after execution.
+
+#### Scenario: Planning gate stays visible post-execution
+GIVEN a change with planning-stage gate evidence
+WHEN status, validate, and next read gate state after execution
+THEN the planning gate remains visible and consistent.
 `)))
 	require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "decision.md", []byte(`# Decision
 ## Alternatives Considered

--- a/cmd/instructions.go
+++ b/cmd/instructions.go
@@ -1,0 +1,102 @@
+package cmd
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/signalridge/slipway/internal/engine/artifact"
+	"github.com/spf13/cobra"
+)
+
+// instructionsArtifacts maps a public artifact name to its embedded template
+// file name. The engine owns structure (these templates); the authoring skill
+// owns substance. `slipway instructions <artifact>` serves a rendered exemplar
+// plus the quality bar so a skill reads it before writing (issue #91).
+var instructionsArtifacts = map[string]string{
+	"intent":       "intent.md",
+	"requirements": "requirements.md",
+	"tasks":        "tasks.md",
+	"decision":     "decision.md",
+	"research":     "research.md",
+	"assurance":    "assurance.md",
+}
+
+type instructionsView struct {
+	Artifact string `json:"artifact"`
+	Guidance string `json:"guidance"`
+	Template string `json:"template"`
+}
+
+func instructionsArtifactNames() []string {
+	names := make([]string, 0, len(instructionsArtifacts))
+	for name := range instructionsArtifacts {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func instructionsGuidance(name string) string {
+	switch name {
+	case "requirements":
+		return "Author each requirement as `### Requirement: <title>` followed by a `REQ-` " +
+			"body that states what the system MUST, SHALL, or is REQUIRED to do (an RFC-2119 " +
+			"strong-obligation keyword), and at least one concrete `#### Scenario:` with real " +
+			"GIVEN/WHEN/THEN lines. The engine seeds an obviously-not-real placeholder; replace " +
+			"it — an unedited scaffold is rejected by the requirements substance gate and cannot " +
+			"reach done."
+	case "tasks":
+		return "Author each task as a checklist line (- [ ] t-NN <objective>) with wave, " +
+			"depends_on, target_files, task_kind, and covers metadata. Replace the placeholder " +
+			"objective; a placeholder tasks list is rejected by the tasks substance gate."
+	default:
+		return "Replace the seeded placeholder with concrete, substantive content. The engine " +
+			"owns structure; you own substance."
+	}
+}
+
+func makeInstructionsCmd() *cobra.Command {
+	var jsonOutput bool
+
+	cmd := &cobra.Command{
+		Use:   "instructions <artifact>",
+		Short: desc("instructions"),
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := strings.ToLower(strings.TrimSpace(args[0]))
+			templateName, ok := instructionsArtifacts[name]
+			if !ok {
+				return newInvalidUsageError(
+					"unknown_artifact",
+					fmt.Sprintf("unknown artifact %q", name),
+					"Choose a governed artifact: "+strings.Join(instructionsArtifactNames(), ", "),
+					nil,
+				)
+			}
+			content, err := artifact.RenderArtifactExample(templateName)
+			if err != nil {
+				return err
+			}
+			view := instructionsView{
+				Artifact: name,
+				Guidance: instructionsGuidance(name),
+				Template: content,
+			}
+			if jsonOutput {
+				return encodeJSONResponse(cmd, view)
+			}
+			out := cmd.OutOrStdout()
+			fmt.Fprintf(out, "# Authoring instructions: %s\n\n", name)
+			fmt.Fprintln(out, view.Guidance)
+			fmt.Fprintln(out)
+			fmt.Fprintln(out, "## Template")
+			fmt.Fprintln(out)
+			fmt.Fprintln(out, content)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "JSON output")
+	return cmd
+}

--- a/cmd/instructions_test.go
+++ b/cmd/instructions_test.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func runInstructions(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	cmd := makeInstructionsCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+func TestInstructionsReturnsTemplateAndGuidance(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"requirements": "## Requirements",
+		"tasks":        "## Task List",
+	}
+	for name, marker := range cases {
+		name, marker := name, marker
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			out, err := runInstructions(t, name)
+			require.NoError(t, err)
+			assert.Contains(t, out, "Authoring instructions")
+			assert.Contains(t, out, "## Template")
+			assert.Contains(t, out, marker, "should include the artifact template body")
+		})
+	}
+}
+
+func TestInstructionsJSONIncludesTemplateAndGuidance(t *testing.T) {
+	t.Parallel()
+	out, err := runInstructions(t, "requirements", "--json")
+	require.NoError(t, err)
+
+	var view instructionsView
+	require.NoError(t, json.Unmarshal([]byte(out), &view))
+	assert.Equal(t, "requirements", view.Artifact)
+	assert.NotEmpty(t, view.Guidance)
+	assert.Contains(t, view.Template, "## Requirements")
+	assert.Contains(t, strings.ToUpper(view.Guidance), "MUST")
+	// Issue #91: the served template is a rendered exemplar, not the raw
+	// Go-template source — its consumer is an authoring skill, so unresolved
+	// `{{ … }}` actions must not leak through.
+	assert.NotContains(t, view.Template, "{{", "served template must be rendered, not raw Go-template source")
+}
+
+func TestInstructionsUnknownArtifactErrors(t *testing.T) {
+	t.Parallel()
+	_, err := runInstructions(t, "not-an-artifact")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown artifact")
+}

--- a/cmd/lifecycle_commands_test.go
+++ b/cmd/lifecycle_commands_test.go
@@ -1835,6 +1835,11 @@ INT-001: finalize governed closeout
 	require.NoError(t, writeBundleArtifactFile(bundlePath, change.Slug, "requirements.md", []byte(`# Requirements
 ### Requirement: ShipReadyCloseout
 REQ-001: The change MUST satisfy ship-ready governance evidence before finalization.
+
+#### Scenario: Finalization requires fresh evidence
+GIVEN a change carrying ship-ready governance evidence
+WHEN finalization runs the ship gate
+THEN the change is allowed to finalize.
 `)))
 	require.NoError(t, writeBundleArtifactFile(bundlePath, change.Slug, "decision.md", []byte(`# Decision
 ## Alternatives Considered
@@ -1879,7 +1884,12 @@ INT-001: test fixture intent
 `)))
 	require.NoError(t, writeBundleArtifactFile(bundlePath, change.Slug, "requirements.md", []byte(`# Requirements
 ### Requirement: FixtureContract
-REQ-001: The fixture must provide a valid governed bundle.
+REQ-001: The fixture MUST provide a valid governed bundle.
+
+#### Scenario: Fixture bundle validates
+GIVEN a minimal governed bundle fixture
+WHEN governed validation runs
+THEN the bundle passes structural and substance checks.
 `)))
 	if change.NeedsDiscovery {
 		require.NoError(t, writeBundleArtifactFile(bundlePath, change.Slug, "research.md", []byte(`## Research Findings

--- a/cmd/progression_next_test.go
+++ b/cmd/progression_next_test.go
@@ -1386,7 +1386,12 @@ func TestNextAdvancesWithPlanAuditEvidence(t *testing.T) {
 	require.NoError(t, writeBundleArtifactFile(bundlePath, change.Slug, "requirements.md", []byte(`# Requirements
 
 ### Requirement: Plan Audit
-REQ-001: The plan audit path must advance only when the task checklist is valid.
+REQ-001: The plan audit path MUST advance only when the task checklist is valid.
+
+#### Scenario: Advance only on a valid checklist
+GIVEN a governed change with passing plan-audit evidence and a valid task checklist
+WHEN next evaluates planning readiness
+THEN the change advances to S2_EXECUTE.
 `)))
 	require.NoError(t, os.WriteFile(filepath.Join(bundlePath, "tasks.md"), []byte(`
 - [ ] `+"`t-01`"+` implement plan audit checks

--- a/cmd/review_test.go
+++ b/cmd/review_test.go
@@ -287,7 +287,12 @@ func TestReviewPassFromS7VerifyPreservesGovernedState(t *testing.T) {
 
 ### Requirement: ReviewContract
 
-REQ-001: The system must preserve governed verify-state when review prerequisites remain valid.
+REQ-001: The system MUST preserve governed verify-state when review prerequisites remain valid.
+
+#### Scenario: Verify-state preserved on valid review
+GIVEN a governed change at S4_VERIFY with valid review prerequisites
+WHEN the review runs
+THEN the governed verify-state is preserved.
 `), 0o644))
 
 		writePassingExecutionSummary(t, root, slug, 1, "t-01")
@@ -341,7 +346,12 @@ func TestReviewRequiresStoredWaveRunsForExecutionSummary(t *testing.T) {
 
 ### Requirement: ReviewContract
 
-REQ-001: The system must preserve governed verify-state when review prerequisites remain valid.
+REQ-001: The system MUST preserve governed verify-state when review prerequisites remain valid.
+
+#### Scenario: Verify-state preserved on valid review
+GIVEN a governed change at S4_VERIFY with valid review prerequisites
+WHEN the review runs
+THEN the governed verify-state is preserved.
 `), 0o644))
 
 		now := time.Now().UTC()
@@ -428,7 +438,12 @@ func TestReviewFailsClosedOnWaveRunsMissingEvenWhenReadinessIsAlreadyBlocked(t *
 
 ### Requirement: ReviewContract
 
-REQ-001: The system must preserve governed verify-state when review prerequisites remain valid.
+REQ-001: The system MUST preserve governed verify-state when review prerequisites remain valid.
+
+#### Scenario: Verify-state preserved on valid review
+GIVEN a governed change at S4_VERIFY with valid review prerequisites
+WHEN the review runs
+THEN the governed verify-state is preserved.
 `), 0o644))
 
 		now := time.Now().UTC()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,6 +66,7 @@ var helpGroups = []commandGroup{
 			{Name: "learn", Description: desc("learn")},
 			{Name: "stats", Description: desc("stats")},
 			{Name: "health", Description: desc("health")},
+			{Name: "instructions", Description: desc("instructions")},
 		},
 	},
 	{
@@ -158,6 +159,7 @@ func newRootCmd() *cobra.Command {
 	cmd.AddCommand(makeLearnCmd())
 	cmd.AddCommand(makeStatsCmd())
 	cmd.AddCommand(makeHealthCmd())
+	cmd.AddCommand(makeInstructionsCmd())
 	cmd.AddCommand(makeRootPathCmd())
 	cmd.AddCommand(makeDoneCmd())
 	cmd.AddCommand(makeAbortCmd())

--- a/cmd/root_help_test.go
+++ b/cmd/root_help_test.go
@@ -22,6 +22,10 @@ func TestRootHelpUsesCurrentEntrySurfaceDescriptions(t *testing.T) {
 	assert.Contains(t, help, "Create or refresh the durable repo-scoped codebase map")
 	assert.Contains(t, help, "Show repo-wide governance freshness and workflow statistics")
 	assert.Contains(t, help, "Show repo-local integrity and repairability findings")
+	// Issue #91 (P2b): the new public authoring surface must be discoverable from
+	// the main `slipway help` path, not only docs/toolgen.
+	assert.Contains(t, help, "instructions")
+	assert.Contains(t, help, "Show the template and authoring guidance for a governed artifact")
 	assert.Contains(t, help, "Finalize a done-ready change and archive it")
 	assert.NotContains(t, help, "completed change")
 	assert.NotContains(t, help, "Auto-classify advisory versus governed work")

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -38,7 +38,8 @@ type validateView struct {
 	EvidenceFreshness         string                               `json:"evidence_freshness"`
 	FreshnessDiagnostics      *state.ExecutionFreshnessDiagnostics `json:"freshness_diagnostics,omitempty"`
 	ActionableNextSkill       *actionableNextSkillView             `json:"actionable_next_skill,omitempty"`
-	RequirementsContract      *requirementsContractView            `json:"requirements_contract,omitempty"`
+	RequirementsContract      *artifactContractView                `json:"requirements_contract,omitempty"`
+	TasksContract             *artifactContractView                `json:"tasks_contract,omitempty"`
 	ScopeContract             *scopeContractView                   `json:"scope_contract,omitempty"`
 	Diagnostics               []string                             `json:"diagnostics,omitempty"`
 	Mode                      string                               `json:"mode,omitempty"`
@@ -54,7 +55,9 @@ type actionableNextSkillView struct {
 	RequiredTokens   []string `json:"required_tokens,omitempty"`
 }
 
-type requirementsContractView struct {
+// artifactContractView is the read-only projection of an artifact substance
+// contract. It backs both the requirements_contract and tasks_contract fields.
+type artifactContractView struct {
 	Status  string `json:"status"`
 	Source  string `json:"source,omitempty"`
 	Message string `json:"message,omitempty"`
@@ -221,14 +224,23 @@ func buildValidateViewForSlug(root, slug string) (validateView, error) {
 		return view, nil
 	}
 
-	var requirementsContract *requirementsContractView
+	var requirementsContract *artifactContractView
+	var tasksContract *artifactContractView
 	if bundleDir, err := state.GovernedBundleDir(root, change); err == nil {
 		contract, err := artifact.EvaluateRequirementsContract(bundleDir, change.Slug)
 		if err == nil {
-			requirementsContract = &requirementsContractView{
+			requirementsContract = &artifactContractView{
 				Status:  string(contract.Status),
 				Source:  contract.Source,
 				Message: contract.Message,
+			}
+		}
+		tasks, err := artifact.EvaluateTasksContract(bundleDir, change.Slug)
+		if err == nil {
+			tasksContract = &artifactContractView{
+				Status:  string(tasks.Status),
+				Source:  tasks.Source,
+				Message: tasks.Message,
 			}
 		}
 	}
@@ -270,6 +282,7 @@ func buildValidateViewForSlug(root, slug string) (validateView, error) {
 	view.GovernanceForecast = presetFields.GovernanceForecast
 	view.NeedsDiscovery = profile.NeedsDiscovery
 	view.RequirementsContract = requirementsContract
+	view.TasksContract = tasksContract
 	view.ScopeContract = buildScopeContractView(readiness.ScopeContract)
 	view.FreshnessDiagnostics = attachFreshnessDiagnostics(readiness.FreshnessDiagnostics)
 	view.ActionableNextSkill = buildActionableNextSkillView(change, readiness)

--- a/cmd/validate_requirements_contract_test.go
+++ b/cmd/validate_requirements_contract_test.go
@@ -29,7 +29,12 @@ func TestValidateIncludesRequirementsContractForGovernedChange(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "requirements.md"), []byte(`# Requirements
 
 ### Requirement: Auth
-REQ-001: The system must authenticate requests.
+REQ-001: The system MUST authenticate requests before serving protected routes.
+
+#### Scenario: Unauthenticated request is rejected
+GIVEN a request without valid credentials
+WHEN it reaches a protected route
+THEN the system returns 401 and does not serve the resource.
 `), 0o644))
 
 		view, err := buildValidateViewForSlug(root, slug)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -56,6 +56,12 @@ Workflow profiles shape checks: `code`, `docs`, `research`, `config`, or `meta`.
 | `slipway stats` | query | Show repo-wide governance freshness and workflow statistics. |
 | `slipway health` | query | Show repo-local integrity and repairability findings. |
 | `slipway codebase-map` | mutation | Create or refresh advisory repo-scoped context under `artifacts/codebase/`. |
+| `slipway instructions <artifact>` | query | Show the template and authoring guidance for a governed artifact (e.g. `requirements`, `tasks`). |
+
+`slipway instructions <artifact>` serves the artifact template plus its quality
+bar so an authoring skill writes substance instead of accepting the engine's
+obviously-not-real placeholder; the engine owns structure, the skill owns
+substance.
 
 `codebase-map --json` reports `status: "baseline"` when documents contain only
 CLI-detected repository facts. Baseline docs are useful starting context, not

--- a/internal/engine/artifact/manager.go
+++ b/internal/engine/artifact/manager.go
@@ -153,6 +153,21 @@ func TemplateContent(name string) (string, error) {
 	return tmpl.Content(filepath.Join("artifacts", name))
 }
 
+// RenderArtifactExample renders the named artifact template (e.g.
+// "requirements.md") with representative example data so callers such as
+// `slipway instructions` can present a concrete, directive-free exemplar —
+// headings, authoring-guidance comments, and the honest placeholder seed —
+// instead of the raw Go-template source with unresolved `{{ … }}` actions. The
+// engine owns this structure; the authoring skill owns the substance that
+// replaces the seed (issue #91).
+func RenderArtifactExample(name string) (string, error) {
+	example := model.Change{
+		Slug:        "example-change",
+		Description: "describe the change here",
+	}
+	return renderTemplateWithFallback("", name, "", buildTemplateData("", example, nil))
+}
+
 type templateData struct {
 	Slug               string
 	InitialRequest     string
@@ -455,12 +470,31 @@ func appendRequirementBlock(b *strings.Builder, reqNum int, objective string) {
 		b.WriteString("\n")
 	}
 	cleanedObjective := strings.Join(strings.Fields(strings.TrimSpace(objective)), " ")
+	// The engine owns structure (heading + stable REQ-* id); the authoring skill
+	// owns substance. Emit an honest, obviously-not-real placeholder — no
+	// normative MUST/SHALL and an explicit "replace" instruction — so it is
+	// caught by LooksLikeTemplatePlaceholder and rejected by the requirements
+	// substance gate until a skill writes the real requirement.
 	fmt.Fprintf(b, "### Requirement: %s\n", cleanedObjective)
-	fmt.Fprintf(b, "REQ-%03d: %s\n", reqNum, requirementNormativeSentence(cleanedObjective))
-	b.WriteString("\n#### Scenario: Primary flow\n")
-	b.WriteString("GIVEN the relevant workflow is exercised\n")
-	b.WriteString("WHEN the requirement is implemented in the target flow\n")
-	fmt.Fprintf(b, "THEN the expected behavior for %s is observed.\n", strings.ToLower(cleanedObjective))
+	fmt.Fprintf(b, "REQ-%03d: %s\n", reqNum, requirementPlaceholderSentence(cleanedObjective))
+	b.WriteString("\n#### Scenario: Pending — replace with a concrete scenario\n")
+	b.WriteString("GIVEN pending — replace with the precondition\n")
+	b.WriteString("WHEN pending — replace with the triggering action\n")
+	b.WriteString("THEN pending — replace with the observable expected outcome\n")
+}
+
+// requirementPlaceholderSentence returns an honest, non-normative placeholder for
+// a seeded requirement body. It deliberately contains no RFC-2119 MUST/SHALL and
+// a placeholder sentinel ("define requirements based on the initial request") so
+// the substance gate rejects an unedited scaffold.
+func requirementPlaceholderSentence(objective string) string {
+	if strings.TrimSpace(objective) == "" {
+		return "Pending — replace with the normative requirement. Define requirements based on the initial request."
+	}
+	return fmt.Sprintf(
+		"Pending — replace with the normative requirement (state what the system is required to do). Define requirements based on the initial request: %s.",
+		objective,
+	)
 }
 
 func appendGuardrailRequirementBlock(b *strings.Builder, reqNum int, guardrailDomain string) {
@@ -473,34 +507,6 @@ func appendGuardrailRequirementBlock(b *strings.Builder, reqNum int, guardrailDo
 	b.WriteString("GIVEN the change touches a guarded domain\n")
 	b.WriteString("WHEN the implementation is updated\n")
 	fmt.Fprintf(b, "THEN %s guardrail requirements remain satisfied.\n", guardrailDomain)
-}
-
-func requirementNormativeSentence(objective string) string {
-	lowerObjective := strings.ToLower(strings.TrimSpace(objective))
-	if lowerObjective == "" {
-		return "The system MUST support the approved change intent."
-	}
-	if looksLikeActionPhrase(lowerObjective) {
-		return "The system MUST " + lowerObjective + "."
-	}
-	return "The system MUST support the requested change described as: " + lowerObjective + "."
-}
-
-func looksLikeActionPhrase(objective string) bool {
-	firstWord := objective
-	if fields := strings.Fields(objective); len(fields) > 0 {
-		firstWord = fields[0]
-	}
-	switch firstWord {
-	case "add", "allow", "block", "create", "deny", "detect", "disable", "document",
-		"enable", "enforce", "expire", "expose", "fix", "generate", "improve", "infer",
-		"keep", "limit", "migrate", "parse", "preserve", "prevent", "reduce", "remove",
-		"replace", "require", "reuse", "seed", "support", "track", "update", "use",
-		"validate", "verify", "write":
-		return true
-	default:
-		return false
-	}
 }
 
 func docSectionItems(section string) []string {
@@ -932,8 +938,17 @@ func ParseDecisionLockedDecisions(content string) []string {
 
 // LooksLikeTemplatePlaceholder returns true if the text looks like unedited
 // scaffold content, including seeded draft prose that still needs explicit
-// confirmation before it should satisfy governance/runtime checks.
+// confirmation before it should satisfy governance/runtime checks. It is the
+// broad matcher used by the decision/runtime and task-objective paths: a
+// superset of LooksLikeRequirementsPlaceholder (the requirements-scaffold seed
+// markers + legacy tautology lines) plus the generic decision/research/task
+// sentinels below. The requirements substance gate uses the narrower
+// LooksLikeRequirementsPlaceholder so legitimately-authored requirement prose
+// that shares a generic phrase is not false-flagged (issue #91).
 func LooksLikeTemplatePlaceholder(text string) bool {
+	if LooksLikeRequirementsPlaceholder(text) {
+		return true
+	}
 	lower := strings.ToLower(text)
 	placeholderPhrases := []string{
 		"describe the chosen approach",
@@ -950,6 +965,7 @@ func LooksLikeTemplatePlaceholder(text string) bool {
 		"pending — assess after",
 		"pending investigation",
 		"pending task objective",
+		"pending verification objective",
 		"replace with concrete",
 		"record the selected approach only after",
 		"name changed interfaces and data flows",

--- a/internal/engine/artifact/manager_test.go
+++ b/internal/engine/artifact/manager_test.go
@@ -518,8 +518,16 @@ func TestScaffoldGovernedBundleSeedsRequirementsDraft(t *testing.T) {
 	require.NoError(t, err)
 	content := string(raw)
 
+	// Structure is seeded (heading + stable REQ id) ...
 	require.Contains(t, content, "REQ-001")
 	require.NotContains(t, content, "Add requirements using")
+	// ... but the engine no longer fabricates substance: the default seed is an
+	// honest, obviously-not-real placeholder that the substance gate rejects.
+	require.True(t, LooksLikeTemplatePlaceholder(content),
+		"default-seeded requirements must read as a placeholder")
+	require.NotContains(t, content, "the relevant workflow is exercised")
+	require.NotContains(t, content, "the expected behavior for")
+	require.NotContains(t, content, "The system MUST")
 }
 
 func TestScaffoldGovernedBundleSeedsDecisionDraft(t *testing.T) {

--- a/internal/engine/artifact/requirements.go
+++ b/internal/engine/artifact/requirements.go
@@ -11,20 +11,75 @@ var (
 	requirementIDPattern      = regexp.MustCompile(`(?i)\bREQ-([A-Z0-9_-]+)\b`)
 )
 
-// RequirementBlock describes one checkbox-native requirement block in requirements.md.
-type RequirementBlock struct {
-	Name     string
-	StableID string
+// placeholderTautologyPatterns match the legacy fabricated requirements scenario
+// lines (issue #91) by their full, content-free shape. Each pattern is anchored
+// to a whole line (`(?im)^…$`) so a concrete authored line that merely shares a
+// leading fragment is NOT misread as a placeholder — e.g.
+//   - "THEN the expected behavior for an expired token is a 401 response."
+//   - "THEN the expected behavior for an audit-log write is observed in the audit log"
+//   - "GIVEN the relevant workflow is exercised by an admin during off-hours"
+//
+// all carry real substance and must pass. Only the exact vacuous legacy lines
+// (whole-line, optionally with trailing punctuation/whitespace) are flagged.
+// These are regex-based rather than substring sentinels precisely because a bare
+// substring ("the relevant workflow is exercised", "… is observed") would also
+// match authored prose that continues past the legacy phrasing.
+var placeholderTautologyPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?im)^\s*GIVEN the relevant workflow is exercised\s*$`),
+	regexp.MustCompile(`(?im)^\s*WHEN the requirement is implemented in the target flow\s*$`),
+	regexp.MustCompile(`(?im)^\s*THEN the expected behavior for .+ is observed\.?\s*$`),
 }
 
-// ParseRequirementBlocks extracts requirement headings and their first stable REQ-* ID.
-func ParseRequirementBlocks(content string) []RequirementBlock {
-	lines := strings.Split(strings.ReplaceAll(content, "\r\n", "\n"), "\n")
-	type heading struct {
-		name string
-		line int
+// requirementsPlaceholderPhrases are the engine's own requirements-scaffold seed
+// markers (issue #91). They are scoped to what the requirements seed actually
+// emits — deliberately NOT the broad decision/research/task sentinels in
+// LooksLikeTemplatePlaceholder — so a legitimately-authored requirement that
+// happens to contain a generic phrase (e.g. a real requirement about cases in
+// "pending investigation" status) is not false-flagged as a placeholder.
+var requirementsPlaceholderPhrases = []string{
+	"pending — replace with the normative requirement",
+	"pending — replace with the precondition",
+	"pending — replace with the triggering action",
+	"pending — replace with the observable expected outcome",
+	"define requirements based on the initial request",
+}
+
+// LooksLikeRequirementsPlaceholder reports whether text still carries the
+// engine's requirements scaffold seed — a requirements-specific seed marker or
+// one of the legacy fabricated GIVEN/WHEN/THEN tautology lines. It is
+// deliberately NARROWER than LooksLikeTemplatePlaceholder: it does not match the
+// generic decision/research/task sentinels, so authored requirement prose that
+// shares a phrase with those seeds is not rejected (issue #91 — avoid false
+// positives that block real work). The requirements substance gate uses this
+// matcher; LooksLikeTemplatePlaceholder remains a superset that folds these in
+// for the decision/runtime and task-objective paths.
+func LooksLikeRequirementsPlaceholder(text string) bool {
+	lower := strings.ToLower(text)
+	for _, phrase := range requirementsPlaceholderPhrases {
+		if strings.Contains(lower, phrase) {
+			return true
+		}
 	}
-	headings := make([]heading, 0)
+	for _, pattern := range placeholderTautologyPatterns {
+		if pattern.MatchString(text) {
+			return true
+		}
+	}
+	return false
+}
+
+// requirementHeading is a recognized "### Requirement: <name>" heading.
+type requirementHeading struct {
+	line int
+	name string
+}
+
+// requirementHeadingsIn returns the requirement headings (line index + title)
+// in the given lines. It is the single recognizer shared by ParseRequirementBlocks
+// and splitRequirementBlocksForSubstance so heading detection cannot drift
+// between the structure check and the substance check.
+func requirementHeadingsIn(lines []string) []requirementHeading {
+	headings := make([]requirementHeading, 0)
 	for i, line := range lines {
 		matches := requirementHeadingPattern.FindStringSubmatch(strings.TrimSpace(line))
 		if len(matches) != 2 {
@@ -34,8 +89,21 @@ func ParseRequirementBlocks(content string) []RequirementBlock {
 		if name == "" {
 			continue
 		}
-		headings = append(headings, heading{name: name, line: i})
+		headings = append(headings, requirementHeading{line: i, name: name})
 	}
+	return headings
+}
+
+// RequirementBlock describes one checkbox-native requirement block in requirements.md.
+type RequirementBlock struct {
+	Name     string
+	StableID string
+}
+
+// ParseRequirementBlocks extracts requirement headings and their first stable REQ-* ID.
+func ParseRequirementBlocks(content string) []RequirementBlock {
+	lines := strings.Split(strings.ReplaceAll(content, "\r\n", "\n"), "\n")
+	headings := requirementHeadingsIn(lines)
 
 	blocks := make([]RequirementBlock, 0, len(headings))
 	for i, heading := range headings {

--- a/internal/engine/artifact/requirements_contract.go
+++ b/internal/engine/artifact/requirements_contract.go
@@ -5,8 +5,23 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"regexp"
 	"strings"
 )
+
+// rfc2119Pattern matches an RFC-2119 normative keyword (uppercase, as authored
+// requirements use them) anywhere in a requirement body. MUST/SHALL also cover
+// their negative forms (MUST NOT / SHALL NOT); REQUIRED is accepted as an
+// equivalent strong-obligation keyword so a legitimately-authored requirement is
+// not hard-blocked for phrasing the obligation as "is REQUIRED to …".
+var rfc2119Pattern = regexp.MustCompile(`\b(MUST|SHALL|REQUIRED)\b`)
+
+// scenarioHeadingPattern matches a "#### Scenario:" heading that separates a
+// requirement's normative statement from its acceptance scenarios. The RFC-2119
+// substance check applies to the statement region only, so a MUST/SHALL that
+// appears in a scenario's GIVEN/WHEN/THEN line does not satisfy the gate
+// (issue #91 blocker).
+var scenarioHeadingPattern = regexp.MustCompile(`(?i)^####\s*Scenario\b`)
 
 type RequirementsContractStatus string
 
@@ -62,9 +77,153 @@ func EvaluateRequirementsContract(bundleDir, slug string) (RequirementsContractR
 		}, nil
 	}
 
+	if substanceBlockers := RequirementSubstanceBlockers(content); len(substanceBlockers) > 0 {
+		return RequirementsContractResult{
+			Status: RequirementsContractStatusInvalid,
+			Source: sourcePath,
+			Message: fmt.Sprintf(
+				"requirements.md is not substantive: %s",
+				strings.Join(substanceBlockers, "; "),
+			),
+		}, nil
+	}
+
 	return RequirementsContractResult{
 		Status:  RequirementsContractStatusValid,
 		Source:  sourcePath,
 		Message: fmt.Sprintf("requirements.md validated (%d requirements)", requirementCount),
 	}, nil
+}
+
+// RequirementSubstanceBlockers returns substance problems in requirements.md
+// beyond structure: template/seed placeholder content, a requirement body with
+// no RFC-2119 MUST/SHALL/REQUIRED keyword, or a requirement without a concrete
+// GIVEN/WHEN/THEN scenario. An empty slice means the requirements carry real
+// substance. This is the gate that stops a mechanical scaffold from reaching
+// done (issue #91): the engine owns structure, the authoring skill owns substance.
+//
+// Placeholder detection uses the requirements-specific LooksLikeRequirementsPlaceholder
+// (not the broad LooksLikeTemplatePlaceholder) so a legitimately-authored
+// requirement containing a generic phrase — e.g. a real requirement about cases
+// in "pending investigation" status — is not false-flagged (issue #91: avoid
+// false positives that block real work).
+func RequirementSubstanceBlockers(content string) []string {
+	var blockers []string
+	if LooksLikeRequirementsPlaceholder(content) {
+		blockers = append(blockers,
+			"contains template/seed placeholder content; author concrete requirements")
+	}
+	for _, block := range splitRequirementBlocksForSubstance(content) {
+		label := block.stableID
+		if label == "" {
+			label = block.name
+		}
+		if !rfc2119Pattern.MatchString(block.statementBody) {
+			blockers = append(blockers,
+				fmt.Sprintf("requirement %s body has no RFC-2119 MUST/SHALL/REQUIRED keyword", label))
+		}
+		if !hasConcreteScenario(block) {
+			blockers = append(blockers,
+				fmt.Sprintf("requirement %s has no concrete #### Scenario (needs GIVEN/WHEN/THEN)", label))
+		}
+	}
+	return blockers
+}
+
+type requirementSubstanceBlock struct {
+	name          string
+	stableID      string
+	text          string // full block, including the heading line
+	statementBody string // requirement statement region: after the heading, before the first scenario
+	scenarioText  string // scenario region: from the first "#### Scenario" to the end of the block ("" if none)
+}
+
+func splitRequirementBlocksForSubstance(content string) []requirementSubstanceBlock {
+	lines := strings.Split(strings.ReplaceAll(content, "\r\n", "\n"), "\n")
+	headings := requirementHeadingsIn(lines)
+	blocks := make([]requirementSubstanceBlock, 0, len(headings))
+	for i, heading := range headings {
+		start := heading.line
+		end := len(lines)
+		if i+1 < len(headings) {
+			end = headings[i+1].line
+		}
+		blockLines := lines[start:end]
+		text := strings.Join(blockLines, "\n")
+
+		// Split the block into the requirement-statement region (the REQ-* body,
+		// which may span multiple lines) and the scenario region. The statement
+		// ends at the first "#### Scenario" heading; everything from there is the
+		// scenario region. RFC-2119 substance must appear in the statement, not in
+		// a scenario line (issue #91 blocker).
+		scenarioStart := -1
+		for j := 1; j < len(blockLines); j++ {
+			if scenarioHeadingPattern.MatchString(strings.TrimSpace(blockLines[j])) {
+				scenarioStart = j
+				break
+			}
+		}
+		var statementBody, scenarioText string
+		if scenarioStart >= 0 {
+			statementBody = strings.Join(blockLines[1:scenarioStart], "\n")
+			scenarioText = strings.Join(blockLines[scenarioStart:], "\n")
+		} else {
+			statementBody = strings.Join(blockLines[1:], "\n")
+		}
+
+		blocks = append(blocks, requirementSubstanceBlock{
+			name:          heading.name,
+			stableID:      firstRequirementID(text),
+			text:          text,
+			statementBody: statementBody,
+			scenarioText:  scenarioText,
+		})
+	}
+	return blocks
+}
+
+// scenarioSegments splits a requirement's scenario region into one segment per
+// "#### Scenario" heading, so a scenario's GIVEN/WHEN/THEN completeness is judged
+// within a single scenario rather than scattered across several.
+func scenarioSegments(scenarioText string) []string {
+	if strings.TrimSpace(scenarioText) == "" {
+		return nil
+	}
+	lines := strings.Split(scenarioText, "\n")
+	var segments []string
+	var cur []string
+	flush := func() {
+		if len(cur) > 0 {
+			segments = append(segments, strings.Join(cur, "\n"))
+			cur = nil
+		}
+	}
+	for _, line := range lines {
+		if scenarioHeadingPattern.MatchString(strings.TrimSpace(line)) {
+			flush()
+		}
+		cur = append(cur, line)
+	}
+	flush()
+	return segments
+}
+
+// hasConcreteScenario reports whether a requirement has at least one real
+// acceptance scenario: a single "#### Scenario" segment that carries GIVEN, WHEN
+// and THEN and is not placeholder/tautology prose. The completeness check is
+// per-scenario so GIVEN/WHEN/THEN scattered across separate scenarios does not
+// count, and a placeholder scenario is rejected via the requirements-specific
+// matcher (issue #91).
+func hasConcreteScenario(block requirementSubstanceBlock) bool {
+	for _, segment := range scenarioSegments(block.scenarioText) {
+		if LooksLikeRequirementsPlaceholder(segment) {
+			continue
+		}
+		if strings.Contains(segment, "GIVEN") &&
+			strings.Contains(segment, "WHEN") &&
+			strings.Contains(segment, "THEN") {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/engine/artifact/requirements_contract.go
+++ b/internal/engine/artifact/requirements_contract.go
@@ -209,19 +209,50 @@ func scenarioSegments(scenarioText string) []string {
 }
 
 // hasConcreteScenario reports whether a requirement has at least one real
-// acceptance scenario: a single "#### Scenario" segment that carries GIVEN, WHEN
-// and THEN and is not placeholder/tautology prose. The completeness check is
-// per-scenario so GIVEN/WHEN/THEN scattered across separate scenarios does not
-// count, and a placeholder scenario is rejected via the requirements-specific
-// matcher (issue #91).
+// acceptance scenario: a single "#### Scenario" segment that carries non-empty
+// GIVEN, WHEN, and THEN step lines and is not placeholder/tautology prose. The
+// completeness check is per-scenario so GIVEN/WHEN/THEN scattered across
+// separate scenarios does not count, and a placeholder scenario is rejected via
+// the requirements-specific matcher (issue #91).
 func hasConcreteScenario(block requirementSubstanceBlock) bool {
 	for _, segment := range scenarioSegments(block.scenarioText) {
 		if LooksLikeRequirementsPlaceholder(segment) {
 			continue
 		}
-		if strings.Contains(segment, "GIVEN") &&
-			strings.Contains(segment, "WHEN") &&
-			strings.Contains(segment, "THEN") {
+		if scenarioSegmentHasConcreteSteps(segment) {
+			return true
+		}
+	}
+	return false
+}
+
+func scenarioSegmentHasConcreteSteps(segment string) bool {
+	return scenarioStepHasContent(segment, "GIVEN") &&
+		scenarioStepHasContent(segment, "WHEN") &&
+		scenarioStepHasContent(segment, "THEN")
+}
+
+func scenarioStepHasContent(segment, keyword string) bool {
+	for _, line := range strings.Split(segment, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if len(trimmed) <= len(keyword) {
+			continue
+		}
+		if !strings.HasPrefix(strings.ToUpper(trimmed), keyword) {
+			continue
+		}
+
+		rest := trimmed[len(keyword):]
+		switch rest[0] {
+		case ' ', '\t', ':':
+		default:
+			continue
+		}
+		rest = strings.TrimSpace(rest)
+		if strings.HasPrefix(rest, ":") {
+			rest = strings.TrimSpace(rest[1:])
+		}
+		if rest != "" {
 			return true
 		}
 	}

--- a/internal/engine/artifact/requirements_contract_test.go
+++ b/internal/engine/artifact/requirements_contract_test.go
@@ -385,3 +385,54 @@ THEN the system returns 401.
 	assert.Empty(t, RequirementSubstanceBlockers(oneComplete),
 		"at least one complete scenario must satisfy the gate")
 }
+
+func TestRequirementSubstanceBlockersRequiresNonEmptyBDDSteps(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{
+			name: "empty step lines",
+			content: `# Requirements
+### Requirement: Auth
+REQ-001: The system MUST authenticate requests before serving protected routes.
+
+#### Scenario: Empty BDD skeleton
+GIVEN
+WHEN
+THEN
+`,
+		},
+		{
+			name: "blank step content",
+			content: "# Requirements\n" +
+				"### Requirement: Auth\n" +
+				"REQ-001: The system MUST authenticate requests before serving protected routes.\n\n" +
+				"#### Scenario: Blank BDD skeleton\n" +
+				"GIVEN   \n" +
+				"WHEN:\n" +
+				"THEN :\n",
+		},
+		{
+			name: "keywords in prose",
+			content: `# Requirements
+### Requirement: Auth
+REQ-001: The system MUST authenticate requests before serving protected routes.
+
+#### Scenario: Keywords in prose only
+This paragraph mentions GIVEN, WHEN, and THEN without defining acceptance steps.
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			blockers := RequirementSubstanceBlockers(tt.content)
+			require.NotEmpty(t, blockers, "non-substantive BDD skeleton must not satisfy the scenario gate")
+			assert.Contains(t, strings.Join(blockers, "; "), "no concrete #### Scenario")
+		})
+	}
+}

--- a/internal/engine/artifact/requirements_contract_test.go
+++ b/internal/engine/artifact/requirements_contract_test.go
@@ -3,6 +3,7 @@ package artifact
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,7 +20,12 @@ func TestEvaluateRequirementsContractReturnsValidResult(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "requirements.md"), []byte(`# Requirements
 
 ### Requirement: Auth
-REQ-001: The system must authenticate requests.
+REQ-001: The system MUST authenticate requests before serving protected routes.
+
+#### Scenario: Unauthenticated request is rejected
+GIVEN a request without valid credentials
+WHEN it reaches a protected route
+THEN the system returns 401 and does not serve the resource.
 `), 0o644))
 
 	result, err := EvaluateRequirementsContract(bundleDir, slug)
@@ -69,6 +75,57 @@ The system must authenticate requests.
 `,
 			wantMessage: "missing stable REQ-* IDs",
 		},
+		{
+			name: "body without RFC-2119 keyword",
+			content: `# Requirements
+
+### Requirement: Auth
+REQ-001: The system authenticates requests.
+
+#### Scenario: Login
+GIVEN a user
+WHEN they log in
+THEN they are authenticated.
+`,
+			wantMessage: "no RFC-2119 MUST/SHALL/REQUIRED keyword",
+		},
+		{
+			name: "no concrete scenario",
+			content: `# Requirements
+
+### Requirement: Auth
+REQ-001: The system MUST authenticate requests.
+`,
+			wantMessage: "no concrete #### Scenario",
+		},
+		{
+			name: "MUST only in scenario line not statement",
+			content: `# Requirements
+
+### Requirement: Auth
+REQ-001: The system authenticates protected routes.
+
+#### Scenario: Login succeeds
+GIVEN the caller MUST present credentials
+WHEN it reaches the route
+THEN the route returns protected content.
+`,
+			wantMessage: "no RFC-2119 MUST/SHALL/REQUIRED keyword",
+		},
+		{
+			name: "mechanical placeholder scaffold",
+			content: `# Requirements
+
+### Requirement: do the thing
+REQ-001: Pending — replace with the normative requirement. Define requirements based on the initial request.
+
+#### Scenario: Pending — replace with a concrete scenario
+GIVEN pending — replace with the precondition
+WHEN pending — replace with the triggering action
+THEN pending — replace with the observable expected outcome
+`,
+			wantMessage: "placeholder content",
+		},
 	}
 
 	for _, tt := range tests {
@@ -88,6 +145,127 @@ The system must authenticate requests.
 	}
 }
 
+func TestLooksLikeTemplatePlaceholderRecognizesRequirementsTautologies(t *testing.T) {
+	t.Parallel()
+	for _, s := range []string{
+		"GIVEN the relevant workflow is exercised",
+		"THEN the expected behavior for foo is observed",
+		"WHEN the requirement is implemented in the target flow",
+		"Define requirements based on the initial request: foo.",
+		"Pending — replace with the normative requirement.",
+	} {
+		assert.True(t, LooksLikeTemplatePlaceholder(s), "should detect placeholder: %q", s)
+	}
+	for _, s := range []string{
+		"The system MUST authenticate requests before serving protected routes.",
+		// Issue #91 false-positive guard: a concrete THEN line that shares the
+		// "the expected behavior for" fragment but is not the vacuous "… is
+		// observed" tautology must NOT be flagged as a placeholder.
+		"THEN the expected behavior for an expired token is a 401 response.",
+		"THEN the expected behavior for a malformed payload is a validation error.",
+		// Issue #91 P2a: an authored line whose middle contains "is observed" but
+		// continues past the legacy tautology (anchored to the whole line) is real
+		// substance and must NOT be flagged.
+		"THEN the expected behavior for an audit-log write is observed in the audit log.",
+		// The GIVEN/WHEN legacy lines are likewise whole-line anchored: an authored
+		// line that merely starts with the legacy fragment but continues must pass.
+		"GIVEN the relevant workflow is exercised by an admin during off-hours",
+		"WHEN the requirement is implemented in the target flow for the billing service",
+	} {
+		assert.False(t, LooksLikeTemplatePlaceholder(s), "should NOT flag concrete prose: %q", s)
+	}
+}
+
+func TestRequirementSubstanceBlockers(t *testing.T) {
+	t.Parallel()
+
+	authored := `# Requirements
+### Requirement: Auth
+REQ-001: The system MUST authenticate requests before serving protected routes.
+
+#### Scenario: Rejects unauthenticated request
+GIVEN a request without credentials
+WHEN it reaches a protected route
+THEN the system returns 401.
+`
+	assert.Empty(t, RequirementSubstanceBlockers(authored), "authored requirements should have no substance blockers")
+
+	// Issue #91: REQUIRED is accepted as an equivalent strong-obligation keyword,
+	// so a requirement phrased with "is REQUIRED to …" is not hard-blocked.
+	requiredKeyword := `# Requirements
+### Requirement: Auth
+REQ-001: The system is REQUIRED to authenticate requests before serving protected routes.
+
+#### Scenario: Rejects unauthenticated request
+GIVEN a request without credentials
+WHEN it reaches a protected route
+THEN the system returns 401.
+`
+	assert.Empty(t, RequirementSubstanceBlockers(requiredKeyword),
+		"a REQUIRED-keyword requirement should satisfy the RFC-2119 substance check")
+
+	// Issue #91 false-positive guard: a concrete scenario whose THEN line shares
+	// the "the expected behavior for" fragment is real substance, not a placeholder.
+	concreteExpectedBehavior := `# Requirements
+### Requirement: Auth
+REQ-001: The system MUST reject requests that carry an expired token.
+
+#### Scenario: Expired token is rejected
+GIVEN a request carrying an expired token
+WHEN it reaches a protected route
+THEN the expected behavior for an expired token is a 401 response.
+`
+	assert.Empty(t, RequirementSubstanceBlockers(concreteExpectedBehavior),
+		"a concrete 'expected behavior for' scenario must not be treated as placeholder")
+
+	mechanical := `# Requirements
+### Requirement: do the thing
+REQ-001: Pending — replace with the normative requirement. Define requirements based on the initial request.
+
+#### Scenario: Pending — replace with a concrete scenario
+GIVEN pending — replace with the precondition
+WHEN pending — replace with the triggering action
+THEN pending — replace with the observable expected outcome
+`
+	assert.NotEmpty(t, RequirementSubstanceBlockers(mechanical), "mechanical scaffold must be rejected")
+}
+
+// Blocker #3 regression (issue #91): the RFC-2119 substance check must apply to
+// the requirement statement, not to scenario GIVEN/WHEN/THEN lines.
+func TestRequirementSubstanceBlockersScopesRFC2119ToStatement(t *testing.T) {
+	t.Parallel()
+
+	// MUST appears only in a scenario line; the requirement statement has no
+	// normative keyword → must be blocked.
+	scenarioOnly := `# Requirements
+### Requirement: Auth
+REQ-001: The system authenticates protected routes.
+
+#### Scenario: Login succeeds
+GIVEN the caller MUST present credentials
+WHEN it reaches the route
+THEN the route returns protected content.
+`
+	blockers := RequirementSubstanceBlockers(scenarioOnly)
+	require.NotEmpty(t, blockers, "MUST in a scenario line must not satisfy the statement gate")
+	assert.Contains(t, strings.Join(blockers, "; "), "no RFC-2119 MUST/SHALL/REQUIRED keyword")
+
+	// MUST on a continuation line of a multi-line statement (before any scenario)
+	// must still pass — guards against narrowing the check to the REQ-* line only.
+	multiLineStatement := `# Requirements
+### Requirement: Engine yields an honest scaffold
+REQ-001: The engine default seed for requirements.md and tasks.md
+MUST NOT fabricate plausible normative requirements or tautology scenarios.
+
+#### Scenario: Default seed is detectably non-substantive
+GIVEN a change with no source document
+WHEN the engine seeds the artifacts
+THEN the seeded body reads as an honest placeholder.
+`
+	assert.Empty(t, RequirementSubstanceBlockers(multiLineStatement),
+		"multi-line statement with MUST before the scenario must pass")
+}
+
 func TestEvaluateRequirementsContractReturnsErrorForUnreadableFile(t *testing.T) {
 	root := t.TempDir()
 	slug := "example-change"
@@ -102,4 +280,108 @@ func TestEvaluateRequirementsContractReturnsErrorForUnreadableFile(t *testing.T)
 
 	_, err := EvaluateRequirementsContract(bundleDir, slug)
 	require.Error(t, err)
+}
+
+// Issue #91 (false-positive guard): the requirements substance gate uses the
+// requirements-specific LooksLikeRequirementsPlaceholder, NOT the broad
+// LooksLikeTemplatePlaceholder. A legitimately-authored requirement that
+// contains a generic sentinel substring (e.g. a real case status "pending
+// investigation", or "replace with concrete") must NOT be rejected.
+func TestRequirementSubstanceBlockersDoesNotFlagGenericSentinelProse(t *testing.T) {
+	t.Parallel()
+
+	// "pending investigation" is a generic decision/research sentinel in
+	// LooksLikeTemplatePlaceholder; here it is legitimate domain terminology.
+	pendingInvestigation := `# Requirements
+### Requirement: Case retention
+REQ-001: The system MUST retain cases whose status is "pending investigation" until manually closed.
+
+#### Scenario: A pending-investigation case is retained
+GIVEN a case in "pending investigation" status
+WHEN the nightly cleanup runs
+THEN the case is retained, not purged.
+`
+	assert.Empty(t, RequirementSubstanceBlockers(pendingInvestigation),
+		"a real requirement containing the generic phrase 'pending investigation' must not be flagged")
+
+	// "replace with concrete" is another generic sentinel; legitimate here.
+	replaceWithConcrete := `# Requirements
+### Requirement: Config migration
+REQ-001: The migrator MUST replace with concrete values every placeholder it finds in the config.
+
+#### Scenario: Placeholders are replaced
+GIVEN a config containing placeholder tokens
+WHEN the migrator runs
+THEN every token is replaced with a concrete value.
+`
+	assert.Empty(t, RequirementSubstanceBlockers(replaceWithConcrete),
+		"a real requirement containing the generic phrase 'replace with concrete' must not be flagged")
+}
+
+// Issue #91 (false-positive guard, parity with tasks_contract_test): an authored
+// requirements.md that RETAINS the seeded authoring-guidance HTML comment must
+// still pass — the comment's prose must not trip the substance gate.
+func TestRequirementSubstanceBlockersAllowsRetainedGuidanceComment(t *testing.T) {
+	t.Parallel()
+
+	withComment := `# Requirements
+
+## Requirements
+
+<!--
+Authoring guidance — the engine owns structure, the authoring skill owns substance:
+- Each requirement is "### Requirement: <title>" + a stable "REQ-" identifier line
+  whose body states what the system MUST, SHALL, or is REQUIRED to do.
+- Replace the seeded placeholder below; an unedited scaffold is rejected by the
+  requirements substance gate and cannot reach done.
+-->
+
+### Requirement: Auth
+REQ-001: The system MUST authenticate requests before serving protected routes.
+
+#### Scenario: Unauthenticated request is rejected
+GIVEN a request without valid credentials
+WHEN it reaches a protected route
+THEN the system returns 401.
+`
+	assert.Empty(t, RequirementSubstanceBlockers(withComment),
+		"authored requirements retaining the guidance comment must pass")
+}
+
+// Issue #91 (F5b): GIVEN/WHEN/THEN must all appear within a SINGLE "#### Scenario"
+// segment. A requirement whose keywords are scattered across two separate
+// scenarios (each individually incomplete) has no concrete scenario.
+func TestRequirementSubstanceBlockersRequiresCompleteSingleScenario(t *testing.T) {
+	t.Parallel()
+
+	splitScenarios := `# Requirements
+### Requirement: Auth
+REQ-001: The system MUST authenticate requests before serving protected routes.
+
+#### Scenario: Only given and when
+GIVEN a request without credentials
+WHEN it reaches a protected route
+
+#### Scenario: Only then
+THEN the system returns 401.
+`
+	blockers := RequirementSubstanceBlockers(splitScenarios)
+	require.NotEmpty(t, blockers, "GIVEN/WHEN/THEN split across separate scenarios must not satisfy the gate")
+	assert.Contains(t, strings.Join(blockers, "; "), "no concrete #### Scenario")
+
+	// A single complete scenario alongside an incomplete one still passes.
+	oneComplete := `# Requirements
+### Requirement: Auth
+REQ-001: The system MUST authenticate requests before serving protected routes.
+
+#### Scenario: Incomplete
+GIVEN a request without credentials
+
+#### Scenario: Complete
+GIVEN a request without credentials
+WHEN it reaches a protected route
+THEN the system returns 401.
+`
+	assert.Empty(t, RequirementSubstanceBlockers(oneComplete),
+		"at least one complete scenario must satisfy the gate")
 }

--- a/internal/engine/artifact/tasks_contract.go
+++ b/internal/engine/artifact/tasks_contract.go
@@ -1,0 +1,104 @@
+package artifact
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"strings"
+
+	"github.com/signalridge/slipway/internal/engine/wave"
+)
+
+// TasksContractStatus mirrors RequirementsContractStatus for tasks.md.
+type TasksContractStatus string
+
+const (
+	TasksContractStatusValid   TasksContractStatus = "valid"
+	TasksContractStatusInvalid TasksContractStatus = "invalid"
+	TasksContractStatusMissing TasksContractStatus = "missing"
+)
+
+// TasksContractResult is the result of evaluating tasks.md substance.
+type TasksContractResult struct {
+	Status  TasksContractStatus
+	Source  string
+	Message string
+}
+
+// EvaluateTasksContract checks tasks.md for substance, not just presence: a
+// tasks list that declares no task, fails to parse, or still carries the
+// engine's placeholder objectives ("Pending task objective" / "Pending
+// verification objective") is the mechanical scaffold the authoring skill must
+// replace (issue #91). The engine owns structure; the skill owns substance.
+func EvaluateTasksContract(bundleDir, slug string) (TasksContractResult, error) {
+	sourcePath := ResolveArtifactPath(bundleDir, slug, "tasks.md")
+	if _, err := os.Stat(sourcePath); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return TasksContractResult{
+				Status:  TasksContractStatusMissing,
+				Source:  sourcePath,
+				Message: "tasks.md is missing",
+			}, nil
+		}
+		return TasksContractResult{}, err
+	}
+
+	raw, err := os.ReadFile(sourcePath)
+	if err != nil {
+		return TasksContractResult{}, err
+	}
+
+	if blockers := TaskSubstanceBlockers(string(raw)); len(blockers) > 0 {
+		return TasksContractResult{
+			Status:  TasksContractStatusInvalid,
+			Source:  sourcePath,
+			Message: fmt.Sprintf("tasks.md is not substantive: %s", strings.Join(blockers, "; ")),
+		}, nil
+	}
+
+	return TasksContractResult{
+		Status:  TasksContractStatusValid,
+		Source:  sourcePath,
+		Message: "tasks.md validated",
+	}, nil
+}
+
+// TaskSubstanceBlockers returns substance problems in tasks.md. An empty slice
+// means the tasks carry real objectives.
+//
+// It parses the checkbox-native task plan rather than scanning the whole file,
+// so authoring-guidance comments and surrounding prose can neither trip nor
+// satisfy the gate (issue #91 blocker): only real checklist task objectives are
+// judged. A tasks.md that is empty, fails to parse, declares no task, or carries
+// an empty/placeholder objective is rejected.
+func TaskSubstanceBlockers(content string) []string {
+	if strings.TrimSpace(content) == "" {
+		return []string{"tasks.md is empty"}
+	}
+	plan, err := wave.ParseTaskPlan(content)
+	if err != nil {
+		return []string{fmt.Sprintf("tasks.md is not well-formed: %v", err)}
+	}
+	if len(plan.Tasks) == 0 {
+		return []string{"tasks.md declares no checklist tasks; author concrete tasks"}
+	}
+
+	var blockers []string
+	for _, task := range plan.Tasks {
+		id := strings.TrimSpace(task.TaskID)
+		if id == "" {
+			id = "(unidentified task)"
+		}
+		objective := strings.TrimSpace(task.Objective)
+		if objective == "" {
+			blockers = append(blockers, fmt.Sprintf("task %s has no objective", id))
+			continue
+		}
+		if LooksLikeTemplatePlaceholder(objective) {
+			blockers = append(blockers, fmt.Sprintf(
+				"task %s has a placeholder objective (%q); author a concrete objective", id, objective))
+		}
+	}
+	return blockers
+}

--- a/internal/engine/artifact/tasks_contract_test.go
+++ b/internal/engine/artifact/tasks_contract_test.go
@@ -1,0 +1,97 @@
+package artifact
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTaskSubstanceBlockers(t *testing.T) {
+	t.Parallel()
+
+	assert.NotEmpty(t, TaskSubstanceBlockers(""), "empty tasks must be rejected")
+
+	mechanical := "# Tasks\n## Task List\n- [ ] `t-01` Pending task objective\n  - wave: 1\n  - covers: [REQ-001]\n"
+	assert.NotEmpty(t, TaskSubstanceBlockers(mechanical), "placeholder objective must be rejected")
+
+	authored := "# Tasks\n## Task List\n- [ ] `t-01` Implement the substance gate in requirements_contract.go\n  - wave: 1\n  - target_files: [\"internal/engine/artifact/requirements_contract.go\"]\n  - covers: [REQ-001]\n"
+	assert.Empty(t, TaskSubstanceBlockers(authored), "authored tasks must pass")
+
+	// Blocker #1 regression (issue #91): the rendered authoring-guidance comment
+	// may itself mention the placeholder sentinel. Because the gate parses the
+	// checklist instead of scanning the whole file, an authored tasks.md that
+	// keeps the comment must still pass.
+	withComment := "# Tasks\n\n## Task List\n\n<!--\nReplace the seeded placeholder objective below; a placeholder tasks list\n(\"Pending task objective\") is rejected by the tasks substance gate.\n-->\n\n- [ ] `t-01` Implement the parser-based tasks substance gate\n  - wave: 1\n  - target_files: [\"internal/engine/artifact/tasks_contract.go\"]\n  - covers: [REQ-001]\n"
+	assert.Empty(t, TaskSubstanceBlockers(withComment), "authored tasks retaining the guidance comment must pass")
+
+	// Blocker #2 regression (issue #91): non-empty prose with no checklist task is
+	// not substantive and must not be reported valid.
+	noTasks := "# Tasks\n\n## Task List\n\nThe author will do the work later.\n"
+	assert.NotEmpty(t, TaskSubstanceBlockers(noTasks), "tasks.md with no checklist task must be rejected")
+
+	// A tasks.md that violates the checkbox-native contract must be rejected
+	// rather than silently passing.
+	malformed := "# Tasks\n\n## Task List\n\n- [ ] `t-01` Do the thing\n  - bogus_key: nope\n"
+	assert.NotEmpty(t, TaskSubstanceBlockers(malformed), "unparseable tasks.md must be rejected")
+}
+
+func TestEvaluateTasksContract(t *testing.T) {
+	t.Parallel()
+
+	write := func(t *testing.T, content string) (string, string) {
+		t.Helper()
+		root := t.TempDir()
+		slug := "tasks-contract"
+		bundleDir := filepath.Join(root, "artifacts", "changes", slug)
+		require.NoError(t, os.MkdirAll(bundleDir, 0o755))
+		if content != "" {
+			require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "tasks.md"), []byte(content), 0o644))
+		}
+		return bundleDir, slug
+	}
+
+	t.Run("missing", func(t *testing.T) {
+		t.Parallel()
+		bundleDir, slug := write(t, "")
+		res, err := EvaluateTasksContract(bundleDir, slug)
+		require.NoError(t, err)
+		assert.Equal(t, TasksContractStatusMissing, res.Status)
+	})
+
+	t.Run("invalid placeholder", func(t *testing.T) {
+		t.Parallel()
+		bundleDir, slug := write(t, "# Tasks\n## Task List\n- [ ] `t-01` Pending task objective\n  - wave: 1\n  - covers: [REQ-001]\n")
+		res, err := EvaluateTasksContract(bundleDir, slug)
+		require.NoError(t, err)
+		assert.Equal(t, TasksContractStatusInvalid, res.Status)
+		assert.Contains(t, res.Message, "placeholder")
+	})
+
+	t.Run("valid authored", func(t *testing.T) {
+		t.Parallel()
+		bundleDir, slug := write(t, "# Tasks\n## Task List\n- [ ] `t-01` Implement the tasks substance validator and wire it into validate\n  - wave: 1\n  - target_files: [\"internal/engine/artifact/tasks_contract.go\"]\n  - covers: [REQ-001]\n")
+		res, err := EvaluateTasksContract(bundleDir, slug)
+		require.NoError(t, err)
+		assert.Equal(t, TasksContractStatusValid, res.Status)
+	})
+
+	t.Run("valid authored keeping guidance comment", func(t *testing.T) {
+		t.Parallel()
+		bundleDir, slug := write(t, "# Tasks\n\n## Task List\n\n<!--\nReplace the seeded placeholder objective below; a placeholder tasks list\n(\"Pending task objective\") is rejected by the tasks substance gate.\n-->\n\n- [ ] `t-01` Implement the tasks substance validator and wire it into validate\n  - wave: 1\n  - target_files: [\"internal/engine/artifact/tasks_contract.go\"]\n  - covers: [REQ-001]\n")
+		res, err := EvaluateTasksContract(bundleDir, slug)
+		require.NoError(t, err)
+		assert.Equal(t, TasksContractStatusValid, res.Status)
+	})
+
+	t.Run("invalid no checklist task", func(t *testing.T) {
+		t.Parallel()
+		bundleDir, slug := write(t, "# Tasks\n\n## Task List\n\nThe author will do the work later.\n")
+		res, err := EvaluateTasksContract(bundleDir, slug)
+		require.NoError(t, err)
+		assert.Equal(t, TasksContractStatusInvalid, res.Status)
+		assert.Contains(t, res.Message, "no checklist task")
+	})
+}

--- a/internal/engine/governance/runtime_actions.go
+++ b/internal/engine/governance/runtime_actions.go
@@ -265,6 +265,12 @@ func artifactSectionHasSubstantiveContent(root string, change model.Change, arti
 	if normalizeSectionBody(body) == normalizeSectionBody(templateBody) {
 		return false
 	}
+	// This runtime helper is only invoked for decision.md and assurance.md (via
+	// hasRollbackDocumentation), so the placeholder gate stays scoped to
+	// decision.md. requirements.md/tasks.md substance is NOT gated here — it is
+	// enforced by the governed validation path (the progression substance gate
+	// and the validate requirements/tasks contracts), so generalizing this gate
+	// to those artifacts would be dead, unreachable code (issue #91).
 	if artifactName == "decision.md" && artifact.LooksLikeTemplatePlaceholder(body) {
 		return false
 	}

--- a/internal/engine/progression/validation.go
+++ b/internal/engine/progression/validation.go
@@ -84,7 +84,12 @@ func ValidateTasksChecklistDetailed(root string, change model.Change) TaskCheckl
 		seen[id] = struct{}{}
 		idSet[id] = struct{}{}
 
-		if strings.TrimSpace(task.Objective) == "" {
+		objective := strings.TrimSpace(task.Objective)
+		// A placeholder objective ("Pending task objective") is, for governance
+		// purposes, a missing concrete objective — the engine seeds it and the
+		// authoring skill must replace it (issue #91). Enforced from plan-audit
+		// onward, mirroring target_files, so pre-audit drafts stay lenient.
+		if objective == "" || (enforceTargetFiles && artifact.LooksLikeTemplatePlaceholder(objective)) {
 			result.Blockers = append(result.Blockers, fmt.Sprintf("plan_dimension_completeness_missing_objective:%s", id))
 		}
 		if !task.HasDeclaredWave() {
@@ -143,7 +148,11 @@ func ValidateTasksChecklistDetailed(root string, change model.Change) TaskCheckl
 			result.Blockers = append(result.Blockers, "plan_dimension_execution_invalid_wave_plan:"+err.Error())
 		}
 	}
-	coverageIssues := validateTaskCoverageAgainstSpec(root, change, plan)
+	coverageIssues, requirementBlockers := validateTaskCoverageAgainstSpec(root, change, plan)
+	// Requirements-validity failures are hard regardless of preset: a mechanical
+	// or non-substantive requirements.md cannot reach done (issue #91). Only the
+	// requirement-to-task coverage advisories follow the light-preset downgrade.
+	result.Blockers = append(result.Blockers, requirementBlockers...)
 	if coverageAsWarning {
 		for _, issue := range coverageIssues {
 			result.Warnings = append(result.Warnings, checklistWarningToken(issue))
@@ -167,35 +176,56 @@ func checklistWarningToken(token string) string {
 	return parts[0] + "_warning:" + parts[1]
 }
 
-func validateTaskCoverageAgainstSpec(root string, change model.Change, plan wave.TaskPlan) []string {
+// validateTaskCoverageAgainstSpec evaluates requirements.md against the task
+// plan and returns two distinct blocker sets:
+//
+//   - coverageIssues: requirement-to-task coverage advisories (missing/unknown
+//     coverage, missing stable id, unreadable spec). The light preset downgrades
+//     these to warnings.
+//   - requirementBlockers: hard requirements-validity failures that block in any
+//     preset — a structurally invalid requirements.md, or (from plan-audit
+//     onward) a non-substantive one: placeholder/seed content, a requirement body
+//     with no RFC-2119 MUST/SHALL keyword, or a requirement with no concrete
+//     scenario. A mechanical or vacuous requirements.md cannot reach done
+//     (issue #91). The umbrella blocker keeps a stable token; the detailed
+//     substance reasons are surfaced by the requirements contract in
+//     `slipway validate`.
+func validateTaskCoverageAgainstSpec(root string, change model.Change, plan wave.TaskPlan) (coverageIssues, requirementBlockers []string) {
 	bundleDir, err := state.GovernedBundleDir(root, change)
 	if err != nil {
-		return nil
+		return nil, nil
 	}
 	specPath := artifact.ResolveArtifactPath(bundleDir, change.Slug, "requirements.md")
 	raw, err := os.ReadFile(specPath)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			return nil
+			return nil, nil
 		}
-		return []string{"plan_dimension_coverage_spec_unreadable"}
+		return []string{"plan_dimension_coverage_spec_unreadable"}, nil
 	}
 
 	content := string(raw)
 	requirementBlocks := artifact.ParseRequirementBlocks(content)
 	if strings.TrimSpace(content) != "" && len(requirementBlocks) == 0 {
-		return []string{"plan_dimension_coverage_requirements_invalid"}
+		return nil, []string{"plan_dimension_coverage_requirements_invalid"}
 	}
 
 	missingStableIDs := artifact.RequirementBlocksMissingStableIDs(content)
-	blockers := make([]string, 0, len(missingStableIDs))
 	for _, name := range missingStableIDs {
-		blockers = append(blockers, "plan_dimension_coverage_requirement_id_missing:"+name)
+		coverageIssues = append(coverageIssues, "plan_dimension_coverage_requirement_id_missing:"+name)
+	}
+
+	// From plan-audit onward, requirements.md must carry real substance, not the
+	// engine's placeholder scaffold and not a structurally-present-but-vacuous
+	// requirement (no MUST/SHALL body, no concrete scenario). This is a hard
+	// validity gate independent of preset (issue #91).
+	if isAtOrPastPlanAudit(change) && len(artifact.RequirementSubstanceBlockers(content)) > 0 {
+		requirementBlockers = append(requirementBlockers, "plan_dimension_coverage_requirements_invalid")
 	}
 
 	requirementIDs := artifact.ExtractRequirementStableIDs(content)
 	if len(requirementIDs) == 0 {
-		return stringutil.UniqueSorted(blockers)
+		return stringutil.UniqueSorted(coverageIssues), stringutil.UniqueSorted(requirementBlockers)
 	}
 
 	requirementByID := make(map[string]string, len(requirementIDs))
@@ -208,11 +238,11 @@ func validateTaskCoverageAgainstSpec(root string, change model.Change, plan wave
 		for _, cover := range task.Covers {
 			requirementID := artifact.NormalizeRequirementID(cover)
 			if requirementID == "" {
-				blockers = append(blockers, fmt.Sprintf("plan_dimension_coverage_unknown_requirement:%s->%s", task.TaskID, strings.TrimSpace(cover)))
+				coverageIssues = append(coverageIssues, fmt.Sprintf("plan_dimension_coverage_unknown_requirement:%s->%s", task.TaskID, strings.TrimSpace(cover)))
 				continue
 			}
 			if _, ok := requirementByID[requirementID]; !ok {
-				blockers = append(blockers, fmt.Sprintf("plan_dimension_coverage_unknown_requirement:%s->%s", task.TaskID, requirementID))
+				coverageIssues = append(coverageIssues, fmt.Sprintf("plan_dimension_coverage_unknown_requirement:%s->%s", task.TaskID, requirementID))
 				continue
 			}
 			covered[requirementID] = true
@@ -223,9 +253,9 @@ func validateTaskCoverageAgainstSpec(root string, change model.Change, plan wave
 		if covered[requirementID] {
 			continue
 		}
-		blockers = append(blockers, "plan_dimension_coverage_missing_requirement:"+requirementID)
+		coverageIssues = append(coverageIssues, "plan_dimension_coverage_missing_requirement:"+requirementID)
 	}
-	return stringutil.UniqueSorted(blockers)
+	return stringutil.UniqueSorted(coverageIssues), stringutil.UniqueSorted(requirementBlockers)
 }
 
 // HasDependencyCycle returns true if the dependency graph contains a cycle.

--- a/internal/engine/progression/validation_test.go
+++ b/internal/engine/progression/validation_test.go
@@ -198,10 +198,18 @@ func TestValidateTasksChecklistDetailed_DowngradesOptionalFieldsAndCoverageToWar
   - depends_on: []
   - target_files: [main.go]
 `), 0o644))
+	// Substantive requirements (MUST body + concrete scenario) so this test
+	// isolates the light-preset coverage downgrade from the substance gate
+	// (issue #91): the only advisory left is REQ-001 being uncovered by t-01.
 	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "requirements.md"), []byte(`## Requirements
 
 ### Requirement: Auth
-REQ-001: The system must authenticate requests.
+REQ-001: The system MUST authenticate requests.
+
+#### Scenario: Rejects anonymous request
+GIVEN a request without credentials
+WHEN it reaches a protected route
+THEN the system returns 401.
 `), 0o644))
 
 	change := model.Change{
@@ -227,6 +235,129 @@ REQ-001: The system must authenticate requests.
 			t.Fatalf("expected warning %s, got %v", want, result.Warnings)
 		}
 	}
+}
+
+func TestValidateTasksChecklistDetailed_RejectsMechanicalScaffoldAtPlanAudit(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	change := model.NewChange("mechanical-reject")
+	change.Description = "do the thing"
+	change.WorkflowPreset = model.WorkflowPresetStandard
+	require.NoError(t, artifact.ScaffoldGovernedBundleForChangeWithPreset(root, change, model.WorkflowPresetStandard))
+
+	// At plan-audit, the engine's placeholder scaffold must fail closed:
+	// placeholder task objective + placeholder requirements (issue #91).
+	change.CurrentState = model.StateS1Plan
+	change.PlanSubStep = model.PlanSubStepAudit
+	require.NoError(t, state.SaveChange(root, change))
+
+	result := ValidateTasksChecklistDetailed(root, change)
+
+	hasObjective, hasReq := false, false
+	for _, b := range result.Blockers {
+		if b == "plan_dimension_completeness_missing_objective:t-01" {
+			hasObjective = true
+		}
+		if b == "plan_dimension_coverage_requirements_invalid" {
+			hasReq = true
+		}
+	}
+	require.True(t, hasObjective, "placeholder task objective must block at plan-audit, got %v", result.Blockers)
+	require.True(t, hasReq, "placeholder requirements must block at plan-audit, got %v", result.Blockers)
+}
+
+func writeSubstanceGateBundle(t *testing.T, root, slug, requirements string) {
+	t.Helper()
+	bundleDir := filepath.Join(root, "artifacts", "changes", slug)
+	require.NoError(t, os.MkdirAll(bundleDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "tasks.md"), []byte(`# Tasks
+
+- [ ] `+"`t-01`"+` implement auth flow
+  - wave: 1
+  - depends_on: []
+  - target_files: [main.go]
+  - task_kind: code
+  - covers: [REQ-001]
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "requirements.md"), []byte(requirements), 0o644))
+}
+
+// Issue #91 (P1): from plan-audit onward the requirements substance gate is a
+// hard blocker — not advisory — and is independent of the workflow preset. A
+// requirement that is non-placeholder yet non-substantive (a MUST body with no
+// concrete scenario, or a body with no RFC-2119 keyword) must block, and the
+// light preset must NOT downgrade that validity failure to a warning.
+func TestValidateTasksChecklistDetailed_RequirementsSubstanceGateIsHardAtPlanAudit(t *testing.T) {
+	t.Parallel()
+
+	const substantive = `## Requirements
+
+### Requirement: Auth
+REQ-001: The system MUST authenticate requests.
+
+#### Scenario: Rejects anonymous request
+GIVEN a request without credentials
+WHEN it reaches a protected route
+THEN the system returns 401.
+`
+	const noScenario = `## Requirements
+
+### Requirement: Auth
+REQ-001: The system MUST authenticate requests.
+`
+	const noNormative = `## Requirements
+
+### Requirement: Auth
+REQ-001: The system handles authentication for requests.
+`
+
+	planAudit := func(slug string, preset model.WorkflowPreset) model.Change {
+		return model.Change{
+			Slug:           slug,
+			WorkflowPreset: preset,
+			CurrentState:   model.StateS1Plan,
+			PlanSubStep:    model.PlanSubStepAudit,
+		}
+	}
+	contains := func(s []string, want string) bool {
+		for _, v := range s {
+			if v == want {
+				return true
+			}
+		}
+		return false
+	}
+
+	t.Run("MUST body with no concrete scenario blocks", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		writeSubstanceGateBundle(t, root, "sub-no-scenario", noScenario)
+		result := ValidateTasksChecklistDetailed(root, planAudit("sub-no-scenario", model.WorkflowPresetStandard))
+		require.True(t, contains(result.Blockers, "plan_dimension_coverage_requirements_invalid"),
+			"a non-placeholder requirement with no concrete scenario must block at plan-audit, got %v", result.Blockers)
+	})
+
+	t.Run("substantive requirements pass", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		writeSubstanceGateBundle(t, root, "sub-ok", substantive)
+		result := ValidateTasksChecklistDetailed(root, planAudit("sub-ok", model.WorkflowPresetStandard))
+		require.False(t, contains(result.Blockers, "plan_dimension_coverage_requirements_invalid"),
+			"substantive requirements must not trip the substance gate, got %v", result.Blockers)
+	})
+
+	t.Run("light preset does not downgrade the substance gate", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		require.NoError(t, model.SaveConfig(state.ConfigPath(root), model.DefaultConfig()))
+		writeSubstanceGateBundle(t, root, "sub-light", noNormative)
+		result := ValidateTasksChecklistDetailed(root, planAudit("sub-light", model.WorkflowPresetLight))
+		require.True(t, contains(result.Blockers, "plan_dimension_coverage_requirements_invalid"),
+			"requirements validity must stay a hard blocker under the light preset, got blockers=%v warnings=%v", result.Blockers, result.Warnings)
+		require.False(t, contains(result.Warnings, "plan_dimension_coverage_requirements_invalid_warning"),
+			"requirements validity must not be downgraded to a warning, got warnings=%v", result.Warnings)
+	})
 }
 
 func TestValidateTasksChecklistDetailed_ScaffoldedGuardrailRequirementsStayCovered(t *testing.T) {

--- a/internal/model/reason_code.go
+++ b/internal/model/reason_code.go
@@ -218,7 +218,7 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 	},
 	"plan_dimension_coverage_requirements_invalid": {
 		Severity: ReasonSeverityError,
-		Message:  "Requirement coverage input is invalid",
+		Message:  "requirements.md is structurally invalid or not substantive",
 	},
 	"plan_dimension_coverage_requirement_id_missing": {
 		Severity: ReasonSeverityError,

--- a/internal/model/recovery.go
+++ b/internal/model/recovery.go
@@ -262,8 +262,8 @@ var blockerRemediations = map[string]blockerRemediation{
 		Class:           RecoveryClassFixScope,
 	},
 	"plan_dimension_coverage_requirements_invalid": {
-		Remediation:     "Fix invalid requirements.md requirement identifiers, then re-run validation.",
-		CommandTemplate: "slipway validate",
+		Remediation:     "Author requirements.md substance: each requirement needs a stable REQ-* id, a normative MUST/SHALL body, and at least one concrete scenario. Run `slipway instructions requirements` for the template and bar, then re-run validation.",
+		CommandTemplate: "slipway instructions requirements",
 		Class:           RecoveryClassFixScope,
 	},
 	"plan_dimension_coverage_requirement_id_missing": {

--- a/internal/tmpl/templates/artifacts/requirements.md
+++ b/internal/tmpl/templates/artifacts/requirements.md
@@ -12,4 +12,16 @@
 
 ## Requirements
 
+<!--
+Authoring guidance — the engine owns structure, the authoring skill owns substance:
+- Each requirement is "### Requirement: <title>" + a stable "REQ-" identifier line
+  whose body states what the system MUST, SHALL, or is REQUIRED to do (an RFC-2119
+  strong-obligation keyword).
+- Each requirement needs at least one concrete "#### Scenario:" with real GIVEN/WHEN/THEN
+  (no placeholder or tautology lines).
+- Replace the seeded placeholder below; an unedited scaffold is rejected by the
+  requirements substance gate and cannot reach done.
+- Run `slipway instructions requirements` for the full template and quality bar.
+-->
+
 {{ .SeededRequirements }}

--- a/internal/tmpl/templates/artifacts/tasks.md
+++ b/internal/tmpl/templates/artifacts/tasks.md
@@ -12,4 +12,13 @@
 
 ## Task List
 
+<!--
+Authoring guidance — the engine owns structure, the authoring skill owns substance:
+- Each task is "- [ ] `t-NN` <real objective>" with wave, depends_on, target_files,
+  task_kind, and covers metadata.
+- Replace the seeded placeholder objective below; an unedited placeholder tasks
+  list is rejected by the tasks substance gate.
+- Run `slipway instructions tasks` for the full template and quality bar.
+-->
+
 {{ .SeededTasks }}

--- a/internal/tmpl/templates/skills/plan-audit/SKILL.md
+++ b/internal/tmpl/templates/skills/plan-audit/SKILL.md
@@ -53,6 +53,24 @@ Populated is not the same as relevant. For a `partial` map, also inspect
 Use `slipway-coding-discipline` as the execution-shape bar: plans should stay
 simple, goal-scoped, and sliced for surgical implementation.
 
+## Author Substance First
+The engine seeds `requirements.md` and `tasks.md` as obviously-not-real
+placeholders — it owns structure, you own substance. Before auditing, run
+`slipway validate` and read its `requirements_contract` / `tasks_contract`: a
+`plan_dimension_coverage_requirements_invalid` blocker, or an `invalid`
+contract, means the seed was never authored.
+
+When that happens, author the real content first — do not audit a placeholder:
+- `slipway instructions requirements` — template and bar: each `REQ-*` body
+  states what the system MUST, SHALL, or is REQUIRED to do (an RFC-2119
+  strong-obligation keyword), with at least one concrete `#### Scenario`
+  (real GIVEN/WHEN/THEN, no tautology).
+- `slipway instructions tasks` — template and bar: each task carries a concrete
+  objective plus `wave`, `depends_on`, `target_files`, `task_kind`, and `covers`.
+
+A mechanical or vacuous requirements/tasks file cannot reach done. Re-run
+`slipway validate` until the substance gate passes, then audit.
+
 ## Validate Artifacts
 Verify the **required artifact set** exists and is structurally valid:
 - Required (all paths): `change.yaml`, `intent.md`, `requirements.md`, `tasks.md`

--- a/internal/toolgen/toolgen.go
+++ b/internal/toolgen/toolgen.go
@@ -197,6 +197,14 @@ var commandRegistry = []CommandDef{
 	{ID: "codebase-map", Class: CommandClassMutation, Description: "Create or refresh the durable repo-scoped codebase map", Tier: "diagnostics",
 		Arguments:     "[--json]",
 		Prerequisites: []string{"`.slipway.yaml` must exist (run `slipway init` first)"}},
+	{ID: "instructions", Class: CommandClassQuery, Description: "Show the template and authoring guidance for a governed artifact", Tier: "diagnostics",
+		Arguments: "<artifact> [--json]",
+		// instructions reads embedded artifact templates only — it needs no
+		// `.slipway.yaml` and no active change. Declare that explicitly so the
+		// generated command-reference does not leak the catch-all default
+		// prerequisites (run `slipway init` / an active change), which would be
+		// false for this prereq-free surface (issue #91).
+		Prerequisites: []string{"None — reads embedded artifact templates; no `slipway init` or active change required."}},
 }
 
 // commandRegistryMap provides O(1) lookup by command ID.
@@ -315,7 +323,7 @@ var workflowSupportingCommandIDs = []string{
 	"abort",
 }
 
-var workflowDiagnosticCommandIDs = []string{"learn", "stats", "health", "codebase-map"}
+var workflowDiagnosticCommandIDs = []string{"learn", "stats", "health", "codebase-map", "instructions"}
 
 type workflowSkillData struct {
 	ToolID             string

--- a/internal/toolgen/toolgen_test.go
+++ b/internal/toolgen/toolgen_test.go
@@ -94,8 +94,8 @@ func TestResolveTools(t *testing.T) {
 
 func TestCommandRegistryContainsAllAdapterSkillIDs(t *testing.T) {
 	t.Parallel()
-	// Verify registry has 19 commands (5 core + 10 situational + 4 diagnostics).
-	assert.Len(t, commandRegistry, 19)
+	// Verify registry has 20 commands (5 core + 10 situational + 5 diagnostics).
+	assert.Len(t, commandRegistry, 20)
 
 	// Verify all registry entries have the required fields.
 	for _, def := range commandRegistry {
@@ -129,8 +129,8 @@ func TestCommandRegistryContainsAllAdapterSkillIDs(t *testing.T) {
 	}
 	assert.Equal(t, 5, core, "expected 5 core commands")
 	assert.Equal(t, 10, sit, "expected 10 situational commands")
-	assert.Equal(t, 4, diag, "expected 4 diagnostics commands")
-	assert.Equal(t, 6, query, "expected 6 query commands")
+	assert.Equal(t, 5, diag, "expected 5 diagnostics commands")
+	assert.Equal(t, 7, query, "expected 7 query commands")
 	assert.Equal(t, 13, mutation, "expected 13 mutation commands")
 
 	// Verify commandIDs() returns sorted list matching adapter skill commands only.
@@ -431,6 +431,36 @@ func TestGenerateProducesAllExpectedFiles(t *testing.T) {
 	}
 }
 
+// referenceSectionFor returns the command-reference body from header up to the
+// next "### " command heading or "## " section heading (or end of file).
+func referenceSectionFor(ref, header string) string {
+	idx := strings.Index(ref, header)
+	if idx < 0 {
+		return ""
+	}
+	rest := ref[idx+len(header):]
+	cut := len(rest)
+	if next := strings.Index(rest, "\n### "); next >= 0 && next < cut {
+		cut = next
+	}
+	if next := strings.Index(rest, "\n## "); next >= 0 && next < cut {
+		cut = next
+	}
+	return rest[:cut]
+}
+
+// TestInstructionsCommandDeclaresNoFalsePrerequisites guards the issue-#91
+// regression where the `instructions` registry entry omitted Prerequisites and
+// commandPrerequisites leaked the catch-all default (run `slipway init` / an
+// active change), both false for a command that reads only embedded templates.
+func TestInstructionsCommandDeclaresNoFalsePrerequisites(t *testing.T) {
+	prereqs := commandPrerequisites("instructions")
+	require.NotEmpty(t, prereqs, "instructions must declare explicit prerequisites so the catch-all default cannot leak")
+	joined := strings.Join(prereqs, "\n")
+	assert.NotContains(t, joined, "an active change must exist", "instructions does not require an active change")
+	assert.NotContains(t, joined, "run `slipway init`", "instructions reads embedded templates; it does not require slipway init")
+}
+
 func TestWorkflowSkillGenerationAndReference(t *testing.T) {
 	root := t.TempDir()
 	codexHome := t.TempDir()
@@ -485,6 +515,15 @@ func TestWorkflowSkillGenerationAndReference(t *testing.T) {
 		assert.Contains(t, ref, "### `slipway codebase-map`", "%s: missing diagnostics command entry", cfg.ID)
 		assert.Contains(t, ref, "Can be used with or without an active change.", "%s: missing explicit status prerequisite", cfg.ID)
 		assert.Contains(t, ref, "an active change must exist, or pass `--change <slug>` when supported.", "%s: missing helper-default prerequisite", cfg.ID)
+
+		// instructions reads embedded templates only; its reference section must
+		// declare it prereq-free and must NOT leak the catch-all default
+		// prerequisites (run `slipway init` / an active change) (issue #91).
+		instrSection := referenceSectionFor(ref, "### `slipway instructions`")
+		assert.NotEmpty(t, instrSection, "%s: missing instructions command entry", cfg.ID)
+		assert.Contains(t, instrSection, "reads embedded artifact templates", "%s: instructions reference missing prereq-free declaration", cfg.ID)
+		assert.NotContains(t, instrSection, "an active change must exist", "%s: instructions reference leaked false active-change prerequisite", cfg.ID)
+		assert.NotContains(t, instrSection, "run `slipway init`", "%s: instructions reference leaked false init prerequisite", cfg.ID)
 		for _, focus := range capability.ExplicitFocusSurfaces() {
 			selector := "`slipway " + focus.Command + " --focus " + focus.PublicName + "`"
 			assert.Contains(t, ref, selector, "%s: missing focus selector %s", cfg.ID, selector)
@@ -784,6 +823,7 @@ func TestGeneratedSkillsReferenceValidCommands(t *testing.T) {
 		"new": true, "next": true, "run": true, "status": true, "done": true,
 		"abort": true, "cancel": true, "review": true, "validate": true,
 		"pivot": true, "preset": true, "repair": true, "init": true, "checkpoint": true,
+		"instructions": true,
 	}
 
 	// Pattern to find `slipway <cmd>` references in generated files.


### PR DESCRIPTION
Closes #91.

## What & why
`slipway new` used Go code to mechanically seed `requirements.md`/`tasks.md` with fake-but-plausible content that passed structure-only validation, so a 100% mechanical scaffold could advance to `done`. This inverts Slipway's positioning (governance engine, not spec generator). This change makes **the engine own structure and the skill own substance**: the engine seeds an obviously-not-real honest placeholder, and governance validates *substance*, not just shape.

## Changes
- **Engine stops fabricating** — `appendRequirementBlock`/`seedTasks` emit honest placeholders (no fake `MUST`, no tautology `GIVEN/WHEN/THEN`); `--from-doc` may still derive titles but not normative bodies.
- **Requirements substance gate** — `EvaluateRequirementsContract` requires an RFC-2119 strong-obligation keyword (`MUST`/`SHALL`/`REQUIRED`) in the statement body and ≥1 concrete `#### Scenario` (GIVEN/WHEN/THEN complete within a single scenario), and rejects placeholder content.
- **Tasks substance gate** — `EvaluateTasksContract` + a progression hard gate reject placeholder/empty task objectives from plan-audit onward.
- **`slipway instructions <artifact>`** — read-only surface serving the artifact template + authoring quality bar (text and `--json`), prereq-free.

## Review hardening (this PR folds in deep-review fixes)
- **No false positives** — the requirements gate uses a requirements-specific matcher (`LooksLikeRequirementsPlaceholder`), so authored prose containing a generic sentinel (e.g. a real requirement about cases in `pending investigation` status) is no longer rejected. `LooksLikeTemplatePlaceholder` composes it as a superset. (+ regression tests, incl. retained guidance-comment parity with tasks.)
- **`REQUIRED` documented** — instructions guidance, the requirements template comment, the plan-audit skill, and the blocker message now state `MUST`/`SHALL`/`REQUIRED` (the regex already accepted the RFC-2119 equivalent; docs were a superset under-documentation).
- **`instructions` prereq leak fixed** — it now declares an explicit no-prereq line so the generated agent-facing command-reference no longer shows false `slipway init` / active-change prerequisites; guarded by a toolgen test + a generated-reference assertion.
- **Shared requirement-heading parser** — one recognizer for both the structure and substance checks (no drift); per-scenario completeness check.
- **No dead code** — the runtime placeholder helper is kept scoped to `decision.md` (its only invoked artifacts); the unreachable `requirements.md`/`tasks.md` generalization and its self-validating tests were removed. Requirements/tasks substance is owned by the progression gate + validate contracts.

## Verification
- `go build ./... && go vet ./... && go test ./...` — green (rebased on top of current `main`).
- Driven through the full governed lifecycle to **done** (intake → plan-audit → wave-orchestration → spec-compliance-review → code-quality-review → goal-verification), live `slipway validate` clean: scope contract pass, requirements/tasks contracts valid, evidence fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)