### PR TITLE
docs: render embedded diagrams on the MkDocs site and replace remaining mermaid

### DIFF
--- a/docs/ai-tools.md
+++ b/docs/ai-tools.md
@@ -2,20 +2,11 @@
 
 `slipway init --tools` exports host-tool files that let AI coding tools invoke Slipway commands and load governed skill instructions from the current project.
 
-```mermaid
-flowchart LR
-  Init["slipway init --tools"] --> Config[".slipway.yaml"]
-  Init --> Claude[".claude/"]
-  Init --> Codex[".codex/ + $CODEX_HOME/prompts"]
-  Init --> Cursor[".cursor/"]
-  Init --> Gemini[".gemini/"]
-  Init --> OpenCode[".opencode/"]
-  Claude --> CLI["slipway CLI"]
-  Codex --> CLI
-  Cursor --> CLI
-  Gemini --> CLI
-  OpenCode --> CLI
-```
+<div align="center" markdown>
+
+![Slipway tool adapters: slipway init --tools generates per-tool adapter bundles for Claude, Codex, Cursor, Gemini and OpenCode plus the .slipway.yaml runtime config; each adapter's generated skills and commands route governed actions to the slipway CLI](assets/diagrams/tool-adapters.svg)
+
+</div>
 
 ## Supported Tools
 

--- a/docs/assets/diagrams/tool-adapters.svg
+++ b/docs/assets/diagrams/tool-adapters.svg
@@ -1,0 +1,96 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 470" width="980" font-family="Inter, ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" role="img" aria-label="Slipway tool adapters: slipway init --tools generates per-tool adapter bundles for Claude, Codex, Cursor, Gemini and OpenCode, plus the .slipway.yaml runtime config; each adapter's generated skills and commands route governed actions to the slipway CLI.">
+  <title>Slipway tool adapters</title>
+  <defs>
+    <style>
+      :root{
+        --text:#0f172a; --muted:#64748b; --line:#94a3b8;
+        --card-fill:#ffffff; --card-border:#e2e8f0;
+        --band-bg:#f8fafc; --band-border:#e2e8f0;
+        --entry-fill:#ecfdf5; --entry-stroke:#059669; --entry-pill:#059669;
+        --plan-pill:#16a34a; --exec-pill:#475569; --verify-pill:#65a30d;
+      }
+      @media (prefers-color-scheme: dark){
+        :root{
+          --text:#e6edf3; --muted:#8b949e; --line:#475569;
+          --card-fill:#161b22; --card-border:#30363d;
+          --band-bg:#0d1117; --band-border:#21262d;
+          --entry-fill:#053024; --entry-stroke:#34d399; --entry-pill:#10b981;
+          --plan-pill:#16a34a; --exec-pill:#64748b; --verify-pill:#84cc16;
+        }
+      }
+      .titleBig{fill:var(--text);font-weight:700;}
+      .title{fill:var(--text);font-weight:600;}
+      .sub{fill:var(--muted);}
+      .tag{fill:var(--muted);font-weight:700;letter-spacing:1.5px;}
+      .mono{fill:var(--text);font-weight:600;font-family:ui-monospace,SFMono-Regular,'SF Mono',Menlo,Consolas,monospace;}
+      .inv{fill:var(--muted);font-family:ui-monospace,SFMono-Regular,'SF Mono',Menlo,Consolas,monospace;}
+      .box{fill:var(--card-fill);stroke:var(--card-border);stroke-width:1.6;}
+      .cli{fill:var(--entry-fill);stroke:var(--entry-stroke);stroke-width:2.4;}
+      .band{fill:var(--band-bg);stroke:var(--band-border);stroke-width:1.5;}
+      .flow{stroke:var(--line);stroke-width:2;fill:none;}
+      .arrowhead{fill:var(--line);}
+      .edgeT{fill:var(--muted);font-style:italic;}
+    </style>
+    <marker id="ah" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path class="arrowhead" d="M0,0 L10,5 L0,10 z"/>
+    </marker>
+  </defs>
+
+  <text class="titleBig" x="40" y="40" font-size="19">Slipway &#183; tool adapters</text>
+  <text class="sub" x="40" y="61" font-size="12.5">slipway init --tools writes .slipway.yaml + per-tool adapter bundles &#183; each adapter routes governed commands to the CLI</text>
+
+  <!-- flow edges (under cards) -->
+  <line class="flow" x1="490" y1="144" x2="490" y2="180" marker-end="url(#ah)"/>
+  <line class="flow" x1="490" y1="330" x2="490" y2="366" marker-end="url(#ah)"/>
+  <text class="edgeT" x="500" y="167" font-size="10.5">generates</text>
+  <text class="edgeT" x="500" y="353" font-size="10.5">invoke</text>
+
+  <!-- init node -->
+  <rect class="box" x="350" y="86" width="280" height="58" rx="14"/>
+  <text class="mono" x="490" y="114" text-anchor="middle" font-size="14">slipway init --tools</text>
+  <text class="sub" x="490" y="133" text-anchor="middle" font-size="11">generate host adapter files</text>
+
+  <!-- adapter band -->
+  <rect class="band" x="40" y="180" width="900" height="150" rx="16"/>
+  <text class="tag" x="60" y="204" font-size="9.5">GENERATED ADAPTER BUNDLES</text>
+
+  <!-- card: Claude -->
+  <rect class="box" x="64" y="218" width="156" height="94" rx="11"/>
+  <circle cx="82" cy="242" r="4.5" fill="var(--entry-pill)"/>
+  <text class="title" x="94" y="246" font-size="13">Claude Code</text>
+  <text class="mono" x="80" y="274" font-size="11">.claude/</text>
+  <text class="inv" x="80" y="298" font-size="10.5">/slipway:&lt;cmd&gt;</text>
+
+  <!-- card: Codex -->
+  <rect class="box" x="238" y="218" width="156" height="94" rx="11"/>
+  <circle cx="256" cy="242" r="4.5" fill="var(--exec-pill)"/>
+  <text class="title" x="268" y="246" font-size="13">Codex</text>
+  <text class="mono" x="254" y="274" font-size="11">.codex/ + prompts</text>
+  <text class="inv" x="254" y="298" font-size="10.5">$slipway-&lt;cmd&gt;</text>
+
+  <!-- card: Cursor -->
+  <rect class="box" x="412" y="218" width="156" height="94" rx="11"/>
+  <circle cx="430" cy="242" r="4.5" fill="var(--plan-pill)"/>
+  <text class="title" x="442" y="246" font-size="13">Cursor</text>
+  <text class="mono" x="428" y="274" font-size="11">.cursor/</text>
+  <text class="inv" x="428" y="298" font-size="10.5">/slipway-&lt;cmd&gt;</text>
+
+  <!-- card: Gemini -->
+  <rect class="box" x="586" y="218" width="156" height="94" rx="11"/>
+  <circle cx="604" cy="242" r="4.5" fill="var(--verify-pill)"/>
+  <text class="title" x="616" y="246" font-size="13">Gemini</text>
+  <text class="mono" x="602" y="274" font-size="11">.gemini/</text>
+  <text class="inv" x="602" y="298" font-size="10.5">/slipway-&lt;cmd&gt;</text>
+
+  <!-- card: OpenCode -->
+  <rect class="box" x="760" y="218" width="156" height="94" rx="11"/>
+  <circle cx="778" cy="242" r="4.5" fill="var(--entry-pill)"/>
+  <text class="title" x="790" y="246" font-size="13">OpenCode</text>
+  <text class="mono" x="776" y="274" font-size="11">.opencode/</text>
+  <text class="inv" x="776" y="298" font-size="10.5">/slipway-&lt;cmd&gt;</text>
+
+  <!-- CLI node -->
+  <rect class="cli" x="350" y="366" width="280" height="64" rx="16"/>
+  <text class="titleBig" x="490" y="397" text-anchor="middle" font-size="20">slipway CLI</text>
+  <text class="sub" x="490" y="418" text-anchor="middle" font-size="11">lifecycle + execution authority</text>
+</svg>

--- a/docs/design.md
+++ b/docs/design.md
@@ -15,9 +15,11 @@ Slipway is a small governance control plane for local AI-assisted development. I
 
 ## Architecture Model
 
-<p align="center">
-  <img alt="Slipway architecture model: human and AI tool feed the slipway CLI, which writes the repository system of record (change.yaml, lifecycle.jsonl, Markdown artifacts, verification YAML); read-only surfaces read state, state-mutating surfaces write it" src="assets/diagrams/architecture.svg" width="840">
-</p>
+<div align="center" markdown>
+
+![Slipway architecture model: human and AI tool feed the slipway CLI, which writes the repository system of record (change.yaml, lifecycle.jsonl, Markdown artifacts, verification YAML); read-only surfaces read state, state-mutating surfaces write it](assets/diagrams/architecture.svg)
+
+</div>
 
 The separation matters. `next`, `status`, and `validate` can recompute readiness without mutating lifecycle authority. `run` and `done` are explicit mutation surfaces. Generated host files help AI tools discover the right action, but the CLI remains the execution authority.
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -9,22 +9,11 @@ Slipway routes work through a governed lifecycle:
 
 The active lifecycle state is stored in `artifacts/changes/<slug>/change.yaml`.
 
-```mermaid
-stateDiagram-v2
-  [*] --> S0_INTAKE: slipway new
-  S0_INTAKE --> S1_PLAN: intent confirmed
-  S1_PLAN --> S2_EXECUTE: plan approved
-  S2_EXECUTE --> S3_REVIEW: task evidence complete
-  S3_REVIEW --> S4_VERIFY: reviews pass
-  S4_VERIFY --> S4_VERIFY: goal-verification then final-closeout skills
-  S4_VERIFY --> DONE: done-ready outcome (gates pass), slipway done
-  DONE --> [*]
+<div align="center" markdown>
 
-  S0_INTAKE --> S0_INTAKE: open questions / clarification
-  S1_PLAN --> S1_PLAN: research / audit blockers
-  S2_EXECUTE --> S2_EXECUTE: wave blockers
-  S3_REVIEW --> S2_EXECUTE: review requires changes
-```
+![Slipway governed lifecycle: new, S0 Intake, S1 Plan, S2 Execute, S3 Review, S4 Verify, done, with clarify, audit, wave and changes-requested loop-backs and a primary command loop of new, next, run and done](assets/diagrams/lifecycle.svg)
+
+</div>
 
 ## Create A Change
 


### PR DESCRIPTION
Follow-up to #126.

## Problem

The SVG diagrams render fine on GitHub but were **broken on the MkDocs docs site**. MkDocs Material serves pages at directory URLs (`design/index.html`) and does **not** rewrite paths inside raw HTML `<img>` tags, so `<img src="assets/diagrams/architecture.svg">` resolved to `/design/assets/...` → 404. Reproduced with a local `mkdocs build`.

## Fix

Switch the embeds to an `md_in_html` wrapper so MkDocs rewrites the path while GitHub still centers and resolves it:

```html
<div align="center" markdown>

![alt](assets/diagrams/architecture.svg)

</div>
```

- **MkDocs:** the `markdown` attribute triggers inner-Markdown processing → path rewritten to `../assets/...`
- **GitHub:** standard centering trick (blank lines render the image as Markdown, relative to the file); the `markdown` attribute is ignored

## Replace remaining mermaid

The repo had two mermaid blocks left; both are now SVGs consistent with the existing set:

- `docs/workflow.md` lifecycle `stateDiagram` → reuse `lifecycle.svg` (same diagram)
- `docs/ai-tools.md` `init --tools` flowchart → new `tool-adapters.svg` (`slipway init --tools` generates per-tool adapter bundles for Claude/Codex/Cursor/Gemini/OpenCode, each routing governed commands to the `slipway CLI`)

Repo-wide ``` ```mermaid ``` count is now **0**.

## Verification

`mkdocs build --strict` (the CI command) on top of current `main`:

- ✅ all three diagram pages resolve `../assets/diagrams/*.svg`
- ✅ every referenced asset is emitted to the build
- ✅ no `mermaid` remains in the built HTML
- ✅ new SVG passes `xmllint`, rendered with no text overlap

### Note (not a regression)

An SVG embedded via `<img>` follows the **OS** color scheme, not Material's in-page light/dark toggle — same behavior as the existing diagrams. Both variants stay legible on either background (cards are bordered). Making diagrams track the in-page toggle would require inlining the SVG (out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)