### PR TITLE
fix(next): split pending decisions from locked decisions

### DIFF
--- a/artifacts/changes/archived/fix-pending-approach-reported-as-locked-decision/assurance.md
+++ b/artifacts/changes/archived/fix-pending-approach-reported-as-locked-decision/assurance.md
@@ -1,0 +1,78 @@
+# Assurance
+
+## Scope Summary
+Issue #140: `slipway next --json` no longer reports a recommended-but-
+unconfirmed decision as a locked decision. The locked-vs-pending split is now
+driven by the lifecycle `G_plan` gate (not the decision-text placeholder
+matcher): a parsed `decision.md` "Selected Approach"/"Selected Direction" is
+reported under `skill_constraints.locked_decisions` only once `G_plan` is
+approved, and under the new `skill_constraints.pending_decisions` field
+otherwise. The `spec-compliance-review` generated surface was updated to enforce
+Decision Fidelity only against `locked_decisions` and treat `pending_decisions`
+as advisory. Delivered across `cmd/next.go`, `cmd/next_skill.go`,
+`cmd/next_skill_view.go`, `cmd/next_handoff.go`, the spec-compliance-review
+template, and tests.
+
+## Verification Verdict
+PASS at run_version 1. All required governance skills carry passing verification
+for run_version 1; both review stages passed; goal-verification passed with
+fresh 3-level evidence; closeout re-ran the full suite green.
+- `go build ./...` exit 0; `go vet ./...` exit 0.
+- `go test ./...` green (24 packages) — see Evidence Index.
+- Confirmed-path e2e: `TestSkillConstraintsLockedDecisionsAfterPlanLock`
+  drives real `next --json --diagnostics` output for a governed change with
+  G_plan approved; `skill_constraints` carries `locked_decisions` and not
+  `pending_decisions`.
+
+## Evidence Index
+All under `artifacts/changes/fix-pending-approach-reported-as-locked-decision/`:
+- `verification/intake-clarification.yaml` — pass
+- `verification/research-orchestration.yaml` — pass
+- `verification/plan-audit.yaml` — pass (8D)
+- `verification/wave-plan.yaml` + `verification/execution-summary.yaml` (run_summary_version 1)
+- runtime task evidence t-01..t-04 (all pass, run_summary_version 1)
+- `verification/wave-orchestration.yaml` — pass
+- `verification/spec-compliance-review.yaml` — pass (layer:R0, scope_contract, negative_path)
+- `verification/code-quality-review.yaml` — pass (layer:IR1)
+- `verification/goal-verification.yaml` — pass (AC-1..AC-7, scope_contract:pass)
+- `verification/final-closeout.yaml` — this closeout
+
+## Requirement Coverage
+- REQ-001 (pending excluded from locked_decisions) → t-01; tests: not_planLocked
+  routing + pending e2e.
+- REQ-002 (surfaced under pending_decisions) → t-01; tests: pending e2e.
+- REQ-003 (locked after G_plan approved) → t-01; tests: locked routing unit +
+  TestPlanLockedFromGates + TestSkillConstraintsLockedDecisionsAfterPlanLock.
+- REQ-004 (gate-derived, parser unchanged) → t-01; tests: TestPlanLockedFromGates;
+  parser package diff empty.
+- REQ-005 (preserved in clone) → t-02; tests: handoff e2e.
+- REQ-006 (spec-compliance-review advisory) → t-03; tests:
+  TestSpecComplianceReviewTreatsPendingDecisionsAsAdvisory.
+
+## Residual Risks and Exceptions
+- External JSON contract change (`next --json` `skill_constraints`): additive
+  `pending_decisions` (omitempty) + tightened `locked_decisions` semantics. This
+  is the intended fix for #140; reviewed as a contract change at S3 (the only
+  in-repo consumer — the spec-compliance-review template + cloneSkillConstraints
+  — was updated consistently; generated `.claude`/`.codex` copies are gitignored
+  and regenerate via toolgen).
+- The previous closeout draft incorrectly described the S4_VERIFY done-ready
+  surface as carrying `next_skill.skill_constraints`; that is not true once
+  `next_skill` is null. The repaired evidence uses
+  `TestSkillConstraintsLockedDecisionsAfterPlanLock`, which exercises a real
+  `next --json --diagnostics` response at an executable state where G_plan is
+  approved and `next_skill.skill_constraints` is present.
+- No accepted spec exceptions.
+
+## Rollback Readiness
+Additive, reversible change: an `omitempty` field, a single conditional split,
+gate-state threading via an unexported view field, and a template-text update.
+Rollback = revert the change (no data migration, no irreversible op). Rollback
+verification: `go test ./...` on the reverted tree.
+
+## Archive Decision
+Ready to archive on `done`. Active-change freshness/readiness was proven by a
+fresh `slipway validate --json` on this worktree at run_version 1 before `done`
+(blockers empty, gates G_plan/G_scope approved, G_ship satisfied at closeout).
+This attestation is for the ACTIVE bundle; once archived the bundle is a frozen
+record and is not described as revalidated through the active validate gate.

--- a/artifacts/changes/archived/fix-pending-approach-reported-as-locked-decision/change.yaml
+++ b/artifacts/changes/archived/fix-pending-approach-reported-as-locked-decision/change.yaml
@@ -1,0 +1,50 @@
+version: 1
+slug: fix-pending-approach-reported-as-locked-decision
+description: fix pending approach reported as locked decision
+status: done
+current_state: DONE
+needs_discovery: true
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-06-08T14:31:28.249966Z
+quality_mode: standard
+workflow_preset: standard
+worktree_branch: feat/fix-pending-approach-reported-as-locked-decision
+artifact_schema: expanded
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: 33de3f53d5ff5a2f430725f9834d1d88299eaa361ee91ae46370ba821d160968
+        updated_at: 2026-06-08T16:16:57.549889089Z
+    decision:
+        id: decision
+        path: decision.md
+        state: frozen
+        content_hash: a7abf804bdd95d52e3120b8ecfee77ef8d555babaf312dd0c03517372e98fb06
+        updated_at: 2026-06-08T14:51:11.798846259Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: 31b255c12fa0131e71adc8b01a4e6c28892cdbde17fafb98bd26b87843c8342a
+        updated_at: 2026-06-08T16:21:20.700379435Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: c43c11133983e1e03f869d21d90471591bba1a2874435f5f7b34a3690ebf31c4
+        updated_at: 2026-06-08T14:50:43.2389941Z
+    research:
+        id: research
+        path: research.md
+        state: frozen
+        content_hash: cad30a0736620d574582de9e6224c9e154e937817d333a111b97802ea21b0e67
+        updated_at: 2026-06-08T16:21:30.818962654Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: 3701ff510e4c5334a1477619ca2eb761abe32fd4adde70bc1475e31779a5c58d
+        updated_at: 2026-06-08T15:20:37.624120175Z

--- a/artifacts/changes/archived/fix-pending-approach-reported-as-locked-decision/decision.md
+++ b/artifacts/changes/archived/fix-pending-approach-reported-as-locked-decision/decision.md
@@ -1,0 +1,84 @@
+# Decision
+
+## Alternatives Considered
+Three ways to determine "locked vs pending" for a `decision.md` Selected
+Approach (the high-level direction — bind to lifecycle confirmation state plus a
+new explicit pending field — was confirmed with the user during intake):
+
+- **Approach A — `G_plan` gate status (SELECTED).** A decision is locked iff the
+  `G_plan` gate is `approved`; otherwise the parsed non-placeholder decisions
+  are reported as pending. Tradeoff: requires threading the gate status from
+  readiness into skill_constraints assembly; gain: semantically precise, ties to
+  the real lifecycle "plan locked" gate, no ordering rework, parser untouched.
+- **Approach B — lifecycle stage.** Pending while in `S0_INTAKE`/`S1_PLAN`,
+  locked at `S2_EXECUTE`+. Tradeoff: no gate threading, but coarser — conflates
+  stage with plan-lock and cannot express "G_plan approved but still S1".
+- **Approach C — reuse `confirmation_requirement`.** Pending while a fresh
+  `hard_stop` confirmation is required. Tradeoff: that signal is derived AFTER
+  skill_constraints assembly (`finalize()`), forcing an ordering rework, and is
+  a broad per-handoff signal, not decision-specific.
+
+Evidence: data-flow trace in `research.md` (`## Alternatives Considered`),
+`cmd/next.go` (`deriveConfirmationRequirement` ordering), `internal/engine/gate/
+gate.go` (`G_plan`).
+
+## Selected Approach
+Approach A — gate `locked_decisions` on the `G_plan` gate state and add an
+explicit `pending_decisions` field.
+
+- Add `PendingDecisions []string \`json:"pending_decisions,omitempty"\`` to the
+  `skillConstraints` struct in `cmd/next.go`.
+- Thread the `G_plan` gate status (a derived `planLocked bool`) from
+  `buildNextView`/readiness through `assembleSkillView(WithOptions)` into
+  `buildSkillConstraints` (`cmd/next_skill.go` / `cmd/next_skill_view.go`).
+- Keep `ParseDecisionLockedDecisions` and `LooksLikeTemplatePlaceholder`
+  unchanged (placeholder filtering still removes scaffold text). Take the parser
+  output and route it: when `planLocked` → `locked_decisions`; otherwise →
+  `pending_decisions`.
+- Preserve `pending_decisions` in `cloneSkillConstraints`
+  (`cmd/next_handoff.go`).
+- Update the `spec-compliance-review` template so Decision Fidelity enforces
+  only `locked_decisions` and treats `pending_decisions` as advisory; regenerate
+  generated surfaces via toolgen.
+
+Why: `G_plan` is the lifecycle authority for "the plan/decision is locked in",
+is computed before skill assembly (no reordering), keeps the parser honest, and
+makes `locked_decisions` mean what it says while preserving the recommendation
+under a clearly-unconfirmed field.
+
+## Interfaces and Data Flow
+- Public JSON contract (`slipway next --json`): `skill_constraints` gains
+  `pending_decisions` (string list, omitempty). `locked_decisions` semantics
+  tighten to "G_plan-approved decisions only".
+- Internal: `buildSkillConstraints(root, def, change)` gains a `planLocked`
+  (gate-state) parameter; `assembleSkillView`/`assembleSkillViewWithOptions`
+  signatures extend to pass it; `cloneSkillConstraints` copies the new slice.
+- Data flow: readiness `GateEvaluations[G_plan].status == approved` → `planLocked`
+  → split `ParseDecisionLockedDecisions` output into locked vs pending.
+- Consumer surface: generated `spec-compliance-review` SKILL text (template
+  source `internal/tmpl/templates/skills/...`, regenerated copies).
+
+## Rollout and Rollback
+- Rollout: single change; additive JSON field + a conditional split + consumer
+  guidance regeneration. No data migration, no kernel half-states between waves.
+- Verification command: `go build ./... && go vet ./... && go test ./...`, plus
+  the new locked-vs-pending unit/e2e tests and the regenerated-surface template
+  test.
+- Rollback: revert the change (or drop the `pending_decisions` field and the
+  gate-threading); the field is `omitempty` and additive, so removing it
+  restores prior output. Rollback verification: `go test ./...` on the reverted
+  tree.
+
+## Risk
+- [low] Threading the gate state changes `assembleSkillView*` signatures — must
+  update all call sites; caught by compilation + tests.
+- [medium] Regression on the confirmed path: once `G_plan` is approved,
+  `locked_decisions` must still populate so `spec-compliance-review` fidelity
+  checks keep working. Mitigation: explicit test for the post-approval case.
+- [medium] Consumer drift: the `spec-compliance-review` guidance must change at
+  the TEMPLATE and be regenerated; hand-editing the `.claude`/`.codex` copy
+  would drift. Mitigation: edit template + run toolgen + template test asserts
+  the new advisory text.
+- [low] Contract surface: `next --json` is external; the change is additive
+  (new omitempty field) and tightens an over-broad field — reviewed as a
+  contract change at S3.

--- a/artifacts/changes/archived/fix-pending-approach-reported-as-locked-decision/intent.md
+++ b/artifacts/changes/archived/fix-pending-approach-reported-as-locked-decision/intent.md
@@ -1,0 +1,106 @@
+# Intent
+
+## Summary
+Fix issue #140: `slipway next --json` reports a recommended-but-unconfirmed
+decision (a `decision.md` "Selected Approach" labeled "Pending explicit user
+confirmation") inside `skill_constraints.locked_decisions`, even while the same
+response sets `confirmation_requirement.required: true` with
+`boundary: hard_stop`. A pending decision must not be presented as locked, and
+the JSON must make the pending/unlocked state explicit.
+
+## Complexity Assessment
+complex
+<!-- Rationale -->
+Root cause is not a one-line text fix: `ParseDecisionLockedDecisions`
+(`internal/engine/artifact/manager.go`) currently treats any non-template-
+placeholder "Selected Approach"/"Selected Direction" text as a locked decision.
+Author-written prose marked pending is real content, so a placeholder-phrase
+list cannot reliably distinguish pending from locked. The chosen fix ties
+"locked" to the governed lifecycle confirmation state and adds a new JSON
+surface, which touches the public `next --json` contract and the data flow
+between `cmd/next.go` (confirmation derivation) and `cmd/next_skill.go`
+(skill_constraints assembly).
+
+## Guardrail Domains
+External API / contract surface: this changes the public `slipway next --json`
+output (`skill_constraints`). Must be reviewed as an external contract change.
+
+## In Scope
+- `internal/engine/artifact/manager.go` — `ParseDecisionLockedDecisions` and how
+  "Selected Approach"/"Selected Direction" become locked decisions.
+- `cmd/next_skill.go` — `buildSkillConstraints` / `parseLockedDecisions`: gate
+  `locked_decisions` on confirmation state; add the new explicit pending field
+  to the `skill_constraints` struct.
+- `cmd/next.go` — reuse the lifecycle confirmation signal
+  (`deriveConfirmationRequirement` / `confirmationRequirement`) as the authority
+  for "confirmed vs pending"; thread it into skill_constraints assembly if not
+  already available.
+- Tests in `cmd/` and `internal/engine/artifact/` covering the pending→locked
+  transition and the new JSON field.
+- Generated `next --json` contract docs / command reference where the field set
+  is documented.
+
+## Out of Scope
+- The unrelated active change `fix-136-...` and any other active governed change
+  or worktree — left untouched.
+- Changing *how* a decision gets confirmed (the confirmation/approval flow
+  itself); only *how* locked-vs-pending is reported is in scope.
+- Adding new fragile text-marker heuristics for pending detection (explicitly
+  rejected in favor of the lifecycle-state signal).
+
+## Constraints
+- Determination must be driven by the governed lifecycle confirmation state, not
+  by expanding the placeholder-phrase text matcher.
+- Public JSON contract change: review `next --json` as an external contract;
+  keep `locked_decisions` semantics ("already confirmed/locked") honest.
+- Use the current worktree's Slipway CLI (dev build) as the source of truth.
+- Fail closed: a decision still pending fresh confirmation must never appear as
+  locked.
+
+## Acceptance Signals
+- Repro: with a `decision.md` "Selected Approach" that is recommended but still
+  pending confirmation (response carries `confirmation_requirement.required:true`,
+  `boundary:hard_stop`), `slipway next --json` does NOT list that approach under
+  `skill_constraints.locked_decisions`.
+- The same response surfaces the recommended approach under a new explicit
+  pending field in `skill_constraints`, clearly marked unconfirmed.
+- After the decision is confirmed/locked through the governed flow, it appears
+  in `locked_decisions` and no longer in the pending field.
+- New unit/e2e tests assert both the exclusion and the new field, and the
+  pending→locked transition; `go build/vet/test ./...` green.
+
+## Open Questions
+- [x] Authoritative lifecycle signal → `G_plan` gate status from
+  `readiness.GateEvaluations` (computed before skill assembly).
+  `confirmationRequirement` is derived later (`finalize()`) and is unusable.
+- [x] Does `buildSkillConstraints` have the gate state? → No; thread G_plan
+  status from `buildNextView` through `assembleSkillView` into
+  `buildSkillConstraints`.
+- [x] New pending field → `pending_decisions []string` on `skillConstraints`;
+  consumers: `cloneSkillConstraints`, the `spec-compliance-review` skill
+  template (regenerate via toolgen), and tests. (See research.md.)
+
+## Deferred Ideas
+<!-- none -->
+
+## Approved Summary
+Confirmed 2026-06-08T14:38:13Z.
+
+Fix issue #140 so `slipway next --json` stops presenting a recommended-but-
+unconfirmed decision as locked. Determine "locked vs pending" from the governed
+lifecycle confirmation state (not a placeholder text matcher): a decision enters
+`skill_constraints.locked_decisions` only once it has been confirmed through the
+flow; while the same response still requires fresh confirmation
+(`confirmation_requirement.required:true`, `boundary:hard_stop`), the recommended
+approach is excluded from `locked_decisions` and surfaced under a new explicit
+pending field so downstream skills still see it but know it is unconfirmed.
+
+In scope: decision parsing in `internal/engine/artifact/manager.go`,
+skill_constraints assembly + new pending field in `cmd/next_skill.go`,
+confirmation-signal reuse in `cmd/next.go`, tests, and `next --json` contract
+docs. Out of scope: the unrelated `fix-136` change, the confirmation flow
+itself, and new text-marker heuristics.
+
+Primary acceptance signal: in a pending-confirmation scenario the recommended
+approach is absent from `locked_decisions` and present in the new pending field;
+after confirmation the two reverse; `go build/vet/test ./...` green.

--- a/artifacts/changes/archived/fix-pending-approach-reported-as-locked-decision/requirements.md
+++ b/artifacts/changes/archived/fix-pending-approach-reported-as-locked-decision/requirements.md
@@ -1,0 +1,71 @@
+# Requirements
+
+## Requirements
+
+### Requirement: Pending decisions are never reported as locked
+REQ-001: `slipway next --json` MUST NOT include a recommended-but-unconfirmed
+decision (a `decision.md` "Selected Approach"/"Selected Direction" that the
+lifecycle has not yet locked) in `skill_constraints.locked_decisions`.
+
+#### Scenario: Unconfirmed approach excluded from locked_decisions
+GIVEN a governed change whose `decision.md` records a recommended "Selected
+Approach" while the `G_plan` gate is not approved
+WHEN `slipway next --json` is run
+THEN the recommended approach does NOT appear in
+`skill_constraints.locked_decisions`.
+
+### Requirement: Pending decisions are surfaced explicitly
+REQ-002: The system MUST surface the recommended-but-unconfirmed decision under
+an explicit `skill_constraints.pending_decisions` field so downstream hosts can
+see the recommendation while knowing it is unconfirmed.
+
+#### Scenario: Unconfirmed approach present in pending_decisions
+GIVEN the same change with a recommended "Selected Approach" and `G_plan` not
+approved
+WHEN `slipway next --json` is run
+THEN the recommended approach appears in `skill_constraints.pending_decisions`.
+
+### Requirement: Confirmed decisions are reported as locked
+REQ-003: Once the lifecycle has locked the plan (the `G_plan` gate is
+`approved`), the system MUST report the decision under
+`skill_constraints.locked_decisions` and MUST NOT report it under
+`pending_decisions`.
+
+#### Scenario: Locked decision moves to locked_decisions after G_plan approval
+GIVEN a governed change whose `G_plan` gate is `approved`
+WHEN `slipway next --json` is run
+THEN the decision appears in `skill_constraints.locked_decisions`
+AND it does NOT appear in `skill_constraints.pending_decisions`.
+
+### Requirement: Lock state is derived from the lifecycle gate, not text matching
+REQ-004: The locked-vs-pending determination MUST be derived from the governed
+lifecycle gate state (`G_plan`) and MUST NOT rely on expanding the decision-text
+placeholder matcher to detect pending wording.
+
+#### Scenario: Non-placeholder pending prose is still excluded while unlocked
+GIVEN a `decision.md` "Selected Approach" containing concrete, author-written
+prose (not template placeholder text) while `G_plan` is not approved
+WHEN `slipway next --json` is run
+THEN the approach is still excluded from `locked_decisions` and surfaced under
+`pending_decisions`, with no change to placeholder-phrase matching.
+
+### Requirement: Pending field is preserved in handoff payloads
+REQ-005: The `pending_decisions` field MUST be preserved when
+`skill_constraints` is cloned for handoff payloads.
+
+#### Scenario: Cloned skill constraints retain pending_decisions
+GIVEN a `skill_constraints` value carrying `pending_decisions`
+WHEN it is cloned for a handoff payload (`cloneSkillConstraints`)
+THEN the clone carries the identical `pending_decisions` contents.
+
+### Requirement: Consumer guidance treats pending as advisory
+REQ-006: The generated `spec-compliance-review` surface MUST direct hosts to
+treat `pending_decisions` as advisory (do NOT enforce decision-fidelity
+violations against an unconfirmed decision), and MUST be regenerated from its
+template source rather than hand-edited.
+
+#### Scenario: spec-compliance-review distinguishes pending from locked
+GIVEN the regenerated `spec-compliance-review` skill surface
+WHEN a host reads its Decision Fidelity guidance
+THEN it enforces fidelity only against `locked_decisions`
+AND it is instructed not to flag fidelity violations for `pending_decisions`.

--- a/artifacts/changes/archived/fix-pending-approach-reported-as-locked-decision/research.md
+++ b/artifacts/changes/archived/fix-pending-approach-reported-as-locked-decision/research.md
@@ -1,0 +1,153 @@
+# Research
+
+## Alternatives Considered
+
+### Architecture
+- Affected modules / files:
+  - `internal/engine/artifact/manager.go` — `ParseDecisionLockedDecisions`
+    (~L443) parses decision.md "Selected Approach" / "Selected Direction" and
+    gates ONLY on `LooksLikeTemplatePlaceholder` (~L474). Author-written prose
+    marked "Pending explicit user confirmation" is not a placeholder, so it
+    leaks into locked decisions.
+  - `cmd/next.go` — `skillConstraints` struct (~L119-131, json tags); the JSON
+    contract surface; `deriveConfirmationRequirement` (~L609) and
+    `confirmationHardStop`/`confirmationCommandRequired` helpers.
+  - `cmd/next_skill.go` — `buildSkillConstraints` (~L20-42) and
+    `parseLockedDecisions` (~L59-74) wrapper that calls the artifact parser.
+  - `cmd/next_skill_view.go` — `assembleSkillViewWithOptions` (~L78) calls
+    `buildSkillConstraints` (~L332); this is the threading point.
+  - `cmd/next_handoff.go` — `cloneSkillConstraints` (~L253) deep-copies the
+    struct for handoff payloads; must copy any new field.
+  - `internal/engine/gate/gate.go` — `G_plan` evaluation (~L66-86) =
+    bundleReady + planAuditPass + DecisionContractBlockers. This is the
+    lifecycle "plan locked" gate and the chosen lock signal.
+- Dependency chains:
+  - `next`/`run` RunE → `buildNextView` → `buildNextContextByMode` (loads
+    Change + readiness + GateEvaluations incl. G_plan) → `assembleSkillView` →
+    `assembleSkillViewWithOptions` → `buildSkillConstraints` →
+    `parseLockedDecisions` → `artifact.ParseDecisionLockedDecisions`.
+  - `view.ConfirmationRequirement` is derived in `finalize()` AFTER
+    `assembleSkillView` returns — so it is NOT available at skill_constraints
+    assembly time. The readiness gate evaluations ARE computed earlier and can
+    be threaded in.
+- Blast radius: `slipway next`/`run` JSON `skill_constraints`. Read by the
+  `spec-compliance-review` host (Decision Fidelity Check) and cloned for
+  handoff payloads. No engine gate weakening.
+- Constraints / invariants:
+  - `internal/tmpl/templates/skills/` is the SOURCE OF TRUTH for generated
+    skills; `.claude`/`.codex` copies must be regenerated via toolgen, never
+    hand-edited (per ARCHITECTURE codebase map).
+  - `locked_decisions` semantics must mean "the plan gate has locked this in",
+    not "the text is non-placeholder".
+
+### Patterns
+- Existing conventions:
+  - `skillConstraints` uses `json:"...,omitempty"` string-slice fields
+    (`locked_decisions`); a new `pending_decisions []string
+    json:"pending_decisions,omitempty"` field mirrors that idiom exactly.
+  - Gate status is surfaced as `gate_status.G_plan.status` (`approved` /
+    `blocked` / ...) — see `slipway status --json`.
+- Reusable abstractions:
+  - `readiness` / `GateEvaluations` already carry G_plan status; thread the
+    G_plan status (or a derived `planLocked bool`) into
+    `assembleSkillViewWithOptions` → `buildSkillConstraints`.
+  - `ParseDecisionLockedDecisions` already returns the parsed (non-placeholder)
+    decisions; reuse its output and split it into locked vs pending based on the
+    gate signal rather than changing the parser's placeholder logic.
+- Convention deviations: none required. No new text-marker heuristics are
+  added (explicitly out of scope).
+
+### Risks
+- Technical risks:
+  - [low] Threading gate status into skill assembly: a mechanical signature
+    change; must update all call sites of `assembleSkillView*`.
+  - [low] Regression on already-locked decisions: once G_plan is `approved`
+    (S2+/review), locked_decisions must still populate so
+    `spec-compliance-review` fidelity check keeps working — covered by tests.
+  - [medium] Consumer drift: `spec-compliance-review` SKILL template must learn
+    that `pending_decisions` is advisory (do NOT enforce fidelity on pending),
+    and be regenerated via toolgen so `.claude`/`.codex` stay in sync.
+- Guardrail domains: external API / contract surface (public `next --json`).
+  Review as an external contract change. Fail-closed: a decision still pending
+  fresh confirmation must never appear as locked.
+- Reversibility: fully reversible (additive field + a conditional); no data
+  migration, no irreversible ops.
+
+### Test Strategy
+- Existing coverage:
+  - `cmd/next_skill_constraints_test.go` — `TestParseLockedDecisions`,
+    `TestSkillConstraintsLockedDecisionsFromDecision` (asserts populated).
+  - `internal/engine/artifact/*` — placeholder/parse tests.
+  - There is existing assertion that unconfirmed/placeholder decisions yield nil
+    locked decisions; the new gate signal must not break the confirmed path.
+- Infrastructure needs: none new; reuse table-driven cmd tests + an e2e in
+  `cmd/cli_e2e_test.go` style that drives a change to a pre-confirm vs
+  post-G_plan-approved state and asserts the field split.
+- Verification approach per acceptance signal:
+  - Pending scenario (G_plan not approved) → assert recommended approach is in
+    `pending_decisions` and absent from `locked_decisions`.
+  - Confirmed scenario (G_plan approved) → assert it is in `locked_decisions`
+    and absent from `pending_decisions`.
+  - Placeholder/no decision → both empty.
+  - Regenerated `spec-compliance-review` surface contains the pending advisory
+    (template/toolgen test).
+
+### Options
+- Approach A (G_plan gate status) — locked iff `G_plan` is `approved`; otherwise
+  the parsed non-placeholder decisions go to `pending_decisions`. Thread G_plan
+  status from readiness into `buildSkillConstraints`. Tradeoff: a small
+  signature/threading change; gain: semantically precise, ties to the real
+  "plan locked" gate.
+- Approach B (lifecycle stage) — pending while in S0/S1, locked at S2+. No gate
+  threading needed. Tradeoff: coarser; cannot express "G_plan approved but still
+  S1" and conflates stage with plan-lock.
+- Approach C (reuse confirmation_requirement) — pending while a fresh hard_stop
+  confirmation is required. Tradeoff: that signal is derived AFTER skill
+  assembly (ordering rework) and is a broad per-handoff signal, not
+  decision-specific.
+- Selected: **Approach A — G_plan gate status** (user-selected). Rationale:
+  G_plan is the lifecycle authority for "the plan/decision is locked in"; it is
+  computed before skill assembly (so no ordering rework), and it keeps the
+  parser's placeholder logic untouched while making locked-vs-pending honest.
+
+## Unknowns
+- Resolved: Authoritative confirmation signal reachable at skill_constraints
+  assembly time -> `G_plan` gate status from `readiness.GateEvaluations`
+  (computed in `buildNextContextByMode`, before `assembleSkillView`).
+  `view.ConfirmationRequirement` is NOT usable (derived later in `finalize()`).
+- Resolved: Does `buildSkillConstraints` already have the gate state? -> No; it
+  receives `(root, def, governedChange)`. The G_plan status must be threaded
+  from `buildNextView` through `assembleSkillView(WithOptions)` into
+  `buildSkillConstraints`.
+- Resolved: New JSON field name/shape + consumers -> `pending_decisions
+  []string json:"pending_decisions,omitempty"` on `skillConstraints`
+  (mirrors `locked_decisions`). Consumers to update: `cloneSkillConstraints`
+  (`cmd/next_handoff.go`), the `spec-compliance-review` skill TEMPLATE
+  (`internal/tmpl/templates/skills/.../spec-compliance-review` + toolgen
+  regeneration), and tests.
+- Remaining: None.
+
+## Assumptions
+- `G_plan.status == "approved"` is a faithful proxy for "decision is locked in"
+  - Evidence: `internal/engine/gate/gate.go` G_plan = bundleReady +
+    planAuditPass + DecisionContractBlockers; once approved the plan bundle
+    (including decision.md) is the locked authority. Confirmed by
+    `slipway status --json` `gate_status.G_plan`.
+- The recommended-but-pending approach is still worth surfacing (not dropped)
+  - Evidence: issue #140 "JSON field should clarify the pending/unlocked state";
+    downstream skills benefit from seeing the recommendation while knowing it is
+    unconfirmed.
+- Generated skill surfaces must be edited at the template, not the copy
+  - Evidence: `artifacts/codebase/ARCHITECTURE.md` and repo `CLAUDE.md` change
+    discipline ("keep code, generated skills, docs aligned as one product
+    surface").
+
+## Canonical References
+- `internal/engine/artifact/manager.go` (ParseDecisionLockedDecisions, LooksLikeTemplatePlaceholder)
+- `cmd/next.go` (skillConstraints struct, deriveConfirmationRequirement)
+- `cmd/next_skill.go` (buildSkillConstraints, parseLockedDecisions)
+- `cmd/next_skill_view.go` (assembleSkillViewWithOptions, buildSkillConstraints call site)
+- `cmd/next_handoff.go` (cloneSkillConstraints)
+- `internal/engine/gate/gate.go` (G_plan evaluation)
+- `cmd/next_skill_constraints_test.go` (existing locked-decisions tests)
+- `internal/tmpl/templates/skills/` (spec-compliance-review template; generated-surface source of truth)

--- a/artifacts/changes/archived/fix-pending-approach-reported-as-locked-decision/tasks.md
+++ b/artifacts/changes/archived/fix-pending-approach-reported-as-locked-decision/tasks.md
@@ -1,0 +1,31 @@
+# Tasks
+
+## Task List
+
+- [x] `t-01` Add `pending_decisions` to `skillConstraints` and gate locked-vs-pending on the `G_plan` state; thread the gate status into skill_constraints assembly and split `ParseDecisionLockedDecisions` output (locked when G_plan approved, else pending)
+  - wave: 1
+  - depends_on: []
+  - target_files: [cmd/next.go, cmd/next_skill.go, cmd/next_skill_view.go]
+  - task_kind: code
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004]
+
+- [x] `t-02` Preserve `pending_decisions` when `skill_constraints` is cloned for handoff payloads
+  - wave: 2
+  - depends_on: [t-01]
+  - target_files: [cmd/next_handoff.go]
+  - task_kind: code
+  - covers: [REQ-005]
+
+- [x] `t-03` Update the `spec-compliance-review` template so Decision Fidelity enforces only `locked_decisions` and treats `pending_decisions` as advisory (edit template source; generated copies regenerate via toolgen)
+  - wave: 2
+  - depends_on: [t-01]
+  - target_files: [internal/tmpl/templates/skills/spec-compliance-review/SKILL.md.tmpl]
+  - task_kind: code
+  - covers: [REQ-006]
+
+- [x] `t-04` Add/extend tests: unit tests for the locked-vs-pending split and the new field (pending when G_plan unapproved, locked after approval, both empty for placeholder), an e2e asserting the JSON field split, and a template test asserting the regenerated spec-compliance-review pending advisory
+  - wave: 3
+  - depends_on: [t-01, t-02, t-03]
+  - target_files: [cmd/next_skill_constraints_test.go, cmd/cli_e2e_test.go, internal/tmpl/templates_test.go]
+  - task_kind: test
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004, REQ-005, REQ-006]

--- a/artifacts/codebase/ARCHITECTURE.md
+++ b/artifacts/codebase/ARCHITECTURE.md
@@ -1,33 +1,49 @@
 # Architecture
 
+Re-authored for change `fix-pending-approach-reported-as-locked-decision`
+(issue #140). The prior map described issue #114 (skill-template thinning) and
+was out of scope; this scopes to the `slipway next --json` skill_constraints
+path.
+
 - Module responsibilities:
-  - `internal/tmpl/templates/skills/` is the source of truth for generated
-    governance skill surfaces. Hand-editing `.codex/`, `.claude/`, `.cursor/`,
-    or other generated copies is out of bounds.
-  - `internal/toolgen/toolgen.go` owns which template-backed skills are exported
-    for each supported tool and how generated runtime surfaces are laid out.
-  - `internal/tmpl/templates_test.go` and focused `internal/tmpl/*_test.go`
-    files protect generated-surface text contracts.
+  - `cmd/next.go` — owns the `next`/`run` command, the `skillConstraints` JSON
+    struct (the public `next --json` contract), and `deriveConfirmationRequirement`.
+  - `cmd/next_skill.go` — `buildSkillConstraints` / `parseDecisionItems`:
+    parses selected decision text and routes it into
+    `skill_constraints.locked_decisions` or
+    `skill_constraints.pending_decisions` according to the G_plan gate.
+  - `cmd/next_skill_view.go` — `assembleSkillViewWithOptions` resolves the next
+    skill and calls `buildSkillConstraints` (the threading point for gate state).
+  - `cmd/next_handoff.go` — `cloneSkillConstraints` deep-copies the struct for
+    handoff payloads.
+  - `internal/engine/artifact/manager.go` — `ParseDecisionLockedDecisions` +
+    `LooksLikeTemplatePlaceholder`: parse decision.md sections; placeholder
+    detection (NOT confirmation detection).
+  - `internal/engine/gate/gate.go` — `G_plan` gate evaluation; the lifecycle
+    authority for "the plan/decision is locked in" (the chosen lock signal).
+  - `internal/tmpl/templates/skills/` — SOURCE OF TRUTH for generated skill
+    surfaces (e.g. spec-compliance-review). `.claude`/`.codex` copies are
+    regenerated via `internal/toolgen`; never hand-edited.
 - Dependency flow:
-  - Template files embed shared partials from `internal/tmpl/templates/_partials`
-    where needed, then `toolgen` renders those files into per-tool skills and
-    prompt surfaces.
-  - The lifecycle engine routes by `next_skill.name`; the generated skill text
-    instructs the host AI how to execute the stage without changing engine gates.
+  - `next`/`run` RunE → `buildNextView` → `buildNextContextByMode` (loads Change
+    + readiness + `GateEvaluations` incl. G_plan) → `assembleSkillView` →
+    `assembleSkillViewWithOptions` → `buildSkillConstraints` →
+    `parseDecisionItems` → `artifact.ParseDecisionLockedDecisions`; the
+    returned items are locked only when G_plan is approved and pending otherwise.
+  - Ordering: `view.ConfirmationRequirement` is derived in `finalize()` AFTER
+    skill assembly; the readiness gate evaluations are computed BEFORE it, so
+    G_plan status (not confirmation_requirement) is the usable signal.
 - Coupling hotspots:
-  - `goal-verification` is closeout-adjacent and produces high-risk safety
-    baseline references; any context optimization must preserve fail-closed
-    evidence requirements.
-  - `worktree-preflight` owns baseline proof before execution; it must record
-    required worktree references while avoiding long baseline output in the
-    main host.
-  - `wave-orchestration` already dispatches task executors, but the host text
-    still asks the coordinator to read broad codebase-map files before dispatch.
+  - `skill_constraints.locked_decisions` is read by the `spec-compliance-review`
+    host (Decision Fidelity Check); `pending_decisions` is advisory context.
+    Both fields are cloned in handoff payloads and must stay in sync.
 - Current change blast radius:
-  - Generated governance skill templates and tests for template contracts.
-  - No lifecycle engine gate weakening and no generated output hand edits.
-- Notes:
-  - Source references: `internal/tmpl/templates/skills/goal-verification/SKILL.md.tmpl`,
-    `internal/tmpl/templates/skills/worktree-preflight/SKILL.md`,
-    `internal/tmpl/templates/skills/wave-orchestration/SKILL.md.tmpl`,
-    `internal/toolgen/toolgen.go`, `internal/tmpl/templates_test.go`.
+  - `skillConstraints` struct (+`pending_decisions`), `buildSkillConstraints`
+    signature/logic, the assembleSkillView threading, `cloneSkillConstraints`,
+    the spec-compliance-review template + toolgen regeneration, and tests.
+  - No engine gate weakening; decision parser placeholder logic unchanged.
+- Notes / source references:
+  - `cmd/next.go`, `cmd/next_skill.go`, `cmd/next_skill_view.go`,
+    `cmd/next_handoff.go`, `internal/engine/artifact/manager.go`,
+    `internal/engine/gate/gate.go`,
+    `internal/tmpl/templates/skills/` (spec-compliance-review).

--- a/artifacts/codebase/CONCERNS.md
+++ b/artifacts/codebase/CONCERNS.md
@@ -1,32 +1,37 @@
 # Concerns
 
+Re-authored for change `fix-pending-approach-reported-as-locked-decision`
+(issue #140); replaces the stale issue-#114 map.
+
 - Architectural pressure points:
-  - Verification and preflight stages are gate-bearing; context reduction must
-    not change the evidence required to pass those gates.
-  - Host wording must be runtime-portable: Codex currently does not receive
-    generated agent directories, so the template must allow "subagent if
-    supported; structured-summary fallback otherwise" rather than depending on a
-    single runtime's Task API.
+  - `locked_decisions` is a public `next --json` contract field; its meaning
+    ("the plan gate has locked this in") must stay honest. Adding
+    `pending_decisions` is additive but still a contract change to review.
+  - The lock signal must come from the lifecycle (`G_plan` gate), not from
+    expanding the placeholder text matcher — text heuristics were explicitly
+    rejected and would re-introduce the same false-positive class.
 - Brittle areas:
-  - `goal-verification` must still record
-    `high_risk_check:<domain>.safety_baseline=pass` from a real SAST run when a
-    guardrail domain is set.
-  - `worktree-preflight` must still record worktree path, branch, and exact
-    baseline command references even if the baseline's full output is delegated.
-  - `wave-orchestration` must still record task evidence with
-    `slipway evidence task`; slimming context cannot permit skipped task
-    evidence.
+  - `deriveConfirmationRequirement` runs AFTER skill_constraints assembly; do
+    not try to reuse `view.ConfirmationRequirement` inside
+    `buildSkillConstraints` (it is not populated yet). Use the readiness/G_plan
+    status which is available earlier.
+  - `cloneSkillConstraints` must copy any new field or handoff payloads silently
+    drop it.
 - Migration traps:
-  - Editing generated `.codex/`, `.claude/`, `.cursor/`, or `.gemini/` files by
-    hand would drift from the template source of truth.
-  - Implementing token telemetry or model-profile routing here would broaden the
-    issue #114 scope beyond the first context-span optimization.
+  - Editing generated `.claude/`/`.codex/` skill copies by hand drifts from the
+    template source of truth — change the `spec-compliance-review` TEMPLATE and
+    regenerate via toolgen.
+- Fail-closed requirement:
+  - A decision still pending fresh confirmation (G_plan not approved) must NEVER
+    appear in `locked_decisions`. The confirmed path (G_plan approved) must keep
+    populating `locked_decisions` so spec-compliance fidelity checks still work.
 - Recheck routing:
-  - Run focused template tests after editing skill templates, then full
-    `go test ./...`.
-  - Refresh generated surfaces through the repo-native init/refresh command if
-    template tests or repository policy require generated copies to be updated.
-- Notes:
-  - Source references: `internal/tmpl/templates/skills/goal-verification/SKILL.md.tmpl`,
-    `internal/tmpl/templates/skills/worktree-preflight/SKILL.md`,
-    `internal/tmpl/templates/skills/wave-orchestration/SKILL.md.tmpl`.
+  - Run focused `cmd/` tests for
+    `TestSkillConstraintsPendingDecisionsBeforePlanLock`,
+    `TestSkillConstraintsLockedDecisionsAfterPlanLock`,
+    `TestBuildSkillConstraintsLockedVsPending`, and
+    `TestPlanLockedFromGates`; run `internal/tmpl` / `internal/toolgen`
+    generated-surface tests, then full `go build/vet/test ./...`.
+- Notes / source references:
+  - `cmd/next.go`, `cmd/next_skill.go`, `internal/engine/gate/gate.go`,
+    `cmd/next_handoff.go`, `internal/tmpl/templates/skills/` (spec-compliance-review).

--- a/artifacts/codebase/TESTING.md
+++ b/artifacts/codebase/TESTING.md
@@ -1,25 +1,31 @@
 # Testing
 
-- Test layout: Go *_test.go files
-- Coverage hotspots:
-  - `internal/tmpl/templates_test.go` covers generated template contracts,
-    stale text removal, prompt surfaces, and skill export expectations.
-  - `internal/tmpl/wave_isolation_content_test.go` covers wave dispatch
-    isolation phrasing.
-  - `internal/toolgen/toolgen_test.go` covers exported host skill inventory,
-    generated directory layouts, and tool-specific surface behavior.
-- Coverage gaps:
-  - Existing tests assert some wave dispatch language, but do not yet guard that
-    goal-verification and worktree-preflight stay thin-host/summary-first.
-  - Generated skill contract tests should prevent future regressions that move
-    long command output or source-file reading back into main host context.
-- Verification commands: go build ./...; go test ./...
+Re-authored for change `fix-pending-approach-reported-as-locked-decision`
+(issue #140); replaces the stale issue-#114 map.
+
+- Test layout: Go `*_test.go` files alongside packages.
+- Coverage hotspots for this change:
+  - `cmd/next_skill_constraints_test.go` — `TestParseDecisionItems`,
+    `TestBuildSkillConstraintsLockedVsPending`, `TestPlanLockedFromGates`, and
+    `TestSkillConstraintsPendingDecisionsBeforePlanLock` /
+    `TestSkillConstraintsLockedDecisionsAfterPlanLock` (locked-vs-pending split
+    assembly plus full `next --json` pending and confirmed paths).
+  - `internal/engine/artifact/*_test.go` — decision parsing / placeholder
+    detection.
+  - `internal/tmpl/templates_test.go` / `internal/toolgen/toolgen_test.go` —
+    generated `spec-compliance-review` surface text contracts (assert the new
+    pending advisory is present after regeneration).
+- Coverage gaps to close:
+  - No known blocking gap for issue #140. The unconfirmed path is covered by
+    `TestSkillConstraintsPendingDecisionsBeforePlanLock`; the confirmed path is
+    covered by `TestSkillConstraintsLockedDecisionsAfterPlanLock`, which drives
+    real `next --json --diagnostics` output with G_plan approved.
+- Verification commands: `go build ./...`; `go vet ./...`; `go test ./...`.
 - Fixture patterns:
-  - Template tests commonly read from the embedded template FS and assert on
-    rendered markdown substrings.
-  - Toolgen tests build generated trees in temporary directories and inspect
-    emitted skill/prompt files.
-- Notes:
-  - Source references: `internal/tmpl/templates_test.go`,
-    `internal/tmpl/wave_isolation_content_test.go`,
-    `internal/toolgen/toolgen_test.go`.
+  - cmd tests build a governed change/view in temp dirs and assert on the
+    rendered JSON struct.
+  - Template/toolgen tests read the embedded template FS and assert on rendered
+    markdown substrings.
+- Notes / source references:
+  - `cmd/next_skill_constraints_test.go`, `internal/engine/artifact`,
+    `internal/tmpl/templates_test.go`, `internal/toolgen/toolgen_test.go`.

--- a/cmd/next.go
+++ b/cmd/next.go
@@ -51,6 +51,10 @@ type nextView struct {
 	ConfirmationRequirement   confirmationRequirement              `json:"confirmation_requirement"`
 
 	consumeActiveCheckpoint bool
+	// planLocked records whether the lifecycle G_plan gate has approved the plan.
+	// It is unexported (never serialized) and drives whether a parsed decision.md
+	// selection is reported as a locked or pending skill_constraint (issue #140).
+	planLocked bool
 }
 
 type confirmationRequirement struct {
@@ -119,7 +123,14 @@ type nextSkillView struct {
 // skillConstraints carries per-skill metadata from the Go registry
 // and state context, replacing level-conditional logic in skill templates.
 type skillConstraints struct {
-	LockedDecisions  []string `json:"locked_decisions,omitempty"`
+	LockedDecisions []string `json:"locked_decisions,omitempty"`
+	// PendingDecisions carries the recommended-but-unconfirmed selected
+	// approach/direction parsed from decision.md while the lifecycle has NOT yet
+	// locked the plan (the G_plan gate is not approved). It is surfaced
+	// separately from LockedDecisions so a host still sees the recommendation but
+	// knows it is pending fresh confirmation and must not treat it as locked
+	// (issue #140).
+	PendingDecisions []string `json:"pending_decisions,omitempty"`
 	GuardrailDomain  string   `json:"guardrail_domain,omitempty"`
 	MitigationTarget string   `json:"mitigation_target,omitempty"`
 	RunSummaryBound  bool     `json:"run_summary_bound,omitempty"`
@@ -388,6 +399,7 @@ func buildNextView(root string, ref changeRef, resumeResponse string, preview bo
 		nextSkillArtifactProjection = readiness.ArtifactProjection
 		applyReadinessToNextContext(&view, readiness)
 		applyGovernanceSurfaceToNext(readiness, &view)
+		view.planLocked = planLockedFromGates(readiness)
 	}
 
 	// Attach wave plan when at S2_EXECUTE for governed changes.

--- a/cmd/next_handoff.go
+++ b/cmd/next_handoff.go
@@ -113,6 +113,10 @@ func buildNextHandoffSourceView(root string, ref changeRef, resumeResponse strin
 		// path free of them preserves the narrow handoff contract.
 		nextSkillEvidence = readiness.PassingSkills
 		nextSkillArtifactProjection = readiness.ArtifactProjection
+		// A parsed decision.md selection is only a locked skill_constraint once the
+		// G_plan gate is approved; otherwise it is carried as pending so the
+		// handoff payload stays consistent with the full next view (issue #140).
+		view.planLocked = planLockedFromGates(readiness)
 	}
 
 	if view.CurrentState == model.StateDone {
@@ -256,6 +260,7 @@ func cloneSkillConstraints(in *skillConstraints) *skillConstraints {
 	}
 	return &skillConstraints{
 		LockedDecisions:  append([]string(nil), in.LockedDecisions...),
+		PendingDecisions: append([]string(nil), in.PendingDecisions...),
 		GuardrailDomain:  in.GuardrailDomain,
 		MitigationTarget: in.MitigationTarget,
 		RunSummaryBound:  in.RunSummaryBound,

--- a/cmd/next_skill.go
+++ b/cmd/next_skill.go
@@ -17,7 +17,7 @@ import (
 // governance registry and artifact state, replacing level-conditional logic in
 // skill templates.
 // governedChange is the already-loaded unified Change (nil for intake-only mode).
-func buildSkillConstraints(root string, def skill.Definition, governedChange *model.Change) *skillConstraints {
+func buildSkillConstraints(root string, def skill.Definition, governedChange *model.Change, planLocked bool) *skillConstraints {
 	sc := &skillConstraints{
 		MitigationTarget: def.Mitigation,
 		RunSummaryBound:  def.RunSummaryBound,
@@ -26,9 +26,18 @@ func buildSkillConstraints(root string, def skill.Definition, governedChange *mo
 	if governedChange != nil {
 		sc.GuardrailDomain = governedChange.GuardrailDomain
 
-		// Parse locked decisions from decision.md (canonical source for selected approach).
+		// Parse the selected approach/direction from decision.md and route it by
+		// lifecycle lock state: a decision is "locked" only once the G_plan gate
+		// has approved the plan. While the plan is not yet locked, a recommended
+		// Selected Approach is still pending fresh user confirmation and must be
+		// surfaced as pending, never as a locked decision (issue #140).
 		if paths, err := state.ResolveChangePaths(root, *governedChange); err == nil {
-			sc.LockedDecisions = parseLockedDecisions(filepath.Join(paths.GovernedBundleDir, "decision.md"))
+			decisions := parseDecisionItems(filepath.Join(paths.GovernedBundleDir, "decision.md"))
+			if planLocked {
+				sc.LockedDecisions = decisions
+			} else {
+				sc.PendingDecisions = decisions
+			}
 		}
 
 		// Surface the exact high-risk reference tokens goal-verification must
@@ -56,9 +65,20 @@ func requiredHighRiskTokenHints(domain string) []string {
 	return out
 }
 
-// parseLockedDecisions extracts locked decision items from decision.md.
-// Returns nil if the file is absent or only contains scaffolded draft text.
-func parseLockedDecisions(decisionPath string) []string {
+// planLockedFromGates reports whether the lifecycle has locked the plan — the
+// G_plan gate is approved. Decisions parsed from decision.md are only "locked"
+// once this is true; before plan approval a recommended Selected Approach is
+// still pending fresh confirmation and is surfaced as pending (issue #140).
+func planLockedFromGates(readiness progression.GovernanceReadiness) bool {
+	eval, ok := readiness.GateEvaluations[gate.GatePlan]
+	return ok && eval.Status == model.GateStatusApproved
+}
+
+// parseDecisionItems extracts the selected approach/direction items from
+// decision.md. Returns nil if the file is absent or only contains scaffolded
+// draft text. Whether these items are reported as locked or pending is decided
+// by the caller from the lifecycle G_plan gate state (issue #140).
+func parseDecisionItems(decisionPath string) []string {
 	data, err := os.ReadFile(decisionPath)
 	if err != nil {
 		return nil

--- a/cmd/next_skill_constraints_test.go
+++ b/cmd/next_skill_constraints_test.go
@@ -6,8 +6,10 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/signalridge/slipway/internal/bootstrap"
+	"github.com/signalridge/slipway/internal/engine/gate"
 	"github.com/signalridge/slipway/internal/engine/progression"
 	"github.com/signalridge/slipway/internal/engine/skill"
 	"github.com/signalridge/slipway/internal/model"
@@ -32,7 +34,7 @@ func TestBuildSkillConstraintsSurfacesHighRiskTokensForGoalVerification(t *testi
 	change.GuardrailDomain = model.GuardrailDomainExternalAPIContracts
 	def := skill.Definition{Name: progression.SkillGoalVerification}
 
-	sc := buildSkillConstraints(t.TempDir(), def, &change)
+	sc := buildSkillConstraints(t.TempDir(), def, &change, true)
 	require.NotNil(t, sc)
 	assert.Contains(t, sc.RequiredHighRiskTokens, "high_risk_check:external_api_contracts.safety_baseline=pass")
 }
@@ -42,15 +44,15 @@ func TestBuildSkillConstraintsNoHighRiskTokensWithoutGuardrailDomain(t *testing.
 	change := model.NewChange("plain-change") // no guardrail domain
 	def := skill.Definition{Name: progression.SkillGoalVerification}
 
-	sc := buildSkillConstraints(t.TempDir(), def, &change)
+	sc := buildSkillConstraints(t.TempDir(), def, &change, true)
 	require.NotNil(t, sc)
 	assert.Empty(t, sc.RequiredHighRiskTokens)
 }
 
-func TestParseLockedDecisions(t *testing.T) {
+func TestParseDecisionItems(t *testing.T) {
 	t.Parallel()
 	t.Run("absent file returns nil", func(t *testing.T) {
-		result := parseLockedDecisions("/nonexistent/decision.md")
+		result := parseDecisionItems("/nonexistent/decision.md")
 		assert.Nil(t, result)
 	})
 
@@ -58,7 +60,7 @@ func TestParseLockedDecisions(t *testing.T) {
 		tmp := t.TempDir()
 		p := filepath.Join(tmp, "decision.md")
 		require.NoError(t, os.WriteFile(p, []byte("## Objectives\n- obj1\n"), 0o644))
-		result := parseLockedDecisions(p)
+		result := parseDecisionItems(p)
 		assert.Nil(t, result)
 	})
 
@@ -66,7 +68,7 @@ func TestParseLockedDecisions(t *testing.T) {
 		tmp := t.TempDir()
 		p := filepath.Join(tmp, "decision.md")
 		require.NoError(t, os.WriteFile(p, []byte("## Alternatives Considered\n\n## Selected Approach\n\n## Risk\n"), 0o644))
-		result := parseLockedDecisions(p)
+		result := parseDecisionItems(p)
 		assert.Nil(t, result)
 	})
 
@@ -83,7 +85,7 @@ Use Go modules with a clean interface boundary for the new subsystem.
 - Low risk overall
 `
 		require.NoError(t, os.WriteFile(p, []byte(content), 0o644))
-		result := parseLockedDecisions(p)
+		result := parseDecisionItems(p)
 		require.NotNil(t, result)
 		assert.Contains(t, result[0], "Selected Approach:")
 	})
@@ -108,7 +110,7 @@ Use the refactor-first path and keep the external contract stable.
 - Medium risk overall
 `
 		require.NoError(t, os.WriteFile(p, []byte(content), 0o644))
-		result := parseLockedDecisions(p)
+		result := parseDecisionItems(p)
 		require.Len(t, result, 2)
 		assert.Contains(t, result[0], "Selected Direction:")
 		assert.Contains(t, result[1], "Selected Approach:")
@@ -144,23 +146,31 @@ func TestSkillConstraintsPopulatedInNextOutput(t *testing.T) {
 		assert.Equal(t, "stale or incomplete plan bundle", sc.MitigationTarget)
 		assert.False(t, sc.RunSummaryBound)
 		assert.Nil(t, sc.LockedDecisions, "fresh scaffolded seeded decision text must not be treated as a locked human-reviewed decision")
+		assert.Nil(t, sc.PendingDecisions, "scaffolded placeholder decision text is neither locked nor pending")
 	})
 }
 
-func TestSkillConstraintsLockedDecisionsFromDecision(t *testing.T) {
+// TestSkillConstraintsPendingDecisionsBeforePlanLock reproduces issue #140: a
+// real, author-written Selected Approach in decision.md while the plan is NOT
+// yet locked (G_plan not approved at S1_PLAN/audit, no plan-audit evidence)
+// must be surfaced as a PENDING decision, never as a locked one — in both the
+// full next view and the compact handoff payload.
+func TestSkillConstraintsPendingDecisionsBeforePlanLock(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {
 		require.NoError(t, bootstrap.InitWorkspace(root, []string{"claude"}, false))
 
-		slug := createGovernedRequest(t, root, "L2", "locked decisions test")
+		slug := createGovernedRequest(t, root, "L2", "pending decisions test")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
+		// S1_PLAN/audit without plan-audit evidence: the plan is not locked, so
+		// G_plan is not approved.
 		change.CurrentState = model.StateS1Plan
 		change.PlanSubStep = model.PlanSubStepAudit
 		require.NoError(t, state.SaveChange(root, change))
 
-		// Write decision.md with selected approach (canonical source for locked decisions).
+		// Write decision.md with a concrete (non-placeholder) selected approach.
 		bundlePath := filepath.Join(root, "artifacts", "changes", change.Slug)
 		require.NoError(t, os.MkdirAll(bundlePath, 0o755))
 		require.NoError(t, os.WriteFile(filepath.Join(bundlePath, "decision.md"), []byte(`## Alternatives Considered
@@ -190,8 +200,11 @@ Low risk.
 		require.NotNil(t, view.NextSkill)
 		require.NotNil(t, view.NextSkill.SkillConstraints)
 
-		require.NotNil(t, view.NextSkill.SkillConstraints.LockedDecisions)
-		assert.Contains(t, view.NextSkill.SkillConstraints.LockedDecisions[0], "Selected Approach:")
+		// The plan is not locked: the recommended approach is pending, not locked.
+		assert.Empty(t, view.NextSkill.SkillConstraints.LockedDecisions,
+			"a recommended approach must not appear as locked before the plan is locked (issue #140)")
+		require.NotEmpty(t, view.NextSkill.SkillConstraints.PendingDecisions)
+		assert.Contains(t, view.NextSkill.SkillConstraints.PendingDecisions[0], "Selected Approach:")
 
 		var handoffOut bytes.Buffer
 		handoffCmd := makeNextCmd()
@@ -203,9 +216,162 @@ Low risk.
 		require.NoError(t, json.Unmarshal(handoffOut.Bytes(), &handoff))
 		require.NotNil(t, handoff.NextSkill)
 		require.NotNil(t, handoff.NextSkill.SkillConstraints)
-		require.NotEmpty(t, handoff.NextSkill.SkillConstraints.LockedDecisions)
-		assert.Contains(t, handoff.NextSkill.SkillConstraints.LockedDecisions[0], "Selected Approach:")
+		// The handoff clone preserves the pending field and never promotes it to locked.
+		assert.Empty(t, handoff.NextSkill.SkillConstraints.LockedDecisions)
+		require.NotEmpty(t, handoff.NextSkill.SkillConstraints.PendingDecisions)
+		assert.Contains(t, handoff.NextSkill.SkillConstraints.PendingDecisions[0], "Selected Approach:")
 	})
+}
+
+// TestSkillConstraintsLockedDecisionsAfterPlanLock verifies the confirmed path
+// through real next JSON output: once G_plan is approved, the selected approach
+// moves from pending_decisions to locked_decisions.
+func TestSkillConstraintsLockedDecisionsAfterPlanLock(t *testing.T) {
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		require.NoError(t, bootstrap.InitWorkspace(root, []string{"claude"}, false))
+
+		slug := createGovernedRequest(t, root, "L2", "locked decisions test")
+		change, err := state.LoadChange(root, slug)
+		require.NoError(t, err)
+
+		change.CurrentState = model.StateS2Execute
+		change.PlanSubStep = model.PlanSubStepNone
+		require.NoError(t, state.SaveChange(root, change))
+
+		writeShipReadyGovernedBundle(t, root, change)
+		bundlePath := filepath.Join(root, "artifacts", "changes", change.Slug)
+		require.NoError(t, writeBundleArtifactFile(bundlePath, change.Slug, "decision.md", []byte(`# Decision
+## Alternatives Considered
+### Option A
+Keep reporting parsed decision text as locked.
+
+### Option B
+Use the G_plan gate as the lock signal.
+
+## Selected Approach
+Use the G_plan gate state as the locked-vs-pending decision authority.
+
+## Interfaces and Data Flow
+Readiness GateEvaluations[G_plan] sets planLocked before skill constraints are assembled.
+
+## Rollout and Rollback
+Roll forward by preserving the recommendation under pending_decisions until G_plan is approved.
+
+## Risk
+Low risk; the public field split is additive and fail-closed before approval.
+`)))
+		writeSkillVerification(t, root, slug, progression.SkillPlanAudit, model.VerificationRecord{
+			Verdict:   model.VerificationVerdictPass,
+			Blockers:  []model.ReasonCode{},
+			Timestamp: time.Now().UTC(),
+		})
+		refreshPassingSkillDigestsForTest(t, root, slug, progression.SkillPlanAudit)
+
+		var out bytes.Buffer
+		cmd := makeNextCmd()
+		cmd.SetArgs([]string{"--json", "--diagnostics"})
+		cmd.SetOut(&out)
+		require.NoError(t, cmd.Execute())
+
+		var view nextView
+		require.NoError(t, json.Unmarshal(out.Bytes(), &view))
+		require.NotNil(t, view.NextSkill)
+		require.NotNil(t, view.NextSkill.SkillConstraints)
+		assert.Equal(t, "approved", view.InputContext.GateStatus[string(gate.GatePlan)])
+
+		require.NotEmpty(t, view.NextSkill.SkillConstraints.LockedDecisions)
+		assert.Contains(t, view.NextSkill.SkillConstraints.LockedDecisions[0], "Selected Approach:")
+		assert.Empty(t, view.NextSkill.SkillConstraints.PendingDecisions)
+	})
+}
+
+// TestBuildSkillConstraintsLockedVsPending pins the routing contract directly:
+// the same parsed decision is reported as locked iff the plan is locked
+// (G_plan approved), as pending otherwise, and placeholder/empty decision text
+// is neither (issue #140).
+func TestBuildSkillConstraintsLockedVsPending(t *testing.T) {
+	t.Parallel()
+	def := skill.Definition{Name: progression.SkillWaveOrchestration}
+
+	writeDecision := func(t *testing.T, root string, change model.Change, body string) {
+		t.Helper()
+		bundlePath := filepath.Join(root, "artifacts", "changes", change.Slug)
+		require.NoError(t, os.MkdirAll(bundlePath, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(bundlePath, "decision.md"), []byte(body), 0o644))
+	}
+
+	realDecision := `## Alternatives Considered
+List approaches.
+
+## Selected Approach
+Use event-driven architecture with Go channels.
+
+## Risk
+Low risk.
+`
+
+	t.Run("planLocked routes to locked_decisions", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		change := model.NewChange("locked-routing")
+		writeDecision(t, root, change, realDecision)
+
+		sc := buildSkillConstraints(root, def, &change, true)
+		require.NotNil(t, sc)
+		require.NotEmpty(t, sc.LockedDecisions)
+		assert.Contains(t, sc.LockedDecisions[0], "Selected Approach:")
+		assert.Empty(t, sc.PendingDecisions)
+	})
+
+	t.Run("not planLocked routes to pending_decisions", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		change := model.NewChange("pending-routing")
+		writeDecision(t, root, change, realDecision)
+
+		sc := buildSkillConstraints(root, def, &change, false)
+		require.NotNil(t, sc)
+		assert.Empty(t, sc.LockedDecisions)
+		require.NotEmpty(t, sc.PendingDecisions)
+		assert.Contains(t, sc.PendingDecisions[0], "Selected Approach:")
+	})
+
+	t.Run("placeholder decision is neither locked nor pending", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		change := model.NewChange("placeholder-routing")
+		writeDecision(t, root, change, "## Selected Approach\nConfirm or replace this after research and user selection.\n")
+
+		scLocked := buildSkillConstraints(root, def, &change, true)
+		require.NotNil(t, scLocked)
+		assert.Empty(t, scLocked.LockedDecisions)
+		assert.Empty(t, scLocked.PendingDecisions)
+
+		scPending := buildSkillConstraints(root, def, &change, false)
+		require.NotNil(t, scPending)
+		assert.Empty(t, scPending.LockedDecisions)
+		assert.Empty(t, scPending.PendingDecisions)
+	})
+}
+
+// TestPlanLockedFromGates pins the lock signal: locked iff the G_plan gate is
+// approved (issue #140).
+func TestPlanLockedFromGates(t *testing.T) {
+	t.Parallel()
+	approved := progression.GovernanceReadiness{
+		GateEvaluations: map[gate.GateID]gate.GateEvaluation{
+			gate.GatePlan: {GateID: gate.GatePlan, Status: model.GateStatusApproved},
+		},
+	}
+	blocked := progression.GovernanceReadiness{
+		GateEvaluations: map[gate.GateID]gate.GateEvaluation{
+			gate.GatePlan: {GateID: gate.GatePlan, Status: model.GateStatusBlocked},
+		},
+	}
+	assert.True(t, planLockedFromGates(approved))
+	assert.False(t, planLockedFromGates(blocked))
+	assert.False(t, planLockedFromGates(progression.GovernanceReadiness{}), "missing G_plan evaluation is not locked")
 }
 
 func TestSkillConstraintsGuardrailDomainFromAdmission(t *testing.T) {

--- a/cmd/next_skill_view.go
+++ b/cmd/next_skill_view.go
@@ -329,7 +329,7 @@ func assembleSkillViewWithOptions(
 	}
 
 	if def, ok := skill.LookupDefinitionInRegistry(registry, nextSkillName); ok {
-		ns.SkillConstraints = buildSkillConstraints(root, def, governedChange)
+		ns.SkillConstraints = buildSkillConstraints(root, def, governedChange, view.planLocked)
 	}
 
 	view.NextSkill = ns

--- a/internal/tmpl/templates/skills/spec-compliance-review/SKILL.md.tmpl
+++ b/internal/tmpl/templates/skills/spec-compliance-review/SKILL.md.tmpl
@@ -89,6 +89,12 @@ If `skill_constraints.locked_decisions` is present:
 2. verify the implementation honors it without workaround or reinterpretation
 3. flag violations as `decision_fidelity:violated:<decision_summary>`
 
+Enforce fidelity ONLY against `skill_constraints.locked_decisions`.
+`skill_constraints.pending_decisions` carries a recommended-but-unconfirmed
+selected approach (the lifecycle has not yet locked the plan): treat it as
+advisory context, not a contract. Do not raise `decision_fidelity:violated`
+against a pending decision — the implementation is not yet bound to it.
+
 ### Stub Detection
 Block zero-value or hardcoded production responses, TODO/FIXME/HACK in claimed
 complete code, assertion-free tests, handlers that only log, placeholder API

--- a/internal/tmpl/templates_test.go
+++ b/internal/tmpl/templates_test.go
@@ -1062,6 +1062,24 @@ func TestSpecComplianceReviewGuardsAgainstTestPresenceOverTrust(t *testing.T) {
 	assert.Contains(t, specTrace, "exercises the literal clause it maps to")
 }
 
+// TestSpecComplianceReviewTreatsPendingDecisionsAsAdvisory pins issue #140:
+// the Decision Fidelity Check must enforce fidelity only against
+// locked_decisions and treat pending_decisions (a recommended-but-unconfirmed
+// approach) as advisory, never raising decision_fidelity:violated against it.
+func TestSpecComplianceReviewTreatsPendingDecisionsAsAdvisory(t *testing.T) {
+	t.Parallel()
+
+	data := map[string]string{"ToolID": "claude", "Trigger": "/slipway:test", "Description": "test"}
+
+	specCompliance, err := Render("skills/spec-compliance-review/SKILL.md.tmpl", data)
+	require.NoError(t, err)
+	assert.Contains(t, specCompliance, "skill_constraints.pending_decisions")
+	assert.Contains(t, specCompliance, "Enforce fidelity ONLY against `skill_constraints.locked_decisions`")
+	assert.Contains(t, specCompliance, "Do not raise `decision_fidelity:violated`")
+	assert.Contains(t, specCompliance, "against a pending decision")
+	assert.Contains(t, specCompliance, "treat it as\nadvisory context, not a contract")
+}
+
 func TestRootCauseTracingAbsorbsSystematicDebuggingDoctrine(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- add `skill_constraints.pending_decisions` so recommended-but-unconfirmed decision.md selections are visible without being treated as locked
- derive locked-vs-pending behavior from the lifecycle `G_plan` gate and preserve pending decisions in handoff payloads
- update the spec-compliance-review template to enforce decision fidelity only against locked decisions
- archive governed change `fix-pending-approach-reported-as-locked-decision`

## Verification
- `git diff --check`
- `go test ./cmd -run 'TestSkillConstraintsPendingDecisionsBeforePlanLock|TestSkillConstraintsLockedDecisionsAfterPlanLock|TestBuildSkillConstraintsLockedVsPending|TestPlanLockedFromGates|TestSkillConstraintsPopulatedInNextOutput'`
- `go test ./internal/tmpl -run 'TestSpecComplianceReviewTreatsPendingDecisionsAsAdvisory'`
- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `go run . validate --json` before `done`: fresh, G_plan/G_scope/G_ship approved
- `go run . done --json`: archived=true, archive_commit_required=true
- `go run . status --json` after commit: no active change

Closes #140