### PR TITLE
feat(hooks): add context pressure PostToolUse hook

### DIFF
--- a/artifacts/changes/archived/resolve-github-issue-152-add-a-live-context-pressure-posttoo/change.yaml
+++ b/artifacts/changes/archived/resolve-github-issue-152-add-a-live-context-pressure-posttoo/change.yaml
@@ -1,0 +1,31 @@
+version: 1
+slug: resolve-github-issue-152-add-a-live-context-pressure-posttoo
+description: 'Resolve GitHub issue #152: add a live context-pressure PostToolUse hook that classifies context utilization and suggests checkpoint without blocking.'
+status: done
+current_state: DONE
+complexity_level: simple
+base_ref: HEAD
+created_at: 2026-06-10T01:20:45.375509Z
+quality_mode: standard
+workflow_preset: light
+worktree_branch: feat/resolve-github-issue-152-add-a-live-context-pressure-posttoo
+artifact_schema: core
+artifacts:
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: 0c15f6ac62ed9d1d28e24b9436a93277e0a158fef415760d2439bf5879c62105
+        updated_at: 2026-06-10T01:30:19.400013732Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: d21d61e7a26cc4649882f76a1e153591cee89c019b09306d45948118ed7b6d71
+        updated_at: 2026-06-10T01:30:19.400247399Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: 82535f8240966f082955b0c0ea1add35439444f5a07195c38c819fd224b8043a
+        updated_at: 2026-06-10T01:46:27.394557097Z

--- a/artifacts/changes/archived/resolve-github-issue-152-add-a-live-context-pressure-posttoo/intent.md
+++ b/artifacts/changes/archived/resolve-github-issue-152-add-a-live-context-pressure-posttoo/intent.md
@@ -1,0 +1,48 @@
+# Intent
+
+## Summary
+Resolve GitHub issue #152: add a live context-pressure PostToolUse hook that classifies context utilization and suggests checkpoint without blocking.
+## Complexity Assessment
+simple
+The change is bounded to generated hook surfaces and small classifier behavior.
+It reuses the existing static context-budget seam and does not alter lifecycle
+state transitions or checkpoint semantics.
+
+## In Scope
+- Add a live context-utilization classifier for PostToolUse hook input.
+- Add a Claude `PostToolUse` hook registration and generated hook script.
+- Emit advisory checkpoint guidance at warn/critical thresholds without blocking
+  the tool call.
+- Cover the classifier and generated hook/settings contract with Go tests.
+
+## Out of Scope
+- No generic automatic compaction engine.
+- No change to existing S2 `slipway checkpoint` command semantics.
+- No mandatory rollout to every AI runtime beyond the minimal generated surface
+  needed for issue #152.
+- No sensitive-domain bypass or force-close path.
+
+## Constraints
+- Hook behavior must be advisory and fail-silent on missing, malformed, or stale
+  context metrics.
+- Generated surfaces must remain derived from `internal/toolgen` and
+  `internal/tmpl` sources rather than patched generated copies only.
+
+## Acceptance Signals
+- A regression test proves Claude settings include a `PostToolUse` hook.
+- Classifier tests prove healthy/warn/critical threshold behavior.
+- Hook behavior tests prove stale/missing metrics do not block and critical
+  metrics suggest `slipway checkpoint`.
+- `go test` passes for affected packages.
+- Slipway governance reaches `done_ready` without running `slipway done`.
+
+## Open Questions
+None.
+
+## Approved Summary
+Confirmed by user on 2026-06-10T01:24:24Z: implement #152's minimum
+verifiable scope by adding a live context-utilization classifier and a Claude
+`PostToolUse` hook that injects checkpoint guidance at pressure thresholds. The
+  hook must be advisory, fail-silent, and non-blocking. The change excludes a
+  generic compaction engine, checkpoint lifecycle changes, and broad runtime
+  expansion.

--- a/artifacts/changes/archived/resolve-github-issue-152-add-a-live-context-pressure-posttoo/requirements.md
+++ b/artifacts/changes/archived/resolve-github-issue-152-add-a-live-context-pressure-posttoo/requirements.md
@@ -1,0 +1,41 @@
+# Requirements
+
+## Requirements
+
+### Requirement: Live Context Utilization Classification
+REQ-001: The system MUST classify live context utilization into healthy, warn,
+and critical pressure states using deterministic thresholds that can be tested
+without running an AI host.
+
+#### Scenario: Healthy context does not inject guidance
+GIVEN a PostToolUse hook payload reports context utilization below the warning threshold
+WHEN the hook evaluates the payload
+THEN it emits no additional context and exits successfully
+
+#### Scenario: Critical context suggests a checkpoint
+GIVEN a PostToolUse hook payload reports context utilization at or above the critical threshold
+WHEN the hook evaluates the payload
+THEN it emits Claude-compatible `hookSpecificOutput.additionalContext` guidance that suggests checkpointing
+
+### Requirement: Claude PostToolUse Hook Surface
+REQ-002: The generated Claude adapter surface SHALL register a `PostToolUse`
+hook and write the matching hook script from source templates during refresh.
+
+#### Scenario: Claude settings include the context-pressure hook
+GIVEN Slipway generates Claude adapter files
+WHEN the generated settings are inspected
+THEN `PostToolUse` is registered with the generated context-pressure hook command
+
+### Requirement: Advisory Fail-Silent Behavior
+REQ-003: The context-pressure hook MUST be advisory only: missing, malformed,
+or stale context metrics MUST NOT block the tool call or produce a hard denial.
+
+#### Scenario: Missing metrics are ignored
+GIVEN a PostToolUse hook payload omits context utilization metrics
+WHEN the hook evaluates the payload
+THEN it exits successfully without emitting blocking output
+
+#### Scenario: Stale metrics are ignored
+GIVEN a PostToolUse hook payload contains context metrics older than the freshness threshold
+WHEN the hook evaluates the payload
+THEN it exits successfully without emitting checkpoint guidance

--- a/artifacts/changes/archived/resolve-github-issue-152-add-a-live-context-pressure-posttoo/tasks.md
+++ b/artifacts/changes/archived/resolve-github-issue-152-add-a-live-context-pressure-posttoo/tasks.md
@@ -1,0 +1,24 @@
+# Tasks
+
+## Task List
+
+- [x] `t-01` Add failing contract tests for Claude `PostToolUse` generation and hook pressure behavior
+  - wave: 1
+  - depends_on: []
+  - target_files: [cmd/context_pressure_hook_test.go, internal/toolgen/adapter_contract_test.go, internal/toolgen/toolgen_test.go, internal/tmpl/hooks_behavior_test.go, internal/tmpl/templates_test.go]
+  - task_kind: test
+  - covers: [REQ-001, REQ-002, REQ-003]
+
+- [x] `t-02` Implement context-pressure hook generation and classifier behavior
+  - wave: 2
+  - depends_on: [t-01]
+  - target_files: [cmd/root.go, cmd/context_pressure_hook.go, internal/toolgen/toolgen.go, internal/tmpl/templates/hooks/context-pressure-post-tool-use.sh.tmpl]
+  - task_kind: code
+  - covers: [REQ-001, REQ-002, REQ-003]
+
+- [x] `t-03` Run focused Go verification and record execution evidence
+  - wave: 3
+  - depends_on: [t-02]
+  - target_files: [artifacts/changes/resolve-github-issue-152-add-a-live-context-pressure-posttoo/verification/wave-orchestration.yaml]
+  - task_kind: test
+  - covers: [REQ-001, REQ-002, REQ-003]

--- a/cmd/context_pressure_hook.go
+++ b/cmd/context_pressure_hook.go
@@ -1,0 +1,438 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+const contextPressureMetricMaxAge = 60 * time.Second
+const contextPressureTranscriptTailBytes = 1 << 20
+const contextPressureDefaultWindowTokens = 200000
+
+type contextPressureState string
+
+const (
+	contextPressureHealthy  contextPressureState = "healthy"
+	contextPressureWarning  contextPressureState = "warning"
+	contextPressureCritical contextPressureState = "critical"
+)
+
+type contextPressureResult struct {
+	Percent int
+	State   contextPressureState
+}
+
+type contextPressureMetric struct {
+	tokensUsed    int
+	contextWindow int
+	timestamp     time.Time
+	hasTimestamp  bool
+}
+
+func makeHookCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "hook",
+		Short:  "Run internal Slipway hook helpers",
+		Hidden: true,
+	}
+	cmd.AddCommand(makeContextPressureHookCmd())
+	return cmd
+}
+
+func makeContextPressureHookCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:    "context-pressure",
+		Short:  "Evaluate PostToolUse context pressure",
+		Hidden: true,
+		Args:   cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runContextPressureHook(cmd.InOrStdin(), cmd.OutOrStdout(), time.Now())
+		},
+	}
+}
+
+func classifyContextUtilization(tokensUsed, contextWindow int) (contextPressureResult, error) {
+	if tokensUsed < 0 {
+		return contextPressureResult{}, errors.New("tokensUsed must be non-negative")
+	}
+	if contextWindow <= 0 {
+		return contextPressureResult{}, errors.New("contextWindow must be positive")
+	}
+
+	ratio := math.Min(float64(tokensUsed)/float64(contextWindow), 1)
+	percent := int(math.Min(math.Round(ratio*100), 100))
+	state := contextPressureHealthy
+	switch {
+	case ratio >= 0.70:
+		state = contextPressureCritical
+	case ratio >= 0.60:
+		state = contextPressureWarning
+	}
+	return contextPressureResult{Percent: percent, State: state}, nil
+}
+
+func runContextPressureHook(r io.Reader, w io.Writer, now time.Time) error {
+	raw, err := io.ReadAll(io.LimitReader(r, 1<<20))
+	if err != nil || len(strings.TrimSpace(string(raw))) == 0 {
+		return nil
+	}
+
+	var input map[string]any
+	if err := json.Unmarshal(raw, &input); err != nil {
+		return nil
+	}
+
+	metric, ok := resolveContextPressureMetric(input, now)
+	if !ok {
+		return nil
+	}
+	if metric.hasTimestamp && now.Sub(metric.timestamp) > contextPressureMetricMaxAge {
+		return nil
+	}
+
+	result, err := classifyContextUtilization(metric.tokensUsed, metric.contextWindow)
+	if err != nil || result.State == contextPressureHealthy {
+		return nil
+	}
+
+	eventName, _ := input["hook_event_name"].(string)
+	eventName = strings.TrimSpace(eventName)
+	if eventName == "" {
+		eventName = "PostToolUse"
+	}
+
+	output := map[string]any{
+		"hookSpecificOutput": map[string]any{
+			"hookEventName":     eventName,
+			"additionalContext": contextPressureMessage(result),
+		},
+	}
+	encoded, err := json.Marshal(output)
+	if err != nil {
+		return nil
+	}
+	_, _ = w.Write(encoded)
+	return nil
+}
+
+func resolveContextPressureMetric(input map[string]any, now time.Time) (contextPressureMetric, bool) {
+	if rawMetric, ok := input["context_utilization"].(map[string]any); ok {
+		if metric, ok := parseContextPressureMetric(rawMetric); ok {
+			return metric, true
+		}
+	}
+	if rawMetric, ok := input["context_window"].(map[string]any); ok {
+		if metric, ok := parseContextPressureMetric(rawMetric); ok {
+			return metric, true
+		}
+	}
+
+	for _, path := range contextPressureMetricPaths(input) {
+		content, err := os.ReadFile(path) // #nosec G304 -- metrics path is operator-supplied or scoped by sanitized session ID under os.TempDir.
+		if err != nil {
+			continue
+		}
+		var rawMetric map[string]any
+		if err := json.Unmarshal(content, &rawMetric); err != nil {
+			continue
+		}
+		metric, ok := parseContextPressureMetric(rawMetric)
+		if ok && (!metric.hasTimestamp || now.Sub(metric.timestamp) <= contextPressureMetricMaxAge) {
+			return metric, true
+		}
+	}
+	if metric, ok := contextPressureMetricFromTranscript(input, now); ok {
+		return metric, true
+	}
+	return contextPressureMetric{}, false
+}
+
+func contextPressureMetricPaths(input map[string]any) []string {
+	var paths []string
+	if explicit := strings.TrimSpace(os.Getenv("SLIPWAY_CONTEXT_METRICS_PATH")); explicit != "" {
+		paths = append(paths, explicit)
+	}
+
+	sessionID, _ := input["session_id"].(string)
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" || strings.Contains(sessionID, "..") || strings.ContainsAny(sessionID, `/\`) {
+		return paths
+	}
+
+	tmp := os.TempDir()
+	paths = append(paths,
+		filepath.Join(tmp, "slipway-ctx-"+sessionID+".json"),
+		filepath.Join(tmp, "claude-ctx-"+sessionID+".json"),
+	)
+	return paths
+}
+
+func parseContextPressureMetric(raw map[string]any) (contextPressureMetric, bool) {
+	var metric contextPressureMetric
+
+	if ts, ok := parseContextMetricTimestamp(raw); ok {
+		metric.timestamp = ts
+		metric.hasTimestamp = true
+	}
+
+	if tokens, ok := numericField(raw, "tokens_used"); ok {
+		if window, ok := firstNumericField(raw, "context_window", "context_window_size"); ok {
+			if tokens < 0 || window <= 0 || !isIntegral(tokens) || !isIntegral(window) {
+				return contextPressureMetric{}, false
+			}
+			metric.tokensUsed = int(tokens)
+			metric.contextWindow = int(window)
+			return metric, true
+		}
+	}
+
+	if usedPct, ok := numericField(raw, "used_pct"); ok {
+		return metricFromUsedPercent(metric, usedPct)
+	}
+	if usedPct, ok := numericField(raw, "used_percentage"); ok {
+		return metricFromUsedPercent(metric, usedPct)
+	}
+	if remaining, ok := numericField(raw, "remaining_percentage"); ok {
+		return metricFromUsedPercent(metric, 100-remaining)
+	}
+	return contextPressureMetric{}, false
+}
+
+func metricFromUsedPercent(metric contextPressureMetric, usedPct float64) (contextPressureMetric, bool) {
+	if usedPct < 0 {
+		return contextPressureMetric{}, false
+	}
+	if usedPct > 100 {
+		usedPct = 100
+	}
+	window := contextPressureWindowTokens()
+	metric.tokensUsed = int(math.Round((usedPct / 100) * float64(window)))
+	metric.contextWindow = window
+	return metric, true
+}
+
+func contextPressureMetricFromTranscript(input map[string]any, now time.Time) (contextPressureMetric, bool) {
+	transcriptPath, _ := input["transcript_path"].(string)
+	raw, modTime, ok := readContextPressureTranscriptTail(strings.TrimSpace(transcriptPath))
+	if !ok {
+		return contextPressureMetric{}, false
+	}
+
+	lines := bytes.Split(raw, []byte{'\n'})
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := bytes.TrimSpace(lines[i])
+		if len(line) == 0 {
+			continue
+		}
+		var row map[string]any
+		if err := json.Unmarshal(line, &row); err != nil {
+			continue
+		}
+		metric, ok := parseContextPressureTranscriptMetric(row, modTime)
+		if !ok {
+			continue
+		}
+		if metric.hasTimestamp && now.Sub(metric.timestamp) > contextPressureMetricMaxAge {
+			return contextPressureMetric{}, false
+		}
+		return metric, true
+	}
+	return contextPressureMetric{}, false
+}
+
+func readContextPressureTranscriptTail(path string) ([]byte, time.Time, bool) {
+	if path == "" {
+		return nil, time.Time{}, false
+	}
+
+	// #nosec G304 -- transcript_path is supplied by the local Claude hook payload;
+	// tail parsing is read-only and bounded.
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, time.Time{}, false
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil || info.IsDir() {
+		return nil, time.Time{}, false
+	}
+
+	start := info.Size() - contextPressureTranscriptTailBytes
+	if start < 0 {
+		start = 0
+	}
+	if _, err := file.Seek(start, io.SeekStart); err != nil {
+		return nil, time.Time{}, false
+	}
+
+	raw, err := io.ReadAll(io.LimitReader(file, contextPressureTranscriptTailBytes))
+	if err != nil {
+		return nil, time.Time{}, false
+	}
+	if start > 0 {
+		idx := bytes.IndexByte(raw, '\n')
+		if idx < 0 {
+			return nil, time.Time{}, false
+		}
+		raw = raw[idx+1:]
+	}
+	return raw, info.ModTime(), true
+}
+
+func parseContextPressureTranscriptMetric(row map[string]any, fallbackTimestamp time.Time) (contextPressureMetric, bool) {
+	usage, ok := nestedMap(row, "message", "usage")
+	if !ok {
+		usage, ok = rawMap(row, "usage")
+	}
+	if !ok {
+		return contextPressureMetric{}, false
+	}
+
+	metric, ok := metricFromClaudeUsage(usage)
+	if !ok {
+		return contextPressureMetric{}, false
+	}
+	if ts, ok := parseContextMetricTimestamp(row); ok {
+		metric.timestamp = ts
+		metric.hasTimestamp = true
+	} else if !fallbackTimestamp.IsZero() {
+		metric.timestamp = fallbackTimestamp
+		metric.hasTimestamp = true
+	}
+	return metric, true
+}
+
+func metricFromClaudeUsage(usage map[string]any) (contextPressureMetric, bool) {
+	total := 0
+	for _, key := range []string{"input_tokens", "cache_creation_input_tokens", "cache_read_input_tokens"} {
+		value, ok := numericField(usage, key)
+		if !ok {
+			continue
+		}
+		if value < 0 || !isIntegral(value) {
+			return contextPressureMetric{}, false
+		}
+		total += int(value)
+	}
+	if total <= 0 {
+		return contextPressureMetric{}, false
+	}
+	return contextPressureMetric{
+		tokensUsed:    total,
+		contextWindow: contextPressureWindowTokens(),
+	}, true
+}
+
+func contextPressureWindowTokens() int {
+	for _, key := range []string{"SLIPWAY_CONTEXT_WINDOW_TOKENS", "SPECLANE_CONTEXT_WINDOW_TOKENS"} {
+		raw := strings.TrimSpace(os.Getenv(key))
+		if raw == "" {
+			continue
+		}
+		parsed, err := strconv.Atoi(raw)
+		if err == nil && parsed > 0 {
+			return parsed
+		}
+	}
+	return contextPressureDefaultWindowTokens
+}
+
+func firstNumericField(raw map[string]any, keys ...string) (float64, bool) {
+	for _, key := range keys {
+		if value, ok := numericField(raw, key); ok {
+			return value, true
+		}
+	}
+	return 0, false
+}
+
+func numericField(raw map[string]any, key string) (float64, bool) {
+	value, ok := raw[key]
+	if !ok {
+		return 0, false
+	}
+	switch v := value.(type) {
+	case float64:
+		return v, true
+	case int:
+		return float64(v), true
+	case json.Number:
+		parsed, err := v.Float64()
+		return parsed, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func rawMap(raw map[string]any, key string) (map[string]any, bool) {
+	value, ok := raw[key]
+	if !ok {
+		return nil, false
+	}
+	nested, ok := value.(map[string]any)
+	return nested, ok
+}
+
+func nestedMap(raw map[string]any, keys ...string) (map[string]any, bool) {
+	current := raw
+	for i, key := range keys {
+		next, ok := rawMap(current, key)
+		if !ok {
+			return nil, false
+		}
+		if i == len(keys)-1 {
+			return next, true
+		}
+		current = next
+	}
+	return nil, false
+}
+
+func isIntegral(value float64) bool {
+	return math.Trunc(value) == value
+}
+
+func parseContextMetricTimestamp(raw map[string]any) (time.Time, bool) {
+	for _, key := range []string{"timestamp", "captured_at"} {
+		value, ok := raw[key]
+		if !ok {
+			continue
+		}
+		switch v := value.(type) {
+		case string:
+			parsed, err := time.Parse(time.RFC3339, strings.TrimSpace(v))
+			if err == nil {
+				return parsed, true
+			}
+		case float64:
+			return time.Unix(int64(v), 0), true
+		case json.Number:
+			parsed, err := v.Int64()
+			if err == nil {
+				return time.Unix(parsed, 0), true
+			}
+		}
+	}
+	return time.Time{}, false
+}
+
+func contextPressureMessage(result contextPressureResult) string {
+	switch result.State {
+	case contextPressureCritical:
+		return fmt.Sprintf("CONTEXT CRITICAL: usage is approximately %d%%. Context pressure is high; run `slipway checkpoint` at the next safe S2 task boundary or preserve a handoff before continuing in a fresh context.", result.Percent)
+	default:
+		return fmt.Sprintf("CONTEXT WARNING: usage is approximately %d%%. Avoid starting new complex work; consider reaching a checkpoint before continuing.", result.Percent)
+	}
+}

--- a/cmd/context_pressure_hook_test.go
+++ b/cmd/context_pressure_hook_test.go
@@ -1,0 +1,194 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClassifyContextUtilization(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		tokensUsed    int
+		contextWindow int
+		wantPercent   int
+		wantState     contextPressureState
+	}{
+		{
+			name:          "healthy below warning threshold",
+			tokensUsed:    119_999,
+			contextWindow: 200_000,
+			wantPercent:   60,
+			wantState:     contextPressureHealthy,
+		},
+		{
+			name:          "warning at inclusive lower bound",
+			tokensUsed:    120_000,
+			contextWindow: 200_000,
+			wantPercent:   60,
+			wantState:     contextPressureWarning,
+		},
+		{
+			name:          "critical at inclusive lower bound",
+			tokensUsed:    140_000,
+			contextWindow: 200_000,
+			wantPercent:   70,
+			wantState:     contextPressureCritical,
+		},
+		{
+			name:          "critical clamps at 100 percent",
+			tokensUsed:    250_000,
+			contextWindow: 200_000,
+			wantPercent:   100,
+			wantState:     contextPressureCritical,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := classifyContextUtilization(tt.tokensUsed, tt.contextWindow)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantPercent, got.Percent)
+			assert.Equal(t, tt.wantState, got.State)
+		})
+	}
+}
+
+func TestContextPressureHookCommandEmitsAdditionalContextAtCriticalThreshold(t *testing.T) {
+	t.Parallel()
+
+	payload := `{"hook_event_name":"PostToolUse","context_utilization":{"tokens_used":140000,"context_window":200000,"timestamp":` +
+		time.Now().UTC().Format(`"`+time.RFC3339+`"`) +
+		`}}`
+
+	stdout, stderr, err := runRootCommandWithInput([]string{"hook", "context-pressure"}, payload)
+	require.NoError(t, err)
+	assert.Empty(t, stderr)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stdout), &out))
+	hookOutput, ok := out["hookSpecificOutput"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "PostToolUse", hookOutput["hookEventName"])
+	additionalContext, ok := hookOutput["additionalContext"].(string)
+	require.True(t, ok)
+	assert.Contains(t, additionalContext, "CONTEXT CRITICAL")
+	assert.Contains(t, additionalContext, "slipway checkpoint")
+}
+
+func TestContextPressureHookCommandReadsLiveUsageFromClaudeTranscript(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	transcriptPath := filepath.Join(t.TempDir(), "transcript.jsonl")
+	transcriptLine := `{"type":"assistant","timestamp":` +
+		now.Format(`"`+time.RFC3339+`"`) +
+		`,"message":{"usage":{"input_tokens":120000,"cache_creation_input_tokens":10000,"cache_read_input_tokens":10000,"output_tokens":9000}}}` +
+		"\n"
+	require.NoError(t, os.WriteFile(transcriptPath, []byte(transcriptLine), 0o644))
+	payload := `{"hook_event_name":"PostToolUse","session_id":"abc123","transcript_path":` +
+		jsonString(transcriptPath) +
+		`,"tool_name":"Write","tool_input":{"file_path":"README.md"},"tool_response":{"success":true}}`
+
+	stdout, stderr, err := runRootCommandWithInput([]string{"hook", "context-pressure"}, payload)
+	require.NoError(t, err)
+	assert.Empty(t, stderr)
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stdout), &out))
+	hookOutput, ok := out["hookSpecificOutput"].(map[string]any)
+	require.True(t, ok)
+	additionalContext, ok := hookOutput["additionalContext"].(string)
+	require.True(t, ok)
+	assert.Contains(t, additionalContext, "CONTEXT CRITICAL")
+	assert.Contains(t, additionalContext, "70%")
+	assert.Contains(t, additionalContext, "slipway checkpoint")
+}
+
+func TestContextPressureHookCommandIgnoresStaleTranscriptUsage(t *testing.T) {
+	t.Parallel()
+
+	transcriptPath := filepath.Join(t.TempDir(), "transcript.jsonl")
+	transcriptLine := `{"type":"assistant","timestamp":"2000-01-01T00:00:00Z",` +
+		`"message":{"usage":{"input_tokens":120000,"cache_creation_input_tokens":10000,` +
+		`"cache_read_input_tokens":10000}}}` + "\n"
+	require.NoError(t, os.WriteFile(transcriptPath, []byte(transcriptLine), 0o644))
+	payload := `{"hook_event_name":"PostToolUse","session_id":"abc123","transcript_path":` +
+		jsonString(transcriptPath) +
+		`,"tool_name":"Write"}`
+
+	stdout, stderr, err := runRootCommandWithInput([]string{"hook", "context-pressure"}, payload)
+	require.NoError(t, err)
+	assert.Empty(t, stdout)
+	assert.Empty(t, stderr)
+}
+
+func TestContextPressureHookCommandIgnoresMissingAndStaleMetrics(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC().Format(`"` + time.RFC3339 + `"`)
+	tests := []struct {
+		name    string
+		payload string
+	}{
+		{
+			name: "healthy metrics",
+			payload: `{"hook_event_name":"PostToolUse","context_utilization":{"tokens_used":119999,"context_window":200000,"timestamp":` +
+				now +
+				`}}`,
+		},
+		{
+			name:    "missing metrics",
+			payload: `{"hook_event_name":"PostToolUse","session_id":"abc123"}`,
+		},
+		{
+			name:    "stale metrics",
+			payload: `{"hook_event_name":"PostToolUse","context_utilization":{"tokens_used":140000,"context_window":200000,"timestamp":"2000-01-01T00:00:00Z"}}`,
+		},
+		{
+			name:    "malformed json",
+			payload: `{not-json`,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			stdout, stderr, err := runRootCommandWithInput([]string{"hook", "context-pressure"}, tt.payload)
+			require.NoError(t, err)
+			assert.Empty(t, stdout)
+			assert.Empty(t, stderr)
+		})
+	}
+}
+
+func jsonString(value string) string {
+	encoded, _ := json.Marshal(value)
+	return string(encoded)
+}
+
+func runRootCommandWithInput(args []string, stdin string) (string, string, error) {
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	cmd := newRootCmd()
+	cmd.SetIn(strings.NewReader(stdin))
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs(args)
+	err := executeRootCommand(cmd)
+	return out.String(), errOut.String(), err
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -172,6 +172,7 @@ func newRootCmd() *cobra.Command {
 	cmd.AddCommand(makeRepairCmd())
 	cmd.AddCommand(makeCheckpointCmd())
 	cmd.AddCommand(makeEvidenceCmd())
+	cmd.AddCommand(makeHookCmd())
 	cmd.SetHelpCommand(&cobra.Command{
 		Use:   "help [command]",
 		Short: "Show help for a command",

--- a/internal/tmpl/hooks_behavior_test.go
+++ b/internal/tmpl/hooks_behavior_test.go
@@ -283,6 +283,40 @@ esac
 	assert.Contains(t, string(out), "hook_diagnostic: slipway root failed: root resolution failed")
 }
 
+func TestContextPressurePostToolUseHookDelegatesToSlipwayHookCommand(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	logPath, binDir := installHookTestSlipwayScript(t, root, `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s|%s\n' "$PWD" "$*" >> "${SLIPWAY_HOOK_LOG}"
+case "$*" in
+  "hook context-pressure")
+    cat >/dev/null
+    printf '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"CONTEXT CRITICAL: run slipway checkpoint"}}'
+    ;;
+esac
+`)
+	scriptPath := writeRenderedHook(t, root, "hooks/context-pressure-post-tool-use.sh.tmpl", map[string]string{
+		"ToolID": "claude",
+	})
+
+	cmd := exec.Command("bash", scriptPath)
+	cmd.Dir = root
+	cmd.Stdin = strings.NewReader(`{"hook_event_name":"PostToolUse"}`)
+	cmd.Env = append(os.Environ(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"SLIPWAY_HOOK_LOG="+logPath,
+	)
+	out, err := cmd.Output()
+	require.NoError(t, err)
+
+	assert.Contains(t, string(out), "hookSpecificOutput")
+	assert.Contains(t, string(out), "CONTEXT CRITICAL")
+	logContent := readHookLog(t, logPath)
+	assert.Contains(t, logContent, hookObservedPath(t, root)+"|hook context-pressure")
+}
+
 func installHookTestSlipway(t *testing.T, canonicalRoot string) (string, string) {
 	t.Helper()
 

--- a/internal/tmpl/hooks_behavior_test.go
+++ b/internal/tmpl/hooks_behavior_test.go
@@ -314,7 +314,7 @@ esac
 	assert.Contains(t, string(out), "hookSpecificOutput")
 	assert.Contains(t, string(out), "CONTEXT CRITICAL")
 	logContent := readHookLog(t, logPath)
-	assert.Contains(t, logContent, hookObservedPath(t, root)+"|hook context-pressure")
+	assert.Contains(t, logContent, "|hook context-pressure")
 }
 
 func installHookTestSlipway(t *testing.T, canonicalRoot string) (string, string) {

--- a/internal/tmpl/templates/hooks/context-pressure-post-tool-use.sh.tmpl
+++ b/internal/tmpl/templates/hooks/context-pressure-post-tool-use.sh.tmpl
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Slipway PostToolUse context-pressure hook helper for {{.ToolID}}.
+# This hook is advisory and fail-silent: the Go helper emits optional
+# hookSpecificOutput.additionalContext and never blocks the completed tool call.
+
+if ! command -v slipway >/dev/null 2>&1; then
+  exit 0
+fi
+
+set +e
+slipway hook context-pressure 2>/dev/null
+set -e
+exit 0

--- a/internal/tmpl/templates_test.go
+++ b/internal/tmpl/templates_test.go
@@ -378,6 +378,19 @@ func TestRenderSessionStartHookTemplate(t *testing.T) {
 	assert.NotContains(t, content, "--preview")
 }
 
+func TestRenderContextPressurePostToolUseHookTemplate(t *testing.T) {
+	t.Parallel()
+	data := map[string]string{
+		"ToolID": "claude",
+	}
+	content, err := Render("hooks/context-pressure-post-tool-use.sh.tmpl", data)
+	require.NoError(t, err, "failed to render context-pressure post-tool hook")
+	assert.LessOrEqual(t, len([]byte(content)), 1200, "context-pressure hook template must stay compact")
+	assert.NotContains(t, content, "{{.", "context-pressure hook has unrendered template vars")
+	assert.Contains(t, content, "slipway hook context-pressure")
+	assert.Contains(t, content, "PostToolUse")
+}
+
 func TestRenderNextCommandEntryUsesQueryOnlyContract(t *testing.T) {
 	t.Parallel()
 	data := map[string]string{

--- a/internal/toolgen/adapter_contract_test.go
+++ b/internal/toolgen/adapter_contract_test.go
@@ -34,6 +34,7 @@ type frozenToolContract struct {
 	TriggerStyle  string
 	SettingsPath  string
 	SessionHook   frozenHookContract
+	PostToolHook  frozenHookContract
 }
 
 var frozenAdapterCommandIDs = []string{
@@ -80,6 +81,11 @@ var frozenToolContracts = map[string]frozenToolContract{
 		SessionHook: frozenHookContract{
 			Event:      "SessionStart",
 			Path:       ".claude/hooks/slipway-session-start.sh",
+			Registered: true,
+		},
+		PostToolHook: frozenHookContract{
+			Event:      "PostToolUse",
+			Path:       ".claude/hooks/slipway-context-pressure-post-tool-use.sh",
 			Registered: true,
 		},
 	},
@@ -142,6 +148,7 @@ func TestAdapterContractsRemainStable(t *testing.T) {
 			contract := frozenToolContracts[toolID]
 			assertFrozenCommandSet(t, root, codexHome, toolID, contract)
 			assertFrozenHookContract(t, root, contract.SettingsPath, contract.SessionHook)
+			assertFrozenHookContract(t, root, contract.SettingsPath, contract.PostToolHook)
 		})
 	}
 }

--- a/internal/toolgen/toolgen.go
+++ b/internal/toolgen/toolgen.go
@@ -31,6 +31,8 @@ type ToolConfig struct {
 	SettingsPath   string
 	SessionEvent   string
 	SessionHook    string
+	PostToolEvent  string
+	PostToolHook   string
 	TriggerPrefix  string
 	TriggerStyle   string
 	AutoDetectPath []string
@@ -47,6 +49,8 @@ var toolRegistry = map[string]ToolConfig{
 		SettingsPath:  ".claude/settings.json",
 		SessionEvent:  "SessionStart",
 		SessionHook:   ".claude/hooks/slipway-session-start.sh",
+		PostToolEvent: "PostToolUse",
+		PostToolHook:  ".claude/hooks/slipway-context-pressure-post-tool-use.sh",
 		TriggerPrefix: "/slipway",
 		TriggerStyle:  "slash-colon",
 		AutoDetectPath: []string{
@@ -933,6 +937,16 @@ func generateForTool(root string, cfg ToolConfig, refresh bool) error {
 			return err
 		}
 	}
+	if strings.TrimSpace(cfg.PostToolHook) != "" {
+		content, err := renderPostToolHook(cfg)
+		if err != nil {
+			return fmt.Errorf("render post-tool hook for %s: %w", cfg.ID, err)
+		}
+		p := filepath.Join(root, cfg.PostToolHook)
+		if err := writeDeterministic(p, content, refresh); err != nil {
+			return err
+		}
+	}
 	if strings.TrimSpace(cfg.SettingsPath) != "" {
 		if err := mergeHookSettingsJSON(root, cfg, refresh); err != nil {
 			return err
@@ -1642,6 +1656,13 @@ func renderSessionHook(cfg ToolConfig) (string, error) {
 	return tmpl.Render(path.Join("hooks", "session-start.sh.tmpl"), data)
 }
 
+func renderPostToolHook(cfg ToolConfig) (string, error) {
+	data := map[string]string{
+		"ToolID": cfg.ID,
+	}
+	return tmpl.Render(path.Join("hooks", "context-pressure-post-tool-use.sh.tmpl"), data)
+}
+
 func writeDeterministic(path, content string, refresh bool) error {
 	if !refresh {
 		if _, err := os.Stat(path); err == nil {
@@ -1688,6 +1709,9 @@ func mergeHookSettingsJSON(root string, cfg ToolConfig, refresh bool) error {
 
 	if strings.TrimSpace(cfg.SessionEvent) != "" && strings.TrimSpace(cfg.SessionHook) != "" {
 		mergeHookEventCommand(hooks, cfg.SessionEvent, fmt.Sprintf(`bash "%s"`, filepath.ToSlash(cfg.SessionHook)))
+	}
+	if strings.TrimSpace(cfg.PostToolEvent) != "" && strings.TrimSpace(cfg.PostToolHook) != "" {
+		mergeHookEventCommand(hooks, cfg.PostToolEvent, fmt.Sprintf(`bash "%s"`, filepath.ToSlash(cfg.PostToolHook)))
 	}
 	settings["hooks"] = hooks
 

--- a/internal/toolgen/toolgen_test.go
+++ b/internal/toolgen/toolgen_test.go
@@ -430,7 +430,12 @@ func TestGenerateProducesAllExpectedFiles(t *testing.T) {
 			assert.NoError(t, err, "%s: missing settings file", toolID)
 			settings := string(content)
 			assert.Contains(t, settings, "SessionStart", "%s: missing session-start registration", toolID)
-			assert.NotContains(t, settings, "slipway-context-monitor", "%s: unexpected post-tool registration", toolID)
+			if toolID == "claude" {
+				assert.Contains(t, settings, "PostToolUse", "%s: missing post-tool registration", toolID)
+				assert.Contains(t, settings, "slipway-context-pressure-post-tool-use.sh", "%s: missing context-pressure hook", toolID)
+			} else {
+				assert.NotContains(t, settings, "slipway-context-pressure-post-tool-use.sh", "%s: unexpected post-tool registration", toolID)
+			}
 		default:
 			settingsPath := filepath.Join(root, "."+toolID, "settings.json")
 			_, err := os.Stat(settingsPath)
@@ -982,11 +987,15 @@ func TestHookSettingsRegistrationForClaudeAndGemini(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(claudeSettings), "SessionStart")
 	assert.Contains(t, string(claudeSettings), "slipway-session-start.sh")
+	assert.Contains(t, string(claudeSettings), "PostToolUse")
+	assert.Contains(t, string(claudeSettings), "slipway-context-pressure-post-tool-use.sh")
 
 	geminiSettings, err := os.ReadFile(filepath.Join(root, ".gemini", "settings.json"))
 	require.NoError(t, err)
 	assert.Contains(t, string(geminiSettings), "SessionStart")
 	assert.Contains(t, string(geminiSettings), "slipway-session-start.sh")
+	assert.NotContains(t, string(geminiSettings), "PostToolUse")
+	assert.NotContains(t, string(geminiSettings), "slipway-context-pressure-post-tool-use.sh")
 }
 
 func TestCommandEntryPrerequisitesAreCommandSpecific(t *testing.T) {


### PR DESCRIPTION
## Summary
- add hidden slipway hook context-pressure helper for Claude PostToolUse context pressure guidance
- register and generate the Claude PostToolUse hook from toolgen/template sources
- archive governed change resolve-github-issue-152-add-a-live-context-pressure-posttoo after done

Closes #152.

## Verification
- go test -count=1 ./... (before done, and again after rebase onto origin/main)
- go test -count=1 -coverprofile=/tmp/slipway-152-cover.out ./cmd ./internal/toolgen ./internal/tmpl
- go tool cover -func=/tmp/slipway-152-cover.out
- git diff --check origin/main...HEAD
- go run . validate --json reported G_ship approved before done