### PR TITLE
ci: harden SBOM syft install with retries and pin badges to main

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,17 +1,14 @@
 name: Security
-
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:
-
 permissions:
   actions: read
   contents: read
   security-events: write
-
 jobs:
   govulncheck:
     name: Go Vulnerability Check
@@ -53,7 +50,6 @@ jobs:
         with:
           sarif_file: govulncheck.sarif
           category: govulncheck
-
   trivy:
     name: Trivy Filesystem Scan
     runs-on: ubuntu-latest
@@ -82,7 +78,6 @@ jobs:
         with:
           sarif_file: trivy-results.sarif
           category: trivy
-
   sbom:
     name: Generate SBOM
     runs-on: ubuntu-latest
@@ -90,7 +85,23 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install syft
-        uses: anchore/sbom-action/download-syft@v0
+        # Install via the official script with retries: GitHub intermittently
+        # returns HTTP 504 on the anchore/syft release pages, and the
+        # download-syft action has no retry, so a single blip fails the workflow.
+        env:
+          SYFT_VERSION: v1.45.1
+        run: |
+          for attempt in 1 2 3 4 5; do
+            if curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh \
+              | sh -s -- -b /usr/local/bin "$SYFT_VERSION"; then
+              syft version
+              exit 0
+            fi
+            echo "::warning::syft install attempt ${attempt} failed; retrying in $((attempt * 10))s"
+            sleep $((attempt * 10))
+          done
+          echo "::error::Failed to install syft after 5 attempts"
+          exit 1
       - name: Generate SBOM
         run: |
           syft . -o spdx-json > sbom.spdx.json
@@ -103,7 +114,6 @@ jobs:
             sbom.spdx.json
             sbom.cdx.json
           retention-days: 30
-
   license-check:
     name: License Compliance
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 <br/>
 
 <p>
-  <a href="https://github.com/signalridge/slipway/actions/workflows/ci.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/signalridge/slipway/ci.yml?style=for-the-badge&logo=github&label=CI"></a>&nbsp;
-  <a href="https://github.com/signalridge/slipway/actions/workflows/docs.yml"><img alt="Docs" src="https://img.shields.io/github/actions/workflow/status/signalridge/slipway/docs.yml?style=for-the-badge&logo=materialformkdocs&label=Docs"></a>&nbsp;
+  <a href="https://github.com/signalridge/slipway/actions/workflows/ci.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/signalridge/slipway/ci.yml?branch=main&style=for-the-badge&logo=github&label=CI"></a>&nbsp;
+  <a href="https://github.com/signalridge/slipway/actions/workflows/docs.yml"><img alt="Docs" src="https://img.shields.io/github/actions/workflow/status/signalridge/slipway/docs.yml?branch=main&style=for-the-badge&logo=materialformkdocs&label=Docs"></a>&nbsp;
   <a href="https://github.com/signalridge/slipway/releases"><img alt="Release" src="https://img.shields.io/github/v/release/signalridge/slipway?style=for-the-badge&logo=github"></a>&nbsp;
   <a href="https://pkg.go.dev/github.com/signalridge/slipway"><img alt="Go Reference" src="https://img.shields.io/badge/Go-Reference-00ADD8?style=for-the-badge&logo=go&logoColor=white"></a>
 </p>


### PR DESCRIPTION
## Why

Two related CI reliability issues:

1. **Security workflow fails on transient GitHub 504s.** The `Generate SBOM`
   job installs syft via `anchore/sbom-action/download-syft@v0`, which has no
   retry. GitHub intermittently returns `HTTP 504` for the anchore/syft release
   pages, and a single blip fails the entire Security workflow (and turns the
   status red on `main`). Re-running does not help while the upstream outage
   persists.

2. **CI/Docs badges show errors while CI is running.** The README shields.io
   badges omit `branch`, so they pick the latest run across *all* branches and
   events — including in-progress PR runs — instead of `main`'s status.

## What

- **`.github/workflows/security.yaml`** — install syft via the official script
  with a pinned version (`v1.45.1`) and 5 retries (10/20/30/40s backoff). No new
  third-party action is added, keeping the workflow's supply-chain posture
  (consistent with the SHA-pinned Trivy action).
- **`README.md`** — pin the CI and Docs badges to `branch=main` so they reflect
  `main`'s latest run and no longer flicker during in-progress/PR runs.

## Verification

- `actionlint` (with shellcheck) passes with no findings.
- Confirmed `branch=main` shields.io badges render `passing` consistently,
  whereas the unpinned URL intermittently returned `inaccessible`/in-progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)