### PR TITLE
refactor(artifacts): defer planning artifact authoring

### DIFF
--- a/cmd/cli_e2e_test.go
+++ b/cmd/cli_e2e_test.go
@@ -417,7 +417,7 @@ func TestCLIEndToEndSuccessfulReviewPassAtS7(t *testing.T) {
 		change.PlanSubStep = model.PlanSubStepNone
 		change.Artifacts = map[string]model.ArtifactState{}
 		require.NoError(t, state.SaveChange(root, change))
-		require.NoError(t, artifact.ScaffoldGovernedBundleForChangeWithContext(root, change, "", model.ProjectContext{}))
+		require.NoError(t, artifact.ScaffoldGovernedBundleForChange(root, change, ""))
 
 		// Write spec with a single requirement.
 		bundlePath := filepath.Join(root, "artifacts", "changes", slug)

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -547,7 +547,7 @@ func TestStatusCommandFromBoundWorktreeUsesBoundScopeConfigCopy(t *testing.T) {
 		change.NeedsDiscovery = true
 		change.WorkflowPreset = model.WorkflowPresetLight
 		require.NoError(t, state.SaveChange(root, change))
-		require.NoError(t, artifact.ScaffoldGovernedBundleForChangeWithContext(root, change, "", model.ProjectContext{}))
+		require.NoError(t, artifact.ScaffoldGovernedBundleForChange(root, change, ""))
 
 		cfg, err := model.LoadConfig(state.ConfigPath(root))
 		require.NoError(t, err)
@@ -609,7 +609,7 @@ func TestResolveActiveChangeRefFromNestedBoundWorktreeCWD(t *testing.T) {
 		change.PlanSubStep = model.PlanSubStepNone
 		change.NeedsDiscovery = true
 		require.NoError(t, state.SaveChange(root, change))
-		require.NoError(t, artifact.ScaffoldGovernedBundleForChangeWithContext(root, change, "", model.ProjectContext{}))
+		require.NoError(t, artifact.ScaffoldGovernedBundleForChange(root, change, ""))
 
 		worktreeRoot := filepath.Join(t.TempDir(), slug)
 		branch := "feat/" + slug

--- a/cmd/done_bulk_reason_codes_test.go
+++ b/cmd/done_bulk_reason_codes_test.go
@@ -22,7 +22,11 @@ func TestDoneAllReadyPreservesShipGateReasonCodes(t *testing.T) {
 	blocked.CurrentState = model.StateS4Verify
 	blocked.PlanSubStep = model.PlanSubStepNone
 	require.NoError(t, state.SaveChange(root, blocked))
-	require.NoError(t, artifact.ScaffoldGovernedBundleForChangeWithContext(root, blocked, "", model.ProjectContext{}))
+	require.NoError(t, artifact.ScaffoldGovernedBundleForChange(root, blocked, ""))
+	// requirements.md/decision.md/tasks.md are authored by the host skill, not
+	// scaffolded (issue #119); write a real bundle so the ship gate reaches the
+	// missing-review-skill check instead of failing closed on a missing artifact.
+	writeShipReadyGovernedBundle(t, root, blocked)
 	writePassingExecutionSummary(t, root, blocked.Slug, 1, "t-01")
 	writePassingWaveEvidence(t, root, blocked.Slug, 1)
 	writePassingGoalVerificationEvidence(t, root, blocked.Slug, 1)
@@ -51,7 +55,12 @@ func TestDoneAllReadyPreservesSpecificReadinessArtifactBlockers(t *testing.T) {
 	blocked.CurrentState = model.StateS4Verify
 	blocked.PlanSubStep = model.PlanSubStepNone
 	require.NoError(t, state.SaveChange(root, blocked))
-	require.NoError(t, artifact.ScaffoldGovernedBundleForChangeWithContext(root, blocked, "", model.ProjectContext{}))
+	require.NoError(t, artifact.ScaffoldGovernedBundleForChange(root, blocked, ""))
+	// requirements.md/decision.md/tasks.md are authored by the host skill, not
+	// scaffolded (issue #119). Write a real bundle so requirements.md/tasks.md are
+	// present; removing decision.md below then isolates the specific missing
+	// artifact blocker this test asserts is preserved.
+	writeShipReadyGovernedBundle(t, root, blocked)
 	writePassingExecutionSummary(t, root, blocked.Slug, 1, "t-01")
 	writePassingWaveEvidence(t, root, blocked.Slug, 1)
 	writePassingReviewEvidencePack(t, root, blocked.Slug, 1)

--- a/cmd/governance_gate_consistency_test.go
+++ b/cmd/governance_gate_consistency_test.go
@@ -213,7 +213,7 @@ func TestReviewLayerBlockersStayConsistentAcrossStatusValidateNextAndReview(t *t
 	change.PlanSubStep = model.PlanSubStepNone
 	require.NoError(t, state.SaveChange(root, change))
 
-	require.NoError(t, artifact.ScaffoldGovernedBundleForChangeWithContext(root, change, "", model.ProjectContext{}))
+	require.NoError(t, artifact.ScaffoldGovernedBundleForChange(root, change, ""))
 	writeShipReadyGovernedBundle(t, root, change)
 	writeAssuranceMD(t, root, slug, validAssuranceContent())
 	writePassingExecutionSummary(t, root, slug, 1, "t-01")

--- a/cmd/instructions.go
+++ b/cmd/instructions.go
@@ -1,18 +1,26 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
 	"github.com/signalridge/slipway/internal/engine/artifact"
+	"github.com/signalridge/slipway/internal/engine/progression"
+	"github.com/signalridge/slipway/internal/model"
+	"github.com/signalridge/slipway/internal/state"
 	"github.com/spf13/cobra"
 )
 
 // instructionsArtifacts maps a public artifact name to its embedded template
 // file name. The engine owns structure (these templates); the authoring skill
 // owns substance. `slipway instructions <artifact>` serves a rendered exemplar
-// plus the quality bar so a skill reads it before writing (issue #91).
+// plus the quality bar so a skill reads it before writing (issue #91), and —
+// inside a governed change — the resolved output path, dependency/unlock graph,
+// and tagged background it must honor while authoring (issue #119).
 var instructionsArtifacts = map[string]string{
 	"intent":       "intent.md",
 	"requirements": "requirements.md",
@@ -22,10 +30,37 @@ var instructionsArtifacts = map[string]string{
 	"assurance":    "assurance.md",
 }
 
-type instructionsView struct {
+// instructionsDependency names an upstream artifact this one depends on, with a
+// path the authoring skill reads lazily and a done flag (the upstream file
+// already exists on disk). Mirrors OpenSpec's dependency-as-path model: upstream
+// inputs are referenced by path, never inlined into the produced artifact.
+type instructionsDependency struct {
 	Artifact string `json:"artifact"`
-	Guidance string `json:"guidance"`
-	Template string `json:"template"`
+	Path     string `json:"path"`
+	Done     bool   `json:"done"`
+}
+
+// instructionsView is the authoring payload returned by `slipway instructions`.
+// Outside a governed change only Artifact/Guidance/Template are populated (a
+// static exemplar a skill can read before any change exists). Inside an active
+// change it is enriched with the resolved output path, the dependency/unlock
+// graph, and tagged background (Context/Rules) the skill must respect but must
+// NOT copy into the authored file.
+type instructionsView struct {
+	Artifact           string                   `json:"artifact"`
+	Guidance           string                   `json:"guidance"`
+	Template           string                   `json:"template"`
+	ResolvedOutputPath string                   `json:"resolved_output_path,omitempty"`
+	Dependencies       []instructionsDependency `json:"dependencies,omitempty"`
+	Unlocks            []string                 `json:"unlocks,omitempty"`
+	Context            string                   `json:"context,omitempty"`
+	// ContextIsBaseline distinguishes the two opposite copy policies that share
+	// the Context field: codebase-map baseline facts are meant to be preserved and
+	// extended INTO the authored doc, whereas a governed artifact's project
+	// context is background the skill must NOT copy. Text output uses it to pick a
+	// non-contradictory heading (issue #119).
+	ContextIsBaseline bool     `json:"context_is_baseline,omitempty"`
+	Rules             []string `json:"rules,omitempty"`
 }
 
 func instructionsArtifactNames() []string {
@@ -43,34 +78,144 @@ func instructionsGuidance(name string) string {
 		return "Author each requirement as `### Requirement: <title>` followed by a `REQ-` " +
 			"body that states what the system MUST, SHALL, or is REQUIRED to do (an RFC-2119 " +
 			"strong-obligation keyword), and at least one concrete `#### Scenario:` with real " +
-			"GIVEN/WHEN/THEN lines. The engine seeds an obviously-not-real placeholder; replace " +
-			"it — an unedited scaffold is rejected by the requirements substance gate and cannot " +
-			"reach done."
+			"GIVEN/WHEN/THEN lines. The engine does not seed a body — this file is unwritten " +
+			"until you author it; an empty or structure-only requirements file is rejected by " +
+			"the substance gate and cannot reach done."
 	case "tasks":
 		return "Author each task as a checklist line (- [ ] t-NN <objective>) with wave, " +
-			"depends_on, target_files, task_kind, and covers metadata. Replace the placeholder " +
-			"objective; a placeholder tasks list is rejected by the tasks substance gate."
+			"depends_on, target_files, task_kind, and covers metadata. Every task names concrete target_files " +
+			"that bound the files or evidence targets it changes or verifies. The engine does not seed a body; an " +
+			"empty or placeholder tasks list is rejected by the substance gate."
+	case "decision":
+		return "Author a concrete decision with alternatives, selected approach, interfaces and data flow, " +
+			"rollout/rollback, and risk. The engine does not seed this body; a missing or template-only decision " +
+			"is rejected on expanded-schema plan readiness."
+	case "research":
+		return "Author evidence-backed research with alternatives, unknowns, assumptions, and canonical references. " +
+			"The engine may create a comment-only research scaffold for discovery; replace the guidance comments " +
+			"with concrete findings before advancing."
+	case "intent":
+		return "Use the intent structure to preserve confirmed intake facts and scope boundaries. The engine may " +
+			"already have created this file during intake; keep user-confirmed substance and replace placeholder " +
+			"sections instead of treating the template as final content."
+	case "assurance":
+		return "Author final closeout assurance from actual verification evidence: scope summary, verdict, " +
+			"evidence index, requirement coverage, residual risks, rollback readiness, and archive decision. " +
+			"The engine may create the scaffold; replace it with closeout substance before finalization."
 	default:
-		return "Replace the seeded placeholder with concrete, substantive content. The engine " +
-			"owns structure; you own substance."
+		return "Author concrete, substantive content directly. The engine owns structure (the " +
+			"template) and you own substance."
 	}
+}
+
+// codebaseMapGuidance is the authoring quality bar for the repo-scoped
+// codebase-map docs. Unlike a governed bundle artifact, the engine's baseline
+// scan writes real machine-extracted facts (languages, tooling, layout) the
+// author must preserve and extend — not a placeholder seed to delete.
+func codebaseMapGuidance() string {
+	return "Author this repo-scoped codebase-map doc with concrete, file:line-cited " +
+		"findings: module boundaries, dependency direction, conventions, and " +
+		"change-relevant risks. `slipway codebase-map` writes a baseline of real " +
+		"machine-extracted facts (languages, build/test tooling, directory layout) " +
+		"as a trustworthy starting point — preserve and extend it; do not delete it " +
+		"as if it were placeholder seed. This map is advisory: it does not gate any " +
+		"stage, but research, plan-audit, and wave-orchestration consume it by path."
+}
+
+// codebaseMapInstructionsView builds the authoring payload for a codebase-map
+// doc when name matches one (by key or file name). It resolves the output path
+// against the workspace root and offers the baseline facts as context, but never
+// requires an active change. ok is false when name is not a codebase-map doc, so
+// the caller falls through to the bundle-artifact path.
+func codebaseMapInstructionsView(cmd *cobra.Command, name string) (instructionsView, bool) {
+	file, template, ok := artifact.CodebaseMapDocInstruction(name)
+	if !ok {
+		return instructionsView{}, false
+	}
+	view := instructionsView{
+		Artifact: artifact.CodebaseMapDocKey(file),
+		Guidance: codebaseMapGuidance(),
+		Template: template,
+	}
+	// Resolve the repo-scoped output path and baseline context against the
+	// workspace root. A workspace that is not initialized leaves the payload as
+	// the static template+guidance — instructions never fails just because the
+	// root cannot be resolved.
+	root, err := projectRootFromCommand(cmd)
+	if err != nil {
+		return view, true
+	}
+	workspaceRoot := invocationWorkspaceRootFromCommand(cmd, root)
+	docPath := filepath.Join(state.CodebaseMapDir(workspaceRoot), file)
+	view.ResolvedOutputPath = state.DisplayPath(workspaceRoot, docPath)
+	// Offer the baseline only when the scan actually detected facts. When it
+	// matches the bare template there is nothing to preserve, so attaching it as
+	// "real detected facts" would be misleading noise.
+	if baseline, ok := artifact.CodebaseMapBaselineDoc(workspaceRoot, file); ok &&
+		strings.TrimSpace(baseline) != strings.TrimSpace(template) {
+		view.Context = renderCodebaseMapBaselineContext(baseline)
+		// The codebase-map baseline is real detected facts the author preserves
+		// and extends into the doc — the opposite of a governed artifact's
+		// do-not-copy project context. Flag it so text output labels it honestly.
+		view.ContextIsBaseline = true
+	}
+	return view, true
+}
+
+// renderCodebaseMapBaselineContext frames the baseline doc as background the
+// author preserves and extends. It is tagged like other instructions context so
+// the skill respects it, but unlike bundle context the baseline IS meant to seed
+// the authored file (it is real detected facts, not data to keep out of the body).
+func renderCodebaseMapBaselineContext(baseline string) string {
+	baseline = strings.TrimSpace(baseline)
+	if baseline == "" {
+		return ""
+	}
+	return "Baseline facts from `slipway codebase-map` (real detected facts — " +
+		"preserve and extend, do not delete):\n" + baseline
 }
 
 func makeInstructionsCmd() *cobra.Command {
 	var jsonOutput bool
+	var changeSlug string
 
 	cmd := &cobra.Command{
 		Use:   "instructions <artifact>",
 		Short: desc("instructions"),
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			name := strings.ToLower(strings.TrimSpace(args[0]))
+			// Accept both the public name ("decision") and the artifact file
+			// name ("decision.md") so the missing_required_artifact remediation
+			// command (`slipway instructions <subject>`, subject = file name) runs.
+			name, artifactFile := normalizeInstructionsArtifactArg(args[0])
+
+			// Codebase-map docs share the instructions->author contract but are
+			// repo-scoped and advisory: they resolve against the workspace root
+			// and never require an active change.
+			if view, ok := codebaseMapInstructionsView(cmd, name); ok {
+				if jsonOutput {
+					return encodeJSONResponse(cmd, view)
+				}
+				return writeInstructionsText(cmd, view)
+			}
+
 			templateName, ok := instructionsArtifacts[name]
 			if !ok {
+				view, customOK, err := customArtifactInstructionsView(cmd, name, artifactFile, changeSlug)
+				if err != nil {
+					return err
+				}
+				if customOK {
+					if jsonOutput {
+						return encodeJSONResponse(cmd, view)
+					}
+					return writeInstructionsText(cmd, view)
+				}
 				return newInvalidUsageError(
 					"unknown_artifact",
 					fmt.Sprintf("unknown artifact %q", name),
-					"Choose a governed artifact: "+strings.Join(instructionsArtifactNames(), ", "),
+					"Choose a governed artifact: "+strings.Join(instructionsArtifactNames(), ", ")+
+						"; or a codebase-map doc: "+strings.Join(artifact.CodebaseMapInstructionKeys(), ", "),
 					nil,
 				)
 			}
@@ -83,20 +228,273 @@ func makeInstructionsCmd() *cobra.Command {
 				Guidance: instructionsGuidance(name),
 				Template: content,
 			}
+			// Enrich with change-aware authoring context when invoked inside a
+			// governed change. With no --change selector the command still serves
+			// the static exemplar on any resolution failure, but an explicit
+			// --change fails closed (issue #119).
+			if err := enrichInstructionsView(cmd, &view, changeSlug, templateName); err != nil {
+				return err
+			}
+
 			if jsonOutput {
 				return encodeJSONResponse(cmd, view)
 			}
-			out := cmd.OutOrStdout()
-			fmt.Fprintf(out, "# Authoring instructions: %s\n\n", name)
-			fmt.Fprintln(out, view.Guidance)
-			fmt.Fprintln(out)
-			fmt.Fprintln(out, "## Template")
-			fmt.Fprintln(out)
-			fmt.Fprintln(out, content)
-			return nil
+			return writeInstructionsText(cmd, view)
 		},
 	}
 
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "JSON output")
+	cmd.Flags().StringVar(&changeSlug, "change", "", "Governed change slug (defaults to the active change)")
 	return cmd
+}
+
+func normalizeInstructionsArtifactArg(arg string) (name, artifactFile string) {
+	raw := strings.TrimSpace(arg)
+	lower := strings.ToLower(raw)
+	name = strings.TrimSuffix(lower, ".md")
+	artifactFile = raw
+	if filepath.Ext(artifactFile) == "" {
+		artifactFile += ".md"
+	}
+	return name, artifactFile
+}
+
+func customArtifactInstructionsView(
+	cmd *cobra.Command,
+	name string,
+	artifactFile string,
+	changeSlug string,
+) (instructionsView, bool, error) {
+	explicit := strings.TrimSpace(changeSlug) != ""
+	root, err := projectRootFromCommand(cmd)
+	if err != nil {
+		if explicit {
+			return instructionsView{}, false, err
+		}
+		return instructionsView{}, false, nil
+	}
+	ref, err := resolveActiveChangeRef(root, changeSlug)
+	if err != nil {
+		if explicit {
+			return instructionsView{}, false, err
+		}
+		return instructionsView{}, false, nil
+	}
+	change, err := state.LoadChange(root, ref.Slug)
+	if err != nil {
+		return instructionsView{}, false, err
+	}
+	spec, ok := findInstructionsArtifactSpec(
+		artifact.ResolveSchema(change.ArtifactSchema, change.CustomArtifacts),
+		name,
+		artifactFile,
+	)
+	if !ok {
+		return instructionsView{}, false, nil
+	}
+	content, err := artifact.RenderArtifactExampleWithTemplate(root, spec.Name, spec.Template)
+	if err != nil {
+		return instructionsView{}, false, err
+	}
+	viewName := strings.TrimSuffix(spec.Name, filepath.Ext(spec.Name))
+	if strings.TrimSpace(viewName) == "" {
+		viewName = spec.Name
+	}
+	view := instructionsView{
+		Artifact: viewName,
+		Guidance: instructionsGuidance(name),
+		Template: content,
+	}
+	if err := enrichInstructionsView(cmd, &view, changeSlug, spec.Name); err != nil {
+		return instructionsView{}, false, err
+	}
+	return view, true, nil
+}
+
+func findInstructionsArtifactSpec(schema []artifact.ArtifactSpec, name, artifactFile string) (artifact.ArtifactSpec, bool) {
+	for _, spec := range schema {
+		specName := strings.TrimSpace(spec.Name)
+		if specName == "" {
+			continue
+		}
+		if strings.EqualFold(specName, artifactFile) {
+			return spec, true
+		}
+		specKey := strings.TrimSuffix(specName, filepath.Ext(specName))
+		if strings.EqualFold(specKey, name) {
+			return spec, true
+		}
+	}
+	return artifact.ArtifactSpec{}, false
+}
+
+// enrichInstructionsView adds active-change authoring context to view when a
+// governed change can be resolved. With no change selector, a missing active
+// change leaves view as the static exemplar; other resolution failures still
+// fall back but emit a warning so operators do not mistake static output for a
+// resolved authoring payload. But an explicit --change must fail closed:
+// silently downgrading a missing or typo'd slug to static output makes it look
+// successful and defeats the recovery command (issue #119).
+func enrichInstructionsView(cmd *cobra.Command, view *instructionsView, changeSlug, artifactFile string) error {
+	explicit := strings.TrimSpace(changeSlug) != ""
+	fail := func(err error) error {
+		if explicit {
+			return err
+		}
+		warnInstructionsStaticFallback(cmd, err)
+		return nil
+	}
+	root, err := projectRootFromCommand(cmd)
+	if err != nil {
+		if explicit {
+			return err
+		}
+		return nil
+	}
+	ref, err := resolveActiveChangeRef(root, changeSlug)
+	if err != nil {
+		return fail(err)
+	}
+	change, err := state.LoadChange(root, ref.Slug)
+	if err != nil {
+		return fail(err)
+	}
+	paths, err := state.ResolveChangePaths(root, change)
+	if err != nil {
+		return fail(err)
+	}
+
+	view.ResolvedOutputPath = state.DisplayPath(root, artifact.ResolveArtifactPath(paths.GovernedBundleDir, artifactFile))
+
+	schema := artifact.ResolveSchema(change.ArtifactSchema, change.CustomArtifacts)
+	required := make(map[string]bool)
+	for _, name := range progression.RequiredArtifactNames(root, change) {
+		required[name] = true
+	}
+	for _, spec := range schema {
+		if spec.Name == artifactFile {
+			for _, dep := range spec.DependsOn {
+				depPath := artifact.ResolveArtifactPath(paths.GovernedBundleDir, dep)
+				_, statErr := os.Stat(depPath)
+				if !required[dep] && statErr != nil {
+					continue
+				}
+				view.Dependencies = append(view.Dependencies, instructionsDependency{
+					Artifact: dep,
+					Path:     state.DisplayPath(root, depPath),
+					Done:     statErr == nil,
+				})
+			}
+			continue
+		}
+		// Unlocks: required artifacts that depend on this one.
+		if required[spec.Name] {
+			for _, dep := range spec.DependsOn {
+				if dep == artifactFile {
+					view.Unlocks = append(view.Unlocks, spec.Name)
+				}
+			}
+		}
+	}
+	sort.Strings(view.Unlocks)
+
+	view.Context = renderInstructionsContext(change.ProjectContext)
+	view.Rules = instructionsRules(change)
+	return nil
+}
+
+func warnInstructionsStaticFallback(cmd *cobra.Command, err error) {
+	if err == nil {
+		return
+	}
+	var cliErr *CLIError
+	if errors.As(err, &cliErr) && cliErr.ErrorCode == "no_active_change" {
+		return
+	}
+	fmt.Fprintf(cmd.ErrOrStderr(),
+		"warning: serving static instructions because active change context could not be resolved: %v\n",
+		err)
+}
+
+// renderInstructionsContext renders project context as tagged background. Per
+// the OpenSpec model this is information the authoring skill must respect but
+// must NOT copy into the artifact body (it previously leaked in as a
+// "## Project Context" block written straight into the file).
+func renderInstructionsContext(pc model.ProjectContext) string {
+	if pc.IsZero() {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("Background only — do NOT copy this into the authored artifact.\n")
+	if v := strings.TrimSpace(pc.TechStack); v != "" {
+		fmt.Fprintf(&b, "- Tech Stack: %s\n", v)
+	}
+	if len(pc.Languages) > 0 {
+		fmt.Fprintf(&b, "- Languages: %s\n", strings.Join(pc.Languages, ", "))
+	}
+	if v := strings.TrimSpace(pc.TestCmd); v != "" {
+		fmt.Fprintf(&b, "- Test Command: %s\n", v)
+	}
+	if v := strings.TrimSpace(pc.BuildCmd); v != "" {
+		fmt.Fprintf(&b, "- Build Command: %s\n", v)
+	}
+	if v := strings.TrimSpace(pc.Conventions); v != "" {
+		fmt.Fprintf(&b, "- Conventions: %s\n", v)
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// instructionsRules returns artifact-authoring constraints the skill must honor
+// but must not copy into the artifact (tagged background, like context).
+func instructionsRules(change model.Change) []string {
+	var rules []string
+	if gd := strings.TrimSpace(change.GuardrailDomain); gd != "" {
+		rules = append(rules, fmt.Sprintf(
+			"This change touches the %s guarded domain: keep the artifact's guardrail "+
+				"obligations explicit and fail closed to review and evidence (no bypass, "+
+				"force-pass, or private attestation).", gd))
+	}
+	return rules
+}
+
+func writeInstructionsText(cmd *cobra.Command, view instructionsView) error {
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "# Authoring instructions: %s\n\n", view.Artifact)
+	fmt.Fprintln(out, view.Guidance)
+	if view.ResolvedOutputPath != "" {
+		fmt.Fprintf(out, "\nWrite the authored artifact to: %s\n", view.ResolvedOutputPath)
+	}
+	if len(view.Dependencies) > 0 {
+		fmt.Fprintln(out, "\n## Dependencies (read these by path; do not inline them)")
+		for _, dep := range view.Dependencies {
+			status := "missing"
+			if dep.Done {
+				status = "done"
+			}
+			fmt.Fprintf(out, "- %s [%s] — %s\n", dep.Artifact, status, dep.Path)
+		}
+	}
+	if len(view.Unlocks) > 0 {
+		fmt.Fprintf(out, "\nCompleting this unlocks: %s\n", strings.Join(view.Unlocks, ", "))
+	}
+	if view.Context != "" {
+		// The Context field carries two opposite copy policies; label it honestly
+		// so the heading never contradicts the body (issue #119).
+		if view.ContextIsBaseline {
+			fmt.Fprintln(out, "\n## Baseline facts (preserve and extend — this is your starting content)")
+		} else {
+			fmt.Fprintln(out, "\n## Project context (background — do NOT copy into the artifact)")
+		}
+		fmt.Fprintln(out, view.Context)
+	}
+	if len(view.Rules) > 0 {
+		fmt.Fprintln(out, "\n## Rules (constraints — do NOT copy into the artifact)")
+		for _, rule := range view.Rules {
+			fmt.Fprintf(out, "- %s\n", rule)
+		}
+	}
+	fmt.Fprintln(out, "\n## Template")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, view.Template)
+	return nil
 }

--- a/cmd/instructions.go
+++ b/cmd/instructions.go
@@ -12,6 +12,7 @@ import (
 	"github.com/signalridge/slipway/internal/engine/progression"
 	"github.com/signalridge/slipway/internal/model"
 	"github.com/signalridge/slipway/internal/state"
+	"github.com/signalridge/slipway/internal/stringutil"
 	"github.com/spf13/cobra"
 )
 
@@ -31,9 +32,10 @@ var instructionsArtifacts = map[string]string{
 }
 
 // instructionsDependency names an upstream artifact this one depends on, with a
-// path the authoring skill reads lazily and a done flag (the upstream file
-// already exists on disk). Mirrors OpenSpec's dependency-as-path model: upstream
-// inputs are referenced by path, never inlined into the produced artifact.
+// path the authoring skill reads lazily and a done flag (the upstream artifact
+// satisfies the engine-owned contract). Mirrors OpenSpec's dependency-as-path
+// model: upstream inputs are referenced by path, never inlined into the produced
+// artifact.
 type instructionsDependency struct {
 	Artifact string `json:"artifact"`
 	Path     string `json:"path"`
@@ -92,8 +94,7 @@ func instructionsGuidance(name string) string {
 			"is rejected on expanded-schema plan readiness."
 	case "research":
 		return "Author evidence-backed research with alternatives, unknowns, assumptions, and canonical references. " +
-			"The engine may create a comment-only research scaffold for discovery; replace the guidance comments " +
-			"with concrete findings before advancing."
+			"The engine does not seed this body; write the real file from these instructions before advancing."
 	case "intent":
 		return "Use the intent structure to preserve confirmed intake facts and scope boundaries. The engine may " +
 			"already have created this file during intake; keep user-confirmed substance and replace placeholder " +
@@ -305,8 +306,11 @@ func customArtifactInstructionsView(
 		Guidance: instructionsGuidance(name),
 		Template: content,
 	}
-	if err := enrichInstructionsView(cmd, &view, changeSlug, spec.Name); err != nil {
-		return instructionsView{}, false, err
+	if err := enrichInstructionsViewForChange(&view, root, change, spec.Name); err != nil {
+		if explicit {
+			return instructionsView{}, false, err
+		}
+		warnInstructionsStaticFallback(cmd, err)
 	}
 	return view, true, nil
 }
@@ -346,10 +350,7 @@ func enrichInstructionsView(cmd *cobra.Command, view *instructionsView, changeSl
 	}
 	root, err := projectRootFromCommand(cmd)
 	if err != nil {
-		if explicit {
-			return err
-		}
-		return nil
+		return fail(err)
 	}
 	ref, err := resolveActiveChangeRef(root, changeSlug)
 	if err != nil {
@@ -359,9 +360,21 @@ func enrichInstructionsView(cmd *cobra.Command, view *instructionsView, changeSl
 	if err != nil {
 		return fail(err)
 	}
+	if err := enrichInstructionsViewForChange(view, root, change, artifactFile); err != nil {
+		return fail(err)
+	}
+	return nil
+}
+
+func enrichInstructionsViewForChange(
+	view *instructionsView,
+	root string,
+	change model.Change,
+	artifactFile string,
+) error {
 	paths, err := state.ResolveChangePaths(root, change)
 	if err != nil {
-		return fail(err)
+		return err
 	}
 
 	view.ResolvedOutputPath = state.DisplayPath(root, artifact.ResolveArtifactPath(paths.GovernedBundleDir, artifactFile))
@@ -382,7 +395,7 @@ func enrichInstructionsView(cmd *cobra.Command, view *instructionsView, changeSl
 				view.Dependencies = append(view.Dependencies, instructionsDependency{
 					Artifact: dep,
 					Path:     state.DisplayPath(root, depPath),
-					Done:     statErr == nil,
+					Done:     instructionsDependencyDone(paths.GovernedBundleDir, dep, statErr),
 				})
 			}
 			continue
@@ -396,11 +409,37 @@ func enrichInstructionsView(cmd *cobra.Command, view *instructionsView, changeSl
 			}
 		}
 	}
-	sort.Strings(view.Unlocks)
+	view.Unlocks = stringutil.UniqueSorted(view.Unlocks)
 
 	view.Context = renderInstructionsContext(change.ProjectContext)
 	view.Rules = instructionsRules(change)
 	return nil
+}
+
+func instructionsDependencyDone(bundleDir string, artifactName string, statErr error) bool {
+	if statErr != nil {
+		return false
+	}
+
+	switch artifactName {
+	case "requirements.md":
+		result, err := artifact.EvaluateRequirementsContract(bundleDir)
+		return err == nil && result.Status == artifact.RequirementsContractStatusValid
+	case "decision.md":
+		result, err := artifact.EvaluateDecisionContract(bundleDir)
+		return err == nil && result.Status == artifact.DecisionContractStatusValid
+	case "tasks.md":
+		result, err := artifact.EvaluateTasksContract(bundleDir)
+		return err == nil && result.Status == artifact.TasksContractStatusValid
+	case "research.md":
+		data, err := os.ReadFile(artifact.ResolveArtifactPath(bundleDir, artifactName))
+		return err == nil && len(artifact.ResearchStructureBlockers(string(data))) == 0
+	case "assurance.md":
+		data, err := os.ReadFile(artifact.ResolveArtifactPath(bundleDir, artifactName))
+		return err == nil && len(artifact.AssuranceStructureBlockers(string(data))) == 0
+	default:
+		return true
+	}
 }
 
 func warnInstructionsStaticFallback(cmd *cobra.Command, err error) {

--- a/cmd/instructions_test.go
+++ b/cmd/instructions_test.go
@@ -3,9 +3,13 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/signalridge/slipway/internal/model"
+	"github.com/signalridge/slipway/internal/state"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -14,8 +18,9 @@ func runInstructions(t *testing.T, args ...string) (string, error) {
 	t.Helper()
 	cmd := makeInstructionsCmd()
 	var out bytes.Buffer
+	var stderr bytes.Buffer
 	cmd.SetOut(&out)
-	cmd.SetErr(&out)
+	cmd.SetErr(&stderr)
 	cmd.SetArgs(args)
 	err := cmd.Execute()
 	return out.String(), err
@@ -58,9 +63,350 @@ func TestInstructionsJSONIncludesTemplateAndGuidance(t *testing.T) {
 	assert.NotContains(t, view.Template, "{{", "served template must be rendered, not raw Go-template source")
 }
 
+func TestInstructionsGuidanceMatchesScaffoldOwnership(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"intent", "research", "assurance"} {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			out, err := runInstructions(t, name, "--json")
+			require.NoError(t, err)
+			var view instructionsView
+			require.NoError(t, json.Unmarshal([]byte(out), &view))
+			assert.NotContains(t, view.Guidance, "no seeded body",
+				"scaffolded artifacts must not claim there is no seeded body")
+			assert.Contains(t, view.Guidance, "engine may",
+				"guidance should acknowledge engine-owned scaffold behavior")
+		})
+	}
+}
+
+func TestInstructionsTasksGuidanceMatchesTargetFilesGate(t *testing.T) {
+	t.Parallel()
+	out, err := runInstructions(t, "tasks", "--json")
+	require.NoError(t, err)
+
+	var view instructionsView
+	require.NoError(t, json.Unmarshal([]byte(out), &view))
+	assert.Contains(t, view.Guidance, "Every task names concrete target_files")
+	assert.NotContains(t, view.Guidance, "A `task_kind: code` task")
+}
+
 func TestInstructionsUnknownArtifactErrors(t *testing.T) {
 	t.Parallel()
 	_, err := runInstructions(t, "not-an-artifact")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown artifact")
+}
+
+// TestInstructionsCodebaseMapDoc covers issue #119 Phase 4: the repo-scoped
+// codebase-map docs share the instructions->author contract. `slipway
+// instructions architecture` returns the codebase-map template, a
+// resolved_output_path under artifacts/codebase/, and the baseline facts as
+// context — without requiring an active change.
+func TestInstructionsCodebaseMapDoc(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+
+		stdout, stderr, err := runRootCommandIn(root, []string{
+			"instructions", "architecture", "--json",
+		})
+		require.NoError(t, err)
+		assert.Empty(t, stderr)
+
+		var view instructionsView
+		require.NoError(t, json.Unmarshal([]byte(stdout), &view))
+
+		assert.Equal(t, "architecture", view.Artifact)
+		assert.Contains(t, view.Template, "# Architecture",
+			"should serve the codebase-map template, not a bundle artifact")
+		assert.Contains(t, view.Template, "Module responsibilities:")
+		assert.Contains(t, filepath.ToSlash(view.ResolvedOutputPath), "artifacts/codebase/ARCHITECTURE.md",
+			"resolved output path should point at the repo-scoped codebase-map doc")
+		// No active change was created; codebase-map instructions resolve anyway.
+		assert.Empty(t, view.Dependencies)
+		assert.Empty(t, view.Unlocks)
+	})
+}
+
+// TestInstructionsCodebaseMapAcceptsFileName confirms the file-name form
+// ("STACK.md") resolves to the same codebase-map doc as the key ("stack"), so
+// the staleness/missing-doc remediation can hand back either form.
+func TestInstructionsCodebaseMapAcceptsFileName(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		// Seed a manifest so the baseline scan detects real facts; STACK context
+		// should then carry them as background the author preserves, not seed.
+		require.NoError(t, os.WriteFile(filepath.Join(root, "go.mod"),
+			[]byte("module example.com/demo\n\ngo 1.22\n"), 0o644))
+
+		stdout, _, err := runRootCommandIn(root, []string{
+			"instructions", "STACK.md", "--json",
+		})
+		require.NoError(t, err)
+
+		var view instructionsView
+		require.NoError(t, json.Unmarshal([]byte(stdout), &view))
+		assert.Equal(t, "stack", view.Artifact)
+		assert.Contains(t, view.Template, "# Stack")
+		assert.Contains(t, filepath.ToSlash(view.ResolvedOutputPath), "artifacts/codebase/STACK.md")
+		// The baseline scan detected this Go module, so STACK context carries the
+		// real machine-extracted facts the author preserves rather than placeholder seed.
+		assert.Contains(t, view.Context, "Baseline facts")
+		assert.Contains(t, view.Context, "Go")
+	})
+}
+
+// TestInstructionsCodebaseMapServesTemplateAndGuidance confirms codebase-map
+// instructions always serve the template and guidance and never fail — the
+// resolved output path is best-effort context layered on top, not a precondition.
+func TestInstructionsCodebaseMapServesTemplateAndGuidance(t *testing.T) {
+	t.Parallel()
+	out, err := runInstructions(t, "conventions", "--json")
+	require.NoError(t, err)
+
+	var view instructionsView
+	require.NoError(t, json.Unmarshal([]byte(out), &view))
+	assert.Equal(t, "conventions", view.Artifact)
+	assert.Contains(t, view.Template, "# Conventions")
+	assert.NotEmpty(t, view.Guidance)
+}
+
+// TestInstructionsChangeAwareAuthoringPayload covers issue #119: inside a
+// governed change `instructions` returns the resolved output path, the
+// dependency graph with done-status, and the unlock set — so the authoring
+// skill writes the real file straight to the right path and reads upstream
+// inputs by path instead of having them seeded into the body.
+func TestInstructionsChangeAwareAuthoringPayload(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		slug := createGovernedRequest(t, root, "L2", "instructions change-aware payload")
+
+		// Exercise both done-status branches. decision.md depends on intent.md
+		// and requirements.md in the expanded schema. Author intent.md (present →
+		// done); requirements.md is deferred to skill authoring so it is absent by
+		// default (absent → not done). The RemoveAll keeps that absence explicit
+		// and robust regardless of scaffold behavior.
+		bundlePath := filepath.Join(root, "artifacts", "changes", slug)
+		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "intent.md",
+			[]byte("# Intent\n\n## Summary\nchange-aware payload\n")))
+		require.NoError(t, os.RemoveAll(filepath.Join(bundlePath, "requirements.md")))
+
+		stdout, stderr, err := runRootCommandIn(root, []string{
+			"instructions", "decision", "--json", "--change", slug,
+		})
+		require.NoError(t, err)
+		assert.Empty(t, stderr)
+
+		var view instructionsView
+		require.NoError(t, json.Unmarshal([]byte(stdout), &view))
+
+		assert.Equal(t, "decision", view.Artifact)
+		assert.Contains(t, view.ResolvedOutputPath, "decision.md",
+			"resolved output path should point at the artifact in the active bundle")
+
+		done := map[string]bool{}
+		for _, dep := range view.Dependencies {
+			assert.NotEmpty(t, dep.Path, "each dependency carries a readable path")
+			done[dep.Artifact] = dep.Done
+		}
+		require.Contains(t, done, "intent.md")
+		require.Contains(t, done, "requirements.md")
+		assert.True(t, done["intent.md"], "authored upstream dependency is done")
+		assert.False(t, done["requirements.md"], "un-authored upstream dependency is not done")
+
+		// tasks.md depends_on decision.md → authoring decision unlocks tasks.
+		assert.Contains(t, view.Unlocks, "tasks.md")
+	})
+}
+
+func TestInstructionsUnlocksUseEffectivePreset(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+
+		cfg := model.DefaultConfig()
+		cfg.Governance.MinPreset = model.WorkflowPresetStandard
+		require.NoError(t, model.SaveConfig(state.ConfigPath(root), cfg))
+
+		slug := "effective-preset-unlocks"
+		change := model.NewChange(slug)
+		change.WorkflowPreset = model.WorkflowPresetLight
+		change.ArtifactSchema = model.ArtifactSchemaCore
+		require.NoError(t, state.SaveChange(root, change))
+
+		stdout, stderr, err := runRootCommandIn(root, []string{
+			"instructions", "tasks", "--json", "--change", slug,
+		})
+		require.NoError(t, err)
+		assert.Empty(t, stderr)
+
+		var view instructionsView
+		require.NoError(t, json.Unmarshal([]byte(stdout), &view))
+		assert.Contains(t, view.Unlocks, "assurance.md",
+			"unlocks must use the effective preset, not the raw confirmed preset")
+	})
+}
+
+func TestInstructionsDependenciesSkipOptionalMissingArtifacts(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+
+		slug := "optional-dependency-filter"
+		change := model.NewChange(slug)
+		change.ArtifactSchema = model.ArtifactSchemaCustom
+		change.CustomArtifacts = []model.ArtifactDefinition{
+			{Name: "tasks.md"},
+			{Name: "research.md", RequiresDiscovery: true},
+			{Name: "assurance.md", DependsOn: []string{"tasks.md", "research.md"}},
+		}
+		change.NeedsDiscovery = false
+		require.NoError(t, state.SaveChange(root, change))
+
+		stdout, stderr, err := runRootCommandIn(root, []string{
+			"instructions", "assurance", "--json", "--change", slug,
+		})
+		require.NoError(t, err)
+		assert.Empty(t, stderr)
+
+		var view instructionsView
+		require.NoError(t, json.Unmarshal([]byte(stdout), &view))
+		deps := map[string]bool{}
+		for _, dep := range view.Dependencies {
+			deps[dep.Artifact] = dep.Done
+		}
+		require.Contains(t, deps, "tasks.md", "required missing upstream remains visible")
+		assert.False(t, deps["tasks.md"])
+		assert.NotContains(t, deps, "research.md", "optional missing upstream must not be shown as a required dependency")
+	})
+}
+
+func TestInstructionsCustomArtifactUsesActiveChangeSchema(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+
+		slug := "custom-artifact-instructions"
+		change := model.NewChange(slug)
+		change.ArtifactSchema = model.ArtifactSchemaCustom
+		change.CustomArtifacts = []model.ArtifactDefinition{
+			{Name: "intent.md"},
+			{Name: "my-widget.md", DependsOn: []string{"intent.md"}},
+			{Name: "widget-report.md", DependsOn: []string{"my-widget.md"}},
+		}
+		require.NoError(t, state.SaveChange(root, change))
+
+		stdout, stderr, err := runRootCommandIn(root, []string{
+			"instructions", "my-widget.md", "--json",
+		})
+		require.NoError(t, err)
+		assert.Empty(t, stderr)
+
+		var view instructionsView
+		require.NoError(t, json.Unmarshal([]byte(stdout), &view))
+		assert.Equal(t, "my-widget", view.Artifact)
+		assert.Contains(t, view.Guidance, "Author concrete, substantive content")
+		assert.Equal(t, "# my-widget\n", view.Template)
+		assert.Contains(t, filepath.ToSlash(view.ResolvedOutputPath),
+			"artifacts/changes/"+slug+"/my-widget.md")
+
+		require.Len(t, view.Dependencies, 1)
+		assert.Equal(t, "intent.md", view.Dependencies[0].Artifact)
+		assert.False(t, view.Dependencies[0].Done)
+		assert.Contains(t, view.Unlocks, "widget-report.md")
+	})
+}
+
+// TestInstructionsExplicitMissingChangeFailsClosed covers issue #119 F2: an
+// explicit --change that cannot be resolved must fail closed, not silently serve
+// the static exemplar — a typo'd or missing slug should not look successful.
+func TestInstructionsExplicitMissingChangeFailsClosed(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		_, _, err := runRootCommandIn(root, []string{
+			"instructions", "decision", "--change", "definitely-missing", "--json",
+		})
+		require.Error(t, err, "an unresolvable explicit --change must fail closed")
+	})
+}
+
+// TestInstructionsOmittedChangeFallsBackToStatic confirms the complement: with no
+// --change selector and no active change, instructions still serves the static
+// exemplar and exits 0 (issue #119 F2).
+func TestInstructionsOmittedChangeFallsBackToStatic(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		stdout, stderr, err := runRootCommandIn(root, []string{"instructions", "decision", "--json"})
+		require.NoError(t, err)
+		assert.Empty(t, stderr)
+		var view instructionsView
+		require.NoError(t, json.Unmarshal([]byte(stdout), &view))
+		assert.Equal(t, "decision", view.Artifact)
+		assert.Empty(t, view.ResolvedOutputPath, "no active change resolves to the static exemplar")
+	})
+}
+
+func TestInstructionsOmittedChangeWarnsWhenActiveContextAmbiguous(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		require.NoError(t, state.SaveChange(root, model.NewChange("ambiguous-a")))
+		require.NoError(t, state.SaveChange(root, model.NewChange("ambiguous-b")))
+
+		stdout, stderr, err := runRootCommandIn(root, []string{"instructions", "decision", "--json"})
+		require.NoError(t, err)
+		assert.Contains(t, stderr, "warning: serving static instructions")
+		assert.Contains(t, stderr, "active change context is ambiguous")
+
+		var view instructionsView
+		require.NoError(t, json.Unmarshal([]byte(stdout), &view))
+		assert.Equal(t, "decision", view.Artifact)
+		assert.Empty(t, view.ResolvedOutputPath,
+			"ambiguous active context falls back to the static exemplar, not a resolved payload")
+	})
+}
+
+// TestInstructionsCodebaseMapTextLabelsBaselinePreserve covers issue #119 F3: the
+// text output for a codebase-map doc must label its baseline context "preserve
+// and extend", never "do NOT copy" — the baseline is real detected facts the
+// author seeds INTO the doc, the opposite of a governed artifact's do-not-copy
+// project context.
+func TestInstructionsCodebaseMapTextLabelsBaselinePreserve(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		require.NoError(t, os.WriteFile(filepath.Join(root, "go.mod"),
+			[]byte("module example.com/demo\n\ngo 1.22\n"), 0o644))
+
+		stdout, _, err := runRootCommandIn(root, []string{"instructions", "stack"})
+		require.NoError(t, err)
+		assert.Contains(t, stdout, "Baseline facts")
+		assert.Contains(t, stdout, "preserve and extend")
+		assert.NotContains(t, stdout, "do NOT copy",
+			"codebase-map baseline must not be labeled do-not-copy")
+
+		// JSON marks the baseline copy policy explicitly.
+		jsonOut, _, err := runRootCommandIn(root, []string{"instructions", "stack", "--json"})
+		require.NoError(t, err)
+		var view instructionsView
+		require.NoError(t, json.Unmarshal([]byte(jsonOut), &view))
+		assert.True(t, view.ContextIsBaseline, "codebase-map context is baseline to preserve and extend")
+	})
 }

--- a/cmd/instructions_test.go
+++ b/cmd/instructions_test.go
@@ -66,7 +66,7 @@ func TestInstructionsJSONIncludesTemplateAndGuidance(t *testing.T) {
 func TestInstructionsGuidanceMatchesScaffoldOwnership(t *testing.T) {
 	t.Parallel()
 
-	for _, name := range []string{"intent", "research", "assurance"} {
+	for _, name := range []string{"intent", "assurance"} {
 		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -78,6 +78,19 @@ func TestInstructionsGuidanceMatchesScaffoldOwnership(t *testing.T) {
 				"scaffolded artifacts must not claim there is no seeded body")
 			assert.Contains(t, view.Guidance, "engine may",
 				"guidance should acknowledge engine-owned scaffold behavior")
+		})
+	}
+
+	for _, name := range []string{"requirements", "decision", "research", "tasks"} {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			out, err := runInstructions(t, name, "--json")
+			require.NoError(t, err)
+			var view instructionsView
+			require.NoError(t, json.Unmarshal([]byte(out), &view))
+			assert.Contains(t, view.Guidance, "engine does not seed",
+				"skill-authored artifacts must not be described as engine scaffold outputs")
 		})
 	}
 }
@@ -227,6 +240,42 @@ func TestInstructionsChangeAwareAuthoringPayload(t *testing.T) {
 	})
 }
 
+func TestInstructionsDependencyDoneRequiresValidUpstreamArtifact(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		slug := createGovernedRequest(t, root, "L2", "instructions dependency validity")
+
+		bundlePath := filepath.Join(root, "artifacts", "changes", slug)
+		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "intent.md",
+			[]byte("# Intent\n\n## Summary\ninvalid upstream dependency\n")))
+		require.NoError(t, os.WriteFile(filepath.Join(bundlePath, "requirements.md"), []byte(`# Requirements
+
+## Requirements
+
+<!-- template-only; no authored requirement blocks -->
+`), 0o644))
+
+		stdout, stderr, err := runRootCommandIn(root, []string{
+			"instructions", "decision", "--json", "--change", slug,
+		})
+		require.NoError(t, err)
+		assert.Empty(t, stderr)
+
+		var view instructionsView
+		require.NoError(t, json.Unmarshal([]byte(stdout), &view))
+
+		done := map[string]bool{}
+		for _, dep := range view.Dependencies {
+			done[dep.Artifact] = dep.Done
+		}
+		require.Contains(t, done, "requirements.md")
+		assert.False(t, done["requirements.md"],
+			"invalid requirements.md must not satisfy the decision dependency")
+	})
+}
+
 func TestInstructionsUnlocksUseEffectivePreset(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
@@ -303,7 +352,7 @@ func TestInstructionsCustomArtifactUsesActiveChangeSchema(t *testing.T) {
 		change.CustomArtifacts = []model.ArtifactDefinition{
 			{Name: "intent.md"},
 			{Name: "my-widget.md", DependsOn: []string{"intent.md"}},
-			{Name: "widget-report.md", DependsOn: []string{"my-widget.md"}},
+			{Name: "widget-report.md", DependsOn: []string{"my-widget.md", "my-widget.md"}},
 		}
 		require.NoError(t, state.SaveChange(root, change))
 
@@ -324,7 +373,8 @@ func TestInstructionsCustomArtifactUsesActiveChangeSchema(t *testing.T) {
 		require.Len(t, view.Dependencies, 1)
 		assert.Equal(t, "intent.md", view.Dependencies[0].Artifact)
 		assert.False(t, view.Dependencies[0].Done)
-		assert.Contains(t, view.Unlocks, "widget-report.md")
+		assert.Equal(t, []string{"widget-report.md"}, view.Unlocks,
+			"unlocks must be sorted and deduplicated even if a malformed custom schema repeats dependencies")
 	})
 }
 
@@ -359,6 +409,22 @@ func TestInstructionsOmittedChangeFallsBackToStatic(t *testing.T) {
 		assert.Equal(t, "decision", view.Artifact)
 		assert.Empty(t, view.ResolvedOutputPath, "no active change resolves to the static exemplar")
 	})
+}
+
+func TestInstructionsOmittedChangeWarnsWhenProjectRootUnavailable(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	stdout, stderr, err := runRootCommandIn(root, []string{"instructions", "decision", "--json"})
+	require.NoError(t, err)
+	assert.Contains(t, stderr, "warning: serving static instructions")
+	assert.Contains(t, stderr, "workspace is not initialized")
+
+	var view instructionsView
+	require.NoError(t, json.Unmarshal([]byte(stdout), &view))
+	assert.Equal(t, "decision", view.Artifact)
+	assert.Empty(t, view.ResolvedOutputPath,
+		"uninitialized workspace falls back to the static exemplar, not a resolved payload")
 }
 
 func TestInstructionsOmittedChangeWarnsWhenActiveContextAmbiguous(t *testing.T) {

--- a/cmd/lifecycle_commands_test.go
+++ b/cmd/lifecycle_commands_test.go
@@ -571,7 +571,7 @@ func TestDoneRequiresReviewEvidenceBeforeArchive(t *testing.T) {
 		change.PlanSubStep = model.PlanSubStepNone
 		require.NoError(t, state.SaveChange(root, change))
 		writePassingExecutionSummary(t, root, slug, 1, "t-01")
-		require.NoError(t, artifact.ScaffoldGovernedBundleForChangeWithContext(root, change, "", model.ProjectContext{}))
+		require.NoError(t, artifact.ScaffoldGovernedBundleForChange(root, change, ""))
 		writePassingGoalVerificationEvidence(t, root, slug, 1)
 		writeAssuranceMD(t, root, change.Slug, validAssuranceContent())
 
@@ -1925,6 +1925,10 @@ Selected: Option A for test runtime.
 - cmd/lifecycle_commands_test.go
 `)))
 	}
+	// This shared fixture intentionally uses concrete prose, not the comment-only
+	// instructions scaffold. The decision gate currently rejects missing/empty
+	// sections and pure scaffold comments; if it later rejects weak draft prose,
+	// this fixture should be upgraded with it.
 	require.NoError(t, writeBundleArtifactFile(bundlePath, change.Slug, "decision.md", []byte(`# Decision
 ## Alternatives Considered
 ### Option A

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -489,9 +489,9 @@ func createDirectGovernedChange(
 			return err
 		}
 		// S0_INTAKE owns intent clarification. Defer downstream governed
-		// artifacts until S1_PLAN/bundle so they can be seeded from the
-		// confirmed intent instead of from empty template placeholders.
-		if err := artifact.ScaffoldIntentForChangeWithContext(root, change, projectCtx); err != nil {
+		// artifacts until S1_PLAN/bundle so skill-authored artifacts stay
+		// missing until the owning host writes real substance.
+		if err := artifact.ScaffoldIntentForChange(root, change); err != nil {
 			if change.WorkflowPreset.IsValid() {
 				return restoreNewPresetAfterScaffoldFailure(root, &change, err)
 			}

--- a/cmd/pivot_execution_test.go
+++ b/cmd/pivot_execution_test.go
@@ -78,7 +78,7 @@ func TestExecuteGovernedPivotKeepsBundleInBoundWorktreeWhenDiscoveryClears(t *te
 	change.CurrentState = model.StateS2Execute
 	change.PlanSubStep = model.PlanSubStepNone
 	require.NoError(t, state.SaveChange(root, change))
-	require.NoError(t, artifact.ScaffoldGovernedBundleForChangeWithContext(root, change, "", model.ProjectContext{}))
+	require.NoError(t, artifact.ScaffoldGovernedBundleForChange(root, change, ""))
 	require.NoError(t, os.RemoveAll(filepath.Join(root, "artifacts", "changes", slug)))
 
 	worktreeBundle := filepath.Join(normalizedWT, "artifacts", "changes", slug)

--- a/cmd/preset.go
+++ b/cmd/preset.go
@@ -3,9 +3,6 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"io/fs"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/signalridge/slipway/internal/engine/artifact"
@@ -13,7 +10,6 @@ import (
 	"github.com/signalridge/slipway/internal/engine/progression"
 	"github.com/signalridge/slipway/internal/model"
 	"github.com/signalridge/slipway/internal/state"
-	"github.com/signalridge/slipway/internal/stringutil"
 	"github.com/spf13/cobra"
 )
 
@@ -100,15 +96,9 @@ func makePresetCmd() *cobra.Command {
 				// downstream artifacts from empty templates. Keep only intent.md;
 				// S1_PLAN/bundle scaffolds the full bundle from confirmed intent.
 				if needsScaffold {
-					projectCtx := change.ProjectContext
-					if projectCtx.IsZero() {
-						// Fallback for legacy/pure-TTY changes that did not persist
-						// a caller-supplied or creation-time scaffold context.
-						projectCtx = progression.InferProjectContext(root)
-					}
 					var scaffoldErr error
 					if change.CurrentState == model.StateS0Intake {
-						scaffoldErr = artifact.ScaffoldIntentForChangeWithContext(root, change, projectCtx)
+						scaffoldErr = artifact.ScaffoldIntentForChange(root, change)
 					} else {
 						resolution := progression.ResolveChangeSchemaDiagnostics(change)
 						if len(resolution.Blockers) > 0 {
@@ -125,19 +115,7 @@ func makePresetCmd() *cobra.Command {
 							}
 							return err
 						}
-						docs, err := docSectionsFromIntent(root, change)
-						if err != nil {
-							err = fmt.Errorf("extracting doc sections from intent: %w", err)
-							if restoreErr := restorePresetOnScaffoldFailure(root, &change, origPreset, origSuggested); restoreErr != nil {
-								return errors.Join(err, restoreErr)
-							}
-							return err
-						}
-						if docs.Scope != "" || docs.Constraints != "" || docs.Acceptance != "" {
-							scaffoldErr = artifact.ScaffoldGovernedBundleForChangeWithContextAndDocs(root, change, policy.EffectivePreset, projectCtx, docs, resolution.Schema)
-						} else {
-							scaffoldErr = artifact.ScaffoldGovernedBundleForChangeWithContext(root, change, policy.EffectivePreset, projectCtx, resolution.Schema)
-						}
+						scaffoldErr = artifact.ScaffoldGovernedBundleForChange(root, change, policy.EffectivePreset, resolution.Schema)
 					}
 					if scaffoldErr != nil {
 						if restoreErr := restorePresetOnScaffoldFailure(root, &change, origPreset, origSuggested); restoreErr != nil {
@@ -180,26 +158,6 @@ func makePresetCmd() *cobra.Command {
 	addChangeSelectorFlags(cmd, &changeSlug, "Explicit change slug")
 	cmd.Flags().Bool("json", false, "JSON output")
 	return cmd
-}
-
-func docSectionsFromIntent(root string, change model.Change) (artifact.DocSections, error) {
-	paths, err := state.ResolveChangePaths(root, change)
-	if err != nil {
-		return artifact.DocSections{}, err
-	}
-	intentPath := filepath.Join(paths.GovernedBundleDir, "intent.md")
-	data, err := os.ReadFile(intentPath)
-	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return artifact.DocSections{}, nil
-		}
-		return artifact.DocSections{}, err
-	}
-	return artifact.DocSections{
-		Scope:       stringutil.LastMarkdownSectionContent(string(data), "## In Scope"),
-		Constraints: stringutil.LastMarkdownSectionContent(string(data), "## Constraints"),
-		Acceptance:  stringutil.LastMarkdownSectionContent(string(data), "## Acceptance Signals"),
-	}, nil
 }
 
 // restorePresetOnScaffoldFailure restores the pre-command preset state after

--- a/cmd/preset_test.go
+++ b/cmd/preset_test.go
@@ -331,20 +331,27 @@ func TestPresetCommandScaffoldFailureRollsBackToPendingConfirmation(t *testing.T
 		change.PlanSubStep = model.PlanSubStepResearch
 		require.NoError(t, state.SaveChange(root, change))
 
-		// Replace intent.md with a directory so scaffold preparation fails
-		// portably before downstream artifacts are rewritten.
+		// Point intent.md at a target under a missing directory so the current
+		// scaffold path reaches WriteFile(intent.md) and fails after following the
+		// dangling symlink. This deliberately depends on the os.Stat-then-WriteFile
+		// sequence in ScaffoldIntentForChange; if that sequence changes,
+		// replace this with an explicit scaffold fault seam instead of letting the
+		// test pass for a different reason. The bundle dir itself stays writable, so
+		// the rollback's atomic SaveChange still persists. intent.md is always a
+		// required artifact, so the scaffold attempts the write regardless of
+		// discovery classification.
 		bundleDir := filepath.Join(root, "artifacts", "changes", slug)
 		blockedArtifact := filepath.Join(bundleDir, "intent.md")
 		require.NoError(t, os.Remove(blockedArtifact))
-		require.NoError(t, os.Mkdir(blockedArtifact, 0o755))
-		defer func() { _ = os.RemoveAll(blockedArtifact) }()
+		require.NoError(t, os.Symlink(filepath.Join(bundleDir, "missing-parent", "intent.md"), blockedArtifact))
+		defer func() { _ = os.Remove(blockedArtifact) }()
 
 		cmd := makePresetCmd()
 		cmd.SetArgs([]string{"light"})
 		err = cmd.Execute()
 		require.Error(t, err)
 
-		_ = os.RemoveAll(blockedArtifact)
+		_ = os.Remove(blockedArtifact)
 		reloaded, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		assert.True(t, reloaded.WorkflowPresetConfirmationPending(),
@@ -379,20 +386,25 @@ func TestPresetCommandReScaffoldFailurePreservesConfirmedPreset(t *testing.T) {
 		change.PlanSubStep = model.PlanSubStepResearch
 		require.NoError(t, state.SaveChange(root, change))
 
-		// Replace intent.md with a directory so re-scaffold preparation fails
-		// portably.
+		// Point intent.md at a target under a missing directory so the current
+		// re-scaffold path reaches WriteFile(intent.md) and fails after following
+		// the dangling symlink. This deliberately depends on the
+		// os.Stat-then-WriteFile sequence in ScaffoldIntentForChange; if
+		// that sequence changes, replace this with an explicit scaffold fault seam
+		// instead of letting the test pass for a different reason. The bundle dir
+		// itself stays writable, so the rollback's atomic SaveChange still persists.
 		bundleDir := filepath.Join(root, "artifacts", "changes", slug)
 		blockedArtifact := filepath.Join(bundleDir, "intent.md")
 		require.NoError(t, os.Remove(blockedArtifact))
-		require.NoError(t, os.Mkdir(blockedArtifact, 0o755))
-		defer func() { _ = os.RemoveAll(blockedArtifact) }()
+		require.NoError(t, os.Symlink(filepath.Join(bundleDir, "missing-parent", "intent.md"), blockedArtifact))
+		defer func() { _ = os.Remove(blockedArtifact) }()
 
 		retryCmd := makePresetCmd()
 		retryCmd.SetArgs([]string{"strict"})
 		err = retryCmd.Execute()
-		require.Error(t, err, "re-scaffold should fail because intent.md cannot be read as a file")
+		require.Error(t, err, "re-scaffold should fail because intent.md cannot be written through the dangling symlink")
 
-		_ = os.RemoveAll(blockedArtifact)
+		_ = os.Remove(blockedArtifact)
 		reloaded, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		assert.Equal(t, model.WorkflowPresetStrict, reloaded.WorkflowPreset,

--- a/cmd/progression_next_test.go
+++ b/cmd/progression_next_test.go
@@ -3405,7 +3405,7 @@ func TestNextPreviewAdvancesAfterPassingResearchVerification(t *testing.T) {
 		change.WorktreePath = worktreeRoot
 		change.WorktreeBranch = branch
 		require.NoError(t, state.SaveChange(root, change))
-		require.NoError(t, artifact.ScaffoldGovernedBundleForChangeWithContext(root, change, "", model.ProjectContext{}))
+		require.NoError(t, artifact.ScaffoldGovernedBundleForChange(root, change, ""))
 
 		writeSkillVerification(t, root, slug, progression.SkillResearchOrchestration, model.VerificationRecord{
 			Verdict:    model.VerificationVerdictPass,

--- a/cmd/progression_next_test.go
+++ b/cmd/progression_next_test.go
@@ -3407,6 +3407,21 @@ func TestNextPreviewAdvancesAfterPassingResearchVerification(t *testing.T) {
 		require.NoError(t, state.SaveChange(root, change))
 		require.NoError(t, artifact.ScaffoldGovernedBundleForChange(root, change, ""))
 
+		bundlePath := filepath.Join(worktreeRoot, "artifacts", "changes", change.Slug)
+		require.NoError(t, writeBundleArtifactFile(bundlePath, change.Slug, "research.md", []byte(`
+## Alternatives Considered
+Confirmed current CLI behavior and artifact ownership boundaries.
+
+## Unknowns
+None.
+
+## Assumptions
+The research-orchestration skill authored this artifact before recording pass evidence.
+
+## Canonical References
+- artifacts/changes/`+change.Slug+`/research.md
+`)))
+
 		writeSkillVerification(t, root, slug, progression.SkillResearchOrchestration, model.VerificationRecord{
 			Verdict:    model.VerificationVerdictPass,
 			Blockers:   []model.ReasonCode{},

--- a/cmd/review_test.go
+++ b/cmd/review_test.go
@@ -233,7 +233,7 @@ func TestReviewRequiresExecutionSummaryEvenWhenChecklistIsComplete(t *testing.T)
 		change.CurrentState = model.StateS3Review
 		change.PlanSubStep = model.PlanSubStepNone
 		require.NoError(t, state.SaveChange(root, change))
-		require.NoError(t, artifact.ScaffoldGovernedBundleForChangeWithContext(root, change, "", model.ProjectContext{}))
+		require.NoError(t, artifact.ScaffoldGovernedBundleForChange(root, change, ""))
 
 		bundlePath := filepath.Join(root, "artifacts", "changes", slug)
 		require.NoError(t, os.WriteFile(filepath.Join(bundlePath, "tasks.md"), []byte(`# Tasks
@@ -269,7 +269,7 @@ func TestReviewPassFromS7VerifyPreservesGovernedState(t *testing.T) {
 		change.PlanSubStep = model.PlanSubStepNone
 		change.Artifacts = map[string]model.ArtifactState{}
 		require.NoError(t, state.SaveChange(root, change))
-		require.NoError(t, artifact.ScaffoldGovernedBundleForChangeWithContext(root, change, "", model.ProjectContext{}))
+		require.NoError(t, artifact.ScaffoldGovernedBundleForChange(root, change, ""))
 
 		bundlePath := filepath.Join(root, "artifacts", "changes", slug)
 		require.NoError(t, os.WriteFile(filepath.Join(bundlePath, "tasks.md"), []byte(`# Tasks
@@ -591,7 +591,7 @@ func TestReviewFailsWhenExecutionEvidenceIsStale(t *testing.T) {
 		change.CurrentState = model.StateS3Review
 		change.Artifacts = map[string]model.ArtifactState{}
 		require.NoError(t, state.SaveChange(root, change))
-		require.NoError(t, artifact.ScaffoldGovernedBundleForChangeWithContext(root, change, "", model.ProjectContext{}))
+		require.NoError(t, artifact.ScaffoldGovernedBundleForChange(root, change, ""))
 
 		// Write execution summary with CapturedAt = now.
 		writePassingExecutionSummary(t, root, slug, 1, "t-01")
@@ -637,7 +637,7 @@ func TestReviewAllDoesNotTreatImplementationEvidenceAsArtifactEvidence(t *testin
 		change.PlanSubStep = model.PlanSubStepNone
 		change.GuardrailDomain = string(model.GuardrailDomainExternalAPIContracts)
 		require.NoError(t, state.SaveChange(root, change))
-		require.NoError(t, artifact.ScaffoldGovernedBundleForChangeWithContext(root, change, "", model.ProjectContext{}))
+		require.NoError(t, artifact.ScaffoldGovernedBundleForChange(root, change, ""))
 
 		writePassingExecutionSummary(t, root, slug, 1, "t-01")
 		materializeWaveExecutionForSummary(t, root, slug)

--- a/cmd/root_help_test.go
+++ b/cmd/root_help_test.go
@@ -25,7 +25,7 @@ func TestRootHelpUsesCurrentEntrySurfaceDescriptions(t *testing.T) {
 	// Issue #91 (P2b): the new public authoring surface must be discoverable from
 	// the main `slipway help` path, not only docs/toolgen.
 	assert.Contains(t, help, "instructions")
-	assert.Contains(t, help, "Show the template and authoring guidance for a governed artifact")
+	assert.Contains(t, help, "Show the authoring contract")
 	assert.Contains(t, help, "Finalize a done-ready change and archive it")
 	assert.NotContains(t, help, "completed change")
 	assert.NotContains(t, help, "Auto-classify advisory versus governed work")

--- a/cmd/stats_test.go
+++ b/cmd/stats_test.go
@@ -55,7 +55,7 @@ func TestStatsUsesExecutionSummaryForFrozenEvidenceFreshness(t *testing.T) {
 	change.NeedsDiscovery = false
 	change.GuardrailDomain = ""
 	require.NoError(t, state.SaveChange(root, change))
-	require.NoError(t, artifact.ScaffoldGovernedBundleForChangeWithContext(root, change, "", model.ProjectContext{}))
+	require.NoError(t, artifact.ScaffoldGovernedBundleForChange(root, change, ""))
 	bundleDir, err := state.GovernedBundleDir(root, change)
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "tasks.md"), []byte(`# Tasks

--- a/cmd/status_view_build_test.go
+++ b/cmd/status_view_build_test.go
@@ -91,7 +91,7 @@ func TestBuildGovernedStatusViewExposesSummaryBlockersSeparately(t *testing.T) {
 	change.CurrentState = model.StateS2Execute
 	change.PlanSubStep = model.PlanSubStepNone
 	require.NoError(t, state.SaveChange(root, change))
-	require.NoError(t, artifact.ScaffoldGovernedBundleForChangeWithContext(root, change, "", model.ProjectContext{}))
+	require.NoError(t, artifact.ScaffoldGovernedBundleForChange(root, change, ""))
 
 	require.NoError(t, state.SaveExecutionSummary(root, change.Slug, model.ExecutionSummary{
 		Version:           model.ExecutionSummaryVersion,
@@ -136,7 +136,7 @@ func TestBuildGovernedStatusViewIncludesStaleExecutionEvidenceBlocker(t *testing
 	change.CurrentState = model.StateS3Review
 	change.PlanSubStep = model.PlanSubStepNone
 	require.NoError(t, state.SaveChange(root, change))
-	require.NoError(t, artifact.ScaffoldGovernedBundleForChangeWithContext(root, change, "", model.ProjectContext{}))
+	require.NoError(t, artifact.ScaffoldGovernedBundleForChange(root, change, ""))
 
 	staleAt := time.Now().Add(-time.Minute).UTC()
 	require.NoError(t, state.SaveExecutionSummary(root, change.Slug, model.ExecutionSummary{
@@ -188,7 +188,7 @@ func TestBuildGovernedStatusViewKeepsExecutionSummaryProgressWhenChecklistExists
 	change.CurrentState = model.StateS2Execute
 	change.PlanSubStep = model.PlanSubStepNone
 	require.NoError(t, state.SaveChange(root, change))
-	require.NoError(t, artifact.ScaffoldGovernedBundleForChangeWithContext(root, change, "", model.ProjectContext{}))
+	require.NoError(t, artifact.ScaffoldGovernedBundleForChange(root, change, ""))
 
 	bundleDir, err := state.GovernedBundleDir(root, change)
 	require.NoError(t, err)
@@ -244,7 +244,7 @@ func TestBuildGovernedStatusViewDoesNotUseChecklistProgressWhenExecutionSummaryI
 	change.CurrentState = model.StateS2Execute
 	change.PlanSubStep = model.PlanSubStepNone
 	require.NoError(t, state.SaveChange(root, change))
-	require.NoError(t, artifact.ScaffoldGovernedBundleForChangeWithContext(root, change, "", model.ProjectContext{}))
+	require.NoError(t, artifact.ScaffoldGovernedBundleForChange(root, change, ""))
 
 	bundleDir, err := state.GovernedBundleDir(root, change)
 	require.NoError(t, err)

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -40,6 +40,7 @@ type validateView struct {
 	ActionableNextSkill       *actionableNextSkillView             `json:"actionable_next_skill,omitempty"`
 	RequirementsContract      *artifactContractView                `json:"requirements_contract,omitempty"`
 	TasksContract             *artifactContractView                `json:"tasks_contract,omitempty"`
+	DecisionContract          *artifactContractView                `json:"decision_contract,omitempty"`
 	ScopeContract             *scopeContractView                   `json:"scope_contract,omitempty"`
 	Diagnostics               []string                             `json:"diagnostics,omitempty"`
 	Mode                      string                               `json:"mode,omitempty"`
@@ -220,8 +221,9 @@ func buildValidateViewForSlug(root, slug string) (validateView, error) {
 
 	var requirementsContract *artifactContractView
 	var tasksContract *artifactContractView
+	var decisionContract *artifactContractView
 	if bundleDir, err := state.GovernedBundleDir(root, change); err == nil {
-		contract, err := artifact.EvaluateRequirementsContract(bundleDir, change.Slug)
+		contract, err := artifact.EvaluateRequirementsContract(bundleDir)
 		if err == nil {
 			requirementsContract = &artifactContractView{
 				Status:  string(contract.Status),
@@ -229,12 +231,25 @@ func buildValidateViewForSlug(root, slug string) (validateView, error) {
 				Message: contract.Message,
 			}
 		}
-		tasks, err := artifact.EvaluateTasksContract(bundleDir, change.Slug)
+		tasks, err := artifact.EvaluateTasksContract(bundleDir)
 		if err == nil {
 			tasksContract = &artifactContractView{
 				Status:  string(tasks.Status),
 				Source:  tasks.Source,
 				Message: tasks.Message,
+			}
+		}
+		// decision.md is expanded-schema only; surface its substance contract
+		// just for changes that require it so a core change does not report a
+		// misleading decision_contract: missing.
+		if progression.DecisionArtifactRequired(root, change) {
+			decision, err := artifact.EvaluateDecisionContract(bundleDir)
+			if err == nil {
+				decisionContract = &artifactContractView{
+					Status:  string(decision.Status),
+					Source:  decision.Source,
+					Message: decision.Message,
+				}
 			}
 		}
 	}
@@ -276,6 +291,7 @@ func buildValidateViewForSlug(root, slug string) (validateView, error) {
 	view.NeedsDiscovery = profile.NeedsDiscovery
 	view.RequirementsContract = requirementsContract
 	view.TasksContract = tasksContract
+	view.DecisionContract = decisionContract
 	view.ScopeContract = buildScopeContractView(readiness.ScopeContract)
 	view.FreshnessDiagnostics = attachFreshnessDiagnostics(readiness.FreshnessDiagnostics)
 	view.ActionableNextSkill = buildActionableNextSkillView(change, readiness)

--- a/cmd/validate_artifact_gate_test.go
+++ b/cmd/validate_artifact_gate_test.go
@@ -53,6 +53,39 @@ func TestValidateBlocksWhenGovernedBundleIsIncompleteAtSpecBundle(t *testing.T) 
 	})
 }
 
+func TestValidateReportsDeferredArtifactsMissingAfterRealScaffold(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	ensureTestGitRepo(t, root)
+	initTestWorkspace(t, root)
+
+	slug := "real-scaffold-deferred-missing"
+	change := model.NewChange(slug)
+	change.Description = "validate real scaffold deferred artifacts"
+	change.WorkflowPreset = model.WorkflowPresetStandard
+	change.QualityMode = model.QualityModeStandard
+	change.ArtifactSchema = model.ArtifactSchemaExpanded
+	change.CurrentState = model.StateS1Plan
+	change.PlanSubStep = model.PlanSubStepBundle
+	require.NoError(t, state.SaveChange(root, change))
+
+	require.NoError(t, artifact.ScaffoldGovernedBundleForChange(root, change, model.WorkflowPresetStandard))
+	bundlePath := filepath.Join(root, "artifacts", "changes", slug)
+	for _, file := range []string{"requirements.md", "decision.md", "tasks.md"} {
+		_, err := os.Stat(filepath.Join(bundlePath, file))
+		require.ErrorIsf(t, err, os.ErrNotExist, "%s must be deferred to skill authoring", file)
+	}
+
+	view, err := buildValidateViewForSlug(root, slug)
+	require.NoError(t, err)
+	specs := model.ReasonSpecs(view.Blockers)
+	assert.Contains(t, specs, "missing_required_artifact:requirements.md")
+	assert.Contains(t, specs, "missing_required_artifact:decision.md")
+	assert.Contains(t, specs, "missing_required_artifact:tasks.md")
+	require.NotNil(t, view.Recovery)
+	assert.Contains(t, recoveryStepCodes(view.Recovery), "missing_required_artifact")
+}
+
 func TestValidateAllowsJsonFalseAsDefaultJSONOutput(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {
@@ -150,6 +183,71 @@ func TestValidateBlocksPlanAuditAdvanceWhenArtifactsAreMissingEvenIfSkillIsReady
 		assert.False(t, view.CanAdvance)
 		assert.Contains(t, model.ReasonSpecs(view.Blockers), "missing_required_artifact:decision.md")
 	})
+}
+
+func TestValidateBlocksPlanAuditWhenDecisionIsTemplateOnly(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	ensureTestGitRepo(t, root)
+	initTestWorkspace(t, root)
+
+	slug := createGovernedRequest(t, root, "L2", "validate should gate template decision at plan audit")
+	change, err := state.LoadChange(root, slug)
+	require.NoError(t, err)
+
+	change.CurrentState = model.StateS1Plan
+	change.PlanSubStep = model.PlanSubStepAudit
+	change.ArtifactSchema = model.ArtifactSchemaExpanded
+	require.NoError(t, state.SaveChange(root, change))
+
+	bundlePath := filepath.Join(root, "artifacts", "changes", change.Slug)
+	require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "requirements.md", []byte(`# Requirements
+
+### Requirement: Decision substance gate
+REQ-001: The system MUST block plan readiness when decision.md contains only template comments.
+
+#### Scenario: Template decision blocks plan readiness
+GIVEN decision.md contains only generated guidance comments
+WHEN validation previews plan readiness
+THEN G_plan remains blocked with a decision contract blocker.
+`)))
+	templateDecision, err := artifact.RenderArtifactExample("decision.md")
+	require.NoError(t, err)
+	require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "decision.md", []byte(templateDecision)))
+	require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
+
+- [ ] `+"`t-01`"+` Enforce decision substance in plan readiness
+  - wave: 1
+  - depends_on: []
+  - target_files: ["internal/engine/progression/readiness.go"]
+  - task_kind: code
+  - covers: [REQ-001]
+`)))
+	writeSkillVerification(t, root, slug, "plan-audit", model.VerificationRecord{
+		Verdict:   model.VerificationVerdictPass,
+		Blockers:  []model.ReasonCode{},
+		Timestamp: time.Now().UTC(),
+	})
+
+	view, err := buildValidateViewForSlug(root, slug)
+	require.NoError(t, err)
+
+	assert.False(t, view.CanAdvance)
+	requireReasonSpecPrefix(t, model.ReasonSpecs(view.Blockers), "decision_section_placeholder:")
+	require.Contains(t, view.GateDetails, "G_plan")
+	assert.Equal(t, model.GateStatusBlocked, view.GateDetails["G_plan"].Status)
+	requireReasonSpecPrefix(t, model.ReasonSpecs(view.GateDetails["G_plan"].ReasonCodes),
+		"decision_section_placeholder:")
+}
+
+func requireReasonSpecPrefix(t *testing.T, specs []string, prefix string) {
+	t.Helper()
+	for _, spec := range specs {
+		if strings.HasPrefix(spec, prefix) {
+			return
+		}
+	}
+	require.Failf(t, "missing reason prefix", "expected prefix %q in %v", prefix, specs)
 }
 
 func TestValidateUsesFilesystemArtifactReadinessWithoutPersistingReconcile(t *testing.T) {
@@ -442,7 +540,7 @@ func TestValidateAtShipGateRequiresReviewEvidence(t *testing.T) {
 		change.PlanSubStep = model.PlanSubStepNone
 		require.NoError(t, state.SaveChange(root, change))
 		writePassingExecutionSummary(t, root, slug, 1, "t-01")
-		require.NoError(t, artifact.ScaffoldGovernedBundleForChangeWithContext(root, change, "", model.ProjectContext{}))
+		require.NoError(t, artifact.ScaffoldGovernedBundleForChange(root, change, ""))
 		writePassingGoalVerificationEvidence(t, root, slug, 1)
 
 		var out bytes.Buffer
@@ -484,7 +582,7 @@ func TestValidateBlocksWhenExecutionEvidenceIsStale(t *testing.T) {
 	change.CurrentState = model.StateS2Execute
 	change.Artifacts = map[string]model.ArtifactState{}
 	require.NoError(t, state.SaveChange(root, change))
-	require.NoError(t, artifact.ScaffoldGovernedBundleForChangeWithContext(root, change, "", model.ProjectContext{}))
+	require.NoError(t, artifact.ScaffoldGovernedBundleForChange(root, change, ""))
 
 	// Write execution summary first.
 	writePassingExecutionSummary(t, root, slug, 1, "t-01")

--- a/cmd/validate_artifact_gate_test.go
+++ b/cmd/validate_artifact_gate_test.go
@@ -233,11 +233,11 @@ THEN G_plan remains blocked with a decision contract blocker.
 	require.NoError(t, err)
 
 	assert.False(t, view.CanAdvance)
-	requireReasonSpecPrefix(t, model.ReasonSpecs(view.Blockers), "decision_section_placeholder:")
+	requireReasonSpecPrefix(t, model.ReasonSpecs(view.Blockers), "decision_structure_invalid:")
 	require.Contains(t, view.GateDetails, "G_plan")
 	assert.Equal(t, model.GateStatusBlocked, view.GateDetails["G_plan"].Status)
 	requireReasonSpecPrefix(t, model.ReasonSpecs(view.GateDetails["G_plan"].ReasonCodes),
-		"decision_section_placeholder:")
+		"decision_structure_invalid:")
 }
 
 func requireReasonSpecPrefix(t *testing.T, specs []string, prefix string) {

--- a/cmd/worktree_preflight_test.go
+++ b/cmd/worktree_preflight_test.go
@@ -126,7 +126,7 @@ func TestNextL3AdvancesAfterDedicatedWorktreePreflightEvidence(t *testing.T) {
 	})
 }
 
-func TestNextL3AdvanceCreatesResearchArtifactAtScopeEntry(t *testing.T) {
+func TestNextL3AdvanceDefersResearchArtifactAuthoringAtScopeEntry(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
 	ensureTestGitRepo(t, root)
@@ -134,7 +134,7 @@ func TestNextL3AdvanceCreatesResearchArtifactAtScopeEntry(t *testing.T) {
 	initGitRepoForWorktreeTests(t, root)
 
 	change := model.NewChange("l3-scope-artifact")
-	change.Description = "scope entry should have canonical research artifact"
+	change.Description = "scope entry should defer canonical research artifact authoring"
 	change.NeedsDiscovery = true
 	change.CurrentState = model.StateS1Plan
 	change.PlanSubStep = model.PlanSubStepResearch
@@ -150,11 +150,11 @@ func TestNextL3AdvanceCreatesResearchArtifactAtScopeEntry(t *testing.T) {
 
 	assert.Equal(t, model.StateS1Plan, view.CurrentState)
 
-	// Research artifact should be created at the project root bundle dir
-	// (not worktree) at S1_PLAN/research entry for discovery changes.
+	// Research authoring is deferred to research-orchestration; the engine should
+	// not create a placeholder body in either the root or bound worktree bundle.
 	researchPath := filepath.Join(root, "artifacts", "changes", change.Slug, "research.md")
 	_, err = os.Stat(researchPath)
-	require.NoError(t, err)
+	require.ErrorIs(t, err, os.ErrNotExist)
 }
 
 func TestNextUsesDedicatedWorktreePathsAfterPreflight(t *testing.T) {

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -64,12 +64,17 @@ Workflow profiles shape checks: `code`, `docs`, `research`, `config`, or `meta`.
 | `slipway stats` | query | Show repo-wide governance freshness and workflow statistics. |
 | `slipway health` | query | Show repo-local integrity and repairability findings. |
 | `slipway codebase-map` | mutation | Create or refresh advisory repo-scoped context under `artifacts/codebase/`. |
-| `slipway instructions <artifact>` | query | Show the template and authoring guidance for a governed artifact (e.g. `requirements`, `tasks`). |
+| `slipway instructions <artifact>` | query | Show the template, quality bar, and — inside a change — resolved output path + dependency graph for a governed artifact or codebase-map doc. |
 
 `slipway instructions <artifact>` serves the artifact template plus its quality
-bar so an authoring skill writes substance instead of accepting the engine's
-obviously-not-real placeholder; the engine owns structure, the skill owns
-substance.
+bar so an authoring skill writes the real file directly — the engine owns
+structure, the skill owns substance, and there is no seeded body to replace.
+Inside a governed change it also returns the resolved output path, the
+dependency/unlock graph, and tagged background (`context`/`rules`) the skill must
+honor but never copy into the artifact. It covers the six governed bundle
+artifacts (`intent`, `requirements`, `decision`, `research`, `tasks`,
+`assurance`) and the repo-scoped codebase-map docs (`stack`, `architecture`,
+`structure`, `conventions`, `integrations`, `testing`, `concerns`).
 
 `codebase-map --json` reports `status: "baseline"` when documents contain only
 CLI-detected repository facts. Baseline docs are useful starting context, not

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -75,6 +75,9 @@ honor but never copy into the artifact. It covers the six governed bundle
 artifacts (`intent`, `requirements`, `decision`, `research`, `tasks`,
 `assurance`) and the repo-scoped codebase-map docs (`stack`, `architecture`,
 `structure`, `conventions`, `integrations`, `testing`, `concerns`).
+In `--json`, `context_is_baseline: true` marks codebase-map baseline context
+that should be preserved and extended into the authored doc; when absent or
+false, `context` is background to honor but not copy.
 
 `codebase-map --json` reports `status: "baseline"` when documents contain only
 CLI-detected repository facts. Baseline docs are useful starting context, not

--- a/internal/engine/artifact/codebase_map.go
+++ b/internal/engine/artifact/codebase_map.go
@@ -117,6 +117,81 @@ func CodebaseMapDisplayDocs(displayRoot, codebaseMapDir string) map[string]strin
 	return docs
 }
 
+// CodebaseMapInstructionKeys returns the sorted public doc keys (e.g. "stack",
+// "architecture") so `slipway instructions <key>` can route codebase-map docs
+// through the same authoring contract as the governed bundle artifacts. These
+// docs are repo-scoped and advisory — they do not gate any stage.
+func CodebaseMapInstructionKeys() []string {
+	keys := make([]string, 0, len(codebaseMapDocKeys))
+	for _, key := range codebaseMapDocKeys {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	return keys
+}
+
+// CodebaseMapDocInstruction resolves a codebase-map doc by public key
+// ("stack") or file name ("STACK.md", case-insensitive) and returns its file
+// name and static template. ok is false when nameOrKey matches no codebase-map
+// doc, letting the caller fall through to the bundle-artifact path.
+func CodebaseMapDocInstruction(nameOrKey string) (file string, template string, ok bool) {
+	name := codebaseMapDocFileName(nameOrKey)
+	if name == "" {
+		return "", "", false
+	}
+	tmpl, ok := codebaseMapDocTemplates[name]
+	if !ok {
+		return "", "", false
+	}
+	return name, tmpl, true
+}
+
+// CodebaseMapDocKey returns the public key ("stack") for a codebase-map doc
+// given its key or file name. It returns the normalized input when the doc is
+// unknown so callers always get a stable label.
+func CodebaseMapDocKey(nameOrKey string) string {
+	if name := codebaseMapDocFileName(nameOrKey); name != "" {
+		return codebaseMapDocKeys[name]
+	}
+	return strings.TrimSpace(nameOrKey)
+}
+
+// CodebaseMapBaselineDoc returns the machine-extracted baseline content for a
+// codebase-map doc (resolved by key or file name) computed from the workspace
+// manifests under root. These are real detected facts, not placeholder seed, so
+// `slipway instructions` can offer them as background the author preserves and
+// extends. ok is false when nameOrKey matches no codebase-map doc.
+func CodebaseMapBaselineDoc(root, nameOrKey string) (content string, ok bool) {
+	name := codebaseMapDocFileName(nameOrKey)
+	if name == "" {
+		return "", false
+	}
+	if _, exists := codebaseMapDocTemplates[name]; !exists {
+		return "", false
+	}
+	return renderCodebaseMapBaselineDoc(inspectCodebaseMapFacts(root), name), true
+}
+
+// codebaseMapDocFileName normalizes a public key ("stack") or file name
+// ("stack.md", "STACK.md") to the canonical codebase-map file name ("STACK.md"),
+// or "" when it matches no codebase-map doc.
+func codebaseMapDocFileName(nameOrKey string) string {
+	value := strings.TrimSpace(nameOrKey)
+	if value == "" {
+		return ""
+	}
+	if _, ok := codebaseMapDocTemplates[value]; ok {
+		return value
+	}
+	lower := strings.ToLower(value)
+	for _, name := range codebaseMapDocNames {
+		if strings.ToLower(name) == lower || codebaseMapDocKeys[name] == lower {
+			return name
+		}
+	}
+	return ""
+}
+
 func EnsureCodebaseMapDocs(root string) (created []string, err error) {
 	dir := state.CodebaseMapDir(root)
 	if err := os.MkdirAll(dir, 0o755); err != nil {

--- a/internal/engine/artifact/decision_contract.go
+++ b/internal/engine/artifact/decision_contract.go
@@ -1,0 +1,96 @@
+package artifact
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"strings"
+)
+
+// DecisionContractStatus mirrors RequirementsContractStatus / TasksContractStatus
+// for decision.md.
+type DecisionContractStatus string
+
+const (
+	DecisionContractStatusValid   DecisionContractStatus = "valid"
+	DecisionContractStatusInvalid DecisionContractStatus = "invalid"
+	DecisionContractStatusMissing DecisionContractStatus = "missing"
+)
+
+// DecisionContractResult is the result of evaluating decision.md substance.
+type DecisionContractResult struct {
+	Status  DecisionContractStatus
+	Source  string
+	Message string
+}
+
+// EvaluateDecisionContract checks decision.md for substance, not just presence: a
+// decision whose required sections are missing, structurally empty, or still the
+// unwritten template (only the <!-- ... --> guidance comment) is the scaffold the
+// authoring skill must replace before planning is ready (issue #119). The engine
+// owns structure (the five required sections defined in schemas.yaml); the
+// authoring skill owns substance.
+func EvaluateDecisionContract(bundleDir string) (DecisionContractResult, error) {
+	sourcePath := ResolveArtifactPath(bundleDir, "decision.md")
+	if _, err := os.Stat(sourcePath); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return DecisionContractResult{
+				Status:  DecisionContractStatusMissing,
+				Source:  sourcePath,
+				Message: "decision.md is missing",
+			}, nil
+		}
+		return DecisionContractResult{}, err
+	}
+
+	raw, err := os.ReadFile(sourcePath)
+	if err != nil {
+		return DecisionContractResult{}, err
+	}
+
+	if blockers := DecisionSubstanceBlockers(string(raw)); len(blockers) > 0 {
+		return DecisionContractResult{
+			Status:  DecisionContractStatusInvalid,
+			Source:  sourcePath,
+			Message: fmt.Sprintf("decision.md is not substantive: %s", strings.Join(blockers, "; ")),
+		}, nil
+	}
+
+	return DecisionContractResult{
+		Status:  DecisionContractStatusValid,
+		Source:  sourcePath,
+		Message: "decision.md validated",
+	}, nil
+}
+
+// DecisionSubstanceBlockers returns substance problems in decision.md. An empty
+// slice means every required section carries authored content.
+//
+// The engine owns structure (the five required sections from schemas.yaml) and a
+// deterministic placeholder floor; the authoring skill owns substance. A
+// decision.md that omits a required section, leaves one structurally empty, or
+// leaves one as the unwritten template (only the <!-- ... --> guidance comment)
+// is rejected so an unedited `instructions decision` scaffold cannot reach
+// planning readiness (issue #119). The floor derives from the template's own
+// comment-only section bodies — stripping HTML comments leaves an unedited
+// section empty — so detection cannot drift from the template wording.
+func DecisionSubstanceBlockers(content string) []string {
+	headings := requiredSectionsForArtifact("decision.md")
+	if len(headings) == 0 {
+		return []string{"decision_structure_invalid:no required sections configured for decision.md"}
+	}
+
+	if err := validateSectionStructure(content, headings); err != nil {
+		return []string{"decision_structure_invalid:" + err.Error()}
+	}
+
+	var blockers []string
+	for _, heading := range headings {
+		body := strings.Join(markdownSectionLines(content, heading), "\n")
+		if artifactSectionBodyLooksPlaceholder(body) {
+			blockers = append(blockers, "decision_section_placeholder:"+heading)
+		}
+	}
+	return blockers
+}

--- a/internal/engine/artifact/decision_contract_test.go
+++ b/internal/engine/artifact/decision_contract_test.go
@@ -19,10 +19,10 @@ func TestDecisionSubstanceBlockers(t *testing.T) {
 	template, err := RenderArtifactExample("decision.md")
 	require.NoError(t, err)
 	templateBlockers := DecisionSubstanceBlockers(template)
-	require.Len(t, templateBlockers, 5, "every comment-only required section must be flagged")
-	for _, b := range templateBlockers {
-		assert.Contains(t, b, "decision_section_placeholder:", "the raw instructions decision template must not pass")
-	}
+	require.Len(t, templateBlockers, 1,
+		"comment-only required sections must fail closed at the structure layer")
+	assert.Contains(t, templateBlockers[0], "decision_structure_invalid:")
+	assert.Contains(t, templateBlockers[0], "non-empty content")
 
 	// Legacy scaffold regression: existing active changes may still carry the
 	// pre-#119 seeded prose. It is not an HTML comment, but it is still unwritten
@@ -106,7 +106,7 @@ func TestEvaluateDecisionContract(t *testing.T) {
 		res, err := EvaluateDecisionContract(bundleDir)
 		require.NoError(t, err)
 		assert.Equal(t, DecisionContractStatusInvalid, res.Status)
-		assert.Contains(t, res.Message, "decision_section_placeholder")
+		assert.Contains(t, res.Message, "decision_structure_invalid")
 	})
 
 	t.Run("valid authored", func(t *testing.T) {

--- a/internal/engine/artifact/decision_contract_test.go
+++ b/internal/engine/artifact/decision_contract_test.go
@@ -1,0 +1,122 @@
+package artifact
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecisionSubstanceBlockers(t *testing.T) {
+	t.Parallel()
+
+	// Regression (issue #119): the unedited template served by `slipway
+	// instructions decision` is the scaffold the authoring skill must replace —
+	// every required section holds only its <!-- ... --> guidance comment, so the
+	// substance gate must reject it.
+	template, err := RenderArtifactExample("decision.md")
+	require.NoError(t, err)
+	templateBlockers := DecisionSubstanceBlockers(template)
+	require.Len(t, templateBlockers, 5, "every comment-only required section must be flagged")
+	for _, b := range templateBlockers {
+		assert.Contains(t, b, "decision_section_placeholder:", "the raw instructions decision template must not pass")
+	}
+
+	// Legacy scaffold regression: existing active changes may still carry the
+	// pre-#119 seeded prose. It is not an HTML comment, but it is still unwritten
+	// scaffold and must not satisfy the decision contract.
+	legacySeeded := "# Decision\n\n" +
+		"## Alternatives Considered\nPending investigation. Replace with concrete alternatives, tradeoffs, and the selected direction after research or code inspection.\n\n" +
+		"## Selected Approach\nPending investigation. Record the selected approach only after the alternatives have concrete evidence.\n\n" +
+		"## Interfaces and Data Flow\nPending investigation. Name changed interfaces and data flows, or write \"none\" after inspection.\n\n" +
+		"## Rollout and Rollback\nPending investigation. Write the concrete rollback path and verification command after implementation scope is known.\n\n" +
+		"## Risk\nPending investigation. List concrete risks only after inspecting the affected code and contracts.\n"
+	legacyBlockers := DecisionSubstanceBlockers(legacySeeded)
+	require.Len(t, legacyBlockers, 5, "every legacy seeded decision section must be flagged")
+	assert.Contains(t, legacyBlockers, "decision_section_placeholder:## Alternatives Considered")
+	assert.Contains(t, legacyBlockers, "decision_section_placeholder:## Selected Approach")
+	assert.Contains(t, legacyBlockers, "decision_section_placeholder:## Interfaces and Data Flow")
+	assert.Contains(t, legacyBlockers, "decision_section_placeholder:## Rollout and Rollback")
+	assert.Contains(t, legacyBlockers, "decision_section_placeholder:## Risk")
+
+	// An authored decision with real content in every section passes.
+	authored := "# Decision\n\n" +
+		"## Alternatives Considered\nA) keep polling; B) push via webhook. B wins on latency.\n\n" +
+		"## Selected Approach\nWebhook push, grounded in alternative B above.\n\n" +
+		"## Interfaces and Data Flow\nAdds POST /hook; events flow producer -> queue -> consumer.\n\n" +
+		"## Rollout and Rollback\nFeature flag webhook_push; rollback flips it off. Verify with `go test ./...`.\n\n" +
+		"## Risk\nDuplicate delivery; mitigated by idempotency keys.\n"
+	assert.Empty(t, DecisionSubstanceBlockers(authored), "an authored decision must pass")
+
+	// Authored sections that keep the guidance comment alongside real prose pass:
+	// the floor strips HTML comments and judges the remaining authored text. A
+	// terse "none" for Interfaces and Data Flow is a legitimate answer.
+	authoredKeepingComments := "# Decision\n\n" +
+		"## Alternatives Considered\n<!-- At least two real approaches with tradeoffs. -->\nA vs B; B wins.\n\n" +
+		"## Selected Approach\n<!-- guidance -->\nB.\n\n" +
+		"## Interfaces and Data Flow\nnone\n\n" +
+		"## Rollout and Rollback\nFlag flip; verify `go test ./...`.\n\n" +
+		"## Risk\nDuplicate delivery; idempotency keys.\n"
+	assert.Empty(t, DecisionSubstanceBlockers(authoredKeepingComments),
+		"authored sections keeping the guidance comment must pass")
+
+	// A missing required section is rejected by the structure check.
+	missingSection := "# Decision\n\n## Alternatives Considered\nA vs B.\n\n" +
+		"## Selected Approach\nB.\n\n## Interfaces and Data Flow\nnone\n\n## Risk\nlow.\n"
+	missingBlockers := DecisionSubstanceBlockers(missingSection)
+	require.NotEmpty(t, missingBlockers, "a missing required section must be rejected")
+	assert.Contains(t, missingBlockers[0], "decision_structure_invalid")
+
+	// A structurally empty section is rejected.
+	emptySection := "# Decision\n\n## Alternatives Considered\n\n## Selected Approach\nB.\n\n" +
+		"## Interfaces and Data Flow\nnone\n\n## Rollout and Rollback\nFlag.\n\n## Risk\nLow.\n"
+	assert.NotEmpty(t, DecisionSubstanceBlockers(emptySection), "a structurally empty section must be rejected")
+}
+
+func TestEvaluateDecisionContract(t *testing.T) {
+	t.Parallel()
+
+	write := func(t *testing.T, content string) string {
+		t.Helper()
+		root := t.TempDir()
+		slug := "decision-contract"
+		bundleDir := filepath.Join(root, "artifacts", "changes", slug)
+		require.NoError(t, os.MkdirAll(bundleDir, 0o755))
+		if content != "" {
+			require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "decision.md"), []byte(content), 0o644))
+		}
+		return bundleDir
+	}
+
+	t.Run("missing", func(t *testing.T) {
+		t.Parallel()
+		bundleDir := write(t, "")
+		res, err := EvaluateDecisionContract(bundleDir)
+		require.NoError(t, err)
+		assert.Equal(t, DecisionContractStatusMissing, res.Status)
+	})
+
+	t.Run("invalid template-only", func(t *testing.T) {
+		t.Parallel()
+		template, err := RenderArtifactExample("decision.md")
+		require.NoError(t, err)
+		bundleDir := write(t, template)
+		res, err := EvaluateDecisionContract(bundleDir)
+		require.NoError(t, err)
+		assert.Equal(t, DecisionContractStatusInvalid, res.Status)
+		assert.Contains(t, res.Message, "decision_section_placeholder")
+	})
+
+	t.Run("valid authored", func(t *testing.T) {
+		t.Parallel()
+		authored := "# Decision\n\n## Alternatives Considered\nA vs B; B wins.\n\n" +
+			"## Selected Approach\nB.\n\n## Interfaces and Data Flow\nnone\n\n" +
+			"## Rollout and Rollback\nFlag flip; verify tests.\n\n## Risk\nLow.\n"
+		bundleDir := write(t, authored)
+		res, err := EvaluateDecisionContract(bundleDir)
+		require.NoError(t, err)
+		assert.Equal(t, DecisionContractStatusValid, res.Status)
+	})
+}

--- a/internal/engine/artifact/manager.go
+++ b/internal/engine/artifact/manager.go
@@ -313,11 +313,10 @@ func scaffoldGovernedBundleForChange(root string, change model.Change, preset mo
 // directly by the host skill (via `slipway instructions <artifact>`) rather than
 // scaffolded by the engine. The engine defers creation so an un-authored required
 // artifact surfaces as missing (fail-closed), not a passing placeholder the skill
-// must overwrite (issue #119). research.md is excluded: it is governed by the
-// discovery evidence gate (G_scope), not the missing-artifact gate.
+// must overwrite (issue #119).
 func deferredToSkillAuthoring(name string) bool {
 	switch name {
-	case "requirements.md", "decision.md", "tasks.md":
+	case "requirements.md", "decision.md", "research.md", "tasks.md":
 		return true
 	default:
 		return false
@@ -339,32 +338,20 @@ func complexityRank(level string) int {
 	}
 }
 
-// EnsureResearchArtifactForChange ensures research.md exists in the governed bundle.
+// EnsureResearchArtifactForChange ensures the governed bundle directory exists
+// for research authoring. research.md itself stays absent until the
+// research-orchestration host writes the real file from `slipway instructions
+// research`, so an un-authored research artifact fails closed as missing.
 func EnsureResearchArtifactForChange(root string, change model.Change) error {
 	base, err := state.GovernedBundleDir(root, change)
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(base, 0o755); err != nil {
-		return err
-	}
-
-	path := filepath.Join(base, "research.md")
-	if _, err := os.Stat(path); err == nil {
-		return nil
-	} else if !errors.Is(err, fs.ErrNotExist) {
-		return err
-	}
-
-	rendered, err := renderTemplateWithFallback(root, "research.md", "", buildTemplateData(change))
-	if err != nil {
-		return err
-	}
-	return os.WriteFile(path, []byte(rendered), 0o644)
+	return os.MkdirAll(base, 0o755)
 }
 
 // validateSectionStructure validates that content contains the given headings
-// in order, each with at least one non-empty line of content beneath it.
+// in order, each with at least one non-comment content line beneath it.
 func validateSectionStructure(content string, headings []string) error {
 	lines := strings.Split(strings.ReplaceAll(content, "\r\n", "\n"), "\n")
 	indices := make([]int, 0, len(headings))
@@ -391,14 +378,8 @@ func validateSectionStructure(content string, headings []string) error {
 		if i+1 < len(indices) {
 			end = indices[i+1]
 		}
-		hasContent := false
-		for _, line := range lines[start:end] {
-			if strings.TrimSpace(line) != "" {
-				hasContent = true
-				break
-			}
-		}
-		if !hasContent {
+		body := strings.Join(lines[start:end], "\n")
+		if strings.TrimSpace(stringutil.StripHTMLComments(body)) == "" {
 			return fmt.Errorf("section %q must have non-empty content", heading)
 		}
 	}

--- a/internal/engine/artifact/manager.go
+++ b/internal/engine/artifact/manager.go
@@ -11,11 +11,10 @@ import (
 	"strings"
 	"sync"
 	"text/template"
-	"unicode"
-	"unicode/utf8"
 
 	"github.com/signalridge/slipway/internal/model"
 	"github.com/signalridge/slipway/internal/state"
+	"github.com/signalridge/slipway/internal/stringutil"
 	"github.com/signalridge/slipway/internal/tmpl"
 	"gopkg.in/yaml.v3"
 )
@@ -156,554 +155,60 @@ func TemplateContent(name string) (string, error) {
 // RenderArtifactExample renders the named artifact template (e.g.
 // "requirements.md") with representative example data so callers such as
 // `slipway instructions` can present a concrete, directive-free exemplar —
-// headings, authoring-guidance comments, and the honest placeholder seed —
-// instead of the raw Go-template source with unresolved `{{ … }}` actions. The
-// engine owns this structure; the authoring skill owns the substance that
-// replaces the seed (issue #91).
+// headings and authoring-guidance comments — instead of the raw Go-template
+// source with unresolved `{{ … }}` actions. The engine owns this structure; the
+// authoring skill writes the substance into the skeleton (issues #91, #119).
 func RenderArtifactExample(name string) (string, error) {
 	example := model.Change{
 		Slug:        "example-change",
 		Description: "describe the change here",
 	}
-	return renderTemplateWithFallback("", name, "", buildTemplateData("", example, nil))
+	return renderTemplateWithFallback("", name, "", buildTemplateData(example))
+}
+
+// RenderArtifactExampleWithTemplate renders a governed artifact exemplar using
+// an optional external template path. It is the custom-schema companion to
+// RenderArtifactExample for command surfaces such as `slipway instructions`.
+func RenderArtifactExampleWithTemplate(root, name, externalPath string) (string, error) {
+	example := model.Change{
+		Slug:        "example-change",
+		Description: "describe the change here",
+	}
+	return renderTemplateWithFallback(root, name, externalPath, buildTemplateData(example))
 }
 
 type templateData struct {
-	Slug               string
-	InitialRequest     string
-	QualityMode        string
-	BundleRoot         string
-	CodebaseMapRoot    string
-	BundleArchiveRoot  string
-	ProjectTechStack   string
-	ProjectConventions string
-	ProjectTestCmd     string
-	ProjectBuildCmd    string
-	ProjectLanguages   string
-	ComplexityLevel    string
-	ComplexityRank     int    // 0=trivial, 1=simple, 2=complex, 3=critical
-	GuardrailDomain    string // Inferred guardrail domain (e.g. auth_authz, security_credentials)
-
-	// Seeded draft content — computed from InitialRequest, project context,
-	// and optionally from --from-doc extraction.
-	SeededRequirements        string
-	SeededDecision            string
-	SeededDecisionApproach    string
-	SeededDecisionInterfaces  string
-	SeededDecisionRollback    string
-	SeededDecisionRisk        string
-	SeededResearch            string
-	SeededResearchUnknowns    string
-	SeededResearchAssumptions string
-	SeededResearchReferences  string
-	SeededTasks               string
+	Slug              string
+	InitialRequest    string
+	QualityMode       string
+	BundleRoot        string
+	CodebaseMapRoot   string
+	BundleArchiveRoot string
+	ComplexityLevel   string
+	ComplexityRank    int    // 0=trivial, 1=simple, 2=complex, 3=critical
+	GuardrailDomain   string // Inferred guardrail domain (e.g. auth_authz, security_credentials)
 }
 
-// DocSections carries extracted document sections across the cmd → artifact
-// package boundary when --from-doc is used.
-type DocSections struct {
-	Scope       string
-	Constraints string
-	Acceptance  string
-}
-
-func loadProjectContext(root string) model.ProjectContext {
-	projectCtx := model.ProjectContext{}
-	if cfg, err := model.LoadConfig(state.ConfigPath(root)); err == nil {
-		projectCtx = cfg.Context
-	}
-	return projectCtx
-}
-
-func buildTemplateData(root string, change model.Change, docs *DocSections, overrideCtx ...model.ProjectContext) templateData {
-	var projectCtx model.ProjectContext
-	if len(overrideCtx) > 0 {
-		projectCtx = overrideCtx[0]
-	} else {
-		projectCtx = loadProjectContext(root)
-	}
-	projectLanguages := strings.Join(projectCtx.Languages, ", ")
+func buildTemplateData(change model.Change) templateData {
 	slug := strings.TrimSpace(change.Slug)
 	data := templateData{
-		Slug:               slug,
-		InitialRequest:     strings.TrimSpace(change.Description),
-		QualityMode:        string(change.EffectiveQualityMode()),
-		BundleRoot:         filepath.ToSlash(filepath.Join("artifacts", "changes", slug)),
-		CodebaseMapRoot:    filepath.ToSlash(filepath.Join("artifacts", "codebase")),
-		BundleArchiveRoot:  filepath.ToSlash(filepath.Join("artifacts", "changes", "archived", slug)),
-		ProjectTechStack:   strings.TrimSpace(projectCtx.TechStack),
-		ProjectConventions: strings.TrimSpace(projectCtx.Conventions),
-		ProjectTestCmd:     strings.TrimSpace(projectCtx.TestCmd),
-		ProjectBuildCmd:    strings.TrimSpace(projectCtx.BuildCmd),
-		ProjectLanguages:   strings.TrimSpace(projectLanguages),
-		ComplexityLevel:    change.ComplexityLevel,
-		ComplexityRank:     complexityRank(change.ComplexityLevel),
-		GuardrailDomain:    change.GuardrailDomain,
-	}
-	data.SeededRequirements = seedRequirements(data)
-	data.SeededDecision = seedDecision()
-	data.SeededDecisionApproach = seedDecisionApproach()
-	data.SeededDecisionInterfaces = seedDecisionInterfaces()
-	data.SeededDecisionRollback = seedDecisionRollback()
-	data.SeededDecisionRisk = seedDecisionRisk()
-	data.SeededResearch = seedResearch()
-	data.SeededResearchUnknowns = seedResearchUnknowns()
-	data.SeededResearchAssumptions = seedResearchAssumptions()
-	data.SeededResearchReferences = seedResearchReferences(data)
-	data.SeededTasks = seedTasks(data)
-
-	if docs == nil {
-		return data
-	}
-	if docs.Scope != "" {
-		data.SeededRequirements = seededRequirementsContent(data, docSectionItems(docs.Scope))
-	}
-	if docs.Scope != "" || docs.Acceptance != "" {
-		data.SeededTasks = seedTasksFromDoc(data, *docs)
-	}
-	if docs.Constraints != "" {
-		data.SeededDecision += "\n### Constraints (from source document)\n" + docs.Constraints + "\n"
-		constraintItems := constraintSeedItems(docs.Constraints)
-		data.SeededDecisionApproach = appendDocConstraints(
-			data.SeededDecisionApproach,
-			constraintItems,
-			"This direction must continue honoring the documented constraints:",
-		)
-		data.SeededDecisionInterfaces = appendDocConstraints(
-			data.SeededDecisionInterfaces,
-			constraintItems,
-			"Interface and data-flow changes must respect these documented constraints:",
-		)
-		data.SeededDecisionRollback = appendDocConstraints(
-			data.SeededDecisionRollback,
-			constraintItems,
-			"Rollback planning must preserve these documented constraints:",
-		)
-		data.SeededDecisionRisk = appendDocConstraints(
-			data.SeededDecisionRisk,
-			constraintItems,
-			"Constraint-driven risks to keep explicit during implementation:",
-		)
-		data.SeededResearch += "\n### Constraints (from source document)\n" + docs.Constraints + "\n"
-		if len(constraintItems) > 0 {
-			var unknowns strings.Builder
-			unknowns.WriteString(data.SeededResearchUnknowns)
-			for _, item := range constraintItems {
-				fmt.Fprintf(&unknowns, "- How does the constraint %q limit the implementation of %s?\n", item, strings.ToLower(data.InitialRequest))
-			}
-			data.SeededResearchUnknowns = unknowns.String()
-
-			var assumptions strings.Builder
-			assumptions.WriteString(data.SeededResearchAssumptions)
-			for _, item := range constraintItems {
-				fmt.Fprintf(&assumptions, "- Assume the constraint %q remains binding until code inspection or stakeholder input proves otherwise.\n", item)
-			}
-			data.SeededResearchAssumptions = assumptions.String()
-			data.SeededResearchReferences += "- The `--from-doc` source document, especially its Constraints section.\n"
-		}
+		Slug:              slug,
+		InitialRequest:    strings.TrimSpace(change.Description),
+		QualityMode:       string(change.EffectiveQualityMode()),
+		BundleRoot:        filepath.ToSlash(filepath.Join("artifacts", "changes", slug)),
+		CodebaseMapRoot:   filepath.ToSlash(filepath.Join("artifacts", "codebase")),
+		BundleArchiveRoot: filepath.ToSlash(filepath.Join("artifacts", "changes", "archived", slug)),
+		ComplexityLevel:   change.ComplexityLevel,
+		ComplexityRank:    complexityRank(change.ComplexityLevel),
+		GuardrailDomain:   change.GuardrailDomain,
 	}
 	return data
 }
 
-// seedRequirements generates a first-pass requirements section from the change description.
-func seedRequirements(data templateData) string {
-	requirementItems := []string{strings.TrimSpace(data.InitialRequest)}
-	return seededRequirementsContent(data, requirementItems)
-}
-
-// seedDecision generates a first-pass decision section from available context.
-func seedDecision() string {
-	return "Pending investigation. Replace with concrete alternatives, tradeoffs, and the selected direction after research or code inspection.\n"
-}
-
-func seedDecisionApproach() string {
-	return "Pending investigation. Record the selected approach only after the alternatives have concrete evidence."
-}
-
-func seedDecisionInterfaces() string {
-	return "Pending investigation. Name changed interfaces and data flows, or write \"none\" after inspection."
-}
-
-func seedDecisionRollback() string {
-	return "Pending investigation. Write the concrete rollback path and verification command after implementation scope is known."
-}
-
-func seedDecisionRisk() string {
-	return "Pending investigation. List concrete risks only after inspecting the affected code and contracts."
-}
-
-// seedResearch generates a first-pass research section.
-func seedResearch() string {
-	return "Pending investigation. Replace with concrete alternatives, supporting evidence, and the selected direction.\n"
-}
-
-func seedResearchUnknowns() string {
-	return "- Pending investigation. List unknowns that must be resolved before planning.\n"
-}
-
-func seedResearchAssumptions() string {
-	return "- Pending investigation. List assumptions only after identifying the evidence that supports them.\n"
-}
-
-func seedResearchReferences(data templateData) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "- `artifacts/changes/%s/intent.md` for the original request and intake context.\n", data.Slug)
-	b.WriteString("- `requirements.md` and `decision.md` in the same bundle once planning artifacts are refined.\n")
-	if strings.TrimSpace(data.ProjectTestCmd) != "" {
-		fmt.Fprintf(&b, "- Existing verification flows referenced by the scaffold context, especially `%s`.\n", strings.TrimSpace(data.ProjectTestCmd))
-	} else {
-		b.WriteString("- Existing code paths and tests related to the affected behavior in the repository.\n")
-	}
-	return b.String()
-}
-
-// seedTasks generates a first-pass task list from the change description.
-func seedTasks(data templateData) string {
-	var b strings.Builder
-	reqRefs := strings.Join(seededRequirementRefs(data, 0), ", ")
-	b.WriteString("- [ ] `t-01` Pending task objective\n")
-	b.WriteString("  - wave: 1\n")
-	b.WriteString("  - depends_on: []\n")
-	b.WriteString("  - target_files: []\n")
-	b.WriteString("  - task_kind: investigation\n")
-	fmt.Fprintf(&b, "  - covers: [%s]\n\n", reqRefs)
-	return b.String()
-}
-
-// seedTasksFromDoc enriches tasks with --from-doc extracted scope items.
-func seedTasksFromDoc(data templateData, docs DocSections) string {
-	scopeItems := docSectionItems(docs.Scope)
-	acceptanceItems := docSectionItems(docs.Acceptance)
-	if len(scopeItems) == 0 && len(acceptanceItems) == 0 {
-		return seedTasks(data)
-	}
-
-	var b strings.Builder
-	taskNum := 1
-	codeTaskIDs := make([]string, 0, len(scopeItems))
-	reqRefs := seededRequirementRefs(data, len(scopeItems))
-	for idx, line := range scopeItems {
-		fmt.Fprintf(&b, "- [ ] `t-%02d` %s\n", taskNum, capitalizeFirst(line))
-		b.WriteString("  - wave: 1\n")
-		b.WriteString("  - depends_on: []\n")
-		b.WriteString("  - target_files: []\n")
-		b.WriteString("  - task_kind: code\n")
-		fmt.Fprintf(&b, "  - covers: [%s]\n\n", reqRefs[idx])
-		codeTaskIDs = append(codeTaskIDs, fmt.Sprintf("t-%02d", taskNum))
-		taskNum++
-	}
-
-	if len(codeTaskIDs) == 0 {
-		fmt.Fprintf(&b, "- [ ] `t-%02d` Implement %s\n", taskNum, strings.ToLower(data.InitialRequest))
-		b.WriteString("  - wave: 1\n")
-		b.WriteString("  - depends_on: []\n")
-		b.WriteString("  - target_files: []\n")
-		b.WriteString("  - task_kind: code\n")
-		b.WriteString("  - covers: [REQ-001]\n\n")
-		codeTaskIDs = append(codeTaskIDs, fmt.Sprintf("t-%02d", taskNum))
-		taskNum++
-	}
-
-	if len(acceptanceItems) > 0 {
-		deps := strings.Join(codeTaskIDs, ", ")
-		for _, line := range acceptanceItems {
-			fmt.Fprintf(&b, "- [ ] `t-%02d` %s\n", taskNum, capitalizeFirst(line))
-			b.WriteString("  - wave: 2\n")
-			fmt.Fprintf(&b, "  - depends_on: [%s]\n", deps)
-			b.WriteString("  - target_files: []\n")
-			b.WriteString("  - task_kind: verification\n")
-			fmt.Fprintf(&b, "  - covers: [%s]\n\n", strings.Join(reqRefs, ", "))
-			taskNum++
-		}
-		return b.String()
-	}
-
-	fmt.Fprintf(&b, "- [ ] `t-%02d` Pending verification objective\n", taskNum)
-	b.WriteString("  - wave: 2\n")
-	fmt.Fprintf(&b, "  - depends_on: [%s]\n", strings.Join(codeTaskIDs, ", "))
-	b.WriteString("  - target_files: []\n")
-	b.WriteString("  - task_kind: verification\n")
-	fmt.Fprintf(&b, "  - covers: [%s]\n", strings.Join(reqRefs, ", "))
-	return b.String()
-}
-
-func capitalizeFirst(s string) string {
-	if s == "" {
-		return s
-	}
-	r, size := utf8.DecodeRuneInString(s)
-	if r == utf8.RuneError && size == 1 {
-		return s
-	}
-	return string(unicode.ToUpper(r)) + s[size:]
-}
-
-func seededRequirementsContent(data templateData, requirementItems []string) string {
-	items := make([]string, 0, len(requirementItems))
-	for _, item := range requirementItems {
-		if trimmed := strings.TrimSpace(item); trimmed != "" {
-			items = append(items, trimmed)
-		}
-	}
-	if len(items) == 0 {
-		fallback := strings.TrimSpace(data.InitialRequest)
-		if fallback == "" {
-			fallback = "define requirements based on the initial request"
-		}
-		items = append(items, fallback)
-	}
-
-	var b strings.Builder
-	reqNum := 1
-	for _, item := range items {
-		appendRequirementBlock(&b, reqNum, item)
-		reqNum++
-	}
-	if data.GuardrailDomain != "" {
-		appendGuardrailRequirementBlock(&b, reqNum, data.GuardrailDomain)
-	}
-	return b.String()
-}
-
-func appendRequirementBlock(b *strings.Builder, reqNum int, objective string) {
-	if b.Len() > 0 {
-		b.WriteString("\n")
-	}
-	cleanedObjective := strings.Join(strings.Fields(strings.TrimSpace(objective)), " ")
-	// The engine owns structure (heading + stable REQ-* id); the authoring skill
-	// owns substance. Emit an honest, obviously-not-real placeholder — no
-	// normative MUST/SHALL and an explicit "replace" instruction — so it is
-	// caught by LooksLikeTemplatePlaceholder and rejected by the requirements
-	// substance gate until a skill writes the real requirement.
-	fmt.Fprintf(b, "### Requirement: %s\n", cleanedObjective)
-	fmt.Fprintf(b, "REQ-%03d: %s\n", reqNum, requirementPlaceholderSentence(cleanedObjective))
-	b.WriteString("\n#### Scenario: Pending — replace with a concrete scenario\n")
-	b.WriteString("GIVEN pending — replace with the precondition\n")
-	b.WriteString("WHEN pending — replace with the triggering action\n")
-	b.WriteString("THEN pending — replace with the observable expected outcome\n")
-}
-
-// requirementPlaceholderSentence returns an honest, non-normative placeholder for
-// a seeded requirement body. It deliberately contains no RFC-2119 MUST/SHALL and
-// a placeholder sentinel ("define requirements based on the initial request") so
-// the substance gate rejects an unedited scaffold.
-func requirementPlaceholderSentence(objective string) string {
-	if strings.TrimSpace(objective) == "" {
-		return "Pending — replace with the normative requirement. Define requirements based on the initial request."
-	}
-	return fmt.Sprintf(
-		"Pending — replace with the normative requirement (state what the system is required to do). Define requirements based on the initial request: %s.",
-		objective,
-	)
-}
-
-func appendGuardrailRequirementBlock(b *strings.Builder, reqNum int, guardrailDomain string) {
-	if b.Len() > 0 {
-		b.WriteString("\n")
-	}
-	fmt.Fprintf(b, "### Requirement: %s guardrail compliance\n", guardrailDomain)
-	fmt.Fprintf(b, "REQ-%03d: The implementation MUST comply with %s guardrail requirements.\n", reqNum, guardrailDomain)
-	b.WriteString("\n#### Scenario: Guardrail compliance\n")
-	b.WriteString("GIVEN the change touches a guarded domain\n")
-	b.WriteString("WHEN the implementation is updated\n")
-	fmt.Fprintf(b, "THEN %s guardrail requirements remain satisfied.\n", guardrailDomain)
-}
-
-func docSectionItems(section string) []string {
-	lines := strings.Split(section, "\n")
-	if items := markdownListItems(lines); len(items) > 0 {
-		return items
-	}
-	return proseParagraphItems(lines)
-}
-
-func markdownListItems(lines []string) []string {
-	items := make([]string, 0)
-	current := ""
-	sawListMarker := false
-	currentHasNestedItems := false
-
-	flush := func() {
-		if strings.TrimSpace(current) == "" {
-			current = ""
-			currentHasNestedItems = false
-			return
-		}
-		items = append(items, strings.Join(strings.Fields(current), " "))
-		current = ""
-		currentHasNestedItems = false
-	}
-
-	for _, raw := range lines {
-		trimmed := strings.TrimSpace(raw)
-		if trimmed == "" {
-			if sawListMarker {
-				flush()
-			}
-			continue
-		}
-		if item, ok := listItemText(trimmed); ok {
-			if leadingIndentWidth(raw) == 0 {
-				sawListMarker = true
-				flush()
-				current = item
-				continue
-			}
-			if sawListMarker {
-				if current == "" {
-					current = item
-				} else if !currentHasNestedItems {
-					current += ": " + item
-					currentHasNestedItems = true
-				} else {
-					current += "; " + item
-				}
-				continue
-			}
-		}
-		if sawListMarker {
-			if current == "" {
-				current = trimmed
-			} else {
-				current += " " + trimmed
-			}
-		}
-	}
-
-	if !sawListMarker {
-		return nil
-	}
-	flush()
-	return items
-}
-
-func leadingIndentWidth(s string) int {
-	width := 0
-	for _, r := range s {
-		if r != ' ' && r != '\t' {
-			break
-		}
-		width++
-	}
-	return width
-}
-
-func proseParagraphItems(lines []string) []string {
-	parts := make([]string, 0, len(lines))
-	for _, raw := range lines {
-		trimmed := strings.TrimSpace(raw)
-		if trimmed == "" {
-			continue
-		}
-		parts = append(parts, trimmed)
-	}
-	if len(parts) == 0 {
-		return nil
-	}
-	return []string{strings.Join(parts, " ")}
-}
-
-func listItemText(line string) (string, bool) {
-	for _, prefix := range []string{"- ", "* "} {
-		if strings.HasPrefix(line, prefix) {
-			return strings.TrimSpace(strings.TrimPrefix(line, prefix)), true
-		}
-	}
-
-	idx := 0
-	for idx < len(line) && line[idx] >= '0' && line[idx] <= '9' {
-		idx++
-	}
-	if idx == 0 || idx+1 >= len(line) {
-		return "", false
-	}
-	if (line[idx] != '.' && line[idx] != ')') || line[idx+1] != ' ' {
-		return "", false
-	}
-	return strings.TrimSpace(line[idx+2:]), true
-}
-
-func seededRequirementRefs(data templateData, scopeItemCount int) []string {
-	count := scopeItemCount
-	if count == 0 {
-		count = 1
-	}
-	if data.GuardrailDomain != "" {
-		count++
-	}
-	return reqReferenceList(count)
-}
-
-func reqReferenceList(count int) []string {
-	if count <= 0 {
-		return []string{"REQ-001"}
-	}
-	refs := make([]string, 0, count)
-	for i := 1; i <= count; i++ {
-		refs = append(refs, fmt.Sprintf("REQ-%03d", i))
-	}
-	return refs
-}
-
-func appendDocConstraints(base string, items []string, heading string) string {
-	if len(items) == 0 {
-		return base
-	}
-	var b strings.Builder
-	b.WriteString(strings.TrimSpace(base))
-	b.WriteString("\n\n")
-	b.WriteString(heading)
-	b.WriteString("\n")
-	for _, item := range items {
-		b.WriteString("- ")
-		b.WriteString(item)
-		b.WriteString("\n")
-	}
-	return strings.TrimRight(b.String(), "\n")
-}
-
-func constraintSeedItems(section string) []string {
-	items := docSectionItems(section)
-	if strings.TrimSpace(section) == "" {
-		return items
-	}
-
-	lines := strings.Split(section, "\n")
-	preamble := make([]string, 0, len(lines))
-	sawTopLevelList := false
-	for _, raw := range lines {
-		trimmed := strings.TrimSpace(raw)
-		if trimmed == "" {
-			if sawTopLevelList {
-				break
-			}
-			continue
-		}
-		if _, ok := listItemText(trimmed); ok && leadingIndentWidth(raw) == 0 {
-			sawTopLevelList = true
-			break
-		}
-		if sawTopLevelList {
-			break
-		}
-		preamble = append(preamble, trimmed)
-	}
-	if !sawTopLevelList {
-		return items
-	}
-
-	preambleText := strings.Join(preamble, " ")
-	if strings.TrimSpace(preambleText) == "" {
-		return items
-	}
-	return append([]string{preambleText}, items...)
-}
-
-// ScaffoldIntentForChangeWithContext creates only intent.md in the governed
-// bundle directory using an externally-provided ProjectContext. This is used
-// when preset is pending to ensure the intake artifact exists without creating
-// the full governed bundle.
-func ScaffoldIntentForChangeWithContext(root string, change model.Change, projectCtx model.ProjectContext) error {
+// ScaffoldIntentForChange creates only intent.md in the governed bundle
+// directory. This is used when preset is pending to ensure the intake artifact
+// exists without creating the full governed bundle.
+func ScaffoldIntentForChange(root string, change model.Change) error {
 	slug := strings.TrimSpace(change.Slug)
 	if slug == "" {
 		return fmt.Errorf("slug is required")
@@ -715,7 +220,7 @@ func ScaffoldIntentForChangeWithContext(root string, change model.Change, projec
 	if err := os.MkdirAll(base, 0o755); err != nil {
 		return err
 	}
-	data := buildTemplateData(root, change, nil, projectCtx)
+	data := buildTemplateData(change)
 	intentPath := ResolveArtifactPath(base, "intent.md")
 	if _, err := os.Stat(intentPath); err == nil {
 		return nil // already exists
@@ -730,21 +235,14 @@ func ScaffoldIntentForChangeWithContext(root string, change model.Change, projec
 	return os.WriteFile(intentPath, []byte(rendered), 0o644)
 }
 
-// ScaffoldGovernedBundleForChangeWithContext creates the artifact files using
-// an externally-provided ProjectContext (e.g. from InferProjectContext) instead
-// of loading from .slipway.yaml.
-func ScaffoldGovernedBundleForChangeWithContext(root string, change model.Change, preset model.WorkflowPreset, projectCtx model.ProjectContext, schema ...[]ArtifactSpec) error {
-	return scaffoldGovernedBundleForChange(root, change, preset, &projectCtx, nil, schema...)
+// ScaffoldGovernedBundleForChange creates the artifact files for a governed
+// change. The engine owns structure only; project context is persisted on the
+// change and surfaced through `slipway instructions`, not copied into bodies.
+func ScaffoldGovernedBundleForChange(root string, change model.Change, preset model.WorkflowPreset, schema ...[]ArtifactSpec) error {
+	return scaffoldGovernedBundleForChange(root, change, preset, schema...)
 }
 
-// ScaffoldGovernedBundleForChangeWithContextAndDocs creates the artifact files
-// using an externally-provided ProjectContext and doc sections extracted from
-// --from-doc. The doc sections enrich seeded content in templates.
-func ScaffoldGovernedBundleForChangeWithContextAndDocs(root string, change model.Change, preset model.WorkflowPreset, projectCtx model.ProjectContext, docs DocSections, schema ...[]ArtifactSpec) error {
-	return scaffoldGovernedBundleForChange(root, change, preset, &projectCtx, &docs, schema...)
-}
-
-func scaffoldGovernedBundleForChange(root string, change model.Change, preset model.WorkflowPreset, projectCtx *model.ProjectContext, docs *DocSections, schema ...[]ArtifactSpec) error {
+func scaffoldGovernedBundleForChange(root string, change model.Change, preset model.WorkflowPreset, schema ...[]ArtifactSpec) error {
 	slug := strings.TrimSpace(change.Slug)
 	if slug == "" {
 		return fmt.Errorf("slug is required")
@@ -772,12 +270,7 @@ func scaffoldGovernedBundleForChange(root string, change model.Change, preset mo
 	if err := os.MkdirAll(base, 0o755); err != nil {
 		return err
 	}
-	var data templateData
-	if projectCtx != nil {
-		data = buildTemplateData(root, change, docs, *projectCtx)
-	} else {
-		data = buildTemplateData(root, change, docs)
-	}
+	data := buildTemplateData(change)
 
 	// Build a lookup from artifact name to template source path for custom schemas.
 	templatePaths := map[string]string{}
@@ -788,6 +281,12 @@ func scaffoldGovernedBundleForChange(root string, change model.Change, preset mo
 	}
 
 	for _, file := range files {
+		// The engine defers creation of skill-authored artifacts so an
+		// un-authored required artifact is missing (fail-closed), not a
+		// placeholder body the skill must overwrite (issue #119).
+		if deferredToSkillAuthoring(file) {
+			continue
+		}
 		path := ResolveArtifactPath(base, file)
 		if _, err := os.Stat(path); err == nil {
 			continue
@@ -808,6 +307,21 @@ func scaffoldGovernedBundleForChange(root string, change model.Change, preset mo
 	}
 
 	return nil
+}
+
+// deferredToSkillAuthoring reports whether an artifact's body is authored
+// directly by the host skill (via `slipway instructions <artifact>`) rather than
+// scaffolded by the engine. The engine defers creation so an un-authored required
+// artifact surfaces as missing (fail-closed), not a passing placeholder the skill
+// must overwrite (issue #119). research.md is excluded: it is governed by the
+// discovery evidence gate (G_scope), not the missing-artifact gate.
+func deferredToSkillAuthoring(name string) bool {
+	switch name {
+	case "requirements.md", "decision.md", "tasks.md":
+		return true
+	default:
+		return false
+	}
 }
 
 func complexityRank(level string) int {
@@ -842,7 +356,7 @@ func EnsureResearchArtifactForChange(root string, change model.Change) error {
 		return err
 	}
 
-	rendered, err := renderTemplateWithFallback(root, "research.md", "", buildTemplateData(root, change, nil))
+	rendered, err := renderTemplateWithFallback(root, "research.md", "", buildTemplateData(change))
 	if err != nil {
 		return err
 	}
@@ -901,7 +415,43 @@ func ResearchStructureBlockers(content string) []model.ReasonCode {
 	if err := validateSectionStructure(content, headings); err != nil {
 		return []model.ReasonCode{model.NewReasonCode("research_structure_invalid", err.Error())}
 	}
-	return nil
+
+	var blockers []model.ReasonCode
+	for _, heading := range headings {
+		body := strings.Join(markdownSectionLines(content, heading), "\n")
+		if artifactSectionBodyLooksPlaceholder(body) {
+			blockers = append(blockers, model.NewReasonCode("research_section_placeholder", heading))
+		}
+	}
+	return blockers
+}
+
+var legacyArtifactSectionPlaceholderPhrases = []string{
+	"pending investigation. replace with concrete alternatives, tradeoffs, and the selected direction after research or code inspection.",
+	"pending investigation. record the selected approach only after the alternatives have concrete evidence.",
+	"pending investigation. name changed interfaces and data flows, or write \"none\" after inspection.",
+	"pending investigation. write the concrete rollback path and verification command after implementation scope is known.",
+	"pending investigation. list concrete risks only after inspecting the affected code and contracts.",
+	"pending investigation. replace with concrete alternatives, supporting evidence, and the selected direction.",
+	"pending investigation. list unknowns that must be resolved before planning.",
+	"pending investigation. list assumptions only after identifying the evidence that supports them.",
+	"requirements.md` and `decision.md` in the same bundle once planning artifacts are refined",
+	"existing code paths and tests related to the affected behavior in the repository",
+	"existing verification flows referenced by the scaffold context",
+}
+
+func artifactSectionBodyLooksPlaceholder(body string) bool {
+	stripped := strings.TrimSpace(stringutil.StripHTMLComments(body))
+	if stripped == "" {
+		return true
+	}
+	normalized := strings.ToLower(strings.Join(strings.Fields(stripped), " "))
+	for _, phrase := range legacyArtifactSectionPlaceholderPhrases {
+		if strings.Contains(normalized, phrase) {
+			return true
+		}
+	}
+	return false
 }
 
 // ParseDecisionLockedDecisions extracts decision items from decision.md.

--- a/internal/engine/artifact/manager_test.go
+++ b/internal/engine/artifact/manager_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/signalridge/slipway/internal/engine/wave"
 	"github.com/signalridge/slipway/internal/model"
-	"github.com/signalridge/slipway/internal/state"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -17,19 +17,31 @@ func TestScaffoldGovernedBundleL2CreatesRequiredFiles(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
 	change := model.NewChange("my-change")
-	err := ScaffoldGovernedBundleForChangeWithContext(root, change, "", model.ProjectContext{})
+	err := ScaffoldGovernedBundleForChange(root, change, "")
 	require.NoError(t, err)
 
 	base := filepath.Join(root, "artifacts", "changes", "my-change")
+	// The engine still scaffolds the artifacts whose bodies it owns.
 	for _, file := range []string{
 		"intent.md",
-		"requirements.md",
-		"decision.md",
-		"tasks.md",
 		"assurance.md",
 	} {
 		_, err := os.Stat(ResolveArtifactPath(base, file))
 		require.NoError(t, err, file)
+	}
+
+	// requirements.md/decision.md/tasks.md are authored directly by the host
+	// skill via `slipway instructions`; the engine defers their creation so an
+	// un-authored required artifact surfaces as missing/fail-closed rather than a
+	// placeholder body the skill must overwrite (issue #119).
+	for _, file := range []string{
+		"requirements.md",
+		"decision.md",
+		"tasks.md",
+	} {
+		_, err := os.Stat(ResolveArtifactPath(base, file))
+		require.Error(t, err, file)
+		assert.True(t, os.IsNotExist(err), file)
 	}
 
 	// status.md is no longer written — change.yaml in bundle is the authority.
@@ -49,7 +61,7 @@ func TestScaffoldGovernedBundleNeedsDiscoveryAddsResearch(t *testing.T) {
 	change.NeedsDiscovery = true
 	change.WorktreePath = worktreeRoot
 
-	require.NoError(t, ScaffoldGovernedBundleForChangeWithContext(root, change, "", model.ProjectContext{}))
+	require.NoError(t, ScaffoldGovernedBundleForChange(root, change, ""))
 
 	_, err := os.Stat(filepath.Join(worktreeRoot, "artifacts", "changes", "my-change", "research.md"))
 	require.NoError(t, err)
@@ -60,39 +72,17 @@ func TestScaffoldGovernedBundleNoDiscoverySkipsResearch(t *testing.T) {
 	root := t.TempDir()
 	change := model.NewChange("my-change")
 
-	require.NoError(t, ScaffoldGovernedBundleForChangeWithContext(root, change, "", model.ProjectContext{}))
+	require.NoError(t, ScaffoldGovernedBundleForChange(root, change, ""))
 
 	_, err := os.Stat(filepath.Join(root, "artifacts", "changes", "my-change", "research.md"))
 	require.Error(t, err)
 	assert.True(t, os.IsNotExist(err))
 }
 
-func TestScaffoldGovernedBundleInjectsProjectContext(t *testing.T) {
-	t.Parallel()
-	root := t.TempDir()
-	cfg := model.DefaultConfig()
-	cfg.Context.TechStack = "Go, Cobra"
-	cfg.Context.Conventions = "Deterministic CLI contracts"
-	cfg.Context.TestCmd = "go test ./..."
-	cfg.Context.BuildCmd = "go build ./..."
-	cfg.Context.Languages = []string{"go", "yaml"}
-	require.NoError(t, model.SaveConfig(state.ConfigPath(root), cfg))
-
-	require.NoError(t, ScaffoldGovernedBundleForChangeWithContext(root, model.NewChange("ctx-change"), "", cfg.Context))
-	proposalPath := filepath.Join(root, "artifacts", "changes", "ctx-change", "intent.md")
-	raw, err := os.ReadFile(proposalPath)
-	require.NoError(t, err)
-	content := string(raw)
-	assert.Contains(t, content, "## Project Context")
-	assert.Contains(t, content, "Go, Cobra")
-	assert.Contains(t, content, "go test ./...")
-	assert.Contains(t, content, "go, yaml")
-}
-
 func TestScaffoldGovernedBundleL1CreatesBundle(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
-	require.NoError(t, ScaffoldGovernedBundleForChangeWithContext(root, model.NewChange("my-change"), "", model.ProjectContext{}))
+	require.NoError(t, ScaffoldGovernedBundleForChange(root, model.NewChange("my-change"), ""))
 
 	_, err := os.Stat(filepath.Join(root, "artifacts", "changes", "my-change"))
 	require.NoError(t, err)
@@ -104,10 +94,27 @@ func TestScaffoldGovernedBundleDiscoveryCreatesResearch(t *testing.T) {
 
 	change := model.NewChange("discovery-change")
 	change.NeedsDiscovery = true
-	require.NoError(t, ScaffoldGovernedBundleForChangeWithContext(root, change, "", model.ProjectContext{}))
+	require.NoError(t, ScaffoldGovernedBundleForChange(root, change, ""))
 
 	_, err := os.Stat(filepath.Join(root, "artifacts", "changes", change.Slug, "research.md"))
 	require.NoError(t, err)
+}
+
+// TestArtifactTemplatesParseUnderEngineParsers pins the instructions exemplars
+// (what `slipway instructions` serves) to the engine parsers that consume the
+// authored artifacts, so the template and parser cannot drift — a drift would
+// make skill-authored files unparseable (issue #119).
+func TestArtifactTemplatesParseUnderEngineParsers(t *testing.T) {
+	t.Parallel()
+	req, err := RenderArtifactExample("requirements.md")
+	require.NoError(t, err)
+	assert.NotPanics(t, func() { _ = ParseRequirementBlocks(req) },
+		"requirements template must parse under the requirement parser")
+
+	tasks, err := RenderArtifactExample("tasks.md")
+	require.NoError(t, err)
+	_, err = wave.ParseTaskPlan(tasks)
+	require.NoError(t, err, "tasks template must parse under the engine task-plan parser")
 }
 
 func TestTemplateRequiredSections(t *testing.T) {
@@ -154,6 +161,50 @@ Docs and specs that constrain this work.`
 
 	blockers := ResearchStructureBlockers(valid)
 	assert.Empty(t, blockers)
+
+	template, err := RenderArtifactExample("research.md")
+	require.NoError(t, err)
+	blockers = ResearchStructureBlockers(template)
+	assert.Contains(t, model.ReasonSpecs(blockers), "research_section_placeholder:## Alternatives Considered")
+	assert.Contains(t, model.ReasonSpecs(blockers), "research_section_placeholder:## Unknowns")
+	assert.Contains(t, model.ReasonSpecs(blockers), "research_section_placeholder:## Assumptions")
+	assert.Contains(t, model.ReasonSpecs(blockers), "research_section_placeholder:## Canonical References")
+
+	legacySeeded := `# Research
+
+## Alternatives Considered
+Pending investigation. Replace with concrete alternatives, supporting evidence, and the selected direction.
+
+## Unknowns
+- Pending investigation. List unknowns that must be resolved before planning.
+
+## Assumptions
+- Pending investigation. List assumptions only after identifying the evidence that supports them.
+
+## Canonical References
+- ` + "`artifacts/changes/example-change/intent.md`" + ` for the original request and intake context.
+- ` + "`requirements.md`" + ` and ` + "`decision.md`" + ` in the same bundle once planning artifacts are refined.
+- Existing code paths and tests related to the affected behavior in the repository.
+`
+	blockers = ResearchStructureBlockers(legacySeeded)
+	require.Len(t, blockers, 4, "every legacy seeded research section must be flagged")
+	assert.Contains(t, model.ReasonSpecs(blockers), "research_section_placeholder:## Alternatives Considered")
+	assert.Contains(t, model.ReasonSpecs(blockers), "research_section_placeholder:## Unknowns")
+	assert.Contains(t, model.ReasonSpecs(blockers), "research_section_placeholder:## Assumptions")
+	assert.Contains(t, model.ReasonSpecs(blockers), "research_section_placeholder:## Canonical References")
+
+	authoredFromTemplate := strings.NewReplacer(
+		"<!-- Real alternatives with supporting evidence and the selected direction. -->",
+		"Compared direct engine seeding with skill-authored artifacts; skill authoring preserves fail-closed ownership.",
+		"<!-- Unknowns that must be resolved before planning, or \"None\". -->",
+		"None; parser and readiness contracts were confirmed in tests.",
+		"<!-- Assumptions with the evidence that supports them. -->",
+		"Assumes `slipway instructions research` is the public authoring surface.",
+		"<!-- file:path references used as planning authority. -->",
+		"internal/tmpl/templates/artifacts/research.md\ninternal/engine/artifact/manager.go",
+	).Replace(template)
+	assert.Empty(t, ResearchStructureBlockers(authoredFromTemplate),
+		"an authored research.md derived from the real instructions template must pass")
 
 	// Missing a required section.
 	missing := `## Alternatives Considered
@@ -507,142 +558,13 @@ func TestAssuranceSectionScaffoldDerivesFromTemplate(t *testing.T) {
 	}
 }
 
-func TestScaffoldGovernedBundleSeedsRequirementsDraft(t *testing.T) {
-	t.Parallel()
-	root := t.TempDir()
-	change := model.NewChange("add-session-timeout-policy")
-
-	require.NoError(t, ScaffoldGovernedBundleForChangeWithContext(root, change, "", model.ProjectContext{}))
-
-	raw, err := os.ReadFile(filepath.Join(root, "artifacts", "changes", change.Slug, "requirements.md"))
-	require.NoError(t, err)
-	content := string(raw)
-
-	// Structure is seeded (heading + stable REQ id) ...
-	require.Contains(t, content, "REQ-001")
-	require.NotContains(t, content, "Add requirements using")
-	// ... but the engine no longer fabricates substance: the default seed is an
-	// honest, obviously-not-real placeholder that the substance gate rejects.
-	require.True(t, LooksLikeTemplatePlaceholder(content),
-		"default-seeded requirements must read as a placeholder")
-	require.NotContains(t, content, "the relevant workflow is exercised")
-	require.NotContains(t, content, "the expected behavior for")
-	require.NotContains(t, content, "The system MUST")
-}
-
-func TestScaffoldGovernedBundleSeedsDecisionDraft(t *testing.T) {
-	t.Parallel()
-	root := t.TempDir()
-	change := model.NewChange("add-session-timeout-policy")
-
-	require.NoError(t, ScaffoldGovernedBundleForChangeWithContext(root, change, "", model.ProjectContext{}))
-
-	raw, err := os.ReadFile(filepath.Join(root, "artifacts", "changes", change.Slug, "decision.md"))
-	require.NoError(t, err)
-	content := string(raw)
-
-	require.Contains(t, content, "Pending investigation")
-	require.NotContains(t, content, "Approach A")
-	require.NotContains(t, content, "| | | | |")
-}
-
-func TestScaffoldGovernedBundleSeedsDecisionSectionBodies(t *testing.T) {
-	t.Parallel()
-	root := t.TempDir()
-	change := model.NewChange("add-session-timeout-policy")
-	change.Description = "add session timeout policy"
-
-	require.NoError(t, ScaffoldGovernedBundleForChangeWithContext(root, change, "", model.ProjectContext{}))
-
-	raw, err := os.ReadFile(filepath.Join(root, "artifacts", "changes", change.Slug, "decision.md"))
-	require.NoError(t, err)
-	content := string(raw)
-
-	selected := strings.TrimSpace(strings.Join(markdownSectionLines(content, "Selected Approach"), "\n"))
-	interfaces := strings.TrimSpace(strings.Join(markdownSectionLines(content, "Interfaces and Data Flow"), "\n"))
-	rollback := strings.TrimSpace(strings.Join(markdownSectionLines(content, "Rollout and Rollback"), "\n"))
-	risk := strings.TrimSpace(strings.Join(markdownSectionLines(content, "Risk"), "\n"))
-
-	assert.Contains(t, selected, "Pending investigation")
-	assert.NotContains(t, selected, "session timeout policy")
-	assert.NotContains(t, selected, "Describe the chosen approach")
-
-	assert.Contains(t, interfaces, "Pending investigation")
-	assert.NotContains(t, interfaces, "session timeout policy")
-	assert.NotContains(t, interfaces, "Pending — detail after approach is confirmed.")
-
-	assert.Contains(t, rollback, "Pending investigation")
-	assert.NotContains(t, rollback, "session timeout policy")
-	assert.NotContains(t, rollback, "Pending — define after interfaces are finalized.")
-
-	assert.Contains(t, risk, "Pending investigation")
-	assert.NotContains(t, risk, "session timeout policy")
-	assert.NotContains(t, risk, "Pending — assess after approach is confirmed.")
-}
-
-func TestScaffoldGovernedBundleSeedsTasksDraft(t *testing.T) {
-	t.Parallel()
-	root := t.TempDir()
-	change := model.NewChange("add-session-timeout-policy")
-
-	require.NoError(t, ScaffoldGovernedBundleForChangeWithContext(root, change, "", model.ProjectContext{}))
-
-	raw, err := os.ReadFile(filepath.Join(root, "artifacts", "changes", change.Slug, "tasks.md"))
-	require.NoError(t, err)
-	content := string(raw)
-
-	require.Contains(t, content, "t-01")
-	require.Contains(t, content, "Pending task objective")
-	require.NotContains(t, content, "Define implementation tasks")
-	require.NotContains(t, content, "Add tests for the implementation")
-}
-
-func TestScaffoldGovernedBundleSeedsResearchDraft(t *testing.T) {
-	t.Parallel()
-	root := t.TempDir()
-	change := model.NewChange("add-session-timeout-policy")
-	change.NeedsDiscovery = true
-
-	require.NoError(t, ScaffoldGovernedBundleForChangeWithContext(root, change, "", model.ProjectContext{}))
-
-	raw, err := os.ReadFile(filepath.Join(root, "artifacts", "changes", change.Slug, "research.md"))
-	require.NoError(t, err)
-	content := string(raw)
-
-	require.Contains(t, content, "Pending investigation")
-	require.NotContains(t, content, "Approach A")
-	require.Contains(t, content, "## Alternatives Considered")
-}
-
-func TestScaffoldGovernedBundleSeedsResearchSectionBodies(t *testing.T) {
-	t.Parallel()
-	root := t.TempDir()
-	change := model.NewChange("add-session-timeout-policy")
-	change.Description = "add session timeout policy"
-	change.NeedsDiscovery = true
-
-	require.NoError(t, ScaffoldGovernedBundleForChangeWithContext(root, change, "", model.ProjectContext{}))
-
-	raw, err := os.ReadFile(filepath.Join(root, "artifacts", "changes", change.Slug, "research.md"))
-	require.NoError(t, err)
-	content := string(raw)
-
-	assert.Contains(t, content, "## Unknowns")
-	assert.Contains(t, content, "## Assumptions")
-	assert.Contains(t, content, "## Canonical References")
-	assert.NotContains(t, content, "Unresolved technical questions to investigate.")
-	assert.NotContains(t, content, "Assumptions to validate during planning.")
-	assert.NotContains(t, content, "Docs, specs, code paths, and external references that constrain this work.")
-	assert.NotContains(t, content, "session timeout policy")
-}
-
 func TestScaffoldGovernedBundleMarkdownSizeBudget(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
 	change := model.NewChange("add-session-timeout-policy")
 	change.NeedsDiscovery = true
 
-	require.NoError(t, ScaffoldGovernedBundleForChangeWithContext(root, change, "", model.ProjectContext{}))
+	require.NoError(t, ScaffoldGovernedBundleForChange(root, change, ""))
 
 	base := filepath.Join(root, "artifacts", "changes", change.Slug)
 	entries, err := os.ReadDir(base)
@@ -659,237 +581,6 @@ func TestScaffoldGovernedBundleMarkdownSizeBudget(t *testing.T) {
 	}
 
 	assert.LessOrEqual(t, total, 15000, "fresh artifact bundle scaffold must stay structural, not analytical")
-}
-
-func TestSeedRequirementsContainsGuardrailDomain(t *testing.T) {
-	t.Parallel()
-	data := templateData{
-		Slug:            "auth-change",
-		InitialRequest:  "update auth middleware",
-		GuardrailDomain: "auth_authz",
-	}
-	result := seedRequirements(data)
-	assert.Contains(t, result, "REQ-001")
-	assert.Contains(t, result, "REQ-002")
-	assert.Contains(t, result, "auth_authz")
-}
-
-func TestSeedRequirementsFromDocPreservesGuardrailDomain(t *testing.T) {
-	t.Parallel()
-	data := templateData{
-		Slug:            "auth-change",
-		InitialRequest:  "update auth middleware",
-		GuardrailDomain: "auth_authz",
-	}
-	docs := DocSections{
-		Scope: "- update auth middleware",
-	}
-
-	result := seededRequirementsContent(data, docSectionItems(docs.Scope))
-
-	assert.Contains(t, result, "REQ-001")
-	assert.Contains(t, result, "REQ-002")
-	assert.Contains(t, result, "auth_authz")
-}
-
-func TestSeedRequirementsUsesConservativeFallbackForNounPhraseAndDoesNotInventIntentIDs(t *testing.T) {
-	t.Parallel()
-	data := templateData{
-		Slug:           "session-timeout",
-		InitialRequest: "session timeout",
-	}
-
-	result := seedRequirements(data)
-
-	assert.Contains(t, result, "REQ-001")
-	assert.Contains(t, result, "session timeout")
-	assert.NotContains(t, result, "The system MUST session timeout.")
-	assert.NotContains(t, result, "Traces to INT-001.")
-}
-
-func TestSeedTasksContainsOnlyStructuralPlaceholder(t *testing.T) {
-	t.Parallel()
-	data := templateData{
-		Slug:           "my-change",
-		InitialRequest: "fix login timeout",
-	}
-	result := seedTasks(data)
-	assert.Contains(t, result, "t-01")
-	assert.Contains(t, result, "Pending task objective")
-	assert.Contains(t, result, "task_kind: investigation")
-	assert.NotContains(t, result, "t-02")
-	assert.NotContains(t, result, "task_kind: test")
-}
-
-func TestCapitalizeFirstHandlesUnicodePrefix(t *testing.T) {
-	t.Parallel()
-	assert.Equal(t, "Éclair", capitalizeFirst("éclair"))
-}
-
-func TestScaffoldWithDocSectionsEnrichesRequirements(t *testing.T) {
-	t.Parallel()
-	root := t.TempDir()
-	change := model.NewChange("session-timeout")
-	change.Description = "session timeout"
-
-	docs := DocSections{
-		Scope:      "- expire idle sessions after 15 minutes",
-		Acceptance: "- sessions expire after 15 minutes of inactivity",
-	}
-	projectCtx := model.ProjectContext{}
-
-	require.NoError(t, ScaffoldGovernedBundleForChangeWithContextAndDocs(root, change, "", projectCtx, docs))
-
-	raw, err := os.ReadFile(filepath.Join(root, "artifacts", "changes", change.Slug, "requirements.md"))
-	require.NoError(t, err)
-	content := string(raw)
-	assert.Contains(t, content, "15 minutes")
-	assert.Contains(t, content, "REQ-001")
-}
-
-func TestScaffoldWithDocSectionsCreatesRequirementBlockPerScopeItem(t *testing.T) {
-	t.Parallel()
-	root := t.TempDir()
-	change := model.NewChange("session-timeout")
-	change.Description = "session timeout"
-
-	docs := DocSections{
-		Scope: strings.Join([]string{
-			"- expire idle sessions after 15 minutes",
-			"- preserve MFA enforcement for admin sessions",
-		}, "\n"),
-	}
-
-	require.NoError(t, ScaffoldGovernedBundleForChangeWithContextAndDocs(root, change, "", model.ProjectContext{}, docs))
-
-	raw, err := os.ReadFile(filepath.Join(root, "artifacts", "changes", change.Slug, "requirements.md"))
-	require.NoError(t, err)
-
-	blocks := ParseRequirementBlocks(string(raw))
-	require.Len(t, blocks, 2)
-	assert.Equal(t, "REQ-001", blocks[0].StableID)
-	assert.Equal(t, "REQ-002", blocks[1].StableID)
-}
-
-func TestScaffoldWithDocSectionsTreatsWrappedProseScopeAsSingleRequirement(t *testing.T) {
-	t.Parallel()
-	root := t.TempDir()
-	change := model.NewChange("cache-timeout-update")
-	change.Description = "cache timeout update"
-
-	docs := DocSections{
-		Scope: "expire idle cache entries after 15 minutes while preserving middleware contracts\nfor existing auth flows.",
-	}
-
-	require.NoError(t, ScaffoldGovernedBundleForChangeWithContextAndDocs(root, change, "", model.ProjectContext{}, docs))
-
-	requirementsRaw, err := os.ReadFile(filepath.Join(root, "artifacts", "changes", change.Slug, "requirements.md"))
-	require.NoError(t, err)
-	blocks := ParseRequirementBlocks(string(requirementsRaw))
-	require.Len(t, blocks, 1)
-	assert.NotContains(t, string(requirementsRaw), "REQ-002: The system MUST for existing auth flows.")
-
-	tasksRaw, err := os.ReadFile(filepath.Join(root, "artifacts", "changes", change.Slug, "tasks.md"))
-	require.NoError(t, err)
-	assert.NotContains(t, string(tasksRaw), "`t-02` For existing auth flows.")
-}
-
-func TestScaffoldWithDocSectionsTreatsMultiParagraphScopeAsSingleRequirement(t *testing.T) {
-	t.Parallel()
-	root := t.TempDir()
-	change := model.NewChange("session-timeout")
-	change.Description = "session timeout"
-
-	docs := DocSections{
-		Scope: strings.Join([]string{
-			"expire idle sessions after 15 minutes while keeping middleware contracts stable.",
-			"",
-			"Preserve MFA enforcement for admin sessions throughout the change.",
-		}, "\n"),
-	}
-
-	require.NoError(t, ScaffoldGovernedBundleForChangeWithContextAndDocs(root, change, "", model.ProjectContext{}, docs))
-
-	requirementsRaw, err := os.ReadFile(filepath.Join(root, "artifacts", "changes", change.Slug, "requirements.md"))
-	require.NoError(t, err)
-	blocks := ParseRequirementBlocks(string(requirementsRaw))
-	require.Len(t, blocks, 1)
-	assert.Contains(t, strings.ToLower(string(requirementsRaw)), "preserve mfa enforcement")
-
-	tasksRaw, err := os.ReadFile(filepath.Join(root, "artifacts", "changes", change.Slug, "tasks.md"))
-	require.NoError(t, err)
-	assert.NotContains(t, string(tasksRaw), "`t-02` Preserve MFA enforcement for admin sessions throughout the change.")
-}
-
-func TestScaffoldWithDocSectionsTreatsNestedScopeBulletsAsSingleTopLevelRequirement(t *testing.T) {
-	t.Parallel()
-	root := t.TempDir()
-	change := model.NewChange("session-timeout")
-	change.Description = "session timeout"
-
-	docs := DocSections{
-		Scope: strings.Join([]string{
-			"- update session timeout handling",
-			"  - expire idle sessions after 15 minutes",
-			"  - preserve MFA enforcement for admin sessions",
-		}, "\n"),
-	}
-
-	require.NoError(t, ScaffoldGovernedBundleForChangeWithContextAndDocs(root, change, "", model.ProjectContext{}, docs))
-
-	requirementsRaw, err := os.ReadFile(filepath.Join(root, "artifacts", "changes", change.Slug, "requirements.md"))
-	require.NoError(t, err)
-	blocks := ParseRequirementBlocks(string(requirementsRaw))
-	require.Len(t, blocks, 1)
-	assert.Contains(t, string(requirementsRaw), "15 minutes")
-	assert.Contains(t, strings.ToLower(string(requirementsRaw)), "preserve mfa enforcement")
-
-	tasksRaw, err := os.ReadFile(filepath.Join(root, "artifacts", "changes", change.Slug, "tasks.md"))
-	require.NoError(t, err)
-	assert.NotContains(t, string(tasksRaw), "`t-02` Expire idle sessions after 15 minutes")
-	assert.NotContains(t, string(tasksRaw), "`t-03` Preserve MFA enforcement for admin sessions")
-}
-
-func TestScaffoldWithDocSectionsPreservesConstraintPreambleAlongsideListItems(t *testing.T) {
-	t.Parallel()
-	root := t.TempDir()
-	change := model.NewChange("session-timeout")
-	change.Description = "session timeout"
-
-	docs := DocSections{
-		Constraints: strings.Join([]string{
-			"Preserve the existing session revocation semantics.",
-			"- keep existing middleware contract",
-		}, "\n"),
-	}
-
-	require.NoError(t, ScaffoldGovernedBundleForChangeWithContextAndDocs(root, change, "", model.ProjectContext{}, docs))
-
-	decisionRaw, err := os.ReadFile(filepath.Join(root, "artifacts", "changes", change.Slug, "decision.md"))
-	require.NoError(t, err)
-	selectedApproach := strings.TrimSpace(strings.Join(markdownSectionLines(string(decisionRaw), "Selected Approach"), "\n"))
-
-	assert.Contains(t, selectedApproach, "Preserve the existing session revocation semantics.")
-	assert.Contains(t, selectedApproach, "keep existing middleware contract")
-	assert.Contains(t, selectedApproach, "This direction must continue honoring the documented constraints:")
-}
-
-func TestParseDecisionLockedDecisionsIgnoresScaffoldDraftSelectedDirection(t *testing.T) {
-	t.Parallel()
-
-	content := `# Decision
-
-## Alternatives Considered
-` + seedDecision() + `
-
-## Selected Approach
-` + seedDecisionApproach() + `
-
-## Risk
-` + seedDecisionRisk() + `
-`
-
-	assert.Nil(t, ParseDecisionLockedDecisions(content))
 }
 
 func TestParseDecisionLockedDecisionsIgnoresUnconfirmedSeededTextWithoutDraftComment(t *testing.T) {
@@ -951,7 +642,7 @@ func TestScaffoldCustomSchemaWithExternalTemplate(t *testing.T) {
 		{Name: "custom-artifact.md", Template: filepath.Join("templates", "custom-artifact.md")},
 	}
 
-	err := ScaffoldGovernedBundleForChangeWithContext(root, model.NewChange("test-change"), "", model.ProjectContext{}, customSchema)
+	err := ScaffoldGovernedBundleForChange(root, model.NewChange("test-change"), "", customSchema)
 	require.NoError(t, err)
 
 	base := filepath.Join(root, "artifacts", "changes", "test-change")
@@ -969,7 +660,7 @@ func TestScaffoldCustomSchemaFallbackToStub(t *testing.T) {
 		{Name: "my-widget.md"},
 	}
 
-	err := ScaffoldGovernedBundleForChangeWithContext(root, model.NewChange("test-change"), "", model.ProjectContext{}, customSchema)
+	err := ScaffoldGovernedBundleForChange(root, model.NewChange("test-change"), "", customSchema)
 	require.NoError(t, err)
 
 	content, err := os.ReadFile(filepath.Join(root, "artifacts", "changes", "test-change", "my-widget.md"))

--- a/internal/engine/artifact/manager_test.go
+++ b/internal/engine/artifact/manager_test.go
@@ -53,7 +53,7 @@ func TestScaffoldGovernedBundleL2CreatesRequiredFiles(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 }
 
-func TestScaffoldGovernedBundleNeedsDiscoveryAddsResearch(t *testing.T) {
+func TestScaffoldGovernedBundleNeedsDiscoveryDefersResearchAuthoring(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
 	worktreeRoot := t.TempDir()
@@ -64,7 +64,7 @@ func TestScaffoldGovernedBundleNeedsDiscoveryAddsResearch(t *testing.T) {
 	require.NoError(t, ScaffoldGovernedBundleForChange(root, change, ""))
 
 	_, err := os.Stat(filepath.Join(worktreeRoot, "artifacts", "changes", "my-change", "research.md"))
-	require.NoError(t, err)
+	require.ErrorIs(t, err, os.ErrNotExist)
 }
 
 func TestScaffoldGovernedBundleNoDiscoverySkipsResearch(t *testing.T) {
@@ -88,7 +88,7 @@ func TestScaffoldGovernedBundleL1CreatesBundle(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestScaffoldGovernedBundleDiscoveryCreatesResearch(t *testing.T) {
+func TestScaffoldGovernedBundleDiscoveryDefersResearch(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
 
@@ -97,7 +97,7 @@ func TestScaffoldGovernedBundleDiscoveryCreatesResearch(t *testing.T) {
 	require.NoError(t, ScaffoldGovernedBundleForChange(root, change, ""))
 
 	_, err := os.Stat(filepath.Join(root, "artifacts", "changes", change.Slug, "research.md"))
-	require.NoError(t, err)
+	require.ErrorIs(t, err, os.ErrNotExist)
 }
 
 // TestArtifactTemplatesParseUnderEngineParsers pins the instructions exemplars
@@ -106,10 +106,28 @@ func TestScaffoldGovernedBundleDiscoveryCreatesResearch(t *testing.T) {
 // make skill-authored files unparseable (issue #119).
 func TestArtifactTemplatesParseUnderEngineParsers(t *testing.T) {
 	t.Parallel()
-	req, err := RenderArtifactExample("requirements.md")
+	reqTemplate, err := RenderArtifactExample("requirements.md")
 	require.NoError(t, err)
-	assert.NotPanics(t, func() { _ = ParseRequirementBlocks(req) },
-		"requirements template must parse under the requirement parser")
+	assert.Contains(t, reqTemplate, "### Requirement: <short requirement title>",
+		"requirements instructions must keep the format marker the parser expects authors to fill")
+	req := `# Requirements
+
+## Requirements
+
+### Requirement: Authenticated access
+REQ-001: The system MUST reject protected-route requests that do not carry valid credentials.
+
+#### Scenario: Missing credentials
+GIVEN a request without valid credentials
+WHEN it reaches a protected route
+THEN the system returns 401 and does not serve the protected resource.
+`
+	reqBlocks := ParseRequirementBlocks(req)
+	require.Len(t, reqBlocks, 1, "filled requirements example must parse into one block")
+	assert.Equal(t, "Authenticated access", reqBlocks[0].Name)
+	assert.Equal(t, "REQ-001", reqBlocks[0].StableID)
+	assert.Empty(t, RequirementSubstanceBlockers(req),
+		"filled requirements example must satisfy the requirements substance parser")
 
 	tasks, err := RenderArtifactExample("tasks.md")
 	require.NoError(t, err)
@@ -165,10 +183,10 @@ Docs and specs that constrain this work.`
 	template, err := RenderArtifactExample("research.md")
 	require.NoError(t, err)
 	blockers = ResearchStructureBlockers(template)
-	assert.Contains(t, model.ReasonSpecs(blockers), "research_section_placeholder:## Alternatives Considered")
-	assert.Contains(t, model.ReasonSpecs(blockers), "research_section_placeholder:## Unknowns")
-	assert.Contains(t, model.ReasonSpecs(blockers), "research_section_placeholder:## Assumptions")
-	assert.Contains(t, model.ReasonSpecs(blockers), "research_section_placeholder:## Canonical References")
+	require.Len(t, blockers, 1,
+		"comment-only instructions template sections must fail closed at the structure layer")
+	assert.Equal(t, "research_structure_invalid", blockers[0].Code)
+	assert.Contains(t, blockers[0].Detail, "non-empty content")
 
 	legacySeeded := `# Research
 

--- a/internal/engine/artifact/reconcile_projection_test.go
+++ b/internal/engine/artifact/reconcile_projection_test.go
@@ -1,6 +1,7 @@
 package artifact
 
 import (
+	"os"
 	"testing"
 
 	"github.com/signalridge/slipway/internal/model"
@@ -12,7 +13,18 @@ import (
 func TestReconcileFromFilesystemMaterializesRequiredArtifactsFromDisk(t *testing.T) {
 	root := t.TempDir()
 	slug := "test-change"
-	require.NoError(t, ScaffoldGovernedBundleForChangeWithContext(root, model.NewChange(slug), "", model.ProjectContext{}))
+	require.NoError(t, ScaffoldGovernedBundleForChange(root, model.NewChange(slug), ""))
+
+	// requirements.md is authored directly by the host skill, not scaffolded by
+	// the engine (issue #119). Write it to disk to simulate that authoring so the
+	// test still proves reconcile materializes an on-disk artifact's hash.
+	bundleDir, err := state.GovernedBundleDir(root, model.Change{Slug: slug})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(
+		ResolveArtifactPath(bundleDir, "requirements.md"),
+		[]byte("# Requirements\n### Requirement: Authored on disk\nREQ-001: The system MUST do the thing.\n"),
+		0o644,
+	))
 
 	change := &model.Change{
 		Slug:      slug,
@@ -25,8 +37,6 @@ func TestReconcileFromFilesystemMaterializesRequiredArtifactsFromDisk(t *testing
 	req, ok := change.Artifacts["requirements"]
 	require.True(t, ok)
 	assert.Equal(t, model.ArtifactLifecycleDraft, req.State)
-	bundleDir, err := state.GovernedBundleDir(root, *change)
-	require.NoError(t, err)
 	assert.Equal(t, ResolveArtifactPath(bundleDir, "requirements.md"), req.Path)
 	assert.NotEmpty(t, req.ContentHash)
 

--- a/internal/engine/artifact/requirements.go
+++ b/internal/engine/artifact/requirements.go
@@ -46,16 +46,48 @@ var requirementsPlaceholderPhrases = []string{
 	"define requirements based on the initial request",
 }
 
+// instructionPlaceholderPhrases are literal placeholders emitted by
+// `slipway instructions` examples. They are safe to reject in authored artifact
+// substance because the templates explicitly say every <...> token must be
+// replaced before the file can satisfy governance.
+var instructionPlaceholderPhrases = []string{
+	"<short requirement title>",
+	"<required behavior>",
+	"<scenario name>",
+	"<precondition>",
+	"<triggering action>",
+	"<observable expected outcome>",
+	"<concrete task objective>",
+	"<path/to/file.go>",
+}
+
+// LooksLikeInstructionPlaceholder reports whether text still contains a literal
+// placeholder copied from a `slipway instructions` template.
+func LooksLikeInstructionPlaceholder(text string) bool {
+	lower := strings.ToLower(text)
+	for _, phrase := range instructionPlaceholderPhrases {
+		if strings.Contains(lower, phrase) {
+			return true
+		}
+	}
+	return false
+}
+
 // LooksLikeRequirementsPlaceholder reports whether text still carries the
 // engine's requirements scaffold seed — a requirements-specific seed marker or
-// one of the legacy fabricated GIVEN/WHEN/THEN tautology lines. It is
-// deliberately NARROWER than LooksLikeTemplatePlaceholder: it does not match the
-// generic decision/research/task sentinels, so authored requirement prose that
-// shares a phrase with those seeds is not rejected (issue #91 — avoid false
-// positives that block real work). The requirements substance gate uses this
-// matcher; LooksLikeTemplatePlaceholder remains a superset that folds these in
-// for the decision/runtime and task-objective paths.
+// one of the legacy fabricated GIVEN/WHEN/THEN tautology lines. It also rejects
+// literal `slipway instructions` placeholders such as `<required behavior>`,
+// which are not authored substance. It is deliberately NARROWER than
+// LooksLikeTemplatePlaceholder: it does not match the generic decision/research
+// sentinels, so authored requirement prose that shares a phrase with those seeds
+// is not rejected (issue #91 — avoid false positives that block real work). The
+// requirements substance gate uses this matcher; LooksLikeTemplatePlaceholder
+// remains a superset that folds these in for the decision/runtime and
+// task-objective paths.
 func LooksLikeRequirementsPlaceholder(text string) bool {
+	if LooksLikeInstructionPlaceholder(text) {
+		return true
+	}
 	lower := strings.ToLower(text)
 	for _, phrase := range requirementsPlaceholderPhrases {
 		if strings.Contains(lower, phrase) {

--- a/internal/engine/artifact/requirements.go
+++ b/internal/engine/artifact/requirements.go
@@ -4,6 +4,8 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+
+	"github.com/signalridge/slipway/internal/stringutil"
 )
 
 var (
@@ -68,6 +70,10 @@ func LooksLikeRequirementsPlaceholder(text string) bool {
 	return false
 }
 
+func stripRequirementGuidanceComments(content string) string {
+	return stringutil.StripHTMLComments(content)
+}
+
 // requirementHeading is a recognized "### Requirement: <name>" heading.
 type requirementHeading struct {
 	line int
@@ -102,6 +108,7 @@ type RequirementBlock struct {
 
 // ParseRequirementBlocks extracts requirement headings and their first stable REQ-* ID.
 func ParseRequirementBlocks(content string) []RequirementBlock {
+	content = stripRequirementGuidanceComments(content)
 	lines := strings.Split(strings.ReplaceAll(content, "\r\n", "\n"), "\n")
 	headings := requirementHeadingsIn(lines)
 
@@ -134,6 +141,7 @@ func RequirementBlocksMissingStableIDs(content string) []string {
 
 // ExtractRequirementStableIDs returns the unique stable REQ-* IDs found in content.
 func ExtractRequirementStableIDs(content string) []string {
+	content = stripRequirementGuidanceComments(content)
 	matches := requirementIDPattern.FindAllStringSubmatch(content, -1)
 	seen := map[string]struct{}{}
 	ids := make([]string, 0, len(matches))

--- a/internal/engine/artifact/requirements_contract.go
+++ b/internal/engine/artifact/requirements_contract.go
@@ -37,7 +37,7 @@ type RequirementsContractResult struct {
 	Message string
 }
 
-func EvaluateRequirementsContract(bundleDir, slug string) (RequirementsContractResult, error) {
+func EvaluateRequirementsContract(bundleDir string) (RequirementsContractResult, error) {
 	sourcePath := ResolveArtifactPath(bundleDir, "requirements.md")
 	if _, err := os.Stat(sourcePath); err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
@@ -95,8 +95,8 @@ func EvaluateRequirementsContract(bundleDir, slug string) (RequirementsContractR
 	}, nil
 }
 
-// RequirementSubstanceBlockers returns substance problems in requirements.md
-// beyond structure: template/seed placeholder content, a requirement body with
+// RequirementSubstanceBlockers returns substance problems in requirements.md: no
+// Requirement blocks, template/seed placeholder content, a requirement body with
 // no RFC-2119 MUST/SHALL/REQUIRED keyword, or a requirement without a concrete
 // GIVEN/WHEN/THEN scenario. An empty slice means the requirements carry real
 // substance. This is the gate that stops a mechanical scaffold from reaching
@@ -108,12 +108,17 @@ func EvaluateRequirementsContract(bundleDir, slug string) (RequirementsContractR
 // in "pending investigation" status — is not false-flagged (issue #91: avoid
 // false positives that block real work).
 func RequirementSubstanceBlockers(content string) []string {
+	content = stripRequirementGuidanceComments(content)
 	var blockers []string
 	if LooksLikeRequirementsPlaceholder(content) {
 		blockers = append(blockers,
 			"contains template/seed placeholder content; author concrete requirements")
 	}
-	for _, block := range splitRequirementBlocksForSubstance(content) {
+	blocks := splitRequirementBlocksForSubstance(content)
+	if len(blocks) == 0 {
+		blockers = append(blockers, "requirements.md declares no Requirement blocks; author concrete requirements")
+	}
+	for _, block := range blocks {
 		label := block.stableID
 		if label == "" {
 			label = block.name

--- a/internal/engine/artifact/requirements_contract_test.go
+++ b/internal/engine/artifact/requirements_contract_test.go
@@ -143,6 +143,20 @@ THEN pending — replace with the observable expected outcome
 `,
 			wantMessage: "placeholder content",
 		},
+		{
+			name: "copied instructions placeholders",
+			content: `# Requirements
+
+### Requirement: <short requirement title>
+REQ-001: The system MUST <required behavior>.
+
+#### Scenario: <scenario name>
+GIVEN <precondition>
+WHEN <triggering action>
+THEN <observable expected outcome>
+`,
+			wantMessage: "placeholder content",
+		},
 	}
 
 	for _, tt := range tests {
@@ -170,6 +184,8 @@ func TestLooksLikeTemplatePlaceholderRecognizesRequirementsTautologies(t *testin
 		"WHEN the requirement is implemented in the target flow",
 		"Define requirements based on the initial request: foo.",
 		"Pending — replace with the normative requirement.",
+		"<required behavior>",
+		"<path/to/file.go>",
 	} {
 		assert.True(t, LooksLikeTemplatePlaceholder(s), "should detect placeholder: %q", s)
 	}

--- a/internal/engine/artifact/requirements_contract_test.go
+++ b/internal/engine/artifact/requirements_contract_test.go
@@ -28,7 +28,7 @@ WHEN it reaches a protected route
 THEN the system returns 401 and does not serve the resource.
 `), 0o644))
 
-	result, err := EvaluateRequirementsContract(bundleDir, slug)
+	result, err := EvaluateRequirementsContract(bundleDir)
 	require.NoError(t, err)
 	assert.Equal(t, RequirementsContractStatusValid, result.Status)
 	assert.Equal(t, ResolveArtifactPath(bundleDir, "requirements.md"), result.Source)
@@ -43,11 +43,28 @@ func TestEvaluateRequirementsContractReturnsMissingResult(t *testing.T) {
 	bundleDir := filepath.Join(root, "artifacts", "changes", slug)
 	require.NoError(t, os.MkdirAll(bundleDir, 0o755))
 
-	result, err := EvaluateRequirementsContract(bundleDir, slug)
+	result, err := EvaluateRequirementsContract(bundleDir)
 	require.NoError(t, err)
 	assert.Equal(t, RequirementsContractStatusMissing, result.Status)
 	assert.Equal(t, ResolveArtifactPath(bundleDir, "requirements.md"), result.Source)
 	assert.Contains(t, result.Message, "missing")
+}
+
+func TestEvaluateRequirementsContractRejectsInstructionsTemplate(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	slug := "example-change"
+	bundleDir := filepath.Join(root, "artifacts", "changes", slug)
+	require.NoError(t, os.MkdirAll(bundleDir, 0o755))
+	template, err := RenderArtifactExample("requirements.md")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "requirements.md"), []byte(template), 0o644))
+
+	result, err := EvaluateRequirementsContract(bundleDir)
+	require.NoError(t, err)
+	assert.Equal(t, RequirementsContractStatusInvalid, result.Status)
+	assert.Contains(t, result.Message, "no Requirement blocks found")
 }
 
 func TestEvaluateRequirementsContractReturnsInvalidResults(t *testing.T) {
@@ -136,7 +153,7 @@ THEN pending — replace with the observable expected outcome
 			require.NoError(t, os.MkdirAll(bundleDir, 0o755))
 			require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "requirements.md"), []byte(tt.content), 0o644))
 
-			result, err := EvaluateRequirementsContract(bundleDir, slug)
+			result, err := EvaluateRequirementsContract(bundleDir)
 			require.NoError(t, err)
 			assert.Equal(t, RequirementsContractStatusInvalid, result.Status)
 			assert.Equal(t, ResolveArtifactPath(bundleDir, "requirements.md"), result.Source)
@@ -218,6 +235,11 @@ THEN the expected behavior for an expired token is a 401 response.
 	assert.Empty(t, RequirementSubstanceBlockers(concreteExpectedBehavior),
 		"a concrete 'expected behavior for' scenario must not be treated as placeholder")
 
+	template, err := RenderArtifactExample("requirements.md")
+	require.NoError(t, err)
+	assert.NotEmpty(t, RequirementSubstanceBlockers(template),
+		"instructions template comments must not satisfy the requirements gate")
+
 	mechanical := `# Requirements
 ### Requirement: do the thing
 REQ-001: Pending — replace with the normative requirement. Define requirements based on the initial request.
@@ -278,7 +300,7 @@ func TestEvaluateRequirementsContractReturnsErrorForUnreadableFile(t *testing.T)
 		_ = os.RemoveAll(reqPath)
 	})
 
-	_, err := EvaluateRequirementsContract(bundleDir, slug)
+	_, err := EvaluateRequirementsContract(bundleDir)
 	require.Error(t, err)
 }
 

--- a/internal/engine/artifact/tasks_contract.go
+++ b/internal/engine/artifact/tasks_contract.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/signalridge/slipway/internal/engine/wave"
+	"github.com/signalridge/slipway/internal/stringutil"
 )
 
 // TasksContractStatus mirrors RequirementsContractStatus for tasks.md.
@@ -31,7 +32,7 @@ type TasksContractResult struct {
 // engine's placeholder objectives ("Pending task objective" / "Pending
 // verification objective") is the mechanical scaffold the authoring skill must
 // replace (issue #91). The engine owns structure; the skill owns substance.
-func EvaluateTasksContract(bundleDir, slug string) (TasksContractResult, error) {
+func EvaluateTasksContract(bundleDir string) (TasksContractResult, error) {
 	sourcePath := ResolveArtifactPath(bundleDir, "tasks.md")
 	if _, err := os.Stat(sourcePath); err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
@@ -73,6 +74,7 @@ func EvaluateTasksContract(bundleDir, slug string) (TasksContractResult, error) 
 // judged. A tasks.md that is empty, fails to parse, declares no task, or carries
 // an empty/placeholder objective is rejected.
 func TaskSubstanceBlockers(content string) []string {
+	content = stringutil.StripHTMLComments(content)
 	if strings.TrimSpace(content) == "" {
 		return []string{"tasks.md is empty"}
 	}
@@ -98,6 +100,14 @@ func TaskSubstanceBlockers(content string) []string {
 		if LooksLikeTemplatePlaceholder(objective) {
 			blockers = append(blockers, fmt.Sprintf(
 				"task %s has a placeholder objective (%q); author a concrete objective", id, objective))
+		}
+		// Every task must name the files or evidence targets that bound its
+		// execution scope. target_files feeds plan readiness, scope-contract
+		// checks, freshness digests, and wave evidence; treating it as code-only
+		// would let tasks_contract report valid while the hard plan gate blocks.
+		if len(task.TargetFiles) == 0 {
+			blockers = append(blockers, fmt.Sprintf(
+				"task %s lists no target_files; name the files or evidence targets that bound it", id))
 		}
 	}
 	return blockers

--- a/internal/engine/artifact/tasks_contract.go
+++ b/internal/engine/artifact/tasks_contract.go
@@ -108,6 +108,14 @@ func TaskSubstanceBlockers(content string) []string {
 		if len(task.TargetFiles) == 0 {
 			blockers = append(blockers, fmt.Sprintf(
 				"task %s lists no target_files; name the files or evidence targets that bound it", id))
+		} else {
+			for _, file := range task.TargetFiles {
+				target := strings.TrimSpace(file)
+				if LooksLikeInstructionPlaceholder(target) {
+					blockers = append(blockers, fmt.Sprintf(
+						"task %s has a placeholder target_files entry (%q); name concrete files or evidence targets", id, target))
+				}
+			}
 		}
 	}
 	return blockers

--- a/internal/engine/artifact/tasks_contract_test.go
+++ b/internal/engine/artifact/tasks_contract_test.go
@@ -17,6 +17,10 @@ func TestTaskSubstanceBlockers(t *testing.T) {
 	mechanical := "# Tasks\n## Task List\n- [ ] `t-01` Pending task objective\n  - wave: 1\n  - covers: [REQ-001]\n"
 	assert.NotEmpty(t, TaskSubstanceBlockers(mechanical), "placeholder objective must be rejected")
 
+	copiedInstructionObjective := "# Tasks\n## Task List\n- [ ] `t-01` <concrete task objective>\n  - wave: 1\n  - target_files: [\"internal/engine/artifact/tasks_contract.go\"]\n  - covers: [REQ-001]\n"
+	assert.NotEmpty(t, TaskSubstanceBlockers(copiedInstructionObjective),
+		"copied instructions objective placeholder must be rejected")
+
 	authored := "# Tasks\n## Task List\n- [ ] `t-01` Implement the substance gate in requirements_contract.go\n  - wave: 1\n  - target_files: [\"internal/engine/artifact/requirements_contract.go\"]\n  - covers: [REQ-001]\n"
 	assert.Empty(t, TaskSubstanceBlockers(authored), "authored tasks must pass")
 
@@ -58,6 +62,12 @@ func TestTaskSubstanceBlockers(t *testing.T) {
 	require.Len(t, verificationNoTargetsBlockers, 1, "a non-code task with no target_files yields exactly the target_files blocker")
 	assert.Contains(t, verificationNoTargetsBlockers[0], "target_files",
 		"the blocker must name the missing target_files")
+
+	placeholderTargets := "# Tasks\n## Task List\n- [ ] `t-01` Implement the parser-based code gate in tasks_contract.go\n  - wave: 1\n  - target_files: [<path/to/file.go>]\n  - task_kind: code\n  - covers: [REQ-001]\n"
+	placeholderTargetBlockers := TaskSubstanceBlockers(placeholderTargets)
+	require.Len(t, placeholderTargetBlockers, 1, "a placeholder target_files entry yields exactly the target_files blocker")
+	assert.Contains(t, placeholderTargetBlockers[0], "placeholder target_files",
+		"the blocker must name the copied target_files placeholder")
 
 	template, err := RenderArtifactExample("tasks.md")
 	require.NoError(t, err)
@@ -149,5 +159,14 @@ func TestEvaluateTasksContract(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, TasksContractStatusInvalid, res.Status)
 		assert.Contains(t, res.Message, "target_files")
+	})
+
+	t.Run("invalid placeholder target_files", func(t *testing.T) {
+		t.Parallel()
+		bundleDir := write(t, "# Tasks\n## Task List\n- [ ] `t-01` Implement target_files placeholder rejection\n  - wave: 1\n  - target_files: [<path/to/file.go>]\n  - task_kind: code\n  - covers: [REQ-001]\n")
+		res, err := EvaluateTasksContract(bundleDir)
+		require.NoError(t, err)
+		assert.Equal(t, TasksContractStatusInvalid, res.Status)
+		assert.Contains(t, res.Message, "placeholder target_files")
 	})
 }

--- a/internal/engine/artifact/tasks_contract_test.go
+++ b/internal/engine/artifact/tasks_contract_test.go
@@ -36,12 +36,39 @@ func TestTaskSubstanceBlockers(t *testing.T) {
 	// rather than silently passing.
 	malformed := "# Tasks\n\n## Task List\n\n- [ ] `t-01` Do the thing\n  - bogus_key: nope\n"
 	assert.NotEmpty(t, TaskSubstanceBlockers(malformed), "unparseable tasks.md must be rejected")
+
+	// issue #119: target_files are a kind-agnostic execution/scope boundary.
+	// This code task is just the smallest fixture for the missing-target case.
+	// The objective is concrete, so the target_files blocker is the only one.
+	codeNoTargets := "# Tasks\n## Task List\n- [ ] `t-01` Implement the parser-based code gate in tasks_contract.go\n  - wave: 1\n  - task_kind: code\n  - covers: [REQ-001]\n"
+	codeNoTargetsBlockers := TaskSubstanceBlockers(codeNoTargets)
+	require.Len(t, codeNoTargetsBlockers, 1, "a code task with no target_files yields exactly the target_files blocker")
+	assert.Contains(t, codeNoTargetsBlockers[0], "target_files",
+		"the blocker must name the missing target_files")
+
+	// The same code task passes once it names the files it will change.
+	codeWithTargets := "# Tasks\n## Task List\n- [ ] `t-01` Implement the parser-based code gate in tasks_contract.go\n  - wave: 1\n  - target_files: [\"internal/engine/artifact/tasks_contract.go\"]\n  - task_kind: code\n  - covers: [REQ-001]\n"
+	assert.Empty(t, TaskSubstanceBlockers(codeWithTargets), "a code task naming target_files must pass")
+
+	// target_files are the execution/scope boundary for every task kind, not
+	// just code tasks. A verification task with no target_files would otherwise
+	// make the contract view say "valid" while plan readiness blocks it.
+	verificationNoTargets := "# Tasks\n## Task List\n- [ ] `t-01` Verify the code gate rejects an empty target_files list\n  - wave: 1\n  - task_kind: verification\n  - covers: [REQ-001]\n"
+	verificationNoTargetsBlockers := TaskSubstanceBlockers(verificationNoTargets)
+	require.Len(t, verificationNoTargetsBlockers, 1, "a non-code task with no target_files yields exactly the target_files blocker")
+	assert.Contains(t, verificationNoTargetsBlockers[0], "target_files",
+		"the blocker must name the missing target_files")
+
+	template, err := RenderArtifactExample("tasks.md")
+	require.NoError(t, err)
+	assert.Contains(t, template, "<!--", "regression fixture should exercise authoring guidance comments")
+	assert.NotEmpty(t, TaskSubstanceBlockers(template), "instructions template comments must not satisfy the tasks gate")
 }
 
 func TestEvaluateTasksContract(t *testing.T) {
 	t.Parallel()
 
-	write := func(t *testing.T, content string) (string, string) {
+	write := func(t *testing.T, content string) string {
 		t.Helper()
 		root := t.TempDir()
 		slug := "tasks-contract"
@@ -50,21 +77,21 @@ func TestEvaluateTasksContract(t *testing.T) {
 		if content != "" {
 			require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "tasks.md"), []byte(content), 0o644))
 		}
-		return bundleDir, slug
+		return bundleDir
 	}
 
 	t.Run("missing", func(t *testing.T) {
 		t.Parallel()
-		bundleDir, slug := write(t, "")
-		res, err := EvaluateTasksContract(bundleDir, slug)
+		bundleDir := write(t, "")
+		res, err := EvaluateTasksContract(bundleDir)
 		require.NoError(t, err)
 		assert.Equal(t, TasksContractStatusMissing, res.Status)
 	})
 
 	t.Run("invalid placeholder", func(t *testing.T) {
 		t.Parallel()
-		bundleDir, slug := write(t, "# Tasks\n## Task List\n- [ ] `t-01` Pending task objective\n  - wave: 1\n  - covers: [REQ-001]\n")
-		res, err := EvaluateTasksContract(bundleDir, slug)
+		bundleDir := write(t, "# Tasks\n## Task List\n- [ ] `t-01` Pending task objective\n  - wave: 1\n  - covers: [REQ-001]\n")
+		res, err := EvaluateTasksContract(bundleDir)
 		require.NoError(t, err)
 		assert.Equal(t, TasksContractStatusInvalid, res.Status)
 		assert.Contains(t, res.Message, "placeholder")
@@ -72,26 +99,55 @@ func TestEvaluateTasksContract(t *testing.T) {
 
 	t.Run("valid authored", func(t *testing.T) {
 		t.Parallel()
-		bundleDir, slug := write(t, "# Tasks\n## Task List\n- [ ] `t-01` Implement the tasks substance validator and wire it into validate\n  - wave: 1\n  - target_files: [\"internal/engine/artifact/tasks_contract.go\"]\n  - covers: [REQ-001]\n")
-		res, err := EvaluateTasksContract(bundleDir, slug)
+		bundleDir := write(t, "# Tasks\n## Task List\n- [ ] `t-01` Implement the tasks substance validator and wire it into validate\n  - wave: 1\n  - target_files: [\"internal/engine/artifact/tasks_contract.go\"]\n  - covers: [REQ-001]\n")
+		res, err := EvaluateTasksContract(bundleDir)
 		require.NoError(t, err)
 		assert.Equal(t, TasksContractStatusValid, res.Status)
 	})
 
 	t.Run("valid authored keeping guidance comment", func(t *testing.T) {
 		t.Parallel()
-		bundleDir, slug := write(t, "# Tasks\n\n## Task List\n\n<!--\nReplace the seeded placeholder objective below; a placeholder tasks list\n(\"Pending task objective\") is rejected by the tasks substance gate.\n-->\n\n- [ ] `t-01` Implement the tasks substance validator and wire it into validate\n  - wave: 1\n  - target_files: [\"internal/engine/artifact/tasks_contract.go\"]\n  - covers: [REQ-001]\n")
-		res, err := EvaluateTasksContract(bundleDir, slug)
+		bundleDir := write(t, "# Tasks\n\n## Task List\n\n<!--\nReplace the seeded placeholder objective below; a placeholder tasks list\n(\"Pending task objective\") is rejected by the tasks substance gate.\n-->\n\n- [ ] `t-01` Implement the tasks substance validator and wire it into validate\n  - wave: 1\n  - target_files: [\"internal/engine/artifact/tasks_contract.go\"]\n  - covers: [REQ-001]\n")
+		res, err := EvaluateTasksContract(bundleDir)
 		require.NoError(t, err)
 		assert.Equal(t, TasksContractStatusValid, res.Status)
 	})
 
 	t.Run("invalid no checklist task", func(t *testing.T) {
 		t.Parallel()
-		bundleDir, slug := write(t, "# Tasks\n\n## Task List\n\nThe author will do the work later.\n")
-		res, err := EvaluateTasksContract(bundleDir, slug)
+		bundleDir := write(t, "# Tasks\n\n## Task List\n\nThe author will do the work later.\n")
+		res, err := EvaluateTasksContract(bundleDir)
 		require.NoError(t, err)
 		assert.Equal(t, TasksContractStatusInvalid, res.Status)
 		assert.Contains(t, res.Message, "no checklist task")
+	})
+
+	t.Run("invalid instructions template", func(t *testing.T) {
+		t.Parallel()
+		template, err := RenderArtifactExample("tasks.md")
+		require.NoError(t, err)
+		bundleDir := write(t, template)
+		res, err := EvaluateTasksContract(bundleDir)
+		require.NoError(t, err)
+		assert.Equal(t, TasksContractStatusInvalid, res.Status)
+		assert.Contains(t, res.Message, "no checklist task")
+	})
+
+	t.Run("invalid code task missing target_files", func(t *testing.T) {
+		t.Parallel()
+		bundleDir := write(t, "# Tasks\n## Task List\n- [ ] `t-01` Implement the parser-based code gate in tasks_contract.go\n  - wave: 1\n  - task_kind: code\n  - covers: [REQ-001]\n")
+		res, err := EvaluateTasksContract(bundleDir)
+		require.NoError(t, err)
+		assert.Equal(t, TasksContractStatusInvalid, res.Status)
+		assert.Contains(t, res.Message, "target_files")
+	})
+
+	t.Run("invalid verification task missing target_files", func(t *testing.T) {
+		t.Parallel()
+		bundleDir := write(t, "# Tasks\n## Task List\n- [ ] `t-01` Verify target_files contract parity\n  - wave: 1\n  - task_kind: verification\n  - covers: [REQ-001]\n")
+		res, err := EvaluateTasksContract(bundleDir)
+		require.NoError(t, err)
+		assert.Equal(t, TasksContractStatusInvalid, res.Status)
+		assert.Contains(t, res.Message, "target_files")
 	})
 }

--- a/internal/engine/gate/gate.go
+++ b/internal/engine/gate/gate.go
@@ -34,6 +34,7 @@ func EvaluateGScope(
 	researchContent string,
 	discoveryEvidenceOK bool,
 	worktreeValidationReasons []model.ReasonCode,
+	researchArtifactReasons ...model.ReasonCode,
 ) GateEvaluation {
 	reasonCodes := []model.ReasonCode{}
 	if change.NeedsDiscovery {
@@ -41,7 +42,9 @@ func EvaluateGScope(
 			reasonCodes = append(reasonCodes, model.NewReasonCode("missing_discovery_evidence", ""))
 		}
 
-		if blockers := artifact.ResearchStructureBlockers(researchContent); len(blockers) > 0 {
+		if len(researchArtifactReasons) > 0 {
+			reasonCodes = append(reasonCodes, researchArtifactReasons...)
+		} else if blockers := artifact.ResearchStructureBlockers(researchContent); len(blockers) > 0 {
 			reasonCodes = append(reasonCodes, blockers...)
 		}
 

--- a/internal/engine/progression/advance_governed.go
+++ b/internal/engine/progression/advance_governed.go
@@ -15,7 +15,6 @@ import (
 	"github.com/signalridge/slipway/internal/engine/governance"
 	"github.com/signalridge/slipway/internal/model"
 	"github.com/signalridge/slipway/internal/state"
-	"github.com/signalridge/slipway/internal/stringutil"
 )
 
 const planAuditLastCheckerFeedbackKey = "plan_audit.last_checker_feedback"
@@ -537,38 +536,7 @@ func ensureGovernedBundleScaffolded(root string, change *model.Change) error {
 	if err != nil {
 		return err
 	}
-	projectCtx := change.ProjectContext
-	if projectCtx.IsZero() {
-		projectCtx = InferProjectContext(root)
-	}
-	docs, err := docSectionsFromIntent(root, *change)
-	if err != nil {
-		return fmt.Errorf("extracting doc sections from intent: %w", err)
-	}
-	if docs.Scope != "" || docs.Constraints != "" || docs.Acceptance != "" {
-		return artifact.ScaffoldGovernedBundleForChangeWithContextAndDocs(root, *change, policy.EffectivePreset, projectCtx, docs, resolution.Schema)
-	}
-	return artifact.ScaffoldGovernedBundleForChangeWithContext(root, *change, policy.EffectivePreset, projectCtx, resolution.Schema)
-}
-
-func docSectionsFromIntent(root string, change model.Change) (artifact.DocSections, error) {
-	paths, err := state.ResolveChangePaths(root, change)
-	if err != nil {
-		return artifact.DocSections{}, err
-	}
-	intentPath := filepath.Join(paths.GovernedBundleDir, "intent.md")
-	data, err := os.ReadFile(intentPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return artifact.DocSections{}, nil
-		}
-		return artifact.DocSections{}, err
-	}
-	return artifact.DocSections{
-		Scope:       stringutil.LastMarkdownSectionContent(string(data), "## In Scope"),
-		Constraints: stringutil.LastMarkdownSectionContent(string(data), "## Constraints"),
-		Acceptance:  stringutil.LastMarkdownSectionContent(string(data), "## Acceptance Signals"),
-	}, nil
+	return artifact.ScaffoldGovernedBundleForChange(root, *change, policy.EffectivePreset, resolution.Schema)
 }
 
 // ComputeNextGovernedState determines the next workflow state for a governed change.
@@ -960,6 +928,11 @@ func EvaluatePlanGate(root string, change model.Change, passingSkills map[string
 	if len(checklistBlockers) > 0 {
 		bundleReady = false
 		planBlockers = append(planBlockers, model.ReasonCodesFromSpecs(checklistBlockers)...)
+	}
+	decisionBlockers := DecisionContractBlockers(root, change)
+	if len(decisionBlockers) > 0 {
+		bundleReady = false
+		planBlockers = append(planBlockers, model.ReasonCodesFromSpecs(decisionBlockers)...)
 	}
 	return gate.EvaluateGPlan(bundleReady, planAuditPass, planBlockers)
 }

--- a/internal/engine/progression/advance_governed.go
+++ b/internal/engine/progression/advance_governed.go
@@ -138,7 +138,8 @@ func AdvanceGoverned(root, slug string, opts ...AdvanceOptions) (summary Advance
 
 	preTransitionSideEffects := make([]SideEffect, 0, 2)
 
-	// Ensure research artifact exists for discovery changes entering S1_PLAN/research.
+	// Ensure the bundle directory exists for discovery changes entering
+	// S1_PLAN/research; research.md itself is authored by research-orchestration.
 	isResearchEntry := fromState == model.StateS1Plan && change.PlanSubStep == model.PlanSubStepResearch
 	if isResearchEntry && change.NeedsDiscovery {
 		if err := artifact.EnsureResearchArtifactForChange(root, change); err != nil {
@@ -952,8 +953,15 @@ func EvaluateScopeGate(root string, change model.Change, passingSkills map[strin
 	}
 	researchPath := filepath.Join(paths.GovernedBundleDir, "research.md")
 	researchContent := ""
+	var researchArtifactReasons []model.ReasonCode
 	if data, err := os.ReadFile(researchPath); err == nil {
 		researchContent = string(data)
+	} else if os.IsNotExist(err) {
+		researchArtifactReasons = append(researchArtifactReasons,
+			model.NewReasonCode("missing_required_artifact", "research.md"))
+	} else {
+		researchArtifactReasons = append(researchArtifactReasons,
+			model.NewReasonCode("required_artifact_unreadable", "research.md"))
 	}
 
 	_, discoveryOK := passingSkills[SkillResearchOrchestration]
@@ -969,5 +977,5 @@ func EvaluateScopeGate(root string, change model.Change, passingSkills map[strin
 			return gate.GateEvaluation{}, wtErr
 		}
 	}
-	return gate.EvaluateGScope(change, researchContent, discoveryOK, worktreeReasons), nil
+	return gate.EvaluateGScope(change, researchContent, discoveryOK, worktreeReasons, researchArtifactReasons...), nil
 }

--- a/internal/engine/progression/advance_intake.go
+++ b/internal/engine/progression/advance_intake.go
@@ -254,8 +254,8 @@ func enterPlanningFromIntake(root string, change *model.Change, clearResearchEvi
 			return nil, nil, err
 		}
 		sideEffects = append(sideEffects, SideEffect{
-			Kind:   "scaffolded_research",
-			Detail: "research.md created or verified for S1_PLAN/research",
+			Kind:   "deferred_research_authoring",
+			Detail: "research.md will be authored by research-orchestration via slipway instructions research",
 		})
 	}
 	return sideEffects, cleared, nil

--- a/internal/engine/progression/advance_test.go
+++ b/internal/engine/progression/advance_test.go
@@ -49,86 +49,6 @@ func TestAdvance_NoChangeFile(t *testing.T) {
 	}
 }
 
-func TestEnsureGovernedBundleScaffoldedSeedsFromConfirmedIntent(t *testing.T) {
-	t.Parallel()
-
-	root := t.TempDir()
-	change := model.NewChange("ci-release-maintenance")
-	change.Description = "add CI release and maintenance workflow support"
-	change.WorkflowPreset = model.WorkflowPresetStandard
-	change.ProjectContext = model.ProjectContext{
-		TechStack: "Go, GitHub Actions",
-		TestCmd:   "go test ./...",
-		BuildCmd:  "go build ./...",
-		Languages: []string{"Go"},
-	}
-
-	bundleDir, err := state.GovernedBundleDir(root, change)
-	if err != nil {
-		t.Fatalf("bundle dir: %v", err)
-	}
-	if err := os.MkdirAll(bundleDir, 0o755); err != nil {
-		t.Fatalf("mkdir bundle: %v", err)
-	}
-	intent := `# Intent
-
-## Summary
-Add CI, release, and maintenance automation.
-
-## In Scope
-- add GitHub Actions CI workflow coverage
-- add release-please and GoReleaser release automation
-
-## Out of Scope
-- configure real publishing secrets
-
-## Constraints
-- keep CLI runtime behavior unchanged
-
-## Acceptance Signals
-- go test ./...
-- go build ./...
-
-## Approved Summary
-Confirmed scope.
-`
-	if err := os.WriteFile(filepath.Join(bundleDir, "intent.md"), []byte(intent), 0o644); err != nil {
-		t.Fatalf("write intent: %v", err)
-	}
-
-	if err := ensureGovernedBundleScaffolded(root, &change); err != nil {
-		t.Fatalf("ensure bundle scaffolded: %v", err)
-	}
-
-	requirementsRaw, err := os.ReadFile(filepath.Join(bundleDir, "requirements.md"))
-	if err != nil {
-		t.Fatalf("read requirements: %v", err)
-	}
-	requirements := strings.ToLower(string(requirementsRaw))
-	if !strings.Contains(requirements, "github actions ci workflow coverage") {
-		t.Fatalf("requirements not seeded from intent scope:\n%s", string(requirementsRaw))
-	}
-	if !strings.Contains(string(requirementsRaw), "Tech Stack: Go, GitHub Actions") {
-		t.Fatalf("requirements did not preserve project context:\n%s", string(requirementsRaw))
-	}
-
-	decisionRaw, err := os.ReadFile(filepath.Join(bundleDir, "decision.md"))
-	if err != nil {
-		t.Fatalf("read decision: %v", err)
-	}
-	if !strings.Contains(strings.ToLower(string(decisionRaw)), "keep cli runtime behavior unchanged") {
-		t.Fatalf("decision not seeded from intent constraints:\n%s", string(decisionRaw))
-	}
-
-	tasksRaw, err := os.ReadFile(filepath.Join(bundleDir, "tasks.md"))
-	if err != nil {
-		t.Fatalf("read tasks: %v", err)
-	}
-	if !strings.Contains(strings.ToLower(string(tasksRaw)), "release-please and goreleaser release automation") {
-		t.Fatalf("tasks not seeded from intent scope:\n%s", string(tasksRaw))
-	}
-}
-
 func TestAdvance_DispatchS1Plan(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
@@ -997,12 +917,42 @@ func TestAdvanceGoverned_SyncDoesNotRewriteUnchangedChangeAuthority(t *testing.T
 	if err := state.SaveChange(root, change); err != nil {
 		t.Fatalf("save change: %v", err)
 	}
-	if err := artifact.ScaffoldGovernedBundleForChangeWithContext(root, change, "", model.ProjectContext{}); err != nil {
+	if err := artifact.ScaffoldGovernedBundleForChange(root, change, ""); err != nil {
 		t.Fatalf("scaffold bundle: %v", err)
 	}
 	bundleDir, err := state.GovernedBundleDir(root, change)
 	if err != nil {
 		t.Fatalf("bundle dir: %v", err)
+	}
+	// requirements.md/decision.md are authored by the host skill, not scaffolded
+	// (issue #119); write real ones so the lifecycle does not fail closed on
+	// missing_required_artifact before reaching the task-evidence check.
+	if err := os.WriteFile(filepath.Join(bundleDir, "requirements.md"), []byte(`# Requirements
+
+### Requirement: Change authority
+REQ-001: Sync MUST NOT rewrite unchanged change authority during advance.
+`), 0o644); err != nil {
+		t.Fatalf("write requirements.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(bundleDir, "decision.md"), []byte(`# Decision
+
+## Alternatives Considered
+- A: Rewrite change.yaml on every sync.
+- B: Skip the write when authority is unchanged.
+
+## Selected Approach
+Use B.
+
+## Interfaces and Data Flow
+Advance reconciles change authority and only persists it on a real change.
+
+## Rollout and Rollback
+Limited to the sync write path and revertible directly.
+
+## Risk
+Low; an unchanged authority simply skips the persist.
+`), 0o644); err != nil {
+		t.Fatalf("write decision.md: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(bundleDir, "tasks.md"), []byte(`# Tasks
 
@@ -1091,8 +1041,47 @@ func TestAdvanceGoverned_S2PassesWithCompleteRuntimeTaskEvidence(t *testing.T) {
 	if err := state.SaveChange(root, change); err != nil {
 		t.Fatalf("save change: %v", err)
 	}
-	if err := artifact.ScaffoldGovernedBundleForChangeWithContext(root, change, "", model.ProjectContext{}); err != nil {
+	if err := artifact.ScaffoldGovernedBundleForChange(root, change, ""); err != nil {
 		t.Fatalf("scaffold bundle: %v", err)
+	}
+	// requirements.md/decision.md are authored by the host skill, not scaffolded
+	// (issue #119); write real ones so S2 does not fail closed on
+	// missing_required_artifact before reaching the task-evidence check.
+	s2BundleDir, err := state.GovernedBundleDir(root, change)
+	if err != nil {
+		t.Fatalf("bundle dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(s2BundleDir, "requirements.md"), []byte(`# Requirements
+
+### Requirement: Runtime task evidence
+REQ-001: S2 MUST advance to S3 when every wave task carries complete passing runtime evidence.
+
+#### Scenario: Complete runtime evidence advances
+GIVEN all wave tasks have fresh passing evidence
+WHEN governed advance runs at S2
+THEN the change advances to S3.
+`), 0o644); err != nil {
+		t.Fatalf("write requirements.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(s2BundleDir, "decision.md"), []byte(`# Decision
+
+## Alternatives Considered
+- A: Require manual recovery before advancing.
+- B: Advance directly when runtime evidence is complete.
+
+## Selected Approach
+Use B.
+
+## Interfaces and Data Flow
+S2 advance reads per-task runtime evidence and wave-orchestration verification.
+
+## Rollout and Rollback
+Limited to the S2 advance path and revertible directly.
+
+## Risk
+Low; incomplete or stale evidence still blocks the advance.
+`), 0o644); err != nil {
+		t.Fatalf("write decision.md: %v", err)
 	}
 
 	writeTasksAndMaterializeWavePlan(t, root, change, `# Tasks
@@ -1212,7 +1201,7 @@ func TestAdvanceGoverned_AppliesWorktreePreflightBeforeRequiredActionBlockers(t 
 	if err := state.SaveChange(root, change); err != nil {
 		t.Fatalf("save change: %v", err)
 	}
-	if err := artifact.ScaffoldGovernedBundleForChangeWithContext(root, change, model.WorkflowPresetStrict, model.ProjectContext{}); err != nil {
+	if err := artifact.ScaffoldGovernedBundleForChange(root, change, model.WorkflowPresetStrict); err != nil {
 		t.Fatalf("scaffold bundle: %v", err)
 	}
 	bundleDir, err := state.GovernedBundleDir(root, change)

--- a/internal/engine/progression/advance_test.go
+++ b/internal/engine/progression/advance_test.go
@@ -719,11 +719,11 @@ S1 research must require fresh research evidence.
 	if !hasSideEffect(summary.SideEffects, "cleared_verification") {
 		t.Fatalf("expected stale research verification to be cleared, got %+v", summary.SideEffects)
 	}
-	if !hasSideEffect(summary.SideEffects, "scaffolded_research") {
-		t.Fatalf("expected research artifact to be scaffolded, got %+v", summary.SideEffects)
+	if !hasSideEffect(summary.SideEffects, "deferred_research_authoring") {
+		t.Fatalf("expected research artifact authoring to be deferred, got %+v", summary.SideEffects)
 	}
-	if _, err := os.Stat(filepath.Join(bundleDir, "research.md")); err != nil {
-		t.Fatalf("expected research.md to exist after S1 research handoff: %v", err)
+	if _, err := os.Stat(filepath.Join(bundleDir, "research.md")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected research.md to remain absent until research-orchestration authors it, err=%v", err)
 	}
 	if _, err := os.Stat(filepath.Join(bundleDir, "verification", SkillResearchOrchestration+".yaml")); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("expected stale research verification to be removed, err=%v", err)
@@ -1342,7 +1342,7 @@ func TestAdvanceIntake_ConfirmToS1Plan(t *testing.T) {
 	}
 }
 
-func TestAdvanceIntake_ConfirmToS1PlanResearchMaterializesResearchArtifact(t *testing.T) {
+func TestAdvanceIntake_ConfirmToS1PlanResearchDefersResearchAuthoring(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
 	if err := model.SaveConfig(state.ConfigPath(root), model.DefaultConfig()); err != nil {
@@ -1386,14 +1386,14 @@ func TestAdvanceIntake_ConfirmToS1PlanResearchMaterializesResearchArtifact(t *te
 	if summary.ToState != model.StateS1Plan || summary.ToSubStep != string(model.PlanSubStepResearch) {
 		t.Fatalf("expected transition to S1_PLAN/research, got state=%s substep=%s", summary.ToState, summary.ToSubStep)
 	}
-	if !hasSideEffect(summary.SideEffects, "scaffolded_research") {
-		t.Fatalf("expected scaffolded_research side effect, got %+v", summary.SideEffects)
+	if !hasSideEffect(summary.SideEffects, "deferred_research_authoring") {
+		t.Fatalf("expected deferred_research_authoring side effect, got %+v", summary.SideEffects)
 	}
 	if !hasSideEffect(summary.SideEffects, "cleared_verification") {
 		t.Fatalf("expected stale research verification to be cleared, got %+v", summary.SideEffects)
 	}
-	if _, err := os.Stat(filepath.Join(bundleDir, "research.md")); err != nil {
-		t.Fatalf("expected research.md to exist after intake confirmation: %v", err)
+	if _, err := os.Stat(filepath.Join(bundleDir, "research.md")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected research.md to remain absent until research-orchestration authors it, err=%v", err)
 	}
 	if _, err := os.Stat(filepath.Join(bundleDir, "verification", SkillResearchOrchestration+".yaml")); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("expected stale research verification to be removed, err=%v", err)
@@ -1482,6 +1482,57 @@ Internal docs.
 			if strings.Contains(b.Code, "worktree") || strings.Contains(b.Code, "dedicated_worktree") {
 				t.Fatalf("G_scope must not block on missing worktree at S1_PLAN/research: %v", summary.Blockers)
 			}
+		}
+	}
+}
+
+func TestEvaluateScopeGateReportsMissingResearchArtifact(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	if err := model.SaveConfig(state.ConfigPath(root), model.DefaultConfig()); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	change := model.NewChange("missing-research-artifact")
+	change.CurrentState = model.StateS1Plan
+	change.PlanSubStep = model.PlanSubStepResearch
+	change.IntakeSubStep = model.IntakeSubStepNone
+	change.NeedsDiscovery = true
+	change.WorkflowPreset = model.WorkflowPresetStandard
+	change.ArtifactSchema = model.ArtifactSchemaExpanded
+	if err := state.SaveChange(root, change); err != nil {
+		t.Fatalf("save change: %v", err)
+	}
+
+	bundleDir := filepath.Join(root, "artifacts", "changes", change.Slug)
+	if err := os.MkdirAll(bundleDir, 0o755); err != nil {
+		t.Fatalf("mkdir bundle: %v", err)
+	}
+	for _, file := range []string{"intent.md", "requirements.md", "tasks.md", "assurance.md", "decision.md"} {
+		if err := os.WriteFile(filepath.Join(bundleDir, file), []byte("# "+file+"\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", file, err)
+		}
+	}
+
+	evaluation, err := EvaluateScopeGate(root, change, map[string]model.VerificationRecord{
+		SkillResearchOrchestration: {
+			Verdict:    model.VerificationVerdictPass,
+			Timestamp:  change.CreatedAt,
+			RunVersion: 0,
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if evaluation.Status != model.GateStatusBlocked {
+		t.Fatalf("expected missing research.md to block, got %+v", evaluation)
+	}
+	if !hasAdvanceReasonDetail(evaluation.ReasonCodes, "missing_required_artifact", "research.md") {
+		t.Fatalf("expected missing_required_artifact:research.md blocker, got %+v", evaluation.ReasonCodes)
+	}
+	for _, blocker := range evaluation.ReasonCodes {
+		if blocker.Code == "research_structure_invalid" {
+			t.Fatalf("missing research.md must not be reported as a structure error: %+v", evaluation.ReasonCodes)
 		}
 	}
 }

--- a/internal/engine/progression/readiness.go
+++ b/internal/engine/progression/readiness.go
@@ -259,6 +259,7 @@ func evaluateGovernanceReadinessBaseWithReaders(
 		checklistResult := ValidateTasksChecklistDetailed(root, evaluationChange)
 		readiness.Blockers = append(readiness.Blockers, model.ReasonCodesFromSpecs(checklistResult.Blockers)...)
 		readiness.Diagnostics = append(readiness.Diagnostics, checklistResult.Warnings...)
+		readiness.Blockers = append(readiness.Blockers, model.ReasonCodesFromSpecs(DecisionContractBlockers(root, evaluationChange))...)
 	}
 
 	readiness.Blockers = append(readiness.Blockers, model.ReasonCodesFromSpecs(AssuranceContractBlockers(root, evaluationChange))...)

--- a/internal/engine/progression/validation.go
+++ b/internal/engine/progression/validation.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/signalridge/slipway/internal/engine/artifact"
@@ -422,6 +423,25 @@ func CheckGovernedBundleReady(root string, change model.Change) bool {
 	return len(GovernedBundleBlockers(root, change)) == 0
 }
 
+// RequiredArtifactNames returns the change's required governed artifact set
+// after schema resolution and effective-preset policy are applied.
+func RequiredArtifactNames(root string, change model.Change) []string {
+	resolution := ResolveChangeSchemaDiagnostics(change)
+	requiredPreset := change.WorkflowPreset
+	if policy, err := governance.ResolvePresetPolicy(root, change); err == nil {
+		requiredPreset = policy.EffectivePreset
+	}
+	return artifact.RequiredArtifactsForChange(resolution.Schema, change.NeedsDiscovery, change.WorkflowPreset, requiredPreset)
+}
+
+// DecisionArtifactRequired reports whether decision.md is in the change's
+// required artifact set (expanded/custom schemas may require it). Keep callers
+// on this shared helper so validate, instructions, and progression gates do not
+// drift on preset/schema policy.
+func DecisionArtifactRequired(root string, change model.Change) bool {
+	return slices.Contains(RequiredArtifactNames(root, change), "decision.md")
+}
+
 // GovernedBundleBlockers returns a list of blocker strings for missing governed
 // bundle artifacts. Empty slice means the bundle is ready.
 func GovernedBundleBlockers(root string, change model.Change) []string {
@@ -531,6 +551,39 @@ func AssuranceContractBlockers(root string, change model.Change) []string {
 	return artifact.AssuranceStructureBlockers(string(raw))
 }
 
+// DecisionContractBlockers enforces decision.md substance for changes whose
+// schema requires it (the expanded schema). Parallel to the requirements/tasks
+// substance gates, an unwritten or template-only decision.md (only the
+// <!-- ... --> guidance comments) must not satisfy planning readiness (issue
+// #119). Returns nil when decision.md is not a required artifact, before
+// plan-audit (so pre-audit drafts stay lenient, mirroring the tasks target_files
+// gate), or when the file is absent — a missing required decision.md is owned by
+// GovernedBundleBlockers (missing_required_artifact) rather than double-reported.
+func DecisionContractBlockers(root string, change model.Change) []string {
+	if !DecisionArtifactRequired(root, change) {
+		return nil
+	}
+	// Defer strict substance enforcement to plan-audit and later, mirroring the
+	// tasks checklist gate, so pre-audit planning drafts are not blocked early.
+	if !isAtOrPastPlanAudit(change) {
+		return nil
+	}
+
+	bundleDir, err := state.GovernedBundleDir(root, change)
+	if err != nil {
+		return []string{"decision_contract_path_invalid:" + err.Error()}
+	}
+	path := filepath.Join(bundleDir, "decision.md")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return []string{"decision_contract_unreadable"}
+	}
+	return artifact.DecisionSubstanceBlockers(string(raw))
+}
+
 // ResolveChangeSchemaDiagnostics resolves the artifact schema for a change
 // using strict, frozen change metadata only.
 func ResolveChangeSchemaDiagnostics(change model.Change) ChangeSchemaResolution {
@@ -582,6 +635,12 @@ func ValidatePlanningReadiness(root string, change model.Change) model.PlanningV
 	checklistResult := ValidateTasksChecklistDetailed(root, change)
 	result.Blockers = append(result.Blockers, model.ReasonCodesFromSpecs(checklistResult.Blockers)...)
 	result.Diagnostics = append(result.Diagnostics, checklistResult.Warnings...)
+
+	// 2b. Decision substance (expanded schema): an unwritten or template-only
+	// decision.md must not satisfy planning readiness, parallel to the
+	// requirements/tasks substance gates (issue #119).
+	decisionBlockers := DecisionContractBlockers(root, change)
+	result.Blockers = append(result.Blockers, model.ReasonCodesFromSpecs(decisionBlockers)...)
 
 	// 3. Schema diagnostics.
 	schemaDiag := ResolveChangeSchemaDiagnostics(change)

--- a/internal/engine/progression/validation.go
+++ b/internal/engine/progression/validation.go
@@ -101,15 +101,23 @@ func ValidateTasksChecklistDetailed(root string, change model.Change) TaskCheckl
 			if len(task.TargetFiles) == 0 {
 				result.Blockers = append(result.Blockers, fmt.Sprintf("plan_dimension_key_links_missing_target_files:%s", id))
 			} else {
+				hasPlaceholderTarget := false
 				for _, file := range task.TargetFiles {
 					target := strings.TrimSpace(file)
 					if target == "" {
 						result.Blockers = append(result.Blockers, fmt.Sprintf("plan_dimension_scope_invalid_target:%s", id))
 						continue
 					}
+					if artifact.LooksLikeInstructionPlaceholder(target) {
+						hasPlaceholderTarget = true
+						continue
+					}
 					if filepath.IsAbs(target) || strings.Contains(target, "..") {
 						result.Blockers = append(result.Blockers, fmt.Sprintf("plan_dimension_scope_out_of_bounds_target:%s:%s", id, target))
 					}
+				}
+				if hasPlaceholderTarget {
+					result.Blockers = append(result.Blockers, fmt.Sprintf("plan_dimension_key_links_missing_target_files:%s", id))
 				}
 			}
 		}

--- a/internal/engine/progression/validation_test.go
+++ b/internal/engine/progression/validation_test.go
@@ -75,6 +75,72 @@ func TestValidateTasksChecklist_MissingFields(t *testing.T) {
 	}
 }
 
+func TestValidateTasksChecklist_RejectsInstructionPlaceholderTargetFilesAtPlanAudit(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	slug := "test-change"
+	tasksDir := filepath.Join(dir, "artifacts", "changes", slug)
+	if err := os.MkdirAll(tasksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := `# Tasks
+
+- [ ] ` + "`t-01`" + ` implement target placeholder rejection
+  - wave: 1
+  - target_files: [<path/to/file.go>]
+  - task_kind: code
+`
+	if err := os.WriteFile(filepath.Join(tasksDir, "tasks.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	change := model.Change{
+		Slug:         slug,
+		CurrentState: model.StateS1Plan,
+		PlanSubStep:  model.PlanSubStepAudit,
+	}
+	blockers := ValidateTasksChecklistDetailed(dir, change).Blockers
+	for _, blocker := range blockers {
+		if blocker == "plan_dimension_key_links_missing_target_files:t-01" {
+			return
+		}
+	}
+	t.Fatalf("expected placeholder target_files to block as missing concrete target_files, got %v", blockers)
+}
+
+func TestValidateTasksChecklist_RejectsPlaceholderObjectiveAtPlanAudit(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	slug := "test-change"
+	tasksDir := filepath.Join(dir, "artifacts", "changes", slug)
+	if err := os.MkdirAll(tasksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := `# Tasks
+
+- [ ] ` + "`t-01`" + ` Pending task objective
+  - wave: 1
+  - target_files: [main.go]
+  - task_kind: verification
+`
+	if err := os.WriteFile(filepath.Join(tasksDir, "tasks.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	change := model.Change{
+		Slug:         slug,
+		CurrentState: model.StateS1Plan,
+		PlanSubStep:  model.PlanSubStepAudit,
+	}
+	blockers := ValidateTasksChecklistDetailed(dir, change).Blockers
+	for _, blocker := range blockers {
+		if blocker == "plan_dimension_completeness_missing_objective:t-01" {
+			return
+		}
+	}
+	t.Fatalf("expected placeholder objective to block as missing concrete objective, got %v", blockers)
+}
+
 func assertChecklistCoverageBlocker(t *testing.T, slug, coverRef, specContent, wantBlocker string) {
 	t.Helper()
 
@@ -381,9 +447,8 @@ func TestDecisionContractBlockers(t *testing.T) {
 		root := writeDecision(t, "dec-tmpl", template)
 		blockers := DecisionContractBlockers(root, expandedAudit("dec-tmpl"))
 		require.NotEmpty(t, blockers, "an unedited template-only decision.md must block planning readiness")
-		for _, b := range blockers {
-			require.Contains(t, b, "decision_section_placeholder:")
-		}
+		require.Contains(t, blockers[0], "decision_structure_invalid:")
+		require.Contains(t, blockers[0], "non-empty content")
 	})
 
 	t.Run("authored decision passes", func(t *testing.T) {
@@ -418,7 +483,8 @@ func TestDecisionContractBlockers(t *testing.T) {
 		change.PlanSubStep = model.PlanSubStepNone
 		blockers := DecisionContractBlockers(root, change)
 		require.NotEmpty(t, blockers, "post-plan states must still enforce decision substance")
-		require.Contains(t, blockers[0], "decision_section_placeholder:")
+		require.Contains(t, blockers[0], "decision_structure_invalid:")
+		require.Contains(t, blockers[0], "non-empty content")
 	})
 
 	t.Run("core schema does not require decision substance", func(t *testing.T) {

--- a/internal/engine/progression/validation_test.go
+++ b/internal/engine/progression/validation_test.go
@@ -237,36 +237,6 @@ THEN the system returns 401.
 	}
 }
 
-func TestValidateTasksChecklistDetailed_RejectsMechanicalScaffoldAtPlanAudit(t *testing.T) {
-	t.Parallel()
-
-	root := t.TempDir()
-	change := model.NewChange("mechanical-reject")
-	change.Description = "do the thing"
-	change.WorkflowPreset = model.WorkflowPresetStandard
-	require.NoError(t, artifact.ScaffoldGovernedBundleForChangeWithContext(root, change, model.WorkflowPresetStandard, model.ProjectContext{}))
-
-	// At plan-audit, the engine's placeholder scaffold must fail closed:
-	// placeholder task objective + placeholder requirements (issue #91).
-	change.CurrentState = model.StateS1Plan
-	change.PlanSubStep = model.PlanSubStepAudit
-	require.NoError(t, state.SaveChange(root, change))
-
-	result := ValidateTasksChecklistDetailed(root, change)
-
-	hasObjective, hasReq := false, false
-	for _, b := range result.Blockers {
-		if b == "plan_dimension_completeness_missing_objective:t-01" {
-			hasObjective = true
-		}
-		if b == "plan_dimension_coverage_requirements_invalid" {
-			hasReq = true
-		}
-	}
-	require.True(t, hasObjective, "placeholder task objective must block at plan-audit, got %v", result.Blockers)
-	require.True(t, hasReq, "placeholder requirements must block at plan-audit, got %v", result.Blockers)
-}
-
 func writeSubstanceGateBundle(t *testing.T, root, slug, requirements string) {
 	t.Helper()
 	bundleDir := filepath.Join(root, "artifacts", "changes", slug)
@@ -369,12 +339,122 @@ func TestValidateTasksChecklistDetailed_ScaffoldedGuardrailRequirementsStayCover
 	change.GuardrailDomain = "auth_authz"
 	change.WorkflowPreset = model.WorkflowPresetStandard
 
-	require.NoError(t, artifact.ScaffoldGovernedBundleForChangeWithContext(root, change, model.WorkflowPresetStandard, model.ProjectContext{}))
+	require.NoError(t, artifact.ScaffoldGovernedBundleForChange(root, change, model.WorkflowPresetStandard))
 
 	result := ValidateTasksChecklistDetailed(root, change)
 	for _, blocker := range result.Blockers {
 		require.NotContains(t, blocker, "plan_dimension_coverage_missing_requirement")
 	}
+}
+
+func TestDecisionContractBlockers(t *testing.T) {
+	t.Parallel()
+
+	template, err := artifact.RenderArtifactExample("decision.md")
+	require.NoError(t, err)
+	const authored = "# Decision\n\n## Alternatives Considered\nA vs B; B wins on latency.\n\n" +
+		"## Selected Approach\nB, grounded in the alternatives above.\n\n" +
+		"## Interfaces and Data Flow\nnone\n\n" +
+		"## Rollout and Rollback\nFeature flag; rollback flips it off. Verify with go test.\n\n" +
+		"## Risk\nDuplicate delivery; idempotency keys.\n"
+
+	expandedAudit := func(slug string) model.Change {
+		return model.Change{
+			Slug:           slug,
+			ArtifactSchema: model.ArtifactSchemaExpanded,
+			WorkflowPreset: model.WorkflowPresetStandard,
+			CurrentState:   model.StateS1Plan,
+			PlanSubStep:    model.PlanSubStepAudit,
+		}
+	}
+	writeDecision := func(t *testing.T, slug, content string) string {
+		t.Helper()
+		root := t.TempDir()
+		bundleDir := filepath.Join(root, "artifacts", "changes", slug)
+		require.NoError(t, os.MkdirAll(bundleDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "decision.md"), []byte(content), 0o644))
+		return root
+	}
+
+	t.Run("template-only decision blocks at plan-audit", func(t *testing.T) {
+		t.Parallel()
+		root := writeDecision(t, "dec-tmpl", template)
+		blockers := DecisionContractBlockers(root, expandedAudit("dec-tmpl"))
+		require.NotEmpty(t, blockers, "an unedited template-only decision.md must block planning readiness")
+		for _, b := range blockers {
+			require.Contains(t, b, "decision_section_placeholder:")
+		}
+	})
+
+	t.Run("authored decision passes", func(t *testing.T) {
+		t.Parallel()
+		root := writeDecision(t, "dec-ok", authored)
+		require.Empty(t, DecisionContractBlockers(root, expandedAudit("dec-ok")))
+	})
+
+	t.Run("pre-audit draft stays lenient", func(t *testing.T) {
+		t.Parallel()
+		root := writeDecision(t, "dec-pre", template)
+		change := expandedAudit("dec-pre")
+		change.PlanSubStep = model.PlanSubStepResearch
+		require.Empty(t, DecisionContractBlockers(root, change),
+			"a template-only decision before plan-audit must stay lenient")
+	})
+
+	t.Run("bundle draft stays lenient", func(t *testing.T) {
+		t.Parallel()
+		root := writeDecision(t, "dec-bundle", template)
+		change := expandedAudit("dec-bundle")
+		change.PlanSubStep = model.PlanSubStepBundle
+		require.Empty(t, DecisionContractBlockers(root, change),
+			"a template-only decision before plan-audit must stay lenient")
+	})
+
+	t.Run("post-plan state enforces decision substance", func(t *testing.T) {
+		t.Parallel()
+		root := writeDecision(t, "dec-exec", template)
+		change := expandedAudit("dec-exec")
+		change.CurrentState = model.StateS2Execute
+		change.PlanSubStep = model.PlanSubStepNone
+		blockers := DecisionContractBlockers(root, change)
+		require.NotEmpty(t, blockers, "post-plan states must still enforce decision substance")
+		require.Contains(t, blockers[0], "decision_section_placeholder:")
+	})
+
+	t.Run("core schema does not require decision substance", func(t *testing.T) {
+		t.Parallel()
+		root := writeDecision(t, "dec-core", template)
+		change := expandedAudit("dec-core")
+		change.ArtifactSchema = model.ArtifactSchemaCore
+		require.Empty(t, DecisionContractBlockers(root, change),
+			"decision.md is not required under the core schema")
+	})
+
+	t.Run("missing decision is owned by the bundle gate", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(root, "artifacts", "changes", "dec-missing"), 0o755))
+		require.Empty(t, DecisionContractBlockers(root, expandedAudit("dec-missing")),
+			"a missing decision.md is reported by GovernedBundleBlockers, not double-reported here")
+	})
+
+	t.Run("invalid bundle path returns path blocker", func(t *testing.T) {
+		t.Parallel()
+		blockers := DecisionContractBlockers(t.TempDir(), expandedAudit(""))
+		require.Len(t, blockers, 1)
+		require.Contains(t, blockers[0], "decision_contract_path_invalid:")
+	})
+
+	t.Run("unreadable decision returns unreadable blocker", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		bundleDir := filepath.Join(root, "artifacts", "changes", "dec-unreadable")
+		require.NoError(t, os.MkdirAll(filepath.Join(bundleDir, "decision.md"), 0o755))
+		require.Equal(t,
+			[]string{"decision_contract_unreadable"},
+			DecisionContractBlockers(root, expandedAudit("dec-unreadable")),
+		)
+	})
 }
 
 func TestGovernedBundleBlockers_UsesEffectivePresetForAssuranceRequirement(t *testing.T) {

--- a/internal/engine/status/view_test.go
+++ b/internal/engine/status/view_test.go
@@ -28,7 +28,7 @@ func TestBuildProjectionUsesBundleProgressOutsideExecutionStates(t *testing.T) {
 	change.CurrentState = model.StateS1Plan
 	change.PlanSubStep = model.PlanSubStepBundle
 	require.NoError(t, state.SaveChange(root, change))
-	require.NoError(t, artifact.ScaffoldGovernedBundleForChangeWithContext(root, change, change.WorkflowPreset, model.ProjectContext{}))
+	require.NoError(t, artifact.ScaffoldGovernedBundleForChange(root, change, change.WorkflowPreset))
 
 	bundleDir, err := state.GovernedBundleDir(root, change)
 	require.NoError(t, err)
@@ -62,7 +62,7 @@ func TestBuildProjectionKeepsExecutionSummaryProgressInExecutionStates(t *testin
 	change.CurrentState = model.StateS2Execute
 	change.PlanSubStep = model.PlanSubStepNone
 	require.NoError(t, state.SaveChange(root, change))
-	require.NoError(t, artifact.ScaffoldGovernedBundleForChangeWithContext(root, change, change.WorkflowPreset, model.ProjectContext{}))
+	require.NoError(t, artifact.ScaffoldGovernedBundleForChange(root, change, change.WorkflowPreset))
 
 	bundleDir, err := state.GovernedBundleDir(root, change)
 	require.NoError(t, err)
@@ -101,7 +101,7 @@ func TestBuildProjectionDoesNotSynthesizeWaveProgressWhenWaveRunsAreMissing(t *t
 	change.CurrentState = model.StateS2Execute
 	change.PlanSubStep = model.PlanSubStepNone
 	require.NoError(t, state.SaveChange(root, change))
-	require.NoError(t, artifact.ScaffoldGovernedBundleForChangeWithContext(root, change, change.WorkflowPreset, model.ProjectContext{}))
+	require.NoError(t, artifact.ScaffoldGovernedBundleForChange(root, change, change.WorkflowPreset))
 
 	bundleDir, err := state.GovernedBundleDir(root, change)
 	require.NoError(t, err)
@@ -149,7 +149,7 @@ func TestBuildProjectionDoesNotLabelCompletedExecutionAsResumableWave(t *testing
 	change.CurrentState = model.StateS2Execute
 	change.PlanSubStep = model.PlanSubStepNone
 	require.NoError(t, state.SaveChange(root, change))
-	require.NoError(t, artifact.ScaffoldGovernedBundleForChangeWithContext(root, change, change.WorkflowPreset, model.ProjectContext{}))
+	require.NoError(t, artifact.ScaffoldGovernedBundleForChange(root, change, change.WorkflowPreset))
 
 	bundleDir, err := state.GovernedBundleDir(root, change)
 	require.NoError(t, err)

--- a/internal/model/reason_code.go
+++ b/internal/model/reason_code.go
@@ -48,6 +48,22 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 		Severity: ReasonSeverityError,
 		Message:  "The assurance artifact structure is invalid",
 	},
+	"assurance_contract_missing": {
+		Severity: ReasonSeverityError,
+		Message:  "The assurance artifact is missing",
+	},
+	"assurance_contract_path_invalid": {
+		Severity: ReasonSeverityError,
+		Message:  "The assurance artifact path is invalid",
+	},
+	"assurance_contract_unreadable": {
+		Severity: ReasonSeverityError,
+		Message:  "The assurance artifact is unreadable",
+	},
+	"assurance_section_placeholder": {
+		Severity: ReasonSeverityError,
+		Message:  "The assurance artifact still contains a placeholder section",
+	},
 	"closeout_assurance_attestation_missing": {
 		Severity: ReasonSeverityError,
 		Message:  "The final-closeout assurance attestation is missing",
@@ -71,6 +87,22 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 	"dedicated_worktree_required": {
 		Severity: ReasonSeverityError,
 		Message:  "A dedicated worktree is required for this governed change",
+	},
+	"decision_contract_path_invalid": {
+		Severity: ReasonSeverityError,
+		Message:  "The decision artifact path is invalid",
+	},
+	"decision_contract_unreadable": {
+		Severity: ReasonSeverityError,
+		Message:  "The decision artifact is unreadable",
+	},
+	"decision_section_placeholder": {
+		Severity: ReasonSeverityError,
+		Message:  "The decision artifact still contains a placeholder section",
+	},
+	"decision_structure_invalid": {
+		Severity: ReasonSeverityError,
+		Message:  "The decision artifact structure is invalid",
 	},
 	"execution_interrupted": {
 		Severity: ReasonSeverityWarning,
@@ -271,6 +303,10 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 	"research_structure_invalid": {
 		Severity: ReasonSeverityError,
 		Message:  "The research artifact structure is invalid",
+	},
+	"research_section_placeholder": {
+		Severity: ReasonSeverityError,
+		Message:  "The research artifact still contains a placeholder section",
 	},
 	"run_slipway_done_to_finalize": {
 		Severity: ReasonSeverityWarning,

--- a/internal/model/reason_code.go
+++ b/internal/model/reason_code.go
@@ -218,7 +218,7 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 	},
 	"plan_dimension_key_links_missing_target_files": {
 		Severity: ReasonSeverityError,
-		Message:  "A code task is missing target files",
+		Message:  "A task is missing target files",
 	},
 	"plan_dimension_scope_invalid_target": {
 		Severity: ReasonSeverityError,

--- a/internal/model/recovery.go
+++ b/internal/model/recovery.go
@@ -141,7 +141,7 @@ var blockerRemediations = map[string]blockerRemediation{
 	},
 	"decision_contract_unreadable": {
 		Remediation:     "Fix decision.md so it is readable before continuing.",
-		CommandTemplate: "slipway validate",
+		CommandTemplate: "slipway repair",
 		Class:           RecoveryClassSatisfyControl,
 	},
 	"decision_structure_invalid": {
@@ -256,7 +256,7 @@ var blockerRemediations = map[string]blockerRemediation{
 		Class:           RecoveryClassFixScope,
 	},
 	"plan_dimension_key_links_missing_target_files": {
-		Remediation:     "Fix tasks.md so every code task declares target_files.",
+		Remediation:     "Fix tasks.md so every task declares target_files.",
 		CommandTemplate: "slipway validate",
 		Class:           RecoveryClassFixScope,
 	},
@@ -480,8 +480,8 @@ var blockerRemediations = map[string]blockerRemediation{
 		Class:           RecoveryClassFixScope,
 	},
 	"tasks_checklist_missing": {
-		Remediation:     "Create tasks.md with the governed task checklist before continuing.",
-		CommandTemplate: "slipway validate",
+		Remediation:     "Author tasks.md from the current artifact instructions, write the real task checklist, then re-run validation.",
+		CommandTemplate: "slipway instructions tasks.md",
 		Class:           RecoveryClassFixScope,
 	},
 	"tasks_checklist_path_invalid": {
@@ -634,6 +634,10 @@ func recoveryStepForGroup(group []ReasonCode) RecoveryStep {
 	rep.Normalize()
 	base := blockerRemediations[rep.Code]
 	parsed := parseBlockerForRecovery(rep, base)
+	priority := recoveryPriority(base)
+	if parsed.Code == "missing_required_artifact" {
+		priority = missingRequiredArtifactRecoveryPriority(parsed.Subject)
+	}
 	return RecoveryStep{
 		Code:          parsed.Code,
 		Subject:       parsed.Subject,
@@ -643,7 +647,26 @@ func recoveryStepForGroup(group []ReasonCode) RecoveryStep {
 		Remediation:   fillTemplate(base.Remediation, parsed),
 		Command:       resolveCommandTemplate(base.CommandTemplate, parsed),
 		RecoveryClass: base.Class,
-		priority:      recoveryPriority(base),
+		priority:      priority,
+	}
+}
+
+func missingRequiredArtifactRecoveryPriority(subject string) int {
+	switch strings.TrimSpace(subject) {
+	case "intent.md":
+		return 10
+	case "research.md":
+		return 20
+	case "requirements.md":
+		return 30
+	case "decision.md":
+		return 40
+	case "tasks.md":
+		return 50
+	case "assurance.md":
+		return 60
+	default:
+		return defaultRecoveryPriority
 	}
 }
 

--- a/internal/model/recovery.go
+++ b/internal/model/recovery.go
@@ -110,8 +110,48 @@ var blockerRemediations = map[string]blockerRemediation{
 		Class:           RecoveryClassSatisfyControl,
 	},
 	"assurance_structure_invalid": {
-		Remediation:     "Fix assurance.md so it satisfies the required assurance structure, then re-run validation.",
+		Remediation:     "Author assurance.md from the current artifact instructions, replace placeholder scaffold with real verification substance, then re-run validation.",
+		CommandTemplate: "slipway instructions assurance",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"assurance_contract_missing": {
+		Remediation:     "Author assurance.md from the current artifact instructions, write the real file, then re-run validation.",
+		CommandTemplate: "slipway instructions assurance",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"assurance_contract_path_invalid": {
+		Remediation:     "Repair the governed bundle path for assurance.md before continuing.",
+		CommandTemplate: "slipway repair",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"assurance_contract_unreadable": {
+		Remediation:     "Fix assurance.md so it is readable before continuing.",
 		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"assurance_section_placeholder": {
+		Remediation:     "Replace the placeholder section in assurance.md with real closeout evidence, then re-run validation.",
+		CommandTemplate: "slipway instructions assurance",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"decision_contract_path_invalid": {
+		Remediation:     "Repair the governed bundle path for decision.md before continuing.",
+		CommandTemplate: "slipway repair",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"decision_contract_unreadable": {
+		Remediation:     "Fix decision.md so it is readable before continuing.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"decision_structure_invalid": {
+		Remediation:     "Author decision.md from the current artifact instructions, fix the required decision sections, then re-run validation.",
+		CommandTemplate: "slipway instructions decision",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"decision_section_placeholder": {
+		Remediation:     "Replace the placeholder section in decision.md with a concrete decision, then re-run validation.",
+		CommandTemplate: "slipway instructions decision",
 		Class:           RecoveryClassSatisfyControl,
 	},
 	"closeout_goal_verification_reuse_invalid": {
@@ -316,8 +356,13 @@ var blockerRemediations = map[string]blockerRemediation{
 		Class:           RecoveryClassRerunSkill,
 	},
 	"research_structure_invalid": {
-		Remediation:     "Fix research.md so it satisfies the required research structure, then re-run validation.",
-		CommandTemplate: "slipway validate",
+		Remediation:     "Author research.md from the current artifact instructions, fix the required research sections, then re-run validation.",
+		CommandTemplate: "slipway instructions research",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"research_section_placeholder": {
+		Remediation:     "Replace the placeholder section in research.md with evidence-backed research, then re-run validation.",
+		CommandTemplate: "slipway instructions research",
 		Class:           RecoveryClassSatisfyControl,
 	},
 	"tasks_plan_changed_since_task_evidence": {
@@ -495,8 +540,8 @@ var blockerRemediations = map[string]blockerRemediation{
 		Class:           RecoveryClassRerunSkill,
 	},
 	"missing_required_artifact": {
-		Remediation:     "Create or restore the required governed artifact {subject}, then re-run validation.",
-		CommandTemplate: "slipway validate",
+		Remediation:     "Author the required governed artifact {subject}: run `slipway instructions {subject}` for its template, resolved output path, and upstream inputs, write the real file, then re-run validation.",
+		CommandTemplate: "slipway instructions {subject}",
 		Class:           RecoveryClassSatisfyControl,
 	},
 	"intake_clarification_incomplete": {

--- a/internal/model/recovery_test.go
+++ b/internal/model/recovery_test.go
@@ -547,6 +547,21 @@ func TestBuildRecoveryPrioritizesVerificationBeforeCloseout(t *testing.T) {
 		"goal-verification recovery must precede final-closeout when both S4 blockers are present")
 }
 
+func TestBuildRecoveryPrioritizesMissingArtifactsByAuthoringOrder(t *testing.T) {
+	t.Parallel()
+
+	got := BuildRecovery([]ReasonCode{
+		NewReasonCode("missing_required_artifact", "assurance.md"),
+		NewReasonCode("missing_required_artifact", "tasks.md"),
+		NewReasonCode("missing_required_artifact", "decision.md"),
+		NewReasonCode("missing_required_artifact", "requirements.md"),
+	})
+	require.NotNil(t, got)
+	assert.Equal(t, "slipway instructions requirements.md", got.PrimaryCommand)
+	assert.Contains(t, got.PrimaryAction, "requirements.md",
+		"missing artifact recovery must start at the earliest plan authoring input, not the alphabetically first downstream artifact")
+}
+
 func TestReadyStatesSurfaceAdvanceRecovery(t *testing.T) {
 	t.Parallel()
 
@@ -606,6 +621,25 @@ func TestGovernanceActionRemediationStaysCleanWithoutDetail(t *testing.T) {
 	assert.NotContains(t, step.Remediation, ": .")
 	assert.NotContains(t, step.Remediation, "  ")
 	assert.NotContains(t, step.Remediation, "{")
+}
+
+func TestDecisionContractUnreadableRoutesToRepair(t *testing.T) {
+	t.Parallel()
+
+	step, ok := recoveryStepFor(NewReasonCode("decision_contract_unreadable", ""))
+	require.True(t, ok)
+	assert.Equal(t, "slipway repair", step.Command)
+}
+
+func TestMissingTargetFilesRecoveryAppliesToEveryTaskKind(t *testing.T) {
+	t.Parallel()
+
+	rc := NewReasonCode("plan_dimension_key_links_missing_target_files", "t-01")
+	step, ok := recoveryStepFor(rc)
+	require.True(t, ok)
+	assert.Equal(t, "A task is missing target files: t-01", rc.Message)
+	assert.Contains(t, step.Remediation, "every task")
+	assert.NotContains(t, step.Remediation, "code task")
 }
 
 func recoveryCodes(steps []RecoveryStep) []string {

--- a/internal/model/recovery_test.go
+++ b/internal/model/recovery_test.go
@@ -127,6 +127,15 @@ func TestInScopeProducedBlockersResolveToCanonicalRecovery(t *testing.T) {
 func inScopeProducedRecoverySpecs() []string {
 	return []string{
 		"research_structure_invalid:section \"Findings\" must have non-empty content",
+		"research_section_placeholder:## Alternatives Considered",
+		"decision_structure_invalid:missing required heading \"## Selected Approach\"",
+		"decision_section_placeholder:## Selected Approach",
+		"decision_contract_path_invalid:permission denied",
+		"decision_contract_unreadable",
+		"assurance_contract_missing",
+		"assurance_contract_path_invalid:permission denied",
+		"assurance_contract_unreadable",
+		"assurance_section_placeholder:## Scope Summary",
 		"non_pass_task:t-01",
 		"incomplete_execution_task:t-19",
 		"high_risk_check_missing:external_api_contracts.safety_baseline",
@@ -139,6 +148,10 @@ func inScopeProducedRecoverySpecs() []string {
 func recoveryRelevantCanonicalCodes() []string {
 	exact := map[string]bool{
 		"assurance_structure_invalid":              true,
+		"assurance_contract_missing":               true,
+		"assurance_contract_path_invalid":          true,
+		"assurance_contract_unreadable":            true,
+		"assurance_section_placeholder":            true,
 		"artifact_not_ready":                       true,
 		"artifact_schema_missing":                  true,
 		"closeout_assurance_attestation_missing":   true,
@@ -147,6 +160,10 @@ func recoveryRelevantCanonicalCodes() []string {
 		"dedicated_worktree_metadata_required":     true,
 		"dedicated_worktree_path_invalid":          true,
 		"dedicated_worktree_required":              true,
+		"decision_contract_path_invalid":           true,
+		"decision_contract_unreadable":             true,
+		"decision_section_placeholder":             true,
+		"decision_structure_invalid":               true,
 		"governance_action_required":               true,
 		"governed_bundle_path_invalid":             true,
 		"high_risk_check_failed":                   true,
@@ -164,6 +181,7 @@ func recoveryRelevantCanonicalCodes() []string {
 		"non_pass_task":                            true,
 		"preset_confirmation_required":             true,
 		"research_structure_invalid":               true,
+		"research_section_placeholder":             true,
 		"run_slipway_done_to_finalize":             true,
 		"run_slipway_run_to_advance":               true,
 		"ship_gate_blocked":                        true,
@@ -209,6 +227,10 @@ func sampleRecoveryDetail(code string) string {
 	switch code {
 	case "assurance_structure_invalid":
 		return "missing required Evidence section: closeout:assurance_complete=pass"
+	case "assurance_contract_path_invalid", "decision_contract_path_invalid":
+		return "permission denied"
+	case "assurance_section_placeholder":
+		return "## Scope Summary"
 	case "closeout_assurance_attestation_missing":
 		return "final-closeout must record closeout:assurance_complete=pass on standard/strict"
 	case "closeout_goal_verification_reuse_invalid":
@@ -247,8 +269,14 @@ func sampleRecoveryDetail(code string) string {
 		return "plan-audit:assurance.md"
 	case "required_skill_blockers_present", "required_skill_missing", "required_skill_not_passed", "required_skill_not_ready":
 		return "plan-audit"
+	case "decision_section_placeholder":
+		return "## Selected Approach"
+	case "decision_structure_invalid":
+		return "missing required heading \"## Selected Approach\""
 	case "research_structure_invalid":
 		return "section \"Findings\" must have non-empty content"
+	case "research_section_placeholder":
+		return "## Alternatives Considered"
 	case "ship_gate_blocked":
 		return "required_skill_missing:final-closeout"
 	case "scope_contract_changed_files_missing", "scope_contract_missing", "wave_orchestration_stale_task_evidence":
@@ -366,6 +394,58 @@ func TestRecoveryTokensUseCanonicalMessages(t *testing.T) {
 		rc := ReasonCodeFromSpec(spec)
 		assert.NotEqualf(t, humanizeReasonCode(rc.Code), strings.TrimSuffix(rc.Message, ": "+rc.Detail),
 			"message for %q must be canonical, not the humanize fallthrough", spec)
+	}
+}
+
+func TestArtifactAuthoringBlockersRouteToInstructions(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		spec    string
+		command string
+	}{
+		{
+			name:    "decision structure",
+			spec:    "decision_structure_invalid:missing required heading \"## Selected Approach\"",
+			command: "slipway instructions decision",
+		},
+		{
+			name:    "decision placeholder",
+			spec:    "decision_section_placeholder:## Selected Approach",
+			command: "slipway instructions decision",
+		},
+		{
+			name:    "research structure",
+			spec:    "research_structure_invalid:section \"Findings\" must have non-empty content",
+			command: "slipway instructions research",
+		},
+		{
+			name:    "research placeholder",
+			spec:    "research_section_placeholder:## Alternatives Considered",
+			command: "slipway instructions research",
+		},
+		{
+			name:    "assurance placeholder",
+			spec:    "assurance_section_placeholder:## Scope Summary",
+			command: "slipway instructions assurance",
+		},
+		{
+			name:    "missing custom artifact",
+			spec:    "missing_required_artifact:my-widget.md",
+			command: "slipway instructions my-widget.md",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			step, ok := recoveryStepFor(ReasonCodeFromSpec(tc.spec))
+			require.True(t, ok)
+			assert.Equal(t, tc.command, step.Command)
+			assert.NotContains(t, step.Remediation, "{")
+		})
 	}
 }
 

--- a/internal/tmpl/templates/_partials/command-instructions-body.tmpl
+++ b/internal/tmpl/templates/_partials/command-instructions-body.tmpl
@@ -1,22 +1,38 @@
 {{- define "command-instructions-body" -}}
 # Instructions
 
-Show the embedded template and authoring guidance (required sections and the
-quality bar) for a governed artifact.
+Show the authoring contract for a governed artifact or codebase-map doc: the
+template (required sections), the quality bar, and — inside an active change —
+the resolved output path, the dependency/unlock graph, and tagged background to
+honor while authoring. Read it before writing so you author the real file
+straight to the right path instead of guessing headings.
 
 ## Invocation
 ```bash
-slipway instructions <artifact> --json
+slipway instructions <artifact> [--change <slug>] [--json]
 ```
-`<artifact>` is one of: `assurance`, `decision`, `intent`, `requirements`,
-`research`, `tasks`.
+`<artifact>` is one of the governed bundle artifacts — `intent`, `requirements`,
+`decision`, `research`, `tasks`, `assurance` — or a repo-scoped codebase-map doc
+— `stack`, `architecture`, `structure`, `conventions`, `integrations`,
+`testing`, `concerns`. The `.md` file name (e.g. `decision.md`) also resolves.
 
 ## Contract
-- Read-only and prereq-free: it reads embedded artifact templates only, so it
-  needs no `slipway init` and no active change.
-- Use it before authoring an artifact to get the exact required structure rather
-  than guessing the headings.
+- Read-only. Serves a static template + guidance with no `slipway init` and no
+  active change; it never fails just because no change is active.
+- Inside a governed change (auto-detected, or named with `--change <slug>`) it
+  additionally returns `resolved_output_path`, the `dependencies` to read by path
+  (each with a done flag), the artifacts this one `unlocks`, and tagged
+  `context`/`rules` to honor but not copy into the artifact. An explicit
+  `--change` that cannot be resolved fails closed instead of silently serving the
+  static exemplar.
+- Codebase-map docs are repo-scoped and advisory: they resolve their output path
+  under `artifacts/codebase/` without an active change, and their `context` is
+  baseline facts to preserve and extend into the doc — not do-not-copy
+  background.
 
 ## Flags
-- `--json`: JSON output
+- `--change <slug>`: author against a specific governed change (defaults to the
+  active change).
+- `--json`: JSON output (adds `resolved_output_path`, `dependencies`, `unlocks`,
+  `context`, `rules`).
 {{- end -}}

--- a/internal/tmpl/templates/_partials/command-instructions-body.tmpl
+++ b/internal/tmpl/templates/_partials/command-instructions-body.tmpl
@@ -28,11 +28,11 @@ slipway instructions <artifact> [--change <slug>] [--json]
 - Codebase-map docs are repo-scoped and advisory: they resolve their output path
   under `artifacts/codebase/` without an active change, and their `context` is
   baseline facts to preserve and extend into the doc — not do-not-copy
-  background.
+  background. In JSON, `context_is_baseline: true` marks this copy policy.
 
 ## Flags
 - `--change <slug>`: author against a specific governed change (defaults to the
   active change).
 - `--json`: JSON output (adds `resolved_output_path`, `dependencies`, `unlocks`,
-  `context`, `rules`).
+  `context`, `context_is_baseline`, `rules`).
 {{- end -}}

--- a/internal/tmpl/templates/artifacts/assurance.md
+++ b/internal/tmpl/templates/artifacts/assurance.md
@@ -1,15 +1,5 @@
 # Assurance
 
-{{- if or .ProjectTechStack .ProjectConventions .ProjectTestCmd .ProjectBuildCmd .ProjectLanguages }}
-## Project Context
-- Tech Stack: {{ .ProjectTechStack }}
-- Conventions: {{ .ProjectConventions }}
-- Test Command: {{ .ProjectTestCmd }}
-- Build Command: {{ .ProjectBuildCmd }}
-- Languages: {{ .ProjectLanguages }}
-
-{{- end }}
-
 ## Scope Summary
 Summarize delivered scope.
 

--- a/internal/tmpl/templates/artifacts/decision.md
+++ b/internal/tmpl/templates/artifacts/decision.md
@@ -1,27 +1,24 @@
 # Decision
 
-{{- if or .ProjectTechStack .ProjectConventions .ProjectTestCmd .ProjectBuildCmd .ProjectLanguages }}
-## Project Context
-- Tech Stack: {{ .ProjectTechStack }}
-- Conventions: {{ .ProjectConventions }}
-- Test Command: {{ .ProjectTestCmd }}
-- Build Command: {{ .ProjectBuildCmd }}
-- Languages: {{ .ProjectLanguages }}
-
-{{- end }}
+<!--
+Author the decision here. The engine owns this structure; you own the substance.
+Run `slipway instructions decision` for the quality bar, the resolved output
+path, and the upstream dependencies (intent.md, requirements.md) to read by path.
+Replace each section's guidance with concrete, change-specific content; an
+unwritten section cannot reach done.
+-->
 
 ## Alternatives Considered
-
-{{ .SeededDecision }}
+<!-- At least two real approaches with tradeoffs, and the selected direction. -->
 
 ## Selected Approach
-{{ .SeededDecisionApproach }}
+<!-- The chosen direction and why, grounded in the alternatives above. -->
 
 ## Interfaces and Data Flow
-{{ .SeededDecisionInterfaces }}
+<!-- Changed interfaces and data flows, or "none" after inspection. -->
 
 ## Rollout and Rollback
-{{ .SeededDecisionRollback }}
+<!-- The concrete rollback path and its verification command. -->
 
 ## Risk
-{{ .SeededDecisionRisk }}
+<!-- Concrete risks found by inspecting the affected code and contracts. -->

--- a/internal/tmpl/templates/artifacts/intent.md
+++ b/internal/tmpl/templates/artifacts/intent.md
@@ -1,14 +1,4 @@
 # Intent
-{{- if or .ProjectTechStack .ProjectConventions .ProjectTestCmd .ProjectBuildCmd .ProjectLanguages }}
-
-## Project Context
-<!-- Auto-filled by InferProjectContext(); .slipway.yaml overrides -->
-- Tech Stack: {{ .ProjectTechStack }}
-- Languages: {{ .ProjectLanguages }}
-- Test Command: {{ .ProjectTestCmd }}
-- Build Command: {{ .ProjectBuildCmd }}
-- Conventions: {{ .ProjectConventions }}
-{{- end }}
 
 ## Summary
 {{ if .InitialRequest }}{{ .InitialRequest }}{{ else }}Describe the change objective.{{ end }}

--- a/internal/tmpl/templates/artifacts/requirements.md
+++ b/internal/tmpl/templates/artifacts/requirements.md
@@ -1,27 +1,23 @@
 # Requirements
 
-{{- if or .ProjectTechStack .ProjectConventions .ProjectTestCmd .ProjectBuildCmd .ProjectLanguages }}
-## Project Context
-- Tech Stack: {{ .ProjectTechStack }}
-- Conventions: {{ .ProjectConventions }}
-- Test Command: {{ .ProjectTestCmd }}
-- Build Command: {{ .ProjectBuildCmd }}
-- Languages: {{ .ProjectLanguages }}
-
-{{- end }}
-
 ## Requirements
 
 <!--
-Authoring guidance — the engine owns structure, the authoring skill owns substance:
-- Each requirement is "### Requirement: <title>" + a stable "REQ-" identifier line
-  whose body states what the system MUST, SHALL, or is REQUIRED to do (an RFC-2119
-  strong-obligation keyword).
-- Each requirement needs at least one concrete "#### Scenario:" with real GIVEN/WHEN/THEN
-  (no placeholder or tautology lines).
-- Replace the seeded placeholder below; an unedited scaffold is rejected by the
-  requirements substance gate and cannot reach done.
-- Run `slipway instructions requirements` for the full template and quality bar.
--->
+Author each requirement here. The engine owns this structure; you own the
+substance. Run `slipway instructions requirements` for the quality bar, the
+resolved output path, and the upstream dependencies to read by path.
 
-{{ .SeededRequirements }}
+Format — replace every <...> with concrete, change-specific content:
+
+  ### Requirement: <short requirement title>
+  REQ-001: The system MUST <required behavior> — an RFC-2119 MUST / SHALL /
+  REQUIRED strong-obligation keyword.
+
+  #### Scenario: <scenario name>
+  GIVEN <precondition>
+  WHEN <triggering action>
+  THEN <observable expected outcome>
+
+This file is unwritten until you author it: an empty or structure-only file is
+rejected by the requirements substance gate and cannot reach done.
+-->

--- a/internal/tmpl/templates/artifacts/research.md
+++ b/internal/tmpl/templates/artifacts/research.md
@@ -1,14 +1,20 @@
 # Research
 
-## Alternatives Considered
+<!--
+Author the research here. The engine owns this structure; you own the substance.
+Run `slipway instructions research` for the quality bar, the resolved output
+path, and the inputs to read by path. Replace each section's guidance with
+concrete, evidence-backed content.
+-->
 
-{{ .SeededResearch }}
+## Alternatives Considered
+<!-- Real alternatives with supporting evidence and the selected direction. -->
 
 ## Unknowns
-{{ .SeededResearchUnknowns }}
+<!-- Unknowns that must be resolved before planning, or "None". -->
 
 ## Assumptions
-{{ .SeededResearchAssumptions }}
+<!-- Assumptions with the evidence that supports them. -->
 
 ## Canonical References
-{{ .SeededResearchReferences }}
+<!-- file:path references used as planning authority. -->

--- a/internal/tmpl/templates/artifacts/tasks.md
+++ b/internal/tmpl/templates/artifacts/tasks.md
@@ -1,24 +1,23 @@
 # Tasks
 
-{{- if or .ProjectTechStack .ProjectConventions .ProjectTestCmd .ProjectBuildCmd .ProjectLanguages }}
-## Project Context
-- Tech Stack: {{ .ProjectTechStack }}
-- Conventions: {{ .ProjectConventions }}
-- Test Command: {{ .ProjectTestCmd }}
-- Build Command: {{ .ProjectBuildCmd }}
-- Languages: {{ .ProjectLanguages }}
-
-{{- end }}
-
 ## Task List
 
 <!--
-Authoring guidance — the engine owns structure, the authoring skill owns substance:
-- Each task is "- [ ] `t-NN` <real objective>" with wave, depends_on, target_files,
-  task_kind, and covers metadata.
-- Replace the seeded placeholder objective below; an unedited placeholder tasks
-  list is rejected by the tasks substance gate.
-- Run `slipway instructions tasks` for the full template and quality bar.
--->
+Author the task list here. The engine owns this structure; you own the
+substance. Run `slipway instructions tasks` for the quality bar, the resolved
+output path, and the upstream dependencies to read by path.
 
-{{ .SeededTasks }}
+Format — replace every <...> with concrete, change-specific content:
+
+  - [ ] `t-01` <concrete task objective>
+    - wave: 1
+    - depends_on: []
+    - target_files: [<path/to/file.go>]
+    - task_kind: code
+    - covers: [REQ-001]
+
+Every task MUST name concrete `target_files` that bound the files or evidence
+targets it changes or verifies.
+This file is unwritten until you author it: an empty or placeholder task list is
+rejected by the tasks substance gate and cannot reach done.
+-->

--- a/internal/tmpl/templates/skills/codebase-mapping/SKILL.md
+++ b/internal/tmpl/templates/skills/codebase-mapping/SKILL.md
@@ -36,6 +36,20 @@ Write a durable brownfield map under `artifacts/codebase/` using this fixed docu
 These documents are advisory but canonical. Downstream skills consume them by
 path instead of relying on transient chat context.
 
+Before authoring each doc, read its authoring contract with `slipway
+instructions <doc> --json` (e.g. `slipway instructions architecture --json`;
+both the key `architecture` and the file name `ARCHITECTURE.md` resolve). It
+returns the same instructions->author payload the governed bundle artifacts use:
+- `template` — the doc's structure to fill in.
+- `guidance` — the quality bar (file:line-cited findings, module boundaries,
+  change-relevant risks).
+- `resolved_output_path` — the repo-scoped path under `artifacts/codebase/` to
+  write to. Codebase-map docs are repo-scoped and advisory, so this resolves
+  without an active change and does not gate any stage.
+- `context` — when the CLI's baseline scan detected real facts, the machine-
+  extracted baseline content. These are real detected facts to preserve and
+  extend, NOT a placeholder seed to delete.
+
 `slipway codebase-map --json` may report `status: "baseline"` and
 `baseline_docs` when the CLI has written only detected repository facts. Baseline
 docs are not finished mapping work; refine them with file:line citations,
@@ -61,7 +75,9 @@ Run `slipway codebase-map --json` to scaffold the canonical map directory and th
 fixed document set, then read `codebase_map_dir`/`codebase_map_docs` from its
 output. Do not hand-create the directory or guess the doc set. (Inside an active
 change you may instead read the `input_context.codebase_map_*` fields from
-`slipway next --json`.)
+`slipway next --json`.) For each doc you author, read `slipway instructions
+<doc> --json` to get its template, quality bar, resolved output path, and
+baseline facts (see Durable Output Contract).
 
 ### 2. Repository Structure Scan
 Map top-level directories, build/config files, tests, docs, and
@@ -95,7 +111,10 @@ Document existing patterns that the change should follow:
 - naming, file organization, error handling, tests, and configuration
 
 ### 8. Structured Output
-Write the findings into the durable document set.
+Write the findings into the durable document set. Author each doc against its
+`slipway instructions <doc>` contract — fill the returned `template`, meet the
+`guidance` quality bar, preserve and extend any baseline `context`, and write to
+the `resolved_output_path`.
 
 ```markdown
 artifacts/codebase/STACK.md

--- a/internal/tmpl/templates/skills/plan-audit/SKILL.md
+++ b/internal/tmpl/templates/skills/plan-audit/SKILL.md
@@ -91,7 +91,7 @@ Verify the **required artifact set** exists and is structurally valid:
   a repo configured to default to expanded. A standard non-discovery code change
   uses the **core** schema and does not require it. No public surface exposes the
   frozen schema name, so treat the engine as the authority: a missing one on an
-  expanded change is surfaced as `missing_required_artifact:decision.md`: `decision.md`
+  expanded change is surfaced as `missing_required_artifact:decision.md`.
 - Required when `needs_discovery=true` (the only discovery-gated artifact — check
   `needs_discovery` in `slipway next --json` / `slipway validate`): `research.md`.
   A missing one is a blocker (`missing_required_artifact:research.md`). On

--- a/internal/tmpl/templates/skills/plan-audit/SKILL.md
+++ b/internal/tmpl/templates/skills/plan-audit/SKILL.md
@@ -54,26 +54,38 @@ Use `slipway-coding-discipline` as the execution-shape bar: plans should stay
 simple, goal-scoped, and sliced for surgical implementation.
 
 ## Author Substance First
-The engine seeds `requirements.md` and `tasks.md` as obviously-not-real
-placeholders — it owns structure, you own substance. Before auditing, run
-`slipway validate` and read its `requirements_contract` / `tasks_contract`: a
-`plan_dimension_coverage_requirements_invalid` blocker, or an `invalid`
-contract, means the seed was never authored.
+The engine owns each plan artifact's structure; you own its substance. Author the
+real plan artifacts in schema dependency order: `requirements.md` first,
+`decision.md` next on the expanded schema, then `tasks.md`. Run `slipway validate`
+and read its `requirements_contract` / `decision_contract` / `tasks_contract`,
+and watch for `missing_required_artifact:decision.md`: an `invalid` contract or
+a missing required artifact means the substance was never authored.
 
-When that happens, author the real content first — do not audit a placeholder:
-- `slipway instructions requirements` — template and bar: each `REQ-*` body
-  states what the system MUST, SHALL, or is REQUIRED to do (an RFC-2119
-  strong-obligation keyword), with at least one concrete `#### Scenario`
-  (real GIVEN/WHEN/THEN, no tautology).
-- `slipway instructions tasks` — template and bar: each task carries a concrete
-  objective plus `wave`, `depends_on`, `target_files`, `task_kind`, and `covers`.
+When that happens, author the real content first — do not audit a placeholder.
+Each `slipway instructions <artifact>` payload carries the template, the quality
+bar, the resolved output path to write, and the upstream dependencies to read by
+path; honor its `context`/`rules` but never copy them into the file:
+- `slipway instructions requirements` — each `REQ-*` body states what the system
+  MUST, SHALL, or is REQUIRED to do (an RFC-2119 strong-obligation keyword), with
+  at least one concrete `#### Scenario` (real GIVEN/WHEN/THEN, no tautology).
+- `slipway instructions decision` — each of the five sections (Alternatives
+  Considered, Selected Approach, Interfaces and Data Flow, Rollout and Rollback,
+  Risk) carries concrete, change-specific content. On a discovery change, use the
+  selected approach and evidence recorded in `research.md`; author the formal
+  decision here after the requirements are real.
+- `slipway instructions tasks` — each task carries a concrete objective plus
+  `wave`, `depends_on`, `target_files`, `task_kind`, and `covers`. Every task
+  names concrete `target_files` that bound the files or evidence targets it
+  changes or verifies.
 
-A mechanical or vacuous requirements/tasks file cannot reach done. Re-run
-`slipway validate` until the substance gate passes, then audit.
+A mechanical or vacuous plan artifact cannot reach done. Re-run `slipway validate`
+until the substance gate passes, then audit.
 
 ## Validate Artifacts
 Verify the **required artifact set** exists and is structurally valid:
-- Required (all paths): `change.yaml`, `intent.md`, `requirements.md`, `tasks.md`
+- Required (all paths): `change.yaml`, `intent.md`, `requirements.md`, `tasks.md`.
+  `decision.md` is intentionally listed separately below because only expanded
+  schemas require it.
 - Required whenever the change is on the **expanded** artifact schema — discovery
   changes (`needs_discovery=true`); the research/config/meta workflow profiles; or
   a repo configured to default to expanded. A standard non-discovery code change
@@ -106,7 +118,7 @@ dimension:
 1. **Coverage (Nyquist Check)**: every `REQ-*` SHOULD be covered by at least one task. Standard/strict uncovered requirements block; light uncovered requirements warn.
 2. **Completeness**: each task has objective, `wave`, dependencies, and expected outputs.
 3. **Dependency Integrity**: `depends_on` references valid earlier-wave tasks and has no cycles.
-4. **Key Links**: each task names concrete `target_files` or evidence targets.
+4. **Key Links**: each task names concrete `target_files` for the files or evidence targets it changes or verifies.
 5. **Scope Control**: task targets stay inside declared scope.
 6. **Context Compliance**: task metadata supports context-safe execution (`task_kind` where present).
 7. **Test Coverage Mapping**: acceptance criteria map to automated checks; new scaffolding is an explicit dependency.

--- a/internal/tmpl/templates/skills/research-orchestration/SKILL.md
+++ b/internal/tmpl/templates/skills/research-orchestration/SKILL.md
@@ -54,9 +54,11 @@ approaches** for the change:
 - Recommend one approach with a clear rationale
 - Present alternatives to the user and wait for their selection before proceeding
 
-The selected approach must be reflected in `research.md` under
-`## Alternatives Considered`, and the locked decision recorded in `decision.md`
-under `## Selected Approach`.
+Record the selected approach in `research.md` under
+`## Alternatives Considered` with the evidence and rationale that support it.
+Do not author `decision.md` during research: plan-audit authors the formal
+decision after `requirements.md` exists, using `research.md` as an upstream
+dependency.
 
 ## Codebase Mapping (SHOULD)
 If `input_context.codebase_map_dir` already contains documents, read at least:
@@ -105,12 +107,15 @@ notes: |
 ```
 
 ## Surface Findings
-Write `research.md` using the artifact schema headings directly so `validate`
-and the `G_scope` research gate (surfaced by `slipway next`/`run`) evaluate the
-same structure the host asks you to produce:
+Author `research.md` from `slipway instructions research` — its payload carries
+the template, the resolved output path to write, and the upstream inputs to read
+by path (honor its `context`/`rules` but never copy them into the file). Use the
+artifact schema headings directly so `validate` and the `G_scope` research gate
+(surfaced by `slipway next`/`run`) evaluate the same structure the host asks you
+to produce:
 
 ```markdown
-## Research Findings
+## Alternatives Considered
 
 ### Architecture
 - Affected modules: [list with file paths]
@@ -133,7 +138,7 @@ same structure the host asks you to produce:
 - Infrastructure needs: [new test helpers, fixtures, mocks needed]
 - Verification approach: [how to verify each acceptance criterion]
 
-## Alternatives Considered
+### Options
 - [Approach 1]: [tradeoffs]
 - [Approach 2]: [tradeoffs]
 - Selected: [chosen direction and rationale]
@@ -154,8 +159,9 @@ advances out of `S1_PLAN/research`, the `G_scope` gate checks that discovery
 evidence exists and that the schema-required top-level headings (e.g.
 `## Alternatives Considered`, `## Unknowns`, `## Assumptions`,
 `## Canonical References`) are present and structurally valid — a missing/invalid
-heading surfaces `research_structure_invalid`, missing discovery evidence
-surfaces `missing_discovery_evidence`. The four research dimensions above
+heading surfaces `research_structure_invalid`; a section that still contains only
+the instructions comment surfaces `research_section_placeholder`; missing
+discovery evidence surfaces `missing_discovery_evidence`. The four research dimensions above
 (Architecture, Patterns, Risks, Test Strategy) are required by this host for
 decision-ready research but are not separately gated by the engine; keep them
 complete so the later `S1_PLAN/audit` stage (`slipway-plan-audit`) can build on

--- a/internal/tmpl/templates_test.go
+++ b/internal/tmpl/templates_test.go
@@ -573,6 +573,34 @@ func TestResearchOrchestrationUsesResearchArtifactSchemaHeadings(t *testing.T) {
 	assert.Contains(t, content, "## Assumptions")
 	assert.Contains(t, content, "## Canonical References")
 	assert.NotContains(t, content, "### Unknowns Resolved")
+	assert.NotContains(t, content, "## Research Findings")
+	assert.Contains(t, content, "research_section_placeholder")
+}
+
+func TestPlanningSkillsFollowArtifactDependencyOrder(t *testing.T) {
+	t.Parallel()
+
+	research, err := Content("skills/research-orchestration/SKILL.md")
+	require.NoError(t, err)
+	assert.Contains(t, research, "Record the selected approach in `research.md`")
+	assert.Contains(t, research, "Do not author `decision.md` during research")
+	assert.NotContains(t, research, "`slipway instructions decision`")
+	assert.NotContains(t, research, "locked decision authored into `decision.md`")
+
+	planAudit, err := Content("skills/plan-audit/SKILL.md")
+	require.NoError(t, err)
+	requirementsIdx := strings.Index(planAudit, "`slipway instructions requirements`")
+	decisionIdx := strings.Index(planAudit, "`slipway instructions decision`")
+	tasksIdx := strings.Index(planAudit, "`slipway instructions tasks`")
+	require.NotEqual(t, -1, requirementsIdx)
+	require.NotEqual(t, -1, decisionIdx)
+	require.NotEqual(t, -1, tasksIdx)
+	assert.Less(t, requirementsIdx, decisionIdx)
+	assert.Less(t, decisionIdx, tasksIdx)
+	assert.Contains(t, planAudit, "schema dependency order")
+	assert.Contains(t, planAudit, "`decision_contract`")
+	assert.Contains(t, strings.Join(strings.Fields(planAudit), " "), "Every task names concrete `target_files`")
+	assert.NotContains(t, planAudit, "research-orchestration already locked")
 }
 
 func TestVerificationDoctrineDocumentsStringOnlyReferences(t *testing.T) {

--- a/internal/toolgen/toolgen.go
+++ b/internal/toolgen/toolgen.go
@@ -200,14 +200,16 @@ var commandRegistry = []CommandDef{
 	{ID: "codebase-map", Class: CommandClassMutation, Description: "Create or refresh the durable repo-scoped codebase map", Tier: "diagnostics", HasPromptSurface: true,
 		Arguments:     "[--json]",
 		Prerequisites: []string{"`.slipway.yaml` must exist (run `slipway init` first)"}},
-	{ID: "instructions", Class: CommandClassQuery, Description: "Show the template and authoring guidance for a governed artifact", Tier: "diagnostics", HasPromptSurface: true,
-		Arguments: "<artifact> [--json]",
-		// instructions reads embedded artifact templates only — it needs no
-		// `.slipway.yaml` and no active change. Declare that explicitly so the
-		// generated command-reference does not leak the catch-all default
+	{ID: "instructions", Class: CommandClassQuery, Description: "Show the authoring contract (template, quality bar, and inside a change the resolved output path + dependency graph) for a governed artifact or codebase-map doc", Tier: "diagnostics", HasPromptSurface: true,
+		Arguments: "<artifact> [--change <slug>] [--json]",
+		// instructions serves a static template/guidance exemplar with no
+		// `.slipway.yaml` and no active change, for governed bundle artifacts and
+		// codebase-map docs alike. Inside a change it additionally resolves output
+		// path/dependencies, but never requires one. Declare prereq-free explicitly
+		// so the generated command-reference does not leak the catch-all default
 		// prerequisites (run `slipway init` / an active change), which would be
-		// false for this prereq-free surface (issue #91).
-		Prerequisites: []string{"None — reads embedded artifact templates; no `slipway init` or active change required."}},
+		// false for this prereq-free surface (issues #91, #119).
+		Prerequisites: []string{"None — serves a static template and guidance with no `slipway init` or active change required."}},
 }
 
 // commandRegistryMap provides O(1) lookup by command ID.

--- a/internal/toolgen/toolgen_test.go
+++ b/internal/toolgen/toolgen_test.go
@@ -529,7 +529,7 @@ func TestWorkflowSkillGenerationAndReference(t *testing.T) {
 		// prerequisites (run `slipway init` / an active change) (issue #91).
 		instrSection := referenceSectionFor(ref, "### `slipway instructions`")
 		assert.NotEmpty(t, instrSection, "%s: missing instructions command entry", cfg.ID)
-		assert.Contains(t, instrSection, "reads embedded artifact templates", "%s: instructions reference missing prereq-free declaration", cfg.ID)
+		assert.Contains(t, instrSection, "serves a static template and guidance", "%s: instructions reference missing prereq-free declaration", cfg.ID)
 		assert.NotContains(t, instrSection, "an active change must exist", "%s: instructions reference leaked false active-change prerequisite", cfg.ID)
 		assert.NotContains(t, instrSection, "run `slipway init`", "%s: instructions reference leaked false init prerequisite", cfg.ID)
 		for _, focus := range capability.ExplicitFocusSurfaces() {


### PR DESCRIPTION
## Summary
- Retire engine-authored planning prose for requirements, decision, research, and tasks; `slipway instructions <artifact>` now serves the authoring surface and real files are written by the skill/operator.
- Add fail-closed substance gates for decision/research/tasks, including legacy scaffold prose that previously looked non-empty.
- Wire decision/readiness/recovery/instructions surfaces so missing or placeholder governed artifacts route back to concrete authoring commands.

## Design notes
- `target_files` stays required for every task kind as the plan boundary. Verification/investigation tasks still do not require changed-files execution evidence.
- `--from-doc` remains intentionally supported for intake/intent.md only; planning artifacts are deferred to artifact authoring instructions.

## Verification
- `git diff --check`
- `go test ./...`
- `go build ./...`
- `go vet ./cmd ./internal/engine/artifact ./internal/engine/progression`

Closes #119