### PR TITLE
fix(governance): make S2 scope drift non-destructive

### DIFF
--- a/artifacts/changes/archived/fix-136-make-s2-scope-contract-drift-non-destructive-an-out/change.yaml
+++ b/artifacts/changes/archived/fix-136-make-s2-scope-contract-drift-non-destructive-an-out/change.yaml
@@ -1,0 +1,31 @@
+version: 1
+slug: fix-136-make-s2-scope-contract-drift-non-destructive-an-out
+description: 'Fix #136: make S2 scope_contract_drift non-destructive. An out-of-scope changed file in the worktree (e.g. an untracked scratch file or the dogfooded `slipway` build binary) currently makes `slipway run` silently reopen S2 in place and delete wave-orchestration.yaml + execution-summary.yaml, masking the real cause behind a ''wave-orchestration missing'' blocker. Change the scope-contract advance gate so drift-only failures block visibly with actionable remediation (remove/ignore the file, or `slipway pivot --rescope`) while preserving recorded wave evidence; missing task changed-file evidence still reopens to S2 to re-record. Also makes `slipway run` surface scope_contract_drift instead of masking it.'
+status: done
+current_state: DONE
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-06-08T13:20:48.839614Z
+quality_mode: standard
+workflow_preset: light
+worktree_branch: feat/fix-136-make-s2-scope-contract-drift-non-destructive-an-out
+artifact_schema: core
+artifacts:
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: 8db14dd37efa52718a209300583c9ac257656be359979621ec9ce4890c26171c
+        updated_at: 2026-06-08T13:31:40.749306659Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: 3bdae36201bcb76ad200ddf905382e775c1d465bee7bf6a5883557df8ab5b35b
+        updated_at: 2026-06-08T13:33:04.235335576Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: 80d78de1ee76940d63a52428dd0d6a6a218180638e4b3c3715c8ddef34dd5f63
+        updated_at: 2026-06-08T13:53:49.6959777Z

--- a/artifacts/changes/archived/fix-136-make-s2-scope-contract-drift-non-destructive-an-out/intent.md
+++ b/artifacts/changes/archived/fix-136-make-s2-scope-contract-drift-non-destructive-an-out/intent.md
@@ -1,0 +1,98 @@
+# Intent
+
+## Summary
+Fix #136: make S2 `scope_contract_drift` non-destructive. An out-of-scope changed
+file in the worktree (e.g. an untracked scratch file or the dogfooded `slipway`
+build binary) currently makes `slipway run` silently reopen S2 in place and
+delete `wave-orchestration.yaml` + `execution-summary.yaml`, masking the real
+cause behind a `wave-orchestration missing` blocker. Change the scope-contract
+advance gate so drift-only failures block visibly with actionable remediation
+while preserving recorded wave evidence; missing task changed-file evidence still
+reopens to S2 to re-record.
+
+## Complexity Assessment
+complex
+<!-- Rationale: changes a governed lifecycle gate (S2->S3 advance) whose behavior
+     is a public CLI/JSON contract; touches the engine progression layer plus the
+     recovery/diagnostic surfaces; must not weaken fail-closed scope enforcement. -->
+
+## Guardrail Domains
+<!-- none detected — change makes governance strictly safer (non-destructive) and
+     keeps drift fail-closed; no auth/credentials/financial/schema/irreversible
+     surface is introduced. -->
+
+## In Scope
+- `internal/engine/progression/advance_governed.go`: scope-contract advance gate —
+  drift-only failures return `blockedAdvanceSummary` (non-destructive) instead of
+  `reopenToStaleStage`; missing task changed-file evidence still reopens to S2.
+- `internal/engine/progression/stale_evidence_recovery.go`: add
+  `scopeContractDriftOnly` classifier distinguishing `scope_contract_drift` from
+  `scope_contract_changed_files_missing` / `scope_contract_missing`.
+- `internal/model/recovery.go`: enrich `scope_contract_drift` remediation +
+  `CommandTemplate` (remove/ignore the file, or `slipway pivot --rescope`; note
+  evidence is preserved).
+- `internal/engine/progression/readiness.go`: update
+  `scopeContractRecoveryGuidanceDiagnostic` text so the public guidance matches
+  the new non-destructive behavior.
+- Tests: `internal/engine/progression/scope_contract_gate_test.go` (classifier
+  unit test) and `cmd/scope_contract_test.go` (e2e: drift blocks visibly and
+  preserves `wave-orchestration.yaml` + `execution-summary.yaml`).
+
+## Out of Scope
+- Adding build outputs (`/slipway`, `/dist/`, coverage) to `.gitignore`
+  (#136 proposal #1) — explicitly excluded; the scope contract already honors
+  `.gitignore` via `git ls-files --others --exclude-standard`, and forcing users
+  to ignore every scratch file is the anti-pattern we are removing.
+- Weakening the Scope Contract for genuine out-of-plan **source** changes — drift
+  still fails closed (blocks), just non-destructively.
+- Static SAST CI (#137) and `assurance.md` deferral (#141) — separate issues.
+
+## Constraints
+- Must not delete or restamp engine-owned freshness state for an incidental file
+  (CLAUDE.md Evidence Discipline).
+- The public surface (`run`/`next` JSON + remediation) must carry the next action
+  (CLAUDE.md Self-Optimization Loop).
+- Existing legitimate reopen path (`changed_files_missing` -> S2) must stay green.
+
+## Acceptance Signals
+1. `slipway run` with an untracked out-of-scope file blocks with
+   `scope_contract_drift` (not masked as `wave-orchestration missing`), and
+   `wave-orchestration.yaml` + `execution-summary.yaml` remain on disk.
+2. After the out-of-scope file is removed, advancement resumes on the preserved
+   evidence (no re-run of wave-orchestration required).
+3. Missing task changed-file evidence still reopens to S2
+   (`TestScopeContractReopenTargetReopensToS2WhenChangedFilesMissing` stays green).
+4. `scope_contract_drift` remediation and the recovery-guidance diagnostic
+   describe the remove/ignore/rescope path and state that evidence is preserved.
+5. `go build ./...`, `go vet ./...`, `go test ./...` pass; `gofmt` clean.
+
+## Open Questions
+None.
+
+## Deferred Ideas
+- A `slipway run` side-effect/diagnostic entry that proactively names an
+  out-of-scope untracked file even before the S2->S3 advance attempt (current fix
+  surfaces it via the blocker on the advance attempt, which is sufficient).
+
+## Approved Summary
+Make S2 `scope_contract_drift` non-destructive and visible. An out-of-scope
+changed file in the worktree (untracked scratch file or the dogfooded `slipway`
+build binary) currently makes `slipway run` silently reopen S2 in place and
+delete `wave-orchestration.yaml` + `execution-summary.yaml`, masking the cause as
+`wave-orchestration missing`. The fix blocks drift-only failures visibly with
+actionable remediation (remove/ignore the file, or `slipway pivot --rescope`)
+while preserving the recorded wave evidence, so removing the file lets
+advancement resume on that evidence. Genuine missing task changed-file evidence
+(`scope_contract_changed_files_missing`) still reopens to S2 to re-record. The
+public surface (`run`/`next` blocker + remediation + recovery-guidance
+diagnostic) is updated to match.
+
+Out of scope: editing `.gitignore` (the contract already honors `.gitignore` via
+`--exclude-standard`); weakening fail-closed enforcement for genuine out-of-plan
+source changes; #137 (SAST CI) and #141 (assurance deferral).
+
+Primary acceptance signal: `slipway run` with an untracked out-of-scope file
+reports `scope_contract_drift` while `wave-orchestration.yaml` and
+`execution-summary.yaml` remain on disk.
+
+Confirmed by user: 2026-06-08T13:31:29Z.

--- a/artifacts/changes/archived/fix-136-make-s2-scope-contract-drift-non-destructive-an-out/requirements.md
+++ b/artifacts/changes/archived/fix-136-make-s2-scope-contract-drift-non-destructive-an-out/requirements.md
@@ -1,0 +1,56 @@
+# Requirements
+
+## Requirements
+
+### Requirement: Out-of-scope drift blocks non-destructively
+REQ-001: When the S2 Scope Contract fails only with out-of-scope drift (a changed
+file outside the plan, e.g. an untracked scratch file or build artifact), the
+governed advance gate MUST block visibly and surface `scope_contract_drift`, and
+it MUST NOT delete the recorded wave evidence (`wave-orchestration.yaml`,
+`execution-summary.yaml`) or reopen S2 in place.
+
+#### Scenario: Untracked out-of-scope file on run
+GIVEN a governed change at S2_EXECUTE with a satisfied, recorded execution summary
+and `wave-orchestration.yaml`
+WHEN an untracked file outside the plan's `target_files` exists in the worktree
+and `slipway run` is invoked
+THEN the run is blocked with a `scope_contract_drift` blocker naming the file
+AND `wave-orchestration.yaml` and `execution-summary.yaml` still exist on disk
+AND the change remains at S2_EXECUTE without a `cleared_stale_generated_evidence`
+side effect.
+
+### Requirement: Removing the file resumes on preserved evidence
+REQ-002: After the out-of-scope file is removed (or added to the plan via rescope),
+re-running `slipway run` MUST advance using the preserved wave evidence, without
+requiring wave-orchestration to be re-run.
+
+#### Scenario: Drift cleared by removing the file
+GIVEN a change blocked on `scope_contract_drift` for an untracked out-of-scope file
+WHEN the file is removed and `slipway run` is invoked again
+THEN the `scope_contract_drift` blocker is gone
+AND advancement proceeds on the still-present recorded wave evidence.
+
+### Requirement: Missing task changed-file evidence still reopens
+REQ-003: When the Scope Contract fails because a planned task is missing its
+changed-file evidence (`scope_contract_changed_files_missing` /
+`scope_contract_missing`), the gate MUST still reopen to S2_EXECUTE so the
+evidence can be re-recorded in its owning stage.
+
+#### Scenario: Task missing changed files
+GIVEN a governed change whose execution summary records a code task with no
+changed files
+WHEN the scope-contract advance gate evaluates the change
+THEN the gate reopens to S2_EXECUTE carrying the
+`scope_contract_changed_files_missing` blocker.
+
+### Requirement: Public guidance matches non-destructive behavior
+REQ-004: The public surfaces for `scope_contract_drift` — the blocker remediation
+and the readiness recovery-guidance diagnostic — MUST describe the actionable
+remove/ignore/rescope path and MUST state that the recorded wave evidence is
+preserved.
+
+#### Scenario: Operator reads drift guidance
+GIVEN a `scope_contract_drift` blocker is surfaced by `validate`/`next`/`run`
+WHEN the operator reads its remediation and the recovery-guidance diagnostic
+THEN the guidance names removing/ignoring the file or `slipway pivot --rescope`
+AND states that the recorded wave evidence is preserved (not cleared).

--- a/artifacts/changes/archived/fix-136-make-s2-scope-contract-drift-non-destructive-an-out/tasks.md
+++ b/artifacts/changes/archived/fix-136-make-s2-scope-contract-drift-non-destructive-an-out/tasks.md
@@ -1,0 +1,24 @@
+# Tasks
+
+## Task List
+
+- [x] `t-01` Add `scopeContractDriftOnly` classifier and make the S2 scope-contract advance gate block drift-only failures non-destructively (preserve wave evidence) while still reopening to S2 for missing task changed-file evidence
+  - wave: 1
+  - depends_on: []
+  - target_files: ["internal/engine/progression/advance_governed.go", "internal/engine/progression/stale_evidence_recovery.go"]
+  - task_kind: code
+  - covers: [REQ-001, REQ-002, REQ-003]
+
+- [x] `t-02` Update the public guidance for `scope_contract_drift` — enrich the remediation/CommandTemplate and the readiness recovery-guidance diagnostic to describe remove/ignore/rescope and state that recorded wave evidence is preserved
+  - wave: 1
+  - depends_on: []
+  - target_files: ["internal/model/recovery.go", "internal/engine/progression/readiness.go"]
+  - task_kind: code
+  - covers: [REQ-004]
+
+- [x] `t-03` Add tests: a unit test for `scopeContractDriftOnly` and an e2e test that `slipway run` with an untracked out-of-scope file blocks with `scope_contract_drift` while preserving `wave-orchestration.yaml` + `execution-summary.yaml`
+  - wave: 2
+  - depends_on: [t-01, t-02]
+  - target_files: ["internal/engine/progression/scope_contract_gate_test.go", "cmd/scope_contract_test.go"]
+  - task_kind: test
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004]

--- a/cmd/scope_contract_test.go
+++ b/cmd/scope_contract_test.go
@@ -1,12 +1,15 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/signalridge/slipway/internal/engine/progression"
 	"github.com/signalridge/slipway/internal/model"
 	"github.com/signalridge/slipway/internal/state"
 	"github.com/stretchr/testify/assert"
@@ -37,7 +40,8 @@ func TestValidateAndNextGuideS3ScopeContractDriftToRecoveryPath(t *testing.T) {
 	diagnostics := strings.Join(validateView.Diagnostics, "\n")
 	assert.Contains(t, diagnostics, "scope_contract_recovery_guidance")
 	assert.Contains(t, diagnostics, "tasks.md target_files")
-	assert.Contains(t, diagnostics, "stale_evidence")
+	assert.Contains(t, diagnostics, "preserves the recorded wave evidence")
+	assert.Contains(t, diagnostics, "slipway pivot --rescope")
 	assert.Contains(t, diagnostics, "slipway run")
 
 	nextView, err := buildNextView(root, changeRef{Slug: slug}, "", true, false, false)
@@ -46,7 +50,8 @@ func TestValidateAndNextGuideS3ScopeContractDriftToRecoveryPath(t *testing.T) {
 	warnings := strings.Join(nextView.Warnings, "\n")
 	assert.Contains(t, warnings, "scope_contract_recovery_guidance")
 	assert.Contains(t, warnings, "tasks.md target_files")
-	assert.Contains(t, warnings, "stale_evidence")
+	assert.Contains(t, warnings, "preserves the recorded wave evidence")
+	assert.Contains(t, warnings, "slipway pivot --rescope")
 	assert.Contains(t, warnings, "slipway run")
 }
 
@@ -76,6 +81,112 @@ func TestReviewFailsOnScopeContractDrift(t *testing.T) {
 	assert.Equal(t, "fail", view.Verdict)
 	assert.Contains(t, model.ReasonSpecs(view.Blockers), "scope_contract_drift:cmd/review.go")
 	assert.Contains(t, strings.Join(view.Gaps.ArtifactToCode, "\n"), "scope_contract_drift")
+}
+
+// writeAdvanceableS2Fixture builds a governed change at S2_EXECUTE whose recorded
+// execution + wave evidence is fresh and in-scope, recorded through the canonical
+// `slipway evidence task` path so a plain `slipway run` reaches the Scope Contract
+// advance gate (rather than blocking earlier on execution-summary freshness). The
+// fixture wave-plan's single in-scope target is cmd/lifecycle_commands_test.go.
+func writeAdvanceableS2Fixture(t *testing.T, root string) string {
+	t.Helper()
+	slug, _ := createEvidenceTaskFixture(t, root)
+	capturedAt := time.Now().UTC()
+	cmd := commandForRoot(t, root, makeEvidenceCmd())
+	cmd.SetArgs([]string{
+		"task", "--json",
+		"--task-id", "t-01",
+		"--run-summary-version", "1",
+		"--task-kind", "verification",
+		"--verdict", "pass",
+		"--evidence-ref", "test:scope-drift",
+		"--changed-file", "cmd/lifecycle_commands_test.go",
+		"--target-file", "cmd/lifecycle_commands_test.go",
+		"--captured-at", capturedAt.Format(time.RFC3339Nano),
+		"--session-id", "session-a",
+	})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	require.NoError(t, cmd.Execute())
+	writeSkillVerification(t, root, slug, progression.SkillWaveOrchestration, model.VerificationRecord{
+		Verdict:    model.VerificationVerdictPass,
+		Blockers:   []model.ReasonCode{},
+		Timestamp:  capturedAt.Add(time.Second),
+		RunVersion: 1,
+		References: []string{"task:evidence:t-01"},
+	})
+	return slug
+}
+
+// An untracked, out-of-scope file in the worktree — the common developer case
+// from issue #136 (a scratch file, or the dogfooded `slipway` build binary) —
+// must block `slipway run` visibly with the real scope_contract_drift cause and
+// must NOT clear the earned wave evidence. Before the fix, the gate reopened S2
+// in place and deleted wave-orchestration.yaml + execution-summary.yaml, which
+// then masked the drift behind a "wave-orchestration missing" blocker.
+func TestRunScopeContractDriftBlocksWithoutClearingWaveEvidence(t *testing.T) {
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		slug := writeAdvanceableS2Fixture(t, root)
+
+		waveOrchestrationPath := filepath.Join(
+			state.VerificationDir(root, slug),
+			progression.SkillWaveOrchestration+".yaml",
+		)
+		executionSummaryPath := filepath.Join(
+			state.VerificationDir(root, slug),
+			state.ExecutionSummaryFileName,
+		)
+		require.FileExists(t, waveOrchestrationPath)
+
+		// Drop an untracked file outside the plan's target_files into the worktree.
+		require.NoError(t, os.WriteFile(filepath.Join(root, "scratch.txt"), []byte("scratch\n"), 0o644))
+
+		runCmd := commandForRoot(t, root, makeRunCmd())
+		runCmd.SetArgs([]string{"--json", "--diagnostics", "--change", slug})
+		var buf bytes.Buffer
+		runCmd.SetOut(&buf)
+		require.NoError(t, runCmd.Execute())
+
+		var view nextView
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &view))
+
+		// The real cause is surfaced (not masked) and the change stays in its
+		// owning stage rather than being reopened-in-place.
+		assert.Equal(t, model.StateS2Execute, view.CurrentState)
+		specs := strings.Join(model.ReasonSpecs(view.Blockers), "\n")
+		assert.Contains(t, specs, "scope_contract_drift")
+		assert.Contains(t, specs, "scratch.txt")
+
+		// Non-destructive: the earned wave evidence survives (the reopen/clear path
+		// would have deleted wave-orchestration.yaml and masked the cause).
+		require.FileExists(t, waveOrchestrationPath)
+		require.FileExists(t, executionSummaryPath)
+		if view.Advanced != nil {
+			assert.NotEqual(t, "stale_evidence_recovery_started", view.Advanced.Reason,
+				"scope drift must not trigger the stale-evidence reopen/clear path")
+			for _, effect := range view.Advanced.SideEffects {
+				assert.NotEqual(t, "cleared_stale_generated_evidence", effect.Kind,
+					"scope drift must not clear generated wave evidence")
+			}
+		}
+
+		// Removing the out-of-scope file clears the drift and advancement resumes
+		// on the preserved evidence (no re-run of wave-orchestration).
+		require.NoError(t, os.Remove(filepath.Join(root, "scratch.txt")))
+		resumeCmd := commandForRoot(t, root, makeRunCmd())
+		resumeCmd.SetArgs([]string{"--json", "--diagnostics", "--change", slug})
+		var resumeBuf bytes.Buffer
+		resumeCmd.SetOut(&resumeBuf)
+		require.NoError(t, resumeCmd.Execute())
+
+		var resumeView nextView
+		require.NoError(t, json.Unmarshal(resumeBuf.Bytes(), &resumeView))
+		assert.Equal(t, model.StateS3Review, resumeView.CurrentState,
+			"removing the out-of-scope file advances on the preserved evidence")
+		assert.NotContains(t, strings.Join(model.ReasonSpecs(resumeView.Blockers), "\n"), "scope_contract_drift")
+	})
 }
 
 func writeScopeContractDriftFixture(t *testing.T) (string, string) {

--- a/internal/engine/progression/advance_governed.go
+++ b/internal/engine/progression/advance_governed.go
@@ -126,13 +126,21 @@ func AdvanceGoverned(root, slug string, opts ...AdvanceOptions) (summary Advance
 	}
 
 	// Scope Contract gate (owned by S2_EXECUTE): a satisfied execution summary
-	// must also satisfy the Scope Contract. On failure, reopen to S2_EXECUTE so
-	// the agent re-records task evidence in the owning stage instead of advancing
-	// into S3_REVIEW, where the failure is detected but cannot be repaired (task
-	// evidence is only recordable during S2_EXECUTE) — which would strand the change.
+	// must also satisfy the Scope Contract. Out-of-scope drift (a changed file
+	// outside the plan — typically an untracked scratch file or build artifact)
+	// does not invalidate the recorded wave evidence, so it blocks visibly with
+	// remediation while leaving wave-orchestration/execution-summary intact;
+	// re-running after the file is removed or the plan is rescoped advances
+	// normally (issue #136). Missing task changed-file evidence, by contrast, can
+	// only be repaired by re-recording in the owning stage, so it reopens to
+	// S2_EXECUTE instead of stranding the failure in S3_REVIEW where task evidence
+	// is no longer recordable.
 	if target, err := scopeContractReopenTarget(root, change, executionSummaryCtx.Summary); err != nil {
 		return AdvanceSummary{}, err
 	} else if target.SkillName != "" {
+		if scopeContractDriftOnly(target.Blockers) {
+			return blockedAdvanceSummary(fromState, target.Blockers), nil
+		}
 		return reopenToStaleStage(root, &change, target, fromState)
 	}
 

--- a/internal/engine/progression/readiness.go
+++ b/internal/engine/progression/readiness.go
@@ -82,7 +82,7 @@ type GovernanceReadinessOptions struct {
 	IncludeShipSurface        bool
 }
 
-const scopeContractRecoveryGuidanceDiagnostic = "scope_contract_recovery_guidance: fix tasks.md target_files or execution scope first; if a planning artifact structurally changes, stale_evidence recovery reopens the owning authority via `slipway run`; strict target_files-only drift rebuilds compatible generated evidence in S2."
+const scopeContractRecoveryGuidanceDiagnostic = "scope_contract_recovery_guidance: out-of-scope drift is non-destructive and preserves the recorded wave evidence; remove the out-of-scope file, rely on an existing ignore/local exclude, or include the file or tracked .gitignore rule in the plan with `slipway pivot --rescope` (which edits tasks.md target_files), then re-run; a task missing its changed-file evidence instead reopens to S2_EXECUTE via `slipway run` to re-record it."
 
 type ArtifactReadinessReader interface {
 	Evaluate(root string, change model.Change) (ArtifactReadiness, error)

--- a/internal/engine/progression/scope_contract_gate_test.go
+++ b/internal/engine/progression/scope_contract_gate_test.go
@@ -85,3 +85,24 @@ func TestScopeContractReopenTargetEmptyWhenSummaryNotReady(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, target.SkillName, "no reopen without a ready execution summary")
 }
+
+// Out-of-scope drift (a changed file outside the plan) is non-destructive and
+// must block visibly instead of clearing wave evidence; missing task
+// changed-file evidence still requires a re-record reopen (issue #136).
+func TestScopeContractDriftOnly(t *testing.T) {
+	t.Parallel()
+
+	drift := model.NewReasonCode(scopecontract.ReasonScopeContractDrift, "scratch.txt")
+	missing := model.NewReasonCode(scopecontract.ReasonScopeContractChangedFilesMissing, "t-01")
+
+	assert.True(t, scopeContractDriftOnly([]model.ReasonCode{drift}),
+		"a sole drift blocker is drift-only")
+	assert.True(t, scopeContractDriftOnly([]model.ReasonCode{drift, drift}),
+		"multiple drift blockers are still drift-only")
+	assert.False(t, scopeContractDriftOnly([]model.ReasonCode{drift, missing}),
+		"a mix with missing-evidence is not drift-only")
+	assert.False(t, scopeContractDriftOnly([]model.ReasonCode{missing}),
+		"missing-evidence alone is not drift-only")
+	assert.False(t, scopeContractDriftOnly(nil),
+		"no blockers is not drift-only")
+}

--- a/internal/engine/progression/stale_evidence_recovery.go
+++ b/internal/engine/progression/stale_evidence_recovery.go
@@ -471,3 +471,24 @@ func scopeContractReopenTarget(root string, change model.Change, summary *model.
 		Blockers:    report.Blockers,
 	}, nil
 }
+
+// scopeContractDriftOnly reports whether every scope-contract blocker is
+// out-of-scope drift (a changed file outside the plan) rather than missing task
+// changed-file evidence. Drift is non-destructive: the recorded wave evidence is
+// still valid — the worktree merely holds a file outside the plan (e.g. an
+// untracked scratch file or build artifact). Such a case must block visibly with
+// remediation, not silently clear wave-orchestration/execution-summary evidence
+// and reopen in place (issue #136). Missing task changed-file evidence
+// (scope_contract_changed_files_missing / scope_contract_missing), by contrast,
+// can only be repaired by re-recording in S2_EXECUTE, so it still reopens.
+func scopeContractDriftOnly(blockers []model.ReasonCode) bool {
+	if len(blockers) == 0 {
+		return false
+	}
+	for _, blocker := range blockers {
+		if blocker.Code != scopecontract.ReasonScopeContractDrift {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/model/recovery.go
+++ b/internal/model/recovery.go
@@ -455,8 +455,8 @@ var blockerRemediations = map[string]blockerRemediation{
 		Priority:        90,
 	},
 	"scope_contract_drift": {
-		Remediation:     "Changed files fall outside the planned Scope Contract; add the targets to tasks.md or revert the out-of-scope change.",
-		CommandTemplate: "slipway validate",
+		Remediation:     "Changed files fall outside the planned Scope Contract (recorded wave evidence is preserved). If a listed file is a build artifact or scratch file, remove it or rely on an existing ignore/local exclude; if keeping the file or adding a tracked .gitignore rule is intended, include it in the plan with `slipway pivot --rescope`; then re-run.",
+		CommandTemplate: "slipway pivot --rescope",
 		Class:           RecoveryClassFixScope,
 	},
 	"scope_contract_missing": {


### PR DESCRIPTION
## Summary
- Make drift-only S2 Scope Contract failures block visibly with scope_contract_drift instead of reopening S2 and clearing evidence.
- Preserve wave-orchestration.yaml and execution-summary.yaml for out-of-scope drift, while keeping missing changed-file evidence on the S2 reopen path.
- Update drift remediation/guidance to distinguish removal, existing ignore/local exclude, and planned tracked .gitignore/source changes via pivot --rescope.
- Archive the governed change bundle after done.

## Verification
- git diff --check
- go build ./...
- go vet ./...
- go test ./...
- go test ./cmd ./internal/engine/progression ./internal/model -coverprofile=/tmp/slipway-fix136-cover.out -count=1
- go run . validate --json --change fix-136-make-s2-scope-contract-drift-non-destructive-an-out: G_plan=approved, G_ship=approved, scope_contract=pass
- go run . run --json --diagnostics --change fix-136-make-s2-scope-contract-drift-non-destructive-an-out: done_ready
- go run . done --json --change fix-136-make-s2-scope-contract-drift-non-destructive-an-out: status=done, archived=true

Closes #136