### PR TITLE
fix(intake): gate Open Questions on checklist structure, not prose (#104)

### DIFF
--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -100,7 +100,7 @@ planning gate; treat the flag as the current gate signal.
 Use targeted checks while implementing:
 
 ```bash
-go test ./internal/stringutil ./internal/engine/progression ./internal/engine/governance -run 'TestHasBlockingOpenQuestions|TestAdvanceIntake_OpenQuestionsUseResolvedItemSemantics|TestTraceability.*OpenQuestions' -count=1
+go test ./internal/stringutil ./internal/engine/progression ./internal/engine/governance -run 'TestHasBlockingOpenQuestions|TestFirstBlockingOpenQuestion|TestAdvanceIntake_OpenQuestionsUseChecklistStructure|TestOpenQuestionsRoutingNoteNamesEntryAndEscapeHatch|TestTraceability.*OpenQuestions|TestGovernanceReadinessUsesTraceabilitySnapshot' -count=1
 ```
 
 Use the full proof before closeout:

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -77,7 +77,10 @@ Use `--json` for machine-readable output. Use `--diagnostics` on `next` or `run`
 
 ## Open Questions Semantics
 
-`intent.md` may contain a canonical `## Open Questions` section. Slipway treats these entries as resolved:
+`intent.md` may contain a canonical `## Open Questions` section. The engine gates
+on **structure, not prose**: only an unchecked checklist item blocks intake.
+
+These read as resolved (intake advances to `S0_INTAKE/confirm`):
 
 ```markdown
 ## Open Questions
@@ -86,7 +89,7 @@ Use `--json` for machine-readable output. Use `--diagnostics` on `next` or `run`
 
 ```markdown
 ## Open Questions
-- None.
+- None requiring research — the page model is already specified.
 ```
 
 ```markdown
@@ -94,24 +97,21 @@ Use `--json` for machine-readable output. Use `--diagnostics` on `next` or `run`
 - [x] Installer path resolved by research.
 ```
 
-These entries remain blockers:
+Only an unchecked `- [ ]` entry blocks (routes to `S0_INTAKE/research`):
 
 ```markdown
 ## Open Questions
 - [ ] Which installer path should be documented?
 ```
 
-```markdown
-## Open Questions
-- Which docs build command should be used?
-```
-
-```markdown
-## Open Questions
-Need to decide which adapter layout should be documented.
-```
-
-This lets an artifact preserve the question history without keeping intake stuck after clarification is complete.
+Free-form prose and bare bullets are **documentation, never a blocker**. Deciding
+whether something is a genuine open question is a semantic judgment owned by the
+`intake-clarification` skill, which records a real unknown as a `- [ ]` item; the
+engine never parses intent prose. This keeps a no-unknowns change (`None`, a
+sentinel sentence, or an empty section) from silently detouring into research,
+while letting an artifact preserve question history with `- [x]`. When an entry
+does block, `slipway run` names the specific `- [ ]` line so the routing is not
+silent.
 
 ## Done
 

--- a/internal/engine/governance/traceability_test.go
+++ b/internal/engine/governance/traceability_test.go
@@ -620,7 +620,7 @@ func TestTraceabilityBlockingOpenQuestions(t *testing.T) {
 INT-001: Something
 
 ## Open Questions
-- What about edge cases?
+- [ ] What about edge cases?
 `)
 
 	slug := "test-change"
@@ -645,9 +645,14 @@ REQ-001: Something. INT-001
 	assert.Contains(t, issues, "blocking open questions remain unresolved while downstream artifacts are ready")
 }
 
-func TestTraceabilityBlockingOpenQuestionProse(t *testing.T) {
+// Contract (#104): the Open Questions section blocks only on an unchecked `- [ ]`
+// checklist entry. Free-form prose — even a sentence that reads like a question —
+// is documentation, never an engine blocker. Promoting a real open question to a
+// checklist item is the intake-clarification host skill's job, not the engine's.
+func TestTraceabilityProseOpenQuestionsDoNotBlock(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	slug := "prose-open-questions"
 
 	writeFile(t, filepath.Join(dir, "intent.md"), `# Intent
 INT-001: Something
@@ -655,14 +660,17 @@ INT-001: Something
 ## Open Questions
 Need to decide which adapter layout should be documented.
 `)
-
-	slug := "test-change"
 	writeFile(t, resolveTestArtifact(dir, slug), `# Requirements
 ### Requirement: Something
 REQ-001: Something. INT-001
 `)
-	writeFile(t, filepath.Join(dir, "tasks.md"), `- [ ] Do thing
+	writeFile(t, filepath.Join(dir, "tasks.md"), `# Tasks
+- [ ] `+"`t-01`"+` do thing
   covers: [REQ-001]
+`)
+	writeFile(t, filepath.Join(dir, "assurance.md"), `# Assurance
+## Requirement Coverage
+REQ-001: verified
 `)
 
 	result := EvaluateTraceability(TraceabilityInput{
@@ -670,12 +678,10 @@ REQ-001: Something. INT-001
 		Slug:      slug,
 	})
 
-	assert.Equal(t, model.TraceabilityStatusFail, result.Status)
-	var issues []string
+	assert.Equal(t, model.TraceabilityStatusOK, result.Status)
 	for _, g := range result.Gaps {
-		issues = append(issues, g.Issue)
+		assert.NotEqual(t, "intent-open-questions", g.ID)
 	}
-	assert.Contains(t, issues, "blocking open questions remain unresolved while downstream artifacts are ready")
 }
 
 func TestTraceabilityResolvedOpenQuestionsDoNotBlock(t *testing.T) {

--- a/internal/engine/progression/advance_intake.go
+++ b/internal/engine/progression/advance_intake.go
@@ -91,7 +91,7 @@ func advanceIntakeClarify(root string, change *model.Change, fromState model.Wor
 			Signals:       map[string]bool{"open_questions_detected": true},
 			SideEffects:   evidenceSideEffects,
 			SkillEvidence: skillEvidenceTraceFromPassing(root, *change, passingSkills),
-			Message:       "Advanced to S0_INTAKE/research for open questions.",
+			Message:       "Advanced to S0_INTAKE/research for open questions." + openQuestionsRoutingNote(intentContent),
 		}, nil
 	}
 
@@ -181,7 +181,7 @@ func advanceIntakeResearch(root string, change *model.Change, fromState model.Wo
 			Signals:       map[string]bool{"open_questions_detected": true},
 			SideEffects:   evidenceSideEffects,
 			SkillEvidence: evidenceTraces,
-			Message:       "Returned to S0_INTAKE/clarify with remaining questions.",
+			Message:       "Returned to S0_INTAKE/clarify with remaining questions." + openQuestionsRoutingNote(intentContent),
 		}, nil
 	}
 
@@ -392,4 +392,19 @@ func sectionNonEmpty(content, heading string) bool {
 // hasOpenQuestions checks if the Open Questions section has unresolved items.
 func hasOpenQuestions(content string) bool {
 	return stringutil.HasBlockingOpenQuestions(content)
+}
+
+// openQuestionsRoutingNote names the specific unchecked checklist entry holding
+// intake in clarification so the routing is not silent. It is empty when nothing
+// blocks. Open questions are tracked as a `- [ ]` checklist; prose and explicit
+// `None` never block, so the note also tells the author how to clear the detour.
+func openQuestionsRoutingNote(intentContent string) string {
+	entry := stringutil.FirstBlockingOpenQuestion(intentContent)
+	if entry == "" {
+		return ""
+	}
+	return fmt.Sprintf(
+		" Unresolved `## Open Questions` entry in intent.md: %q. Mark it `- [x]` once resolved or remove it; only unchecked `- [ ]` entries hold intake here.",
+		entry,
+	)
 }

--- a/internal/engine/progression/advance_test.go
+++ b/internal/engine/progression/advance_test.go
@@ -567,7 +567,7 @@ func TestAdvanceIntake_ClarifyToConfirm(t *testing.T) {
 	}
 }
 
-func TestAdvanceIntake_OpenQuestionsUseResolvedItemSemantics(t *testing.T) {
+func TestAdvanceIntake_OpenQuestionsUseChecklistStructure(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -609,20 +609,34 @@ func TestAdvanceIntake_OpenQuestionsUseResolvedItemSemantics(t *testing.T) {
 			wantReason: "open_questions_detected",
 		},
 		{
-			name: "plain bullet advances to research",
+			// Contract: only an unchecked `- [ ]` blocks. A bare bullet is
+			// documentation, so intake advances; promoting it to a real question is
+			// the intake-clarification skill's responsibility, not the engine's.
+			name: "plain bullet is documentation, advances to confirm",
 			questions: `## Open Questions
 - Which docs build command should be used?
 `,
-			wantSub:    model.IntakeSubStepResearch,
-			wantReason: "open_questions_detected",
+			wantSub:    model.IntakeSubStepConfirm,
+			wantReason: "clarification_complete",
 		},
 		{
-			name: "plain prose advances to research",
+			name: "plain prose advances to confirm",
 			questions: `## Open Questions
 Need to decide which adapter layout should be documented.
 `,
-			wantSub:    model.IntakeSubStepResearch,
-			wantReason: "open_questions_detected",
+			wantSub:    model.IntakeSubStepConfirm,
+			wantReason: "clarification_complete",
+		},
+		{
+			// Regression for #104: a sentinel followed by an explanatory clause is
+			// prose, not an open question, and must advance instead of detouring to
+			// research.
+			name: "sentinel prose advances to confirm (#104)",
+			questions: `## Open Questions
+None requiring research — the page model is already specified.
+`,
+			wantSub:    model.IntakeSubStepConfirm,
+			wantReason: "clarification_complete",
 		},
 	}
 
@@ -692,6 +706,23 @@ Docs build
 	}
 }
 
+// Routing out of clarify on a blocking open question must not be silent (#104):
+// the note names the specific unchecked entry and the resolve escape hatch.
+func TestOpenQuestionsRoutingNoteNamesEntryAndEscapeHatch(t *testing.T) {
+	t.Parallel()
+
+	note := openQuestionsRoutingNote("## Open Questions\n- [ ] Which token TTL?\n")
+	if !strings.Contains(note, "Which token TTL?") {
+		t.Fatalf("note should name the blocking entry, got %q", note)
+	}
+	if !strings.Contains(note, "- [x]") {
+		t.Fatalf("note should give the resolve escape hatch, got %q", note)
+	}
+	if got := openQuestionsRoutingNote("## Open Questions\n(none)\n"); got != "" {
+		t.Fatalf("note should be empty when nothing blocks, got %q", got)
+	}
+}
+
 func TestAdvanceIntakeResearchDiscoveryEntersS1ResearchAndClearsStaleEvidence(t *testing.T) {
 	t.Parallel()
 
@@ -731,7 +762,7 @@ Skip direct execution.
 S1 research must require fresh research evidence.
 
 ## Open Questions
-- Which implementation path should be selected?
+- [ ] Which implementation path should be selected?
 `
 	if err := os.WriteFile(filepath.Join(bundleDir, "intent.md"), []byte(intent), 0o644); err != nil {
 		t.Fatalf("write intent.md: %v", err)
@@ -839,7 +870,7 @@ Skip direct execution.
 Advance must block without intake-clarification evidence.
 
 ## Open Questions
-- Which implementation path should be selected?
+- [ ] Which implementation path should be selected?
 `
 	if err := os.WriteFile(filepath.Join(bundleDir, "intent.md"), []byte(intent), 0o644); err != nil {
 		t.Fatalf("write intent.md: %v", err)

--- a/internal/engine/progression/readiness_test.go
+++ b/internal/engine/progression/readiness_test.go
@@ -78,7 +78,7 @@ func TestEvaluateGovernanceReadinessRetainsTraceabilityActionBlockersWhenSnapsho
 	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "intent.md"), []byte(`# Intent
 INT-001: protect auth flows
 ## Open Questions
-- unresolved MFA question
+- [ ] unresolved MFA question
 `), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "requirements.md"), []byte(`# Requirements
 ### Requirement: auth review

--- a/internal/stringutil/html.go
+++ b/internal/stringutil/html.go
@@ -1,7 +1,6 @@
 package stringutil
 
 import (
-	"regexp"
 	"strings"
 )
 
@@ -65,87 +64,32 @@ func LastMarkdownSectionContent(content, heading string) string {
 }
 
 // HasBlockingOpenQuestions reports whether the canonical Open Questions section
-// contains unresolved content. Documentation is not an intake blocker: a resolved
-// checklist entry (`- [x]`), an indented continuation of a list item, an explicit
-// none marker, or a line carrying a RESOLVED/ANSWERED marker all read as resolved.
-// Only an explicitly unchecked checklist item (`- [ ]`) or an unmarked bare entry
-// blocks. Continuations and resolution markers keep a wrapped or prose-documented
-// answer from reading as a fresh question.
+// holds an unresolved entry. Open questions are recorded as a markdown checklist:
+// an unchecked item (`- [ ]` / `* [ ]`) is unresolved and blocks intake; a checked
+// item (`- [x]`) is resolved. Everything else — an empty section, an explicit
+// `None`, or free-form prose — is documentation, not a blocker. Deciding what
+// counts as a real open question is a semantic judgment owned by the
+// intake-clarification host skill, which records it as a checklist item; the
+// engine gates only on that structure, never on prose.
 func HasBlockingOpenQuestions(content string) bool {
+	return FirstBlockingOpenQuestion(content) != ""
+}
+
+// FirstBlockingOpenQuestion returns the trimmed text of the first unchecked
+// checklist entry in the canonical Open Questions section, or "" when nothing
+// blocks. It backs HasBlockingOpenQuestions and lets callers name the specific
+// entry that is holding intake in clarification, so routing is not silent.
+func FirstBlockingOpenQuestion(content string) string {
 	section := LastMarkdownSectionContent(content, "## Open Questions")
 	if section == "" {
-		return false
+		return ""
 	}
 	for _, line := range strings.Split(section, "\n") {
 		trimmed := strings.TrimSpace(line)
-		if trimmed == "" {
-			continue
+		lower := strings.ToLower(trimmed)
+		if strings.HasPrefix(lower, "- [ ]") || strings.HasPrefix(lower, "* [ ]") {
+			return trimmed
 		}
-		// An indented line that does not itself start a list item is a
-		// continuation of the previous entry; it inherits that entry's state and
-		// never blocks on its own. This lets a resolved `- [x]` item wrap across
-		// lines without the wrapped text reading as a new question.
-		if isOpenQuestionContinuation(line, trimmed) {
-			continue
-		}
-		lowerTrimmed := strings.ToLower(trimmed)
-		if strings.HasPrefix(lowerTrimmed, "- [x]") || strings.HasPrefix(lowerTrimmed, "* [x]") {
-			continue
-		}
-		if strings.HasPrefix(lowerTrimmed, "- [ ]") || strings.HasPrefix(lowerTrimmed, "* [ ]") {
-			return true
-		}
-		if isExplicitNoneMarker(trimmed) {
-			continue
-		}
-		if hasResolvedMarker(trimmed) {
-			continue
-		}
-		return true
 	}
-	return false
-}
-
-// isOpenQuestionContinuation reports whether raw is an indented continuation of
-// the previous list item rather than a new top-level entry. An indented line that
-// itself starts a list marker is treated as its own (nested) entry, so a nested
-// `- [ ]` still blocks.
-func isOpenQuestionContinuation(raw, trimmed string) bool {
-	if raw == trimmed {
-		return false // no leading indentation: a top-level line
-	}
-	if strings.HasPrefix(trimmed, "- ") || strings.HasPrefix(trimmed, "* ") {
-		return false // an indented list item is its own entry, not a continuation
-	}
-	return true
-}
-
-var resolvedMarkerPattern = regexp.MustCompile(`(?i)\b(resolved|answered)\b`)
-
-// hasResolvedMarker reports whether a line carries an explicit resolution marker
-// (RESOLVED or ANSWERED, case-insensitive, on a word boundary so "unresolved"
-// does not match). Such a line documents an answered question.
-func hasResolvedMarker(line string) bool {
-	return resolvedMarkerPattern.MatchString(line)
-}
-
-func isExplicitNoneMarker(line string) bool {
-	normalized := strings.TrimSpace(line)
-	for {
-		next := strings.TrimSpace(strings.TrimPrefix(strings.TrimPrefix(normalized, "-"), "*"))
-		if next == normalized {
-			break
-		}
-		normalized = next
-	}
-	normalized = strings.Trim(normalized, " \t().:")
-	normalized = strings.TrimSuffix(normalized, ".")
-	normalized = strings.ToLower(strings.TrimSpace(normalized))
-
-	switch normalized {
-	case "none", "n/a", "na", "not applicable", "no open questions", "no unresolved questions":
-		return true
-	default:
-		return false
-	}
+	return ""
 }

--- a/internal/stringutil/html.go
+++ b/internal/stringutil/html.go
@@ -65,8 +65,8 @@ func LastMarkdownSectionContent(content, heading string) string {
 
 // HasBlockingOpenQuestions reports whether the canonical Open Questions section
 // holds an unresolved entry. Open questions are recorded as a markdown checklist:
-// an unchecked item (`- [ ]` / `* [ ]`) is unresolved and blocks intake; a checked
-// item (`- [x]`) is resolved. Everything else — an empty section, an explicit
+// an unchecked item (`- [ ]`, `* [ ]`, or `+ [ ]`) is unresolved and blocks intake;
+// a checked item (`- [x]`) is resolved. Everything else — an empty section, an explicit
 // `None`, or free-form prose — is documentation, not a blocker. Deciding what
 // counts as a real open question is a semantic judgment owned by the
 // intake-clarification host skill, which records it as a checklist item; the
@@ -87,7 +87,9 @@ func FirstBlockingOpenQuestion(content string) string {
 	for _, line := range strings.Split(section, "\n") {
 		trimmed := strings.TrimSpace(line)
 		lower := strings.ToLower(trimmed)
-		if strings.HasPrefix(lower, "- [ ]") || strings.HasPrefix(lower, "* [ ]") {
+		if strings.HasPrefix(lower, "- [ ]") ||
+			strings.HasPrefix(lower, "* [ ]") ||
+			strings.HasPrefix(lower, "+ [ ]") {
 			return trimmed
 		}
 	}

--- a/internal/stringutil/html_test.go
+++ b/internal/stringutil/html_test.go
@@ -71,13 +71,6 @@ func TestHasBlockingOpenQuestions(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "explicit no open questions bullet",
-			content: `## Open Questions
-* No open questions.
-`,
-			want: false,
-		},
-		{
 			name: "resolved checklist",
 			content: `## Open Questions
 - [x] Resolved by local reference survey.
@@ -85,30 +78,74 @@ func TestHasBlockingOpenQuestions(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "unchecked none checklist remains blocking",
-			content: `## Open Questions
-- [ ] None.
-`,
-			want: true,
-		},
-		{
-			name: "unchecked checklist",
+			name: "unchecked checklist blocks",
 			content: `## Open Questions
 - [ ] Which installer path should be documented?
 `,
 			want: true,
 		},
 		{
-			name: "plain bullet question",
+			name: "unchecked star checklist blocks",
 			content: `## Open Questions
-- Which docs build command should be used?
+* [ ] Which installer path should be documented?
 `,
 			want: true,
 		},
 		{
-			name: "plain prose question",
+			name: "unchecked entry blocks even when its text says none",
+			content: `## Open Questions
+- [ ] None.
+`,
+			want: true,
+		},
+		{
+			// Contract: only checklist items count. A bare bullet is documentation;
+			// the intake-clarification skill must promote a real question to `- [ ]`.
+			name: "plain bullet is documentation, not a blocker",
+			content: `## Open Questions
+- Which docs build command should be used?
+`,
+			want: false,
+		},
+		{
+			name: "plain prose is documentation, not a blocker",
 			content: `## Open Questions
 Need to decide which adapter layout should be documented.
+`,
+			want: false,
+		},
+		{
+			// Regression for #104: a sentinel followed by an explanatory clause must
+			// not read as an open question. Prose never blocks under the checklist
+			// contract, so this advances instead of detouring to research.
+			name: "sentinel with explanatory prose does not block (#104)",
+			content: `## Open Questions
+None requiring research — the page model is already specified.
+`,
+			want: false,
+		},
+		{
+			name: "n/a with explanatory prose does not block (#104)",
+			content: `## Open Questions
+N/A — page model already defined.
+`,
+			want: false,
+		},
+		{
+			// A genuinely-open question written as prose does NOT block the engine;
+			// surfacing it as a `- [ ]` is the intake-clarification skill's job. The
+			// engine deliberately gates on structure only.
+			name: "real open question in prose is not an engine blocker",
+			content: `## Open Questions
+None of the auth flows are specified yet — need to decide token TTL.
+`,
+			want: false,
+		},
+		{
+			name: "mixed list blocks on the unchecked item",
+			content: `## Open Questions
+- [x] Installer path resolved by research.
+- [ ] Token TTL still undecided.
 `,
 			want: true,
 		},
@@ -118,7 +155,7 @@ Need to decide which adapter layout should be documented.
 Copied source.
 
 ## Open Questions
-- Copied unresolved question.
+- [ ] Copied unresolved question.
 
 ## Open Questions
 (none)
@@ -135,41 +172,12 @@ Copied source.
 			want: false,
 		},
 		{
-			name: "uppercase RESOLVED prose is documentation",
-			content: `## Open Questions
-All intake questions RESOLVED during research; see research.md.
-`,
-			want: false,
-		},
-		{
-			name: "lowercase resolved prose is documentation",
-			content: `## Open Questions
-Domain classification resolved: verification.
-`,
-			want: false,
-		},
-		{
-			name: "unresolved prose still blocks",
-			content: `## Open Questions
-Adapter layout is still unresolved.
-`,
-			want: true,
-		},
-		{
 			name: "nested unchecked checklist still blocks",
 			content: `## Open Questions
 - [x] Parent question — RESOLVED.
   - [ ] Nested follow-up still open.
 `,
 			want: true,
-		},
-		{
-			name: "resolved checklist continuation with question mark does not block",
-			content: `## Open Questions
-- [x] Which host emits the hint — RESOLVED: wave-orchestration only. Why not
-  tdd-governance? Because it is ExportOnlyExtra and never a next-skill.
-`,
-			want: false,
 		},
 	}
 
@@ -181,4 +189,32 @@ Adapter layout is still unresolved.
 			assert.Equal(t, tt.want, HasBlockingOpenQuestions(tt.content))
 		})
 	}
+}
+
+func TestFirstBlockingOpenQuestion(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns the first unchecked entry", func(t *testing.T) {
+		t.Parallel()
+		content := `## Open Questions
+- [x] Installer path resolved.
+- [ ] Token TTL still undecided.
+- [ ] Second open item.
+`
+		assert.Equal(t, "- [ ] Token TTL still undecided.", FirstBlockingOpenQuestion(content))
+	})
+
+	t.Run("empty when nothing blocks", func(t *testing.T) {
+		t.Parallel()
+		content := `## Open Questions
+- [x] All resolved.
+None requiring research.
+`
+		assert.Equal(t, "", FirstBlockingOpenQuestion(content))
+	})
+
+	t.Run("empty section", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, "", FirstBlockingOpenQuestion("## Open Questions\n<!-- placeholder -->\n"))
+	})
 }

--- a/internal/stringutil/html_test.go
+++ b/internal/stringutil/html_test.go
@@ -92,6 +92,13 @@ func TestHasBlockingOpenQuestions(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "unchecked plus checklist blocks",
+			content: `## Open Questions
++ [ ] Which installer path should be documented?
+`,
+			want: true,
+		},
+		{
 			name: "unchecked entry blocks even when its text says none",
 			content: `## Open Questions
 - [ ] None.

--- a/internal/tmpl/templates/artifacts/intent.md
+++ b/internal/tmpl/templates/artifacts/intent.md
@@ -37,7 +37,10 @@
 {{- if ge .ComplexityRank 2 }}
 
 ## Open Questions
-<!-- Unresolved questions → consumed by S1_PLAN/research -->
+<!-- Track real unknowns as a checklist. An unchecked `- [ ]` item is unresolved
+     and routes intake to S1_PLAN/research; mark `- [x]` once resolved. Leave the
+     section empty (or write `None`) when there are none. Prose here is
+     documentation, not a blocker — a genuine open question must be a `- [ ]`. -->
 
 ## Deferred Ideas
 <!-- Identified but postponed ideas -->

--- a/internal/tmpl/templates/artifacts/intent.md
+++ b/internal/tmpl/templates/artifacts/intent.md
@@ -38,7 +38,7 @@
 
 ## Open Questions
 <!-- Track real unknowns as a checklist. An unchecked `- [ ]` item is unresolved
-     and routes intake to S1_PLAN/research; mark `- [x]` once resolved. Leave the
+     and routes intake to S0_INTAKE/research; mark `- [x]` once resolved. Leave the
      section empty (or write `None`) when there are none. Prose here is
      documentation, not a blocker — a genuine open question must be a `- [ ]`. -->
 

--- a/internal/tmpl/templates/skills/intake-clarification/SKILL.md
+++ b/internal/tmpl/templates/skills/intake-clarification/SKILL.md
@@ -45,7 +45,10 @@ For each clarification round:
 - `## In Scope`: concrete files, APIs, commands, or user-visible surfaces
 - `## Out of Scope`: at least one explicit exclusion
 - `## Acceptance Signals`: at least one verifiable check, not a hope
-- `## Open Questions`: only technical unknowns that truly require research
+- `## Open Questions`: a `- [ ]` checklist of technical unknowns that truly
+  require research; mark `- [x]` once resolved. You own this semantic judgment —
+  the engine blocks only on an unchecked `- [ ]`, so a real unknown left as prose
+  will NOT route to research. Leave the section empty (or `None`) when there are none.
 - `## Approved Summary`: reviewed with the user before advancement
 
 If the user says "just testing", "trivial change", "quick fix", "that's it",
@@ -53,9 +56,10 @@ or "good enough", accept current scope, fill minimal sections, and move to
 confirmation.
 
 ### 4. Research Route (if needed)
-If `## Open Questions` contains technical unknowns that cannot be resolved via clarification:
-- Document them in `## Open Questions`
-- The state machine will route to S0_INTAKE/research
+If a technical unknown cannot be resolved via clarification:
+- Record it as an unchecked `- [ ]` item under `## Open Questions` (one per unknown)
+- `slipway run` then routes to S0_INTAKE/research; resolve it by marking `- [x]`
+  (or removing it) once research answers it
 
 ### 5. Confirmation
 Once scope is clear:


### PR DESCRIPTION
## Problem (#104)

S0_INTAKE parsed `## Open Questions` with **prose heuristics** (none-marker / resolved-marker / continuation). A sentinel-led answer that genuinely means "no unknowns" — `None requiring research — …`, `N/A — page model already defined`, `None — already specified` — was misread as an unresolved question and **silently** detoured intake into `S0_INTAKE/research`. The CLI gave no hint why.

This is a recurrence pattern, not a one-off: #79 already hardened these heuristics once; #104 is the next prose variant slipping through. Each added heuristic just moves the edge.

> Note: the issue title's `None.` case was already fixed by #79 (`31e9bda`, on `main`). The downstream reporter (Lattice) was treating Slipway as a black box on an older release. The残留 real bug is the sentinel-led prose forms above.

## Fix — gate on structure, not prose

An Open Questions section blocks intake **iff it holds an unchecked `- [ ]` checklist item**. Prose, bare bullets, explicit `None`, and resolved `- [x]` never block.

Deciding *what counts as a real open question* is a semantic judgment that moves to the **`intake-clarification` host skill** (it records a genuine unknown as `- [ ]`), matching Slipway's *engine-owns-structure / host-owns-substance* split (same posture as #91 substance gates and codebase-map AI staleness).

The issue's other half — silent routing — is also closed: `slipway run` now names the specific unchecked `- [ ]` entry and the resolve escape hatch.

## Contract change (reviewed as external surface)

| `## Open Questions` body | before | after |
|---|---|---|
| empty / `(none)` / `- None.` | advance | advance |
| `- [x] resolved` | advance | advance |
| `None requiring research — …`, `N/A — …` | **detour to research** | advance ✅ |
| bare bullet `- Which …?` | detour to research | advance (skill must promote to `- [ ]`) |
| prose `Need to decide …` | detour to research | advance (skill must promote to `- [ ]`) |
| unchecked checklist `- [ ]` / `* [ ]` / `+ [ ]` | detour to research | detour to research |

Trade-off: the engine no longer treats free-form prose as a blocker, so surfacing a genuine open question as `- [ ]` is now the host skill's responsibility (documented in the SKILL + intent template). This is the intended split — fail-closed semantic judgment lives in the host, the engine gates deterministically.

## Changes
- `internal/stringutil/html.go` — drop none/resolved/continuation heuristics; add `FirstBlockingOpenQuestion` (unchecked-only) backing `HasBlockingOpenQuestions` (net −60 lines, `regexp` dep gone)
- `internal/engine/progression/advance_intake.go` — `openQuestionsRoutingNote` makes both routing messages name the blocking entry + escape hatch
- `internal/tmpl/templates/artifacts/intent.md` + `…/skills/intake-clarification/SKILL.md` — document the checklist contract and the host skill's ownership
- `docs/workflow.md` — rewrite **Open Questions Semantics** for the structural rule
- tests — checklist-structure cases, #104 regressions, prose-no-longer-blocks, routing-note assertion; `traceability` prose-blocks test inverted to prose-does-not-block

### Review follow-up (`37347f3`)
Independent review found one boundary the first pass missed: `FirstBlockingOpenQuestion` matched only `- [ ]` and `* [ ]`, so a genuine open question written with the `+` Markdown unordered-list marker (`+ [ ]`) silently advanced past intake — the same boundary-miss class this change set closes. Fixed by recognizing all three unordered-list markers, which **completes the structural contract rather than adding a heuristic**. The reverse review point — a real open question written as prose advances with no engine fallback — was left intentional: an engine fallback would re-introduce the prose heuristic this PR deletes.

## Verification
- `go build ./...` clean
- `go test ./...` — all pass
- `gofmt` clean
- re-run green at HEAD `37347f3` (adds the `+ [ ]` regression case)

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)
