### PR TITLE
fix(model): freeze reason-code taxonomy

### DIFF
--- a/artifacts/changes/archived/resolve-github-issue-160-freeze-reason-code-taxonomy-with-a/assurance.md
+++ b/artifacts/changes/archived/resolve-github-issue-160-freeze-reason-code-taxonomy-with-a/assurance.md
@@ -1,0 +1,98 @@
+# Assurance
+
+## Scope Summary
+
+Delivered GitHub issue #160 and the follow-up independent-review repair. The
+reason-code taxonomy is now an explicit canonical contract; unrecognized codes
+fail closed to `unknown_reason_code` while preserving the raw producer token in
+`detail`; and repo-local tests reject direct assertions against unstable
+reason/error `Message` prose when stable fields are available.
+
+The repair closes the review findings by adding existing bulk-done and workflow
+producer tokens to the canonical taxonomy and recovery map, preserving reachable
+status wave error codes, and wrapping non-reason-domain CLI `error_code` values
+in a canonical `wave_execution_unavailable` reason instead of letting them
+collapse to `unknown_reason_code`.
+
+The follow-up review repair tightens producer closure: in-scope producer specs
+assert the raw produced token is canonical before `ReasonCodeFromSpec`
+normalization, so an unknown producer cannot collapse to `unknown_reason_code`
+and still pass the canonical-map check. The old production
+`humanizeReasonCode` fallback was removed; tests keep a test-only
+`testHumanizeReasonCode` helper as the legacy fallback baseline for proving
+canonical messages are authored prose.
+
+Out of scope remains unchanged: issue #152, a full JSON error schema redesign,
+broad reason-code renaming, new external lint dependencies, and unrelated
+workflow repair.
+
+## Verification Verdict
+
+Execution run_summary_version 1 passed all four planned tasks, review evidence,
+goal verification, and final-closeout closeout checks. Fresh post-repair
+verification evidence shows:
+
+- `go test -count=1 ./internal/model -run 'TestInScopeProducedBlockersResolveToCanonicalRecovery|TestCanonicalReasonCodeTaxonomySnapshot|TestNewReasonCodeMakesUnknownCodeExplicit|TestReasonCodeNormalizeMakesUnknownCodeExplicit|TestReasonAndErrorContractTestsDoNotTextMatchMessageProse|TestMessageProseAssertionLint|TestWaveReasonCodesCarryRemediation|TestRequiredSkillStaleCarriesRemediation'` passed.
+- `go test -count=1 ./...` passed across all 25 packages.
+- `go vet ./...` passed.
+- `go build ./...` passed.
+- `go test -count=1 -coverprofile=/tmp/slipway-issue160-cover.out ./cmd ./internal/model ./internal/engine/progression ./internal/engine/gate ./internal/state` passed; `go tool cover -func=/tmp/slipway-issue160-cover.out` reported 73.4% total statement coverage across the affected package set.
+- `gofmt -l cmd internal` produced no output.
+- `git --no-pager diff --check` passed.
+- Target-file stub and placeholder scans found no TODO/FIXME/HACK/PLACEHOLDER/NotImplemented/not implemented or production stub; mechanical hits were ordinary guard/helper returns and error-path tuples.
+- `/tmp/slipway-issue160-closeout validate --json` in S4_VERIFY reported `evidence_freshness=fresh`, `scope_contract.status=pass`, and `goal-verification=pass` before final-closeout evidence was recorded; remaining blockers at that point were only final-closeout and its required assurance attestation.
+
+## Evidence Index
+
+- `verification/intake-clarification.yaml`: intake scope and user confirmation.
+- `requirements.md`: REQ-001 through REQ-003 contract.
+- `tasks.md`: four-wave execution plan and current target-file scope, including `cmd/status_view_build.go`.
+- `verification/plan-audit.yaml`: approved planning evidence.
+- `verification/wave-plan.yaml`: materialized execution plan.
+- `verification/wave-orchestration.yaml`: wave execution verdict and task-result notes.
+- `verification/execution-summary.yaml`: run_summary_version 1, all tasks pass.
+- `verification/spec-compliance-review.yaml`: R0 spec-compliance pass after the review repair.
+- `verification/code-quality-review.yaml`: IR1 code-quality pass after the final repair pass.
+- `verification/goal-verification.yaml`: S4 acceptance criteria pass with fresh tests, build, vet, coverage, scan, and scope-contract references.
+- `verification/final-closeout.yaml`: final closeout evidence with `closeout:assurance_complete=pass` for the standard workflow preset.
+- `.git/slipway/runtime/changes/resolve-github-issue-160-freeze-reason-code-taxonomy-with-a/evidence/tasks/t-01.json`
+- `.git/slipway/runtime/changes/resolve-github-issue-160-freeze-reason-code-taxonomy-with-a/evidence/tasks/t-02.json`
+- `.git/slipway/runtime/changes/resolve-github-issue-160-freeze-reason-code-taxonomy-with-a/evidence/tasks/t-03.json`
+- `.git/slipway/runtime/changes/resolve-github-issue-160-freeze-reason-code-taxonomy-with-a/evidence/tasks/t-04.json`
+
+## Requirement Coverage
+
+- REQ-001 Freeze Canonical Reason Codes: covered by `TestCanonicalReasonCodeTaxonomySnapshot`, the explicit `canonicalReasonDefinitions` map, and the severity snapshot in `internal/model/reason_code_contract_test.go`.
+- REQ-002 Unknown Codes Are Not Silently Humanized: covered by `TestNewReasonCodeMakesUnknownCodeExplicit`, `TestReasonCodeNormalizeMakesUnknownCodeExplicit`, `newUnknownReasonCode`, and the status bridge tests that preserve canonical reason codes while wrapping non-reason CLI error codes.
+- REQ-002 producer closure: covered by `TestInScopeProducedBlockersResolveToCanonicalRecovery`, which verifies raw producer tokens are canonical before normalization, and by `TestDoneBulkFallbackReasonCodesAreCanonical`, which proves all bulk-done fallback producer tokens remain stable canonical `.code` values and stay recovery-routable.
+- REQ-003 Tests Assert Stable Contracts Instead Of Message Prose: covered by `TestReasonAndErrorContractTestsDoNotTextMatchMessageProse`, the lint bypass/scope tests, and migrated assertions in `cmd`, `internal/engine/gate`, `internal/engine/progression`, `internal/model`, and `internal/state`.
+- Issue #160 documented enum acceptance: covered by `docs/operator-guide.md`, which documents `code` as the stable machine enum, `message` as presentation prose, `unknown_reason_code` behavior, and the reason-code versus CLI `error_code` bridge boundary.
+
+## Residual Risks and Exceptions
+
+- The AST lint remains intentionally syntactic. It blocks direct known payload
+  `Message` prose assertions and can be extended when new reason/error payload
+  surfaces appear, but it is not a typed whole-repo linter.
+- Whole-package coverage percentages are diagnostic. Behavioral confidence for
+  this repair comes from the targeted bulk-done/status regressions plus the
+  taxonomy/recovery contract tests and the full suite.
+- No guardrail domain, dependency/toolchain manifest change, data migration,
+  credential handling, or irreversible operation is involved.
+
+## Rollback Readiness
+
+Rollback is a standard code revert of this branch's changes to reason-code
+normalization, canonical definitions, recovery mapping, status bridge handling,
+tests, operator-guide documentation, and governed artifacts. No data migration,
+external API deployment, credentials, or irreversible operation is involved.
+
+## Archive Decision
+
+This change is ready for final-closeout acceptance and then `done`. Active
+`/tmp/slipway-issue160-closeout validate --json` proof was captured in
+S4_VERIFY before `done`; it reported fresh evidence, passing scope contract, and
+passing goal-verification, with only final-closeout and the standard-preset
+assurance attestation pending before `verification/final-closeout.yaml` is
+accepted. After final-closeout records `closeout:assurance_complete=pass`,
+`slipway run` should surface done-ready and `slipway done --json` should archive
+the governed bundle.

--- a/artifacts/changes/archived/resolve-github-issue-160-freeze-reason-code-taxonomy-with-a/change.yaml
+++ b/artifacts/changes/archived/resolve-github-issue-160-freeze-reason-code-taxonomy-with-a/change.yaml
@@ -1,0 +1,38 @@
+version: 1
+slug: resolve-github-issue-160-freeze-reason-code-taxonomy-with-a
+description: 'Resolve GitHub issue #160: freeze reason-code taxonomy with a snapshot test and add a test lint that bans assertions against ReasonCode/JSON message prose.'
+status: done
+current_state: DONE
+complexity_level: simple
+base_ref: HEAD
+created_at: 2026-06-10T02:14:42.826451Z
+quality_mode: standard
+workflow_profile: code
+workflow_preset: standard
+worktree_branch: feat/resolve-github-issue-160-freeze-reason-code-taxonomy-with-a
+artifact_schema: core
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: 8f5085ff7ff3e044fce51395c1ece1d1b4b6e5032ce51a33d3b8ae881059df27
+        updated_at: 2026-06-10T10:48:19.670052469Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: bf5c3c32f223e83c1219f80994a009215f575a7d66dcf0fadb4ed43449b1584b
+        updated_at: 2026-06-10T02:17:21.2619038Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: 548baf01a403daeb675fed1a39b718616b59a7effdc4b02eaf214e1e3e36bc30
+        updated_at: 2026-06-10T02:20:17.696919529Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: 3a3b96b4f892bd5f45e2560fa9545a8a74b0a3b91f6a8a93a89265daf9801b06
+        updated_at: 2026-06-10T10:02:11.772902351Z

--- a/artifacts/changes/archived/resolve-github-issue-160-freeze-reason-code-taxonomy-with-a/intent.md
+++ b/artifacts/changes/archived/resolve-github-issue-160-freeze-reason-code-taxonomy-with-a/intent.md
@@ -1,0 +1,35 @@
+# Intent
+
+## Summary
+Resolve GitHub issue #160: freeze reason-code taxonomy with a snapshot test and add a test lint that bans assertions against ReasonCode/JSON message prose.
+## Complexity Assessment
+simple
+The change is a focused contract/test-quality hardening task in the Go codebase. It does not introduce a new user workflow, external API, storage migration, or sensitive-domain behavior.
+
+## In Scope
+- Add a freezing/snapshot-style regression for the canonical reason-code taxonomy so additions/removals are explicit.
+- Add a test lint/contract check that rejects tests asserting against unstable `Message` prose for reason/error contract payloads.
+- Update existing tests caught by that lint to assert stable fields such as `Code`, `Detail`, `ErrorCode`, or structured collections.
+- Keep implementation scoped to issue #160's reason-code taxonomy and message-prose assertion contract.
+
+## Out of Scope
+- Do not implement issue #152 or touch the context-pressure hook active change.
+- Do not redesign the full JSON error schema.
+- Do not mass-rename existing reason codes unless required by the freeze test.
+- Do not add an external lint dependency when a repo-local Go test can enforce the contract.
+
+## Constraints
+- Preserve existing operator-facing messages as presentation text; the new contract is about tests and machine-stable reason codes.
+- Prefer repo-native Go tests and current package layout.
+- Use the current governed worktree behavior as the lifecycle authority.
+
+## Acceptance Signals
+- A regression proves the current taxonomy is not frozen and the current message-prose assertions are detectable.
+- `go test -count=1 ./...` passes after the fix.
+- `go run . validate --json` reaches a done-ready ship gate state for this governed change.
+
+## Open Questions
+None
+
+## Approved Summary
+Confirmed by user on 2026-06-10T02:17:02Z. Resolve #160 by freezing the canonical reason-code taxonomy with an explicit regression and adding a repo-local test lint that bans assertions against unstable `Message` prose for reason/error contract payloads. Keep the change limited to the taxonomy/test-contract surface, excluding #152, full JSON schema redesign, broad reason-code renaming, and new external lint tooling unless unavoidable. Completion requires the targeted regressions and full Go test suite to pass, then Slipway validation to reach done-ready.

--- a/artifacts/changes/archived/resolve-github-issue-160-freeze-reason-code-taxonomy-with-a/requirements.md
+++ b/artifacts/changes/archived/resolve-github-issue-160-freeze-reason-code-taxonomy-with-a/requirements.md
@@ -1,0 +1,32 @@
+# Requirements
+
+## Requirements
+
+### Requirement: Freeze Canonical Reason Codes
+REQ-001: The system MUST treat the canonical reason-code taxonomy as an explicit, reviewed contract rather than an implicit mutable map.
+
+#### Scenario: Taxonomy changes are explicit
+GIVEN the canonical reason-code definitions used by `model.NewReasonCode`
+WHEN a developer adds, removes, or renames a canonical code
+THEN a snapshot-style regression MUST fail until the expected taxonomy is intentionally updated.
+
+### Requirement: Unknown Codes Are Not Silently Humanized
+REQ-002: The system MUST NOT silently present an unrecognized reason code as if it were a canonical machine contract.
+
+#### Scenario: Unknown reason code construction fails closed
+GIVEN code constructs or loads a `ReasonCode` with an unrecognized code
+WHEN the reason code is normalized for output or recovery routing
+THEN the resulting code MUST make the unknown-code condition explicit and MUST preserve the original token as detail for diagnosis.
+
+### Requirement: Tests Assert Stable Contracts Instead Of Message Prose
+REQ-003: The test suite MUST reject direct text-matching assertions against unstable reason/error `Message` prose when stable fields are available.
+
+#### Scenario: Message prose matching is linted
+GIVEN a Go test asserts `Contains`, regex, or error-prose matching against a reason/error payload `Message`
+WHEN `go test ./...` runs
+THEN a repo-local lint regression MUST fail and tell the developer to assert stable fields such as `Code`, `Detail`, `ErrorCode`, `Category`, `ExitCode`, or structured `Details`.
+
+#### Scenario: Existing tests use stable fields
+GIVEN current tests that validate reason-code or CLI error behavior
+WHEN they need to prove the contract
+THEN they MUST assert machine-stable fields instead of coupling to presentation message fragments.

--- a/artifacts/changes/archived/resolve-github-issue-160-freeze-reason-code-taxonomy-with-a/tasks.md
+++ b/artifacts/changes/archived/resolve-github-issue-160-freeze-reason-code-taxonomy-with-a/tasks.md
@@ -1,0 +1,31 @@
+# Tasks
+
+## Task List
+
+- [x] `t-01` Add failing reason-code taxonomy and unknown-code regressions.
+  - wave: 1
+  - depends_on: []
+  - target_files: [internal/model/reason_code.go, internal/model/model_test.go, internal/model/recovery_test.go, internal/model/reason_code_contract_test.go]
+  - task_kind: test
+  - covers: [REQ-001, REQ-002]
+
+- [x] `t-02` Implement explicit canonical lookup and unknown-code normalization.
+  - wave: 2
+  - depends_on: [t-01]
+  - target_files: [internal/model/reason_code.go, internal/model/recovery.go, cmd/status_view_build.go, internal/model/model_test.go, internal/model/recovery_test.go, internal/engine/gate/gate_test.go, internal/engine/progression/evidence.go]
+  - task_kind: code
+  - covers: [REQ-001, REQ-002]
+
+- [x] `t-03` Add repo-local message-prose assertion lint and migrate caught tests to stable fields.
+  - wave: 3
+  - depends_on: [t-02]
+  - target_files: [internal/model/reason_code_contract_test.go, internal/model/model_test.go, internal/model/recovery_test.go, internal/engine/gate/gate_test.go, internal/engine/progression/evidence_test.go, internal/engine/progression/readiness_optimization_test.go, internal/engine/progression/wave_sync_test.go, internal/state/execution_summary_test.go, internal/state/health_test.go, internal/state/verification_test.go, cmd/active_change_resolution_test.go, cmd/common_test.go, cmd/delete_test.go, cmd/error_contract_test.go, cmd/governance_readiness_error_test.go, cmd/health_test.go, cmd/hydrate_flag_test.go, cmd/lifecycle_commands_test.go, cmd/new_test.go, cmd/progression_next_test.go, cmd/route_surface_command_test.go]
+  - task_kind: test
+  - covers: [REQ-003]
+
+- [x] `t-04` Run targeted and full verification, then record governed task evidence.
+  - wave: 4
+  - depends_on: [t-03]
+  - target_files: [docs/operator-guide.md, internal/engine/progression/evidence.go, internal/engine/progression/evidence_test.go, internal/model/reason_code.go, internal/model/recovery.go, internal/model/recovery_test.go, internal/model/reason_code_contract_test.go, artifacts/changes/resolve-github-issue-160-freeze-reason-code-taxonomy-with-a/verification/wave-orchestration.yaml]
+  - task_kind: test
+  - covers: [REQ-001, REQ-002, REQ-003]

--- a/cmd/active_change_resolution_test.go
+++ b/cmd/active_change_resolution_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -31,8 +32,8 @@ func TestResolveActiveChangeRefReportsBoundElsewhereFromRoot(t *testing.T) {
 		require.NotNil(t, cliErr)
 		assert.Equal(t, "change_bound_to_other_worktree", cliErr.ErrorCode)
 		assert.Equal(t, categoryPrecondition, cliErr.Category)
-		assert.Contains(t, cliErr.Message, "bound-change")
-		assert.Contains(t, cliErr.Message, normalizedWorktreePath)
+		assert.Contains(t, fmt.Sprint(cliErr.Details["bound_changes"]), "bound-change")
+		assert.Contains(t, fmt.Sprint(cliErr.Details["bound_changes"]), normalizedWorktreePath)
 		assert.Contains(t, cliErr.Remediation, "--change bound-change")
 		assert.Contains(t, cliErr.Remediation, normalizedWorktreePath)
 	})

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -114,7 +114,6 @@ func TestResolveExplicitChangeRejectsArchivedSlugWithConcreteDiagnostic(t *testi
 	assert.Equal(t, string(model.ChangeStatusDone), cliErr.Details["status"])
 	assert.Equal(t, true, cliErr.Details["archived"])
 	assert.Contains(t, fmt.Sprint(cliErr.Details["archive_path"]), filepath.ToSlash(filepath.Join("artifacts", "changes", "archived", slug, "change.yaml")))
-	assert.Contains(t, cliErr.Message, slug)
 	assert.Contains(t, cliErr.Remediation, "archived")
 }
 
@@ -254,6 +253,58 @@ func TestGovernanceReadinessErrorCodeRecognizesVerificationLoadError(t *testing.
 		Err:  fmt.Errorf("parse verification plan-audit: broken"),
 	}
 	assert.Equal(t, "verification_load_failed", governanceReadinessErrorCode(err))
+}
+
+func TestStatusWaveExecutionIssuesPreserveCanonicalCLIErrorCodes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		code string
+	}{
+		{name: "wave plan load failed", code: "wave_plan_load_failed"},
+		{name: "wave runs load failed", code: "wave_runs_load_failed"},
+		{name: "wave runs invalid count", code: "wave_runs_invalid_count"},
+		{name: "wave run version mismatch", code: "wave_run_version_mismatch"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			reasons, diagnostics := statusWaveExecutionIssues(newStateIntegrityError(
+				tt.code,
+				"wave execution artifact error",
+				"Run `slipway repair`.",
+				"status-wave",
+				nil,
+			))
+
+			require.Len(t, reasons, 1)
+			assert.Equal(t, tt.code, reasons[0].Code)
+			assert.NotEqual(t, "unknown_reason_code", reasons[0].Code)
+			assert.NotEmpty(t, diagnostics)
+		})
+	}
+}
+
+func TestStatusWaveExecutionIssuesWrapNonReasonCLIErrorCodes(t *testing.T) {
+	t.Parallel()
+
+	reasons, diagnostics := statusWaveExecutionIssues(newPreconditionError(
+		"change_bound_to_other_worktree",
+		"active change is bound to another worktree",
+		"Use --change.",
+		"",
+		nil,
+	))
+
+	require.Len(t, reasons, 1)
+	assert.Equal(t, "wave_execution_unavailable", reasons[0].Code)
+	assert.Contains(t, reasons[0].Detail, "change_bound_to_other_worktree")
+	assert.NotEqual(t, "unknown_reason_code", reasons[0].Code)
+	assert.NotEmpty(t, diagnostics)
 }
 
 func TestLoadExecutionContextUsesAuthoritativeWorktreeSummaryForHiddenBoundChange(t *testing.T) {

--- a/cmd/delete_test.go
+++ b/cmd/delete_test.go
@@ -110,7 +110,10 @@ func assertOrphanStatusDeleteRecovery(t *testing.T, payload map[string]any, slug
 func assertOrphanErrorDeleteRecovery(t *testing.T, payload map[string]any, slug string) {
 	t.Helper()
 	assert.Equal(t, "orphaned_change_bundle", payload["error_code"])
-	assert.Contains(t, payload["message"], slug)
+	assert.Equal(t, slug, payload["slug"])
+	details, ok := payload["details"].(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, details["orphaned_change_bundles"], slug)
 	assert.Contains(t, payload["remediation"], "slipway delete --change "+slug)
 
 	recovery, ok := payload["recovery"].(map[string]any)
@@ -137,7 +140,10 @@ func assertStaleRuntimeStatusDeleteRecovery(t *testing.T, payload map[string]any
 func assertStaleRuntimeErrorDeleteRecovery(t *testing.T, payload map[string]any, slug string) {
 	t.Helper()
 	assert.Equal(t, "stale_runtime_binding", payload["error_code"])
-	assert.Contains(t, payload["message"], slug)
+	assert.Equal(t, slug, payload["slug"])
+	details, ok := payload["details"].(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, details["stale_runtime_bindings"], slug)
 	assert.Contains(t, payload["remediation"], "slipway delete --change "+slug)
 
 	recovery, ok := payload["recovery"].(map[string]any)

--- a/cmd/error_contract_test.go
+++ b/cmd/error_contract_test.go
@@ -92,13 +92,13 @@ func TestExecuteFailureEnvelopeStateIntegrityForMalformedGovernanceSkill(t *test
 		assert.Equal(t, categoryStateIntegrity, payload.Category)
 		assert.Equal(t, exitCodeStateIntegrity, payload.ExitCode)
 		assert.Equal(t, "skill_registry_invalid", payload.ErrorCode)
-		assert.Contains(t, payload.Message, "evaluate next skill evidence")
-		assert.Contains(t, payload.Message, "parse skill frontmatter")
+		assert.Equal(t, "evaluate next skill evidence", payload.Details["operation"])
+		assert.NotEmpty(t, payload.Details["path"])
 		assert.Contains(t, payload.Remediation, "repair")
 	})
 }
 
-func assertMalformedGovernanceSkillCommandFailsStateIntegrity(t *testing.T, command, description, wantMessage string) {
+func assertMalformedGovernanceSkillCommandFailsStateIntegrity(t *testing.T, command, description, wantOperation string) {
 	t.Helper()
 
 	root := t.TempDir()
@@ -127,36 +127,36 @@ func assertMalformedGovernanceSkillCommandFailsStateIntegrity(t *testing.T, comm
 		assert.Equal(t, categoryStateIntegrity, payload.Category)
 		assert.Equal(t, exitCodeStateIntegrity, payload.ExitCode)
 		assert.Equal(t, "skill_registry_invalid", payload.ErrorCode)
-		assert.Contains(t, payload.Message, wantMessage)
-		assert.Contains(t, payload.Message, "parse skill frontmatter")
+		assert.Equal(t, wantOperation, payload.Details["operation"])
+		assert.NotEmpty(t, payload.Details["path"])
 		assert.Contains(t, payload.Remediation, "repair")
 	})
 }
 
 func TestExecuteFailureEnvelopeStateIntegrityForMalformedGovernanceSkillStateCommands(t *testing.T) {
 	tests := []struct {
-		name        string
-		command     string
-		description string
-		wantMessage string
+		name          string
+		command       string
+		description   string
+		wantOperation string
 	}{
 		{
-			name:        "review",
-			command:     "review",
-			description: "review malformed governance skill through review",
-			wantMessage: "evaluate review prerequisites",
+			name:          "review",
+			command:       "review",
+			description:   "review malformed governance skill through review",
+			wantOperation: "evaluate review prerequisites",
 		},
 		{
-			name:        "validate",
-			command:     "validate",
-			description: "review malformed governance skill through validate",
-			wantMessage: "validate readiness",
+			name:          "validate",
+			command:       "validate",
+			description:   "review malformed governance skill through validate",
+			wantOperation: "validate readiness",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assertMalformedGovernanceSkillCommandFailsStateIntegrity(t, tt.command, tt.description, tt.wantMessage)
+			assertMalformedGovernanceSkillCommandFailsStateIntegrity(t, tt.command, tt.description, tt.wantOperation)
 		})
 	}
 }

--- a/cmd/governance_readiness_error_test.go
+++ b/cmd/governance_readiness_error_test.go
@@ -70,8 +70,7 @@ func TestNextReadinessFailureUsesGovernanceReadinessEnvelope(t *testing.T) {
 		assert.Equal(t, "verification_load_failed", cliErr.ErrorCode)
 		assert.Equal(t, categoryStateIntegrity, cliErr.Category)
 		assert.Equal(t, exitCodeStateIntegrity, cliErr.ExitCode)
-		assert.Contains(t, cliErr.Message, "evaluate next skill evidence")
-		assert.Contains(t, cliErr.Message, "parse verification plan-audit")
+		assert.Equal(t, "evaluate next skill evidence", cliErr.Details["operation"])
 		assert.Equal(t, verificationReadPathForTest(root, slug, "plan-audit"), cliErr.Details["path"])
 	})
 }
@@ -100,8 +99,7 @@ func TestNextReadinessFailureEnvelopeJSON(t *testing.T) {
 		assert.Equal(t, categoryStateIntegrity, payload.Category)
 		assert.Equal(t, exitCodeStateIntegrity, payload.ExitCode)
 		assert.Equal(t, "verification_load_failed", payload.ErrorCode)
-		assert.Contains(t, payload.Message, "evaluate next skill evidence")
-		assert.Contains(t, payload.Message, "parse verification plan-audit")
+		assert.Equal(t, "evaluate next skill evidence", payload.Details["operation"])
 		assert.Equal(t, verificationReadPathForTest(root, slug, "plan-audit"), payload.Details["path"])
 	})
 }
@@ -133,8 +131,8 @@ func TestStatusReadinessFailureUsesGovernanceReadinessEnvelope(t *testing.T) {
 		assert.Equal(t, "verification_load_failed", cliErr.ErrorCode)
 		assert.Equal(t, categoryStateIntegrity, cliErr.Category)
 		assert.Equal(t, exitCodeStateIntegrity, cliErr.ExitCode)
-		assert.Contains(t, cliErr.Message, "build status view")
-		assert.Contains(t, cliErr.Message, "parse verification plan-audit")
+		assert.Equal(t, "build status view", cliErr.Details["operation"])
+		assert.Equal(t, verificationReadPathForTest(root, slug, "plan-audit"), cliErr.Details["path"])
 	})
 }
 
@@ -165,8 +163,8 @@ func TestValidateReadinessFailureUsesGovernanceReadinessEnvelope(t *testing.T) {
 		assert.Equal(t, "verification_load_failed", cliErr.ErrorCode)
 		assert.Equal(t, categoryStateIntegrity, cliErr.Category)
 		assert.Equal(t, exitCodeStateIntegrity, cliErr.ExitCode)
-		assert.Contains(t, cliErr.Message, "validate readiness")
-		assert.Contains(t, cliErr.Message, "parse verification plan-audit")
+		assert.Equal(t, "validate readiness", cliErr.Details["operation"])
+		assert.Equal(t, verificationReadPathForTest(root, slug, "plan-audit"), cliErr.Details["path"])
 	})
 }
 
@@ -200,8 +198,8 @@ func TestReviewReadinessFailureUsesGovernanceReadinessEnvelope(t *testing.T) {
 		assert.Equal(t, "verification_load_failed", cliErr.ErrorCode)
 		assert.Equal(t, categoryStateIntegrity, cliErr.Category)
 		assert.Equal(t, exitCodeStateIntegrity, cliErr.ExitCode)
-		assert.Contains(t, cliErr.Message, "evaluate review prerequisites")
-		assert.Contains(t, cliErr.Message, "parse verification plan-audit")
+		assert.Equal(t, "evaluate review prerequisites", cliErr.Details["operation"])
+		assert.Equal(t, verificationReadPathForTest(root, slug, "plan-audit"), cliErr.Details["path"])
 	})
 }
 
@@ -236,8 +234,7 @@ func TestNextDiagnosticsProjectionFailureUsesGovernanceReadinessEnvelope(t *test
 		assert.Equal(t, "governance_readiness_failed", cliErr.ErrorCode)
 		assert.Equal(t, categoryStateIntegrity, cliErr.Category)
 		assert.Equal(t, exitCodeStateIntegrity, cliErr.ExitCode)
-		assert.Contains(t, cliErr.Message, "evaluate next skill evidence")
-		assert.Contains(t, cliErr.Message, "intent.md")
+		assert.Equal(t, "evaluate next skill evidence", cliErr.Details["operation"])
 	})
 }
 

--- a/cmd/health_test.go
+++ b/cmd/health_test.go
@@ -571,7 +571,7 @@ func TestHealthCommandReportsMissingHostSkillSurface(t *testing.T) {
 			for _, reason := range finding.Reasons {
 				if reason.Code == "skill_prompt_surface_missing" {
 					found = true
-					assert.Contains(t, finding.Message, "missing host skill surface")
+					assert.Contains(t, reason.Detail, "slipway-intake-clarification")
 					assert.Contains(t, finding.RepairHint, "slipway init --tools claude --refresh")
 				}
 			}
@@ -605,7 +605,7 @@ func TestHealthCommandReportsInvalidHostSkillRegistry(t *testing.T) {
 			for _, reason := range finding.Reasons {
 				if reason.Code == "skill_registry_invalid" {
 					found = true
-					assert.Contains(t, finding.Message, "Governance skill registry is invalid")
+					assert.NotEmpty(t, reason.Detail)
 					assert.Contains(t, finding.RepairHint, "Inspect generated host skill surfaces")
 				}
 			}
@@ -682,8 +682,8 @@ func TestHealthCommandReportsInvalidHostSkillRegistryFromInvocationWorktree(t *t
 		for _, reason := range finding.Reasons {
 			if reason.Code == "skill_registry_invalid" {
 				found = true
-				assert.Contains(t, reason.Message, "missing frontmatter")
-				assert.Contains(t, reason.Message, "health-worktree")
+				assert.Contains(t, reason.Detail, "missing frontmatter")
+				assert.Contains(t, reason.Detail, "health-worktree")
 			}
 		}
 	}
@@ -716,7 +716,7 @@ func TestHealthCommandReportsUnreadableHostSkillSurface(t *testing.T) {
 			for _, reason := range finding.Reasons {
 				if reason.Code == "skill_prompt_surface_unreadable" {
 					found = true
-					assert.Contains(t, finding.Message, "unreadable host skill surface")
+					assert.Contains(t, reason.Detail, "slipway-intake-clarification")
 					assert.Contains(t, finding.RepairHint, "slipway init --tools claude --refresh")
 				}
 			}
@@ -743,7 +743,6 @@ func TestHealthCommandDoesNotReportToolResolutionFailureForMultiAdapterWorkspace
 		require.NoError(t, json.Unmarshal(out.Bytes(), &view))
 
 		for _, finding := range view.Findings {
-			assert.NotEqual(t, "Tool adapter resolution failed", finding.Message)
 			for _, reason := range finding.Reasons {
 				assert.NotEqual(t, "tool_resolution_failed", reason.Code)
 			}
@@ -772,11 +771,11 @@ func TestHealthCommandIgnoresMissingProjectAgentSurface(t *testing.T) {
 		require.NoError(t, json.Unmarshal(out.Bytes(), &view))
 
 		for _, finding := range view.Findings {
-			assert.NotContains(t, finding.Message, ".claude/agents/slipway-planner.md")
+			assert.NotContains(t, model.ReasonSpecs(finding.Reasons), ".claude/agents/slipway-planner.md")
 			for _, reason := range finding.Reasons {
 				assert.NotEqual(t, "agent_generated_surface_missing", reason.Code)
 				assert.NotEqual(t, "agent_generated_surface_unreadable", reason.Code)
-				assert.NotEqual(t, ".claude/agents/slipway-planner.md", reason.Message)
+				assert.NotEqual(t, ".claude/agents/slipway-planner.md", reason.Detail)
 			}
 		}
 	})
@@ -806,7 +805,7 @@ func TestHealthCommandReportsMissingHostSkillSurfaceForMultiAdapterWorkspace(t *
 			for _, reason := range finding.Reasons {
 				if reason.Code == "skill_prompt_surface_missing" {
 					found = true
-					assert.Contains(t, finding.Message, "missing host skill surface for claude")
+					assert.Contains(t, reason.Detail, ".claude")
 					assert.Contains(t, finding.RepairHint, "slipway init --tools claude --refresh")
 				}
 			}

--- a/cmd/hydrate_flag_test.go
+++ b/cmd/hydrate_flag_test.go
@@ -101,7 +101,6 @@ func TestEmitHydrateBlocksMissingReferenceFailsDeterministically(t *testing.T) {
 	if cliErr.ErrorCode != "hydrate_reference_missing" {
 		t.Fatalf("unexpected error code %q", cliErr.ErrorCode)
 	}
-	assert.Contains(t, cliErr.Message, "built-in reference set")
 	assert.Contains(t, cliErr.Remediation, "Fix the hydrate reference declaration")
 	assert.Equal(t, map[string]any{"key": "security-review/this-file-does-not-exist.md"}, cliErr.Details)
 }
@@ -390,7 +389,5 @@ func TestLoadHydrateBodyFailsWhenEmbeddedReferenceIsMissing(t *testing.T) {
 	if cliErr == nil || cliErr.ErrorCode != "hydrate_reference_missing" {
 		t.Fatalf("expected hydrate_reference_missing, got %v", err)
 	}
-	assert.Contains(t, cliErr.Message, "built-in reference set")
-	assert.NotContains(t, cliErr.Message, "skills/security-review/references")
 	assert.Equal(t, map[string]any{"key": "security-review/this-file-does-not-exist.md"}, cliErr.Details)
 }

--- a/cmd/lifecycle_commands_test.go
+++ b/cmd/lifecycle_commands_test.go
@@ -666,7 +666,7 @@ func TestDoneRejectsReviewLayerBlockersBeforeArchive(t *testing.T) {
 		cliErr := asCLIError(err)
 		require.NotNil(t, cliErr)
 		assert.Equal(t, "ship_gate_blocked", cliErr.ErrorCode)
-		assert.Contains(t, strings.ToLower(cliErr.Message), "review_layer_missing:ir1")
+		assert.Contains(t, model.ReasonSpecs(cliErr.Reasons), "review_layer_missing:IR1")
 		require.NotNil(t, cliErr.Recovery)
 		assert.Contains(t, recoveryStepCodes(cliErr.Recovery), "review_layer_missing")
 		assert.NotEmpty(t, cliErr.Recovery.PrimaryCommand)
@@ -706,8 +706,8 @@ func TestDoneRejectsExecutionSummaryLevelBlockersBeforeArchive(t *testing.T) {
 		cliErr := asCLIError(err)
 		require.NotNil(t, cliErr)
 		assert.Equal(t, "ship_gate_blocked", cliErr.ErrorCode)
-		assert.Contains(t, cliErr.Message, "session_isolation_warning")
-		assert.NotContains(t, cliErr.Message, "stale_execution_evidence")
+		assert.Contains(t, model.ReasonSpecs(cliErr.Reasons), blocker)
+		assert.NotContains(t, model.ReasonSpecs(cliErr.Reasons), "stale_execution_evidence")
 
 		_, loadErr := state.LoadChange(root, slug)
 		require.NoError(t, loadErr)
@@ -739,7 +739,7 @@ func TestDoneRejectsChecklistBlockersBeforeArchive(t *testing.T) {
 		cliErr := asCLIError(err)
 		require.NotNil(t, cliErr)
 		assert.Equal(t, "ship_gate_blocked", cliErr.ErrorCode)
-		assert.Contains(t, cliErr.Message, "tasks_checklist_empty")
+		assert.Contains(t, model.ReasonSpecs(cliErr.Reasons), "tasks_checklist_empty")
 
 		_, loadErr := state.LoadChange(root, slug)
 		require.NoError(t, loadErr)
@@ -787,6 +787,84 @@ func TestDoneRejectsAllReadyWithExplicitRequest(t *testing.T) {
 		assert.Equal(t, categoryInvalidUsage, cliErr.Category)
 		assert.Equal(t, exitCodeInvalidUsage, cliErr.ExitCode)
 	})
+}
+
+func TestDoneBulkFallbackReasonCodesAreCanonical(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		item doneBulkItem
+		code string
+	}{
+		{
+			name: "list changes failed",
+			item: newDoneBulkFailed("", "list_changes_failed", "permission denied"),
+			code: "list_changes_failed",
+		},
+		{
+			name: "load change failed",
+			item: newDoneBulkFailed("bulk-load-failed", "load_change_failed", "parse error"),
+			code: "load_change_failed",
+		},
+		{
+			name: "change not active",
+			item: newDoneBulkSkipped("bulk-cancelled", string(model.ChangeStatusCancelled), "change_not_active"),
+			code: "change_not_active",
+		},
+		{
+			name: "not done ready",
+			item: newDoneBulkSkipped("bulk-not-ready", string(model.StateS2Execute), "not_done_ready"),
+			code: "not_done_ready",
+		},
+		{
+			name: "artifact reconcile failed",
+			item: newDoneBulkFailed("bulk-reconcile-failed", "artifact_reconcile_failed", "permission denied"),
+			code: "artifact_reconcile_failed",
+		},
+		{
+			name: "artifact validation failed",
+			item: newDoneBulkFailed("bulk-artifact-invalid", "artifact_validation_failed", "assurance.md missing"),
+			code: "artifact_validation_failed",
+		},
+		{
+			name: "lifecycle event write failed",
+			item: newDoneBulkFailed("bulk-event-failed", "lifecycle_event_write_failed", "permission denied"),
+			code: "lifecycle_event_write_failed",
+		},
+		{
+			name: "archive failed",
+			item: newDoneBulkFailed("bulk-archive-failed", "archive_failed", "rename failed"),
+			code: "archive_failed",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Len(t, tt.item.ReasonCodes, 1)
+			assert.Equal(t, tt.code, tt.item.ReasonCodes[0].Code)
+			assert.NotEqual(t, "unknown_reason_code", tt.item.ReasonCodes[0].Code)
+			step, ok := recoveryStepByCode(tt.item.ReasonCodes, tt.code)
+			require.Truef(t, ok, "%s must remain recovery-routable", tt.code)
+			assert.NotEmpty(t, step.Remediation)
+		})
+	}
+}
+
+func recoveryStepByCode(reasons []model.ReasonCode, code string) (model.RecoveryStep, bool) {
+	recovery := model.BuildRecovery(reasons)
+	if recovery == nil {
+		return model.RecoveryStep{}, false
+	}
+	for _, step := range recovery.Steps {
+		if step.Code == code {
+			return step, true
+		}
+	}
+	return model.RecoveryStep{}, false
 }
 
 func TestDoneRejectsMalformedConfigBeforeLockProtectedMutation(t *testing.T) {

--- a/cmd/new_test.go
+++ b/cmd/new_test.go
@@ -807,7 +807,6 @@ func TestNewJSONStdinRejectsGuardrailWithTrivialOverride(t *testing.T) {
 		require.ErrorAs(t, err, &cliErr)
 		assert.Equal(t, "invalid_classification", cliErr.ErrorCode)
 		assert.Equal(t, "complexity", cliErr.Details["field"])
-		assert.Contains(t, cliErr.Message, "requires complexity >= complex")
 
 		changes, listErr := state.ListChanges(root)
 		require.NoError(t, listErr)
@@ -1407,7 +1406,7 @@ func TestNewCommandRejectsWhenActiveChangeIsBoundToCurrentWorktree(t *testing.T)
 		cliErr := asCLIError(err)
 		require.NotNil(t, cliErr)
 		assert.Equal(t, "active_change_exists", cliErr.ErrorCode)
-		assert.Contains(t, cliErr.Message, "bound to this worktree")
+		assert.Equal(t, slug, cliErr.Slug)
 		assert.Contains(t, cliErr.Remediation, "before creating a new change from that worktree")
 	})
 }

--- a/cmd/progression_next_test.go
+++ b/cmd/progression_next_test.go
@@ -2738,7 +2738,6 @@ func TestRunResumeUnavailableExplainsLifecycleBoundary(t *testing.T) {
 		cliErr := asCLIError(err)
 		require.NotNil(t, cliErr)
 		assert.Equal(t, "resume_unavailable", cliErr.ErrorCode)
-		assert.Contains(t, cliErr.Message, "current_state=S3_REVIEW")
 		assert.Equal(t, model.StateS3Review, cliErr.Details["current_state"])
 		assert.Contains(t, cliErr.Remediation, "S2_EXECUTE")
 	})

--- a/cmd/route_surface_command_test.go
+++ b/cmd/route_surface_command_test.go
@@ -17,10 +17,9 @@ func TestWrongSurfaceDiscoveryFlagsFailAtParseTime(t *testing.T) {
 		initTestWorkspace(t, root)
 
 		cases := []struct {
-			args    []string
-			wantMsg string
+			args []string
 		}{
-			{args: []string{"review", "--list-views"}, wantMsg: "unknown flag: --list-views"},
+			{args: []string{"review", "--list-views"}},
 		}
 
 		for _, tc := range cases {
@@ -31,7 +30,7 @@ func TestWrongSurfaceDiscoveryFlagsFailAtParseTime(t *testing.T) {
 			var payload CLIError
 			require.NoError(t, json.Unmarshal([]byte(stderr), &payload))
 			assert.Equal(t, categoryInvalidUsage, payload.Category)
-			assert.Contains(t, payload.Message, tc.wantMsg)
+			assert.Equal(t, "invalid_usage", payload.ErrorCode)
 		}
 	})
 }
@@ -58,7 +57,7 @@ func TestLegacyRawModeFlagFailsAtParseTime(t *testing.T) {
 			var payload CLIError
 			require.NoError(t, json.Unmarshal([]byte(stderr), &payload))
 			assert.Equal(t, categoryInvalidUsage, payload.Category)
-			assert.Contains(t, payload.Message, "unknown flag: --mode")
+			assert.Equal(t, "invalid_usage", payload.ErrorCode)
 		}
 	})
 }

--- a/cmd/status_view_build.go
+++ b/cmd/status_view_build.go
@@ -251,10 +251,26 @@ func statusWaveExecutionIssues(err error) ([]model.ReasonCode, []string) {
 		if len(cliErr.Reasons) > 0 {
 			return append([]model.ReasonCode(nil), cliErr.Reasons...), diagnostics
 		}
-		return []model.ReasonCode{model.NewReasonCode(cliErr.ErrorCode, cliErr.Message)}, diagnostics
+		return []model.ReasonCode{statusReasonFromCLIError(cliErr)}, diagnostics
 	}
 
 	return []model.ReasonCode{model.NewReasonCode("wave_execution_unavailable", err.Error())}, diagnostics
+}
+
+func statusReasonFromCLIError(cliErr *CLIError) model.ReasonCode {
+	code := strings.TrimSpace(cliErr.ErrorCode)
+	detail := strings.TrimSpace(cliErr.Message)
+	if model.IsCanonicalReasonCode(code) {
+		return model.NewReasonCode(code, detail)
+	}
+	if code != "" {
+		if detail != "" {
+			detail = code + ": " + detail
+		} else {
+			detail = code
+		}
+	}
+	return model.NewReasonCode("wave_execution_unavailable", detail)
 }
 
 // governedSourceStateFile returns the display path for the authoritative

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -84,6 +84,26 @@ Missing task evidence blockers include the runtime task evidence directory and
 the required flat JSON fields:
 `task_id,run_summary_version,task_kind,verdict,evidence_ref,captured_at,freshness_inputs`.
 
+Reason-code `code` values are the stable machine contract for blockers,
+recovery routing, JSON consumers, and generated skills. The canonical enum is
+the key set in `internal/model/reason_code.go`'s
+`canonicalReasonDefinitions`, and `internal/model/reason_code_contract_test.go`
+freezes that set and each code's severity with snapshot tests. Treat `message`
+as presentation prose: reason/error payload tests and skill logic must assert
+stable fields such as `code`, `detail`, `error_code`, `category`, `exit_code`,
+or structured details instead of matching message text. The repo-local AST lint
+enforces that rule for syntactically recognizable reason/error payload surfaces
+(`ReasonCode`,
+`CLIError`, `HealthFinding`, known constructors/helpers, and blocker/reason
+collections); other fields named `Message` remain review-owned unless they
+become part of that reason/error payload surface. If a producer emits an
+unrecognized token, normalization fails closed to `unknown_reason_code` and
+preserves the original token in `detail` so the producer can be fixed and added
+to the canonical enum. Bridges from CLI errors to reason payloads must only
+preserve canonical reason codes directly; non-reason-domain `error_code` values
+must be carried in the detail of a canonical wrapper reason instead of being
+normalized as standalone reason codes.
+
 Review handoffs use exact layer tokens. Spec-compliance evidence records
 `layer:R0=pass` and, when the guardrail domain requires it, `layer:R3=pass`.
 Code-quality evidence records `layer:IR1=pass` and, when required,

--- a/internal/engine/gate/gate_test.go
+++ b/internal/engine/gate/gate_test.go
@@ -85,8 +85,11 @@ func TestEvaluateGShipMissingVerificationEvidenceRoutesS4Recovery(t *testing.T) 
 	eval := EvaluateGShip(model.NewChange("slug"), true, false, true, nil, nil)
 	require.NotEmpty(t, eval.ReasonCodes)
 	reason := findGateReasonCode(t, eval.ReasonCodes, "verification_evidence_missing")
-	assert.Contains(t, reason.Message, "goal-verification")
-	assert.Contains(t, reason.Message, "final-closeout")
+	assert.Equal(t, model.ReasonSeverityError, reason.Severity)
+	recovery := model.BuildRecovery(eval.ReasonCodes)
+	require.NotNil(t, recovery)
+	assert.Equal(t, model.RecoveryClassRerunSkill, recovery.RecoveryClass)
+	assert.Equal(t, "slipway run", recovery.PrimaryCommand)
 }
 
 func TestGuardrailHighRiskChecks(t *testing.T) {

--- a/internal/engine/progression/evidence.go
+++ b/internal/engine/progression/evidence.go
@@ -207,19 +207,23 @@ func ParseHighRiskCheckReference(reference string) (checkID string, pass bool, o
 func ValidateChangeYamlR0(changeYamlPath string, slug string) (bool, []string) {
 	raw, err := os.ReadFile(changeYamlPath) // #nosec G304 -- path is resolved from repository or governed artifact authority before this read.
 	if err != nil {
-		return false, []string{"manifest_missing"}
+		return false, []string{manifestR0Blocker("manifest_missing")}
 	}
 	var change model.Change
 	if err := yaml.Unmarshal(raw, &change); err != nil {
-		return false, []string{"manifest_parse_invalid"}
+		return false, []string{manifestR0Blocker("manifest_parse_invalid")}
 	}
 
 	reasons := []string{}
 	if strings.TrimSpace(change.Slug) != strings.TrimSpace(slug) {
-		reasons = append(reasons, "manifest_slug_mismatch")
+		reasons = append(reasons, manifestR0Blocker("manifest_slug_mismatch"))
 	}
 	if change.BaseRef == "" {
-		reasons = append(reasons, "manifest_base_ref_missing")
+		reasons = append(reasons, manifestR0Blocker("manifest_base_ref_missing"))
 	}
 	return len(reasons) == 0, stringutil.UniqueSorted(reasons)
+}
+
+func manifestR0Blocker(reason string) string {
+	return "manifest_r0_invalid:" + strings.TrimSpace(reason)
 }

--- a/internal/engine/progression/evidence_test.go
+++ b/internal/engine/progression/evidence_test.go
@@ -1,6 +1,8 @@
 package progression
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -10,6 +12,60 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestValidateChangeYamlR0ReturnsCanonicalManifestBlockers(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "missing manifest",
+			content: "",
+			want:    "manifest_missing",
+		},
+		{
+			name:    "parse invalid",
+			content: "slug: [",
+			want:    "manifest_parse_invalid",
+		},
+		{
+			name: "slug mismatch",
+			content: `slug: other-change
+base_ref: HEAD
+`,
+			want: "manifest_slug_mismatch",
+		},
+		{
+			name: "base ref missing",
+			content: `slug: expected-change
+`,
+			want: "manifest_base_ref_missing",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := filepath.Join(t.TempDir(), "change.yaml")
+			if tc.content != "" {
+				require.NoError(t, os.WriteFile(path, []byte(tc.content), 0o600))
+			}
+
+			ok, blockers := ValidateChangeYamlR0(path, "expected-change")
+			require.False(t, ok)
+			require.Equal(t, []string{"manifest_r0_invalid:" + tc.want}, blockers)
+
+			reasons := model.ReasonCodesFromSpecs(blockers)
+			require.Len(t, reasons, 1)
+			assert.Equal(t, "manifest_r0_invalid", reasons[0].Code)
+			assert.Equal(t, tc.want, reasons[0].Detail)
+		})
+	}
+}
 
 func TestEvaluateRequiredSkills_NoRegistry(t *testing.T) {
 	t.Parallel()

--- a/internal/engine/progression/readiness_optimization_test.go
+++ b/internal/engine/progression/readiness_optimization_test.go
@@ -546,7 +546,7 @@ func (s *stubArtifactReadinessReader) Evaluate(root string, change model.Change)
 	return ArtifactReadiness{
 		Ready:       false,
 		Required:    []string{"intent.md"},
-		Blockers:    []model.ReasonCode{model.NewReasonCode("artifact_reader_contract_blocker", "")},
+		Blockers:    []model.ReasonCode{model.NewReasonCode("missing_required_artifact", "tasks.md")},
 		Diagnostics: []string{"artifact_reader_contract_diagnostic"},
 	}, nil
 }
@@ -594,7 +594,7 @@ func TestEvaluateGovernanceReadinessRoutesArtifactStateThroughReaderContracts(t 
 	require.NoError(t, err)
 	assert.Equal(t, 1, readinessReader.calls)
 	assert.Equal(t, 1, projectionReader.calls)
-	assert.True(t, hasAdvanceReasonCode(readiness.Blockers, "artifact_reader_contract_blocker"))
+	assert.True(t, hasAdvanceReasonCode(readiness.Blockers, "missing_required_artifact"))
 	assert.Contains(t, readiness.Diagnostics, "artifact_reader_contract_diagnostic")
 	require.NotNil(t, readiness.ArtifactProjection)
 	require.Len(t, readiness.ArtifactProjection.Nodes, 1)

--- a/internal/engine/progression/wave_sync_test.go
+++ b/internal/engine/progression/wave_sync_test.go
@@ -140,20 +140,20 @@ func TestBuildExecutionSummarySyncsDerivedFieldsAndWaveBlockers(t *testing.T) {
 				TaskID:      "task-b",
 				Verdict:     model.TaskVerdictFail,
 				TaskKind:    model.TaskKindCode,
-				Blockers:    []model.ReasonCode{model.NewReasonCode("needs_retry", "")},
+				Blockers:    []model.ReasonCode{model.NewReasonCode("required_skill_missing", "plan-audit")},
 				CapturedAt:  capturedAt.Add(time.Second),
 				EvidenceRef: "artifacts/runtime/task-b.json",
 			},
 		},
 		capturedAt,
-		&model.VerificationRecord{Blockers: []model.ReasonCode{model.NewReasonCode("wave_blocker", "review")}},
+		&model.VerificationRecord{Blockers: []model.ReasonCode{model.NewReasonCode("wave_execution_blocked", "review")}},
 	)
 
 	assert.Equal(t, model.ExecutionVerdictFail, summary.OverallVerdict)
 	assert.Equal(t, []string{"task-a"}, summary.CompletedTasks)
 	assert.Equal(t, []string{"task-b"}, summary.NonPassTasks)
-	assert.True(t, hasWaveReasonCode(summary.OpenBlockers, "task", "task-b:needs_retry"))
-	assert.True(t, hasWaveReasonCode(summary.OpenBlockers, "wave_blocker", "review"))
+	assert.True(t, hasWaveReasonCode(summary.OpenBlockers, "task", "task-b:required_skill_missing:plan-audit"))
+	assert.True(t, hasWaveReasonCode(summary.OpenBlockers, "wave_execution_blocked", "review"))
 }
 
 func TestBuildExecutionSummaryPreservesDistinctTaskBlockerDetails(t *testing.T) {

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -260,25 +260,25 @@ func TestWaveReasonCodesCarryRemediation(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		code            string
-		detail          string
-		messageContains string
+		code   string
+		detail string
 	}{
-		{"wave_orchestration_stale_task_evidence", "task-a", "rerun wave-orchestration to refresh the wave record"},
-		{"wave_orchestration_run_summary_version_invalid", "", "rerun wave-orchestration to produce a versioned run summary"},
-		{"missing_task_evidence_for_run_summary", "", "rerun wave-orchestration to capture task evidence"},
-		{"wave_plan_missing", "slug-a", "materialize the wave plan from tasks.md"},
+		{"wave_orchestration_stale_task_evidence", "task-a"},
+		{"wave_orchestration_run_summary_version_invalid", ""},
+		{"missing_task_evidence_for_run_summary", ""},
+		{"wave_plan_missing", "slug-a"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.code, func(t *testing.T) {
 			t.Parallel()
 			reason := NewReasonCode(tc.code, tc.detail)
+			assert.Equal(t, tc.code, reason.Code)
+			assert.Equal(t, tc.detail, reason.Detail)
 			assert.Equal(t, ReasonSeverityError, reason.Severity)
-			assert.Contains(t, reason.Message, tc.messageContains,
+			definition, ok := canonicalReasonDefinitions[reason.Code]
+			require.True(t, ok)
+			assert.NotEqualf(t, testHumanizeReasonCode(reason.Code), definition.Message,
 				"wave reason code %q must carry an actionable remediation, not a humanized fallback", tc.code)
-			if tc.detail != "" {
-				assert.Contains(t, reason.Message, tc.detail)
-			}
 		})
 	}
 }
@@ -291,8 +291,9 @@ func TestRequiredSkillStaleCarriesRemediation(t *testing.T) {
 	assert.Equal(t, "required_skill_stale", reason.Code)
 	assert.Equal(t, "plan-audit:tasks.md", reason.Detail)
 	assert.Equal(t, ReasonSeverityError, reason.Severity)
-	assert.Contains(t, reason.Message, "rerun the skill to re-certify the named artifact")
-	assert.Contains(t, reason.Message, "plan-audit:tasks.md")
+	definition, ok := canonicalReasonDefinitions[reason.Code]
+	require.True(t, ok)
+	assert.NotEqual(t, testHumanizeReasonCode(reason.Code), definition.Message)
 }
 
 func TestPhaseForMapsWorkflowStates(t *testing.T) {

--- a/internal/model/reason_code.go
+++ b/internal/model/reason_code.go
@@ -35,14 +35,32 @@ type ReasonDefinition struct {
 	Message  string         `json:"message"`
 }
 
+const unknownReasonCode = "unknown_reason_code"
+
 var canonicalReasonDefinitions = map[string]ReasonDefinition{
+	"archive_failed": {
+		Severity: ReasonSeverityError,
+		Message:  "Bulk finalization could not archive a governed change",
+	},
 	"artifact_not_ready": {
 		Severity: ReasonSeverityError,
 		Message:  "Required governed artifacts are not ready",
 	},
+	"artifact_reconcile_failed": {
+		Severity: ReasonSeverityError,
+		Message:  "Done artifact reconciliation failed",
+	},
 	"artifact_schema_missing": {
 		Severity: ReasonSeverityError,
 		Message:  "The governed change is missing a frozen artifact schema",
+	},
+	"artifact_validation_failed": {
+		Severity: ReasonSeverityError,
+		Message:  "Done artifact validation failed",
+	},
+	"archived_lifecycle_event_scan_failed": {
+		Severity: ReasonSeverityError,
+		Message:  "Unable to list archived changes for lifecycle event health",
 	},
 	"assurance_structure_invalid": {
 		Severity: ReasonSeverityError,
@@ -71,6 +89,54 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 	"closeout_goal_verification_reuse_invalid": {
 		Severity: ReasonSeverityError,
 		Message:  "Final-closeout cannot reuse the recorded goal-verification evidence",
+	},
+	"change_bundle_unreadable": {
+		Severity: ReasonSeverityError,
+		Message:  "Change bundle authority is unreadable",
+	},
+	"change_is_done": {
+		Severity: ReasonSeverityInfo,
+		Message:  "The governed change is already done",
+	},
+	"change_not_active": {
+		Severity: ReasonSeverityError,
+		Message:  "Bulk finalization skipped a non-active governed change",
+	},
+	"checkpoint_stale": {
+		Severity: ReasonSeverityWarning,
+		Message:  "Active checkpoint has exceeded the stale threshold",
+	},
+	"checkpoint_task_missing_from_wave_plan": {
+		Severity: ReasonSeverityError,
+		Message:  "Checkpoint task is not present in the current wave plan",
+	},
+	"checkpoint_wave_index_drift": {
+		Severity: ReasonSeverityError,
+		Message:  "Checkpoint wave index does not match the current wave plan",
+	},
+	"codebase_map_freshness_missing": {
+		Severity: ReasonSeverityError,
+		Message:  "Repo-scoped codebase map is missing",
+	},
+	"codebase_map_freshness_partial": {
+		Severity: ReasonSeverityWarning,
+		Message:  "Repo-scoped codebase map is partially populated",
+	},
+	"codebase_map_freshness_scaffold_only": {
+		Severity: ReasonSeverityWarning,
+		Message:  "Repo-scoped codebase map is scaffold-only",
+	},
+	"codebase_map_freshness_stale": {
+		Severity: ReasonSeverityWarning,
+		Message:  "Repo-scoped codebase map is stale",
+	},
+	"codebase_map_freshness_unknown": {
+		Severity: ReasonSeverityWarning,
+		Message:  "Repo-scoped codebase map freshness is unknown",
+	},
+	"config_parse_failure": {
+		Severity: ReasonSeverityError,
+		Message:  "Config parsing failed",
 	},
 	"dedicated_worktree_branch_mismatch": {
 		Severity: ReasonSeverityError,
@@ -108,6 +174,14 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 		Severity: ReasonSeverityWarning,
 		Message:  "Governed execution was interrupted",
 	},
+	"execution_summary_unreadable": {
+		Severity: ReasonSeverityError,
+		Message:  "Execution summary authority is unreadable",
+	},
+	"execution_verdict_fail": {
+		Severity: ReasonSeverityError,
+		Message:  "Execution verdict failed",
+	},
 	"governance_action_required": {
 		Severity: ReasonSeverityError,
 		Message:  "A required governance control must be satisfied before continuing",
@@ -127,6 +201,14 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 	"incomplete_execution_task": {
 		Severity: ReasonSeverityError,
 		Message:  "A planned execution task has no recorded passing evidence",
+	},
+	"intent_drift": {
+		Severity: ReasonSeverityError,
+		Message:  "Implementation intent drift was detected",
+	},
+	"invalid_blocker": {
+		Severity: ReasonSeverityError,
+		Message:  "A blocker token is invalid",
 	},
 	"invalid_pivot_kind": {
 		Severity: ReasonSeverityError,
@@ -148,6 +230,30 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 		Severity: ReasonSeverityError,
 		Message:  "The governed change manifest failed R0 validation",
 	},
+	"lifecycle_event_log_unreadable": {
+		Severity: ReasonSeverityError,
+		Message:  "Lifecycle event log is unreadable",
+	},
+	"lifecycle_event_scan_failed": {
+		Severity: ReasonSeverityError,
+		Message:  "Unable to list active changes for lifecycle event health",
+	},
+	"lifecycle_event_scan_skipped": {
+		Severity: ReasonSeverityWarning,
+		Message:  "Skipped lifecycle event health because change authority is unreadable",
+	},
+	"lifecycle_event_write_failed": {
+		Severity: ReasonSeverityError,
+		Message:  "Bulk finalization could not record a lifecycle event",
+	},
+	"list_changes_failed": {
+		Severity: ReasonSeverityError,
+		Message:  "Bulk finalization could not list active changes",
+	},
+	"load_change_failed": {
+		Severity: ReasonSeverityError,
+		Message:  "Bulk finalization could not load a governed change",
+	},
 	"missing_discovery_evidence": {
 		Severity: ReasonSeverityError,
 		Message:  "Required discovery evidence is missing",
@@ -159,6 +265,10 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 	"missing_task_evidence_for_run_summary": {
 		Severity: ReasonSeverityError,
 		Message:  "Task evidence is missing for the recorded run summary; rerun wave-orchestration to capture task evidence",
+	},
+	"missing_run_summary": {
+		Severity: ReasonSeverityError,
+		Message:  "The execution run summary is missing",
 	},
 	"missing_worktree_branch": {
 		Severity: ReasonSeverityError,
@@ -176,13 +286,37 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 		Severity: ReasonSeverityError,
 		Message:  "A governed task did not pass",
 	},
+	"multiple_active_changes": {
+		Severity: ReasonSeverityError,
+		Message:  "Multiple active changes are present",
+	},
+	"non_pass_wave": {
+		Severity: ReasonSeverityError,
+		Message:  "A governed execution wave did not pass",
+	},
+	"not_done_ready": {
+		Severity: ReasonSeverityError,
+		Message:  "The governed change is not ready for finalization",
+	},
 	"orphaned_change_bundle": {
 		Severity: ReasonSeverityError,
 		Message:  "A governed bundle directory is missing its change.yaml authority",
 	},
+	"orphan_bundle_directory": {
+		Severity: ReasonSeverityError,
+		Message:  "Bundle directory exists without change.yaml",
+	},
+	"orphan_task_evidence": {
+		Severity: ReasonSeverityError,
+		Message:  "Orphan task evidence exists outside the current wave plan",
+	},
 	"stale_runtime_binding": {
 		Severity: ReasonSeverityError,
 		Message:  "A per-change runtime binding remains after its governed bundle was removed",
+	},
+	"pivot_required": {
+		Severity: ReasonSeverityError,
+		Message:  "A pivot is required before continuing",
 	},
 	"pivot_not_approved": {
 		Severity: ReasonSeverityError,
@@ -356,9 +490,29 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 		Severity: ReasonSeverityError,
 		Message:  "Scope Contract is missing required target files",
 	},
+	"session_isolation_warning": {
+		Severity: ReasonSeverityWarning,
+		Message:  "Session isolation warning detected in task evidence",
+	},
 	"ship_gate_blocked": {
 		Severity: ReasonSeverityError,
 		Message:  "The ship gate blocked finalization",
+	},
+	"skill_prompt_surface_missing": {
+		Severity: ReasonSeverityError,
+		Message:  "Governance skill points to a missing host skill surface",
+	},
+	"skill_prompt_surface_unreadable": {
+		Severity: ReasonSeverityError,
+		Message:  "Governance skill points to an unreadable host skill surface",
+	},
+	"skill_registry_invalid": {
+		Severity: ReasonSeverityError,
+		Message:  "Governance skill registry is invalid",
+	},
+	"stale_checkpoint_state": {
+		Severity: ReasonSeverityWarning,
+		Message:  "Active checkpoint exists outside S2_EXECUTE",
 	},
 	"stale_execution_evidence": {
 		Severity: ReasonSeverityError,
@@ -400,9 +554,37 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 		Severity: ReasonSeverityError,
 		Message:  "The governed tasks checklist contains a duplicate task ID",
 	},
+	"task": {
+		Severity: ReasonSeverityError,
+		Message:  "A task-scoped execution blocker is present",
+	},
+	"task_blocker": {
+		Severity: ReasonSeverityError,
+		Message:  "A task-scoped wave blocker is present",
+	},
+	"task_blockers": {
+		Severity: ReasonSeverityError,
+		Message:  "A governed task reported blockers",
+	},
+	"task_blockers_invalid_key": {
+		Severity: ReasonSeverityError,
+		Message:  "A governed task blocker key is invalid",
+	},
+	"task_evidence_invalid": {
+		Severity: ReasonSeverityError,
+		Message:  "Task evidence is invalid",
+	},
+	"task_evidence_unreadable": {
+		Severity: ReasonSeverityError,
+		Message:  "Task evidence is unreadable",
+	},
 	"tasks_plan_changed_since_task_evidence": {
 		Severity: ReasonSeverityError,
 		Message:  "The tasks plan changed after this task's evidence was captured; rerun wave-orchestration for the affected task",
+	},
+	unknownReasonCode: {
+		Severity: ReasonSeverityError,
+		Message:  "An unrecognized reason code was produced",
 	},
 	"verification_evidence_missing": {
 		Severity: ReasonSeverityError,
@@ -416,9 +598,73 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 		Severity: ReasonSeverityError,
 		Message:  "Task evidence was captured after the wave verification record; rerun wave-orchestration to refresh the wave record",
 	},
+	"wave_execution_blocked": {
+		Severity: ReasonSeverityError,
+		Message:  "Wave execution is blocked",
+	},
+	"wave_execution_unavailable": {
+		Severity: ReasonSeverityError,
+		Message:  "Wave execution is unavailable",
+	},
+	"wave_plan_drift": {
+		Severity: ReasonSeverityError,
+		Message:  "Wave plan drift detected against tasks.md",
+	},
+	"wave_plan_load_failed": {
+		Severity: ReasonSeverityError,
+		Message:  "Wave plan authority could not be loaded",
+	},
 	"wave_plan_missing": {
 		Severity: ReasonSeverityError,
 		Message:  "The wave plan is missing; materialize the wave plan from tasks.md before wave execution",
+	},
+	"wave_plan_repair_blocked": {
+		Severity: ReasonSeverityError,
+		Message:  "Wave plan repair is blocked",
+	},
+	"wave_plan_unreadable": {
+		Severity: ReasonSeverityError,
+		Message:  "Wave plan authority is unreadable",
+	},
+	"wave_run_missing": {
+		Severity: ReasonSeverityError,
+		Message:  "A planned wave has no recorded run evidence",
+	},
+	"wave_run_version_mismatch": {
+		Severity: ReasonSeverityError,
+		Message:  "Wave run evidence does not match the requested run version",
+	},
+	"wave_runs_incomplete": {
+		Severity: ReasonSeverityError,
+		Message:  "Wave run evidence is incomplete for the current wave plan",
+	},
+	"wave_runs_invalid_count": {
+		Severity: ReasonSeverityError,
+		Message:  "Wave run evidence count is invalid",
+	},
+	"wave_runs_load_failed": {
+		Severity: ReasonSeverityError,
+		Message:  "Wave run evidence could not be loaded",
+	},
+	"wave_runs_missing": {
+		Severity: ReasonSeverityError,
+		Message:  "Wave runs are missing for the latest execution summary",
+	},
+	"wave_runs_unreadable": {
+		Severity: ReasonSeverityError,
+		Message:  "Wave run evidence is unreadable",
+	},
+	"wave_task_linkage_mismatch": {
+		Severity: ReasonSeverityError,
+		Message:  "Wave run task linkage does not match wave-plan.yaml",
+	},
+	"workspace_scope_config_missing": {
+		Severity: ReasonSeverityError,
+		Message:  "Bound worktree scope config is missing",
+	},
+	"workspace_scope_marker_missing": {
+		Severity: ReasonSeverityError,
+		Message:  "Bound worktree scope marker is missing",
 	},
 	"worktree_validation_error": {
 		Severity: ReasonSeverityError,
@@ -430,19 +676,24 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 	},
 }
 
+func IsCanonicalReasonCode(code string) bool {
+	_, ok := canonicalReasonDefinitions[normalizeReasonCode(strings.TrimSpace(code))]
+	return ok
+}
+
 func NewReasonCode(code, detail string) ReasonCode {
-	code = normalizeReasonCode(code)
+	rawCode := strings.TrimSpace(code)
+	code = normalizeReasonCode(rawCode)
 	detail = strings.TrimSpace(detail)
 	definition, ok := canonicalReasonDefinitions[code]
+	if !ok {
+		return newUnknownReasonCode(rawCode, detail)
+	}
 	reason := ReasonCode{
 		Code:     code,
-		Severity: ReasonSeverityError,
-		Message:  humanizeReasonCode(code),
+		Severity: definition.Severity,
+		Message:  definition.Message,
 		Detail:   detail,
-	}
-	if ok {
-		reason.Severity = definition.Severity
-		reason.Message = definition.Message
 	}
 	if detail != "" {
 		reason.Message = reason.Message + ": " + detail
@@ -483,29 +734,48 @@ func (r *ReasonCode) Normalize() {
 	if r == nil {
 		return
 	}
-	r.Code = normalizeReasonCode(r.Code)
+	rawCode := strings.TrimSpace(r.Code)
+	r.Code = normalizeReasonCode(rawCode)
 	r.Detail = strings.TrimSpace(r.Detail)
 	r.Message = strings.TrimSpace(r.Message)
-	if definition, ok := canonicalReasonDefinitions[r.Code]; ok {
-		if !r.Severity.IsValid() {
-			r.Severity = definition.Severity
-		}
-		if r.Message == "" {
-			r.Message = definition.Message
-			if r.Detail != "" {
-				r.Message = r.Message + ": " + r.Detail
-			}
-		}
+	definition, ok := canonicalReasonDefinitions[r.Code]
+	if !ok {
+		unknown := newUnknownReasonCode(rawCode, r.Detail)
+		*r = unknown
+		return
 	}
 	if !r.Severity.IsValid() {
-		r.Severity = ReasonSeverityError
+		r.Severity = definition.Severity
 	}
 	if r.Message == "" {
-		r.Message = humanizeReasonCode(r.Code)
+		r.Message = definition.Message
 		if r.Detail != "" {
 			r.Message = r.Message + ": " + r.Detail
 		}
 	}
+}
+
+func newUnknownReasonCode(code, detail string) ReasonCode {
+	code = strings.TrimSpace(code)
+	detail = strings.TrimSpace(detail)
+	if code == "" {
+		code = "empty"
+	}
+	unknownDetail := code
+	if detail != "" {
+		unknownDetail += ": " + detail
+	}
+	definition := canonicalReasonDefinitions[unknownReasonCode]
+	reason := ReasonCode{
+		Code:     unknownReasonCode,
+		Severity: definition.Severity,
+		Message:  definition.Message,
+		Detail:   unknownDetail,
+	}
+	if reason.Detail != "" {
+		reason.Message += ": " + reason.Detail
+	}
+	return reason
 }
 
 func (r ReasonCode) Validate() error {
@@ -614,17 +884,4 @@ func normalizeReasonCode(input string) string {
 		}
 	}
 	return strings.Trim(b.String(), "_")
-}
-
-func humanizeReasonCode(code string) string {
-	code = normalizeReasonCode(code)
-	if code == "" {
-		return "Unspecified workflow blocker"
-	}
-	parts := strings.Fields(strings.ReplaceAll(code, "_", " "))
-	if len(parts) == 0 {
-		return "Workflow blocker"
-	}
-	parts[0] = strings.ToUpper(parts[0][:1]) + parts[0][1:]
-	return strings.Join(parts, " ")
 }

--- a/internal/model/reason_code_contract_test.go
+++ b/internal/model/reason_code_contract_test.go
@@ -1,0 +1,732 @@
+package model
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanonicalReasonCodeTaxonomySnapshot(t *testing.T) {
+	t.Parallel()
+
+	got := make([]string, 0, len(canonicalReasonDefinitions))
+	for code := range canonicalReasonDefinitions {
+		got = append(got, code)
+	}
+	sort.Strings(got)
+	wantCodes := canonicalReasonCodeSnapshot()
+	wantSeverities := canonicalReasonSeveritySnapshot(wantCodes)
+	require.Len(t, wantSeverities, len(wantCodes))
+	for code, definition := range canonicalReasonDefinitions {
+		assert.Truef(t, definition.Severity.IsValid(), "%s must define a valid severity", code)
+		assert.NotEmptyf(t, strings.TrimSpace(definition.Message), "%s must define canonical message prose", code)
+		wantSeverity, ok := wantSeverities[code]
+		require.Truef(t, ok, "%s must have frozen severity", code)
+		assert.Equalf(t, wantSeverity, definition.Severity, "%s severity changed", code)
+	}
+
+	assert.Equal(t, wantCodes, got)
+}
+
+func canonicalReasonCodeSnapshot() []string {
+	return []string{
+		"archive_failed",
+		"archived_lifecycle_event_scan_failed",
+		"artifact_not_ready",
+		"artifact_reconcile_failed",
+		"artifact_schema_missing",
+		"artifact_validation_failed",
+		"assurance_contract_missing",
+		"assurance_contract_path_invalid",
+		"assurance_contract_unreadable",
+		"assurance_section_placeholder",
+		"assurance_structure_invalid",
+		"change_bundle_unreadable",
+		"change_is_done",
+		"change_not_active",
+		"checkpoint_stale",
+		"checkpoint_task_missing_from_wave_plan",
+		"checkpoint_wave_index_drift",
+		"closeout_assurance_attestation_missing",
+		"closeout_goal_verification_reuse_invalid",
+		"codebase_map_freshness_missing",
+		"codebase_map_freshness_partial",
+		"codebase_map_freshness_scaffold_only",
+		"codebase_map_freshness_stale",
+		"codebase_map_freshness_unknown",
+		"config_parse_failure",
+		"decision_contract_path_invalid",
+		"decision_contract_unreadable",
+		"decision_section_placeholder",
+		"decision_structure_invalid",
+		"dedicated_worktree_branch_mismatch",
+		"dedicated_worktree_metadata_required",
+		"dedicated_worktree_path_invalid",
+		"dedicated_worktree_required",
+		"execution_interrupted",
+		"execution_summary_unreadable",
+		"execution_verdict_fail",
+		"governance_action_required",
+		"governed_bundle_path_invalid",
+		"high_risk_check_failed",
+		"high_risk_check_missing",
+		"incomplete_execution_task",
+		"intake_clarification_incomplete",
+		"intake_confirmation_incomplete",
+		"intake_substep_invalid",
+		"intent_drift",
+		"invalid_blocker",
+		"invalid_pivot_kind",
+		"lifecycle_event_log_unreadable",
+		"lifecycle_event_scan_failed",
+		"lifecycle_event_scan_skipped",
+		"lifecycle_event_write_failed",
+		"list_changes_failed",
+		"load_change_failed",
+		"manifest_r0_invalid",
+		"missing_discovery_evidence",
+		"missing_required_artifact",
+		"missing_run_summary",
+		"missing_task_evidence_for_run_summary",
+		"missing_worktree_branch",
+		"missing_worktree_path",
+		"multiple_active_changes",
+		"no_skill_required",
+		"non_pass_task",
+		"non_pass_wave",
+		"not_done_ready",
+		"orphan_bundle_directory",
+		"orphan_task_evidence",
+		"orphaned_change_bundle",
+		"pivot_not_approved",
+		"pivot_required",
+		"pivot_state_invalid",
+		"plan_audit_budget_exhausted",
+		"plan_audit_evidence_missing",
+		"plan_audit_failed",
+		"plan_audit_iteration",
+		"plan_audit_stalled",
+		"plan_checker_feedback_required",
+		"plan_checker_loop_terminated",
+		"plan_dimension_completeness_missing_objective",
+		"plan_dimension_coverage_missing_requirement",
+		"plan_dimension_coverage_requirement_id_missing",
+		"plan_dimension_coverage_requirements_invalid",
+		"plan_dimension_coverage_spec_unreadable",
+		"plan_dimension_coverage_unknown_requirement",
+		"plan_dimension_dependency_cycle_detected",
+		"plan_dimension_dependency_self_reference",
+		"plan_dimension_dependency_unknown",
+		"plan_dimension_execution_invalid_wave_plan",
+		"plan_dimension_execution_missing_wave",
+		"plan_dimension_key_links_missing_target_files",
+		"plan_dimension_scope_invalid_target",
+		"plan_dimension_scope_out_of_bounds_target",
+		"preset_confirmation_required",
+		"required_artifact_dependency_missing",
+		"required_artifact_schema_missing",
+		"required_artifact_unreadable",
+		"required_skill_blockers_present",
+		"required_skill_missing",
+		"required_skill_not_passed",
+		"required_skill_not_ready",
+		"required_skill_stale",
+		"rescope_state_invalid",
+		"research_section_placeholder",
+		"research_structure_invalid",
+		"review_layer_failed",
+		"review_layer_missing",
+		"run_slipway_done_to_finalize",
+		"run_slipway_run_to_advance",
+		"scope_contract_changed_files_missing",
+		"scope_contract_drift",
+		"scope_contract_evaluation_failed",
+		"scope_contract_missing",
+		"session_isolation_warning",
+		"ship_gate_blocked",
+		"skill_prompt_surface_missing",
+		"skill_prompt_surface_unreadable",
+		"skill_registry_invalid",
+		"stale_checkpoint_state",
+		"stale_evidence_recovery_available",
+		"stale_execution_evidence",
+		"stale_planning_evidence",
+		"stale_runtime_binding",
+		"task",
+		"task_blocker",
+		"task_blockers",
+		"task_blockers_invalid_key",
+		"task_evidence_invalid",
+		"task_evidence_unreadable",
+		"tasks_checklist_duplicate_task_id",
+		"tasks_checklist_empty",
+		"tasks_checklist_invalid_format",
+		"tasks_checklist_missing",
+		"tasks_checklist_path_invalid",
+		"tasks_checklist_task_id_missing",
+		"tasks_checklist_unreadable",
+		"tasks_plan_changed_since_task_evidence",
+		"unknown_reason_code",
+		"verification_evidence_missing",
+		"wave_execution_blocked",
+		"wave_execution_unavailable",
+		"wave_orchestration_run_summary_version_invalid",
+		"wave_orchestration_stale_task_evidence",
+		"wave_plan_drift",
+		"wave_plan_load_failed",
+		"wave_plan_missing",
+		"wave_plan_repair_blocked",
+		"wave_plan_unreadable",
+		"wave_run_missing",
+		"wave_run_version_mismatch",
+		"wave_runs_incomplete",
+		"wave_runs_invalid_count",
+		"wave_runs_load_failed",
+		"wave_runs_missing",
+		"wave_runs_unreadable",
+		"wave_task_linkage_mismatch",
+		"workspace_scope_config_missing",
+		"workspace_scope_marker_missing",
+		"worktree_metadata_persist_failed",
+		"worktree_validation_error",
+	}
+}
+
+func canonicalReasonSeveritySnapshot(codes []string) map[string]ReasonSeverity {
+	severities := make(map[string]ReasonSeverity, len(codes))
+	for _, code := range codes {
+		severities[code] = ReasonSeverityError
+	}
+	for code, severity := range map[string]ReasonSeverity{
+		"change_is_done":                       ReasonSeverityInfo,
+		"checkpoint_stale":                     ReasonSeverityWarning,
+		"codebase_map_freshness_partial":       ReasonSeverityWarning,
+		"codebase_map_freshness_scaffold_only": ReasonSeverityWarning,
+		"codebase_map_freshness_stale":         ReasonSeverityWarning,
+		"codebase_map_freshness_unknown":       ReasonSeverityWarning,
+		"execution_interrupted":                ReasonSeverityWarning,
+		"lifecycle_event_scan_skipped":         ReasonSeverityWarning,
+		"no_skill_required":                    ReasonSeverityInfo,
+		"run_slipway_done_to_finalize":         ReasonSeverityWarning,
+		"run_slipway_run_to_advance":           ReasonSeverityWarning,
+		"session_isolation_warning":            ReasonSeverityWarning,
+		"stale_checkpoint_state":               ReasonSeverityWarning,
+		"stale_evidence_recovery_available":    ReasonSeverityWarning,
+	} {
+		severities[code] = severity
+	}
+	return severities
+}
+
+func TestNewReasonCodeMakesUnknownCodeExplicit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		code       string
+		detail     string
+		wantDetail string
+	}{
+		{
+			name:       "normalized token",
+			code:       "new_unreviewed_code",
+			detail:     "source-path",
+			wantDetail: "new_unreviewed_code: source-path",
+		},
+		{
+			name:       "raw token with noncanonical separator",
+			code:       "foo/bar",
+			detail:     "source-path",
+			wantDetail: "foo/bar: source-path",
+		},
+		{
+			name:       "empty token",
+			code:       "",
+			detail:     "",
+			wantDetail: "empty",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			reason := NewReasonCode(tt.code, tt.detail)
+
+			assert.Equal(t, "unknown_reason_code", reason.Code)
+			assert.Equal(t, tt.wantDetail, reason.Detail)
+			assert.Equal(t, ReasonSeverityError, reason.Severity)
+		})
+	}
+}
+
+func TestReasonCodeNormalizeMakesUnknownCodeExplicit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		code       string
+		wantDetail string
+	}{
+		{
+			name:       "normalized token",
+			code:       "new_unreviewed_code",
+			wantDetail: "new_unreviewed_code: source-path",
+		},
+		{
+			name:       "raw token with noncanonical separator",
+			code:       "foo/bar",
+			wantDetail: "foo/bar: source-path",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			reason := ReasonCode{
+				Code:     tt.code,
+				Severity: ReasonSeverityWarning,
+				Message:  "looks valid",
+				Detail:   "source-path",
+			}
+			reason.Normalize()
+
+			assert.Equal(t, "unknown_reason_code", reason.Code)
+			assert.Equal(t, tt.wantDetail, reason.Detail)
+			assert.Equal(t, ReasonSeverityError, reason.Severity)
+		})
+	}
+}
+
+func testHumanizeReasonCode(code string) string {
+	code = normalizeReasonCode(code)
+	if code == "" {
+		return "Unspecified workflow blocker"
+	}
+	parts := strings.Fields(strings.ReplaceAll(code, "_", " "))
+	if len(parts) == 0 {
+		return "Workflow blocker"
+	}
+	parts[0] = strings.ToUpper(parts[0][:1]) + parts[0][1:]
+	return strings.Join(parts, " ")
+}
+
+func TestReasonAndErrorContractTestsDoNotTextMatchMessageProse(t *testing.T) {
+	t.Parallel()
+
+	for _, rel := range reasonAndErrorContractLintFiles(t) {
+		rel := rel
+		t.Run(rel, func(t *testing.T) {
+			t.Parallel()
+
+			root := repositoryRootForReasonCodeContractTest(t)
+			path := filepath.Join(root, filepath.FromSlash(rel))
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, path, nil, 0)
+			require.NoError(t, err)
+
+			violations := messageProseAssertionViolations(fset, file)
+
+			assert.Empty(t, violations,
+				"assert stable Code/Detail/ErrorCode/Category/ExitCode/Details fields instead of Message prose")
+		})
+	}
+}
+
+func TestMessageProseAssertionLintDetectsBypassShapes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		src  string
+		want int
+	}{
+		{
+			name: "seeded roots and inline receivers",
+			src: `package model
+
+func TestLintSample(t *testing.T) {
+	got := NewReasonCode("required_skill_missing", "goal-verification")
+	assert.Equal(t, "prose", got.Message)
+	assert.Contains(t, NewReasonCode("required_skill_missing", "goal-verification").Message, "prose")
+	assert.Equal(t, "prose", testReason().Message)
+
+	var finding HealthFinding
+	for _, reason := range finding.Reasons {
+		_ = strings.Contains(reason.Message, "prose")
+	}
+}
+`,
+			want: 4,
+		},
+		{
+			name: "inline receivers without seeded roots",
+			src: `package model
+
+func TestLintSample(t *testing.T) {
+	assert.Contains(t, NewReasonCode("required_skill_missing", "goal-verification").Message, "prose")
+	assert.Equal(t, "prose", testReason().Message)
+}
+`,
+			want: 2,
+		},
+		{
+			name: "json error payload message map index",
+			src: `package model
+
+func TestLintSample(t *testing.T) {
+	payload := decodeJSONMap(t, stderr)
+	assert.Contains(t, payload["message"], "prose")
+	assert.Equal(t, "prose", payload["message"])
+	_ = strings.Contains(payload["message"].(string), "prose")
+	assert.Contains(t, payload["mess\u0061ge"], "prose")
+}
+`,
+			want: 4,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, "lint_sample_test.go", tt.src, 0)
+			require.NoError(t, err)
+
+			violations := messageProseAssertionViolations(fset, file)
+
+			require.Len(t, violations, tt.want)
+			for _, violation := range violations {
+				assert.Contains(t, violation, "lint_sample_test.go")
+			}
+		})
+	}
+}
+
+func TestMessageProseAssertionLintScopesRootsPerFunction(t *testing.T) {
+	t.Parallel()
+
+	source := `package model
+
+func TestReasonMessage(t *testing.T) {
+	reason := NewReasonCode("required_skill_missing", "goal-verification")
+	assert.Contains(t, reason.Message, "prose")
+}
+
+func TestUnrelatedMessage(t *testing.T) {
+	reason := buildSummary()
+	assert.Contains(t, reason.Message, "prose")
+}
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "lint_sample_test.go", source, 0)
+	require.NoError(t, err)
+
+	violations := messageProseAssertionViolations(fset, file)
+
+	require.Len(t, violations, 1)
+	assert.Contains(t, violations[0], "lint_sample_test.go")
+}
+
+func reasonAndErrorContractLintFiles(t *testing.T) []string {
+	t.Helper()
+
+	root := repositoryRootForReasonCodeContractTest(t)
+	files := []string{}
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if shouldSkipReasonContractLintDir(entry.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(entry.Name(), "_test.go") {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		files = append(files, filepath.ToSlash(rel))
+		return nil
+	})
+	require.NoError(t, err)
+	sort.Strings(files)
+	return files
+}
+
+func shouldSkipReasonContractLintDir(name string) bool {
+	switch name {
+	case ".git", ".worktrees", "vendor":
+		return true
+	default:
+		return false
+	}
+}
+
+func messageProseAssertionViolations(fset *token.FileSet, file *ast.File) []string {
+	var violations []string
+	ast.Inspect(file, func(node ast.Node) bool {
+		fn, ok := node.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			return true
+		}
+		contractRoots := contractMessageRootNames(fn.Body)
+		violations = append(violations, messageProseAssertionViolationsInNode(fset, fn.Body, contractRoots)...)
+		return false
+	})
+	return violations
+}
+
+// messageProseAssertionViolationsInNode is a lightweight AST lint for
+// syntactically recognizable reason/error payloads. It is not a typed whole-repo
+// ban on every field named Message; extend the isContractMessage* helpers when
+// new reason/error payload surfaces need enforcement.
+func messageProseAssertionViolationsInNode(fset *token.FileSet, node ast.Node, contractRoots map[string]struct{}) []string {
+	var violations []string
+	ast.Inspect(node, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if !isMessageTextAssertion(call) && !isMessageTextMatchCall(call) {
+			return true
+		}
+		for _, arg := range call.Args {
+			if containsContractMessageSelector(arg, contractRoots) {
+				pos := fset.Position(arg.Pos())
+				violations = append(violations, pos.String())
+				break
+			}
+		}
+		return true
+	})
+	return violations
+}
+
+func contractMessageRootNames(node ast.Node) map[string]struct{} {
+	roots := map[string]struct{}{}
+	ast.Inspect(node, func(node ast.Node) bool {
+		switch typed := node.(type) {
+		case *ast.ValueSpec:
+			if !isContractMessageType(typed.Type) {
+				return true
+			}
+			for _, name := range typed.Names {
+				roots[name.Name] = struct{}{}
+			}
+		case *ast.AssignStmt:
+			for i, expr := range typed.Rhs {
+				if i >= len(typed.Lhs) || !isContractMessageExpr(expr) {
+					continue
+				}
+				if ident, ok := typed.Lhs[i].(*ast.Ident); ok {
+					roots[ident.Name] = struct{}{}
+				}
+			}
+		case *ast.RangeStmt:
+			ident, ok := typed.Value.(*ast.Ident)
+			if ok && isContractMessageCollection(typed.X) {
+				roots[ident.Name] = struct{}{}
+			}
+		}
+		return true
+	})
+	return roots
+}
+
+func repositoryRootForReasonCodeContractTest(t *testing.T) string {
+	t.Helper()
+
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	root := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+	return root
+}
+
+func isMessageTextAssertion(call *ast.CallExpr) bool {
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	pkg, ok := selector.X.(*ast.Ident)
+	if !ok || (pkg.Name != "assert" && pkg.Name != "require") {
+		return false
+	}
+	switch selector.Sel.Name {
+	case "Contains", "Containsf", "NotContains", "NotContainsf",
+		"Regexp", "Regexpf", "NotRegexp", "NotRegexpf",
+		"ErrorContains", "Equal", "Equalf", "NotEqual", "NotEqualf":
+		return true
+	default:
+		return false
+	}
+}
+
+func isMessageTextMatchCall(call *ast.CallExpr) bool {
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	pkg, ok := selector.X.(*ast.Ident)
+	if !ok || pkg.Name != "strings" {
+		return false
+	}
+	switch selector.Sel.Name {
+	case "Contains", "HasPrefix", "HasSuffix", "EqualFold":
+		return true
+	default:
+		return false
+	}
+}
+
+func containsContractMessageSelector(expr ast.Expr, roots map[string]struct{}) bool {
+	found := false
+	ast.Inspect(expr, func(node ast.Node) bool {
+		if found {
+			return false
+		}
+		switch typed := node.(type) {
+		case *ast.SelectorExpr:
+			if typed.Sel.Name != "Message" {
+				return true
+			}
+			if isContractMessageReceiver(typed.X, roots) {
+				found = true
+				return false
+			}
+		case *ast.IndexExpr:
+			if isContractMessageMapIndex(typed, roots) {
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return found
+}
+
+func isContractMessageMapIndex(expr *ast.IndexExpr, roots map[string]struct{}) bool {
+	if expr == nil || !isMessageMapKey(expr.Index) {
+		return false
+	}
+	return isContractMessageReceiver(expr.X, roots)
+}
+
+func isMessageMapKey(expr ast.Expr) bool {
+	lit, ok := expr.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return false
+	}
+	value, err := strconv.Unquote(lit.Value)
+	return err == nil && value == "message"
+}
+
+func isContractMessageReceiver(expr ast.Expr, roots map[string]struct{}) bool {
+	root := rootIdentName(expr)
+	if _, ok := roots[root]; ok {
+		return true
+	}
+	return isContractMessageExpr(expr)
+}
+
+func rootIdentName(expr ast.Expr) string {
+	switch typed := expr.(type) {
+	case *ast.Ident:
+		return typed.Name
+	case *ast.SelectorExpr:
+		return rootIdentName(typed.X)
+	case *ast.CallExpr:
+		return rootIdentName(typed.Fun)
+	case *ast.IndexExpr:
+		return rootIdentName(typed.X)
+	default:
+		return ""
+	}
+}
+
+func isContractMessageExpr(expr ast.Expr) bool {
+	switch typed := expr.(type) {
+	case *ast.CallExpr:
+		return isContractMessageConstructor(typed.Fun)
+	case *ast.CompositeLit:
+		return isContractMessageType(typed.Type)
+	default:
+		return false
+	}
+}
+
+func isContractMessageConstructor(expr ast.Expr) bool {
+	switch typed := expr.(type) {
+	case *ast.Ident:
+		switch typed.Name {
+		case "asCLIError", "decodeJSONMap", "NewReasonCode", "ReasonCodeFromSpec", "findGateReasonCode", "testReason":
+			return true
+		default:
+			return false
+		}
+	case *ast.SelectorExpr:
+		switch typed.Sel.Name {
+		case "NewReasonCode", "ReasonCodeFromSpec":
+			return true
+		default:
+			return false
+		}
+	default:
+		return false
+	}
+}
+
+func isContractMessageType(expr ast.Expr) bool {
+	switch typed := expr.(type) {
+	case *ast.Ident:
+		switch typed.Name {
+		case "CLIError", "ReasonCode", "HealthFinding":
+			return true
+		default:
+			return false
+		}
+	case *ast.SelectorExpr:
+		switch typed.Sel.Name {
+		case "ReasonCode", "HealthFinding":
+			return true
+		default:
+			return false
+		}
+	case *ast.StarExpr:
+		return isContractMessageType(typed.X)
+	default:
+		return false
+	}
+}
+
+func isContractMessageCollection(expr ast.Expr) bool {
+	selector, ok := expr.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	switch selector.Sel.Name {
+	case "Blockers", "OpenBlockers", "ReasonCodes", "Reasons", "Findings":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/model/recovery.go
+++ b/internal/model/recovery.go
@@ -101,14 +101,29 @@ const defaultRecoveryPriority = 100
 // codes and prefix families. It is the recovery-facing companion to
 // canonicalReasonDefinitions, scoped to recovery-relevant tokens.
 var blockerRemediations = map[string]blockerRemediation{
+	"archive_failed": {
+		Remediation:     "Inspect the archive failure detail, repair the governed bundle or filesystem issue, then re-run bulk finalization.",
+		CommandTemplate: "slipway repair",
+		Class:           RecoveryClassSatisfyControl,
+	},
 	"artifact_not_ready": {
 		Remediation:     "Complete the governed artifact readiness issue named in the blocker detail, then re-run the workflow.",
 		CommandTemplate: "slipway run",
 		Class:           RecoveryClassSatisfyControl,
 	},
+	"artifact_reconcile_failed": {
+		Remediation:     "Repair artifact reconciliation for the governed bundle, then re-run finalization.",
+		CommandTemplate: "slipway repair",
+		Class:           RecoveryClassSatisfyControl,
+	},
 	"artifact_schema_missing": {
 		Remediation:     "Repair or regenerate the governed artifact schema before continuing.",
 		CommandTemplate: "slipway repair",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"artifact_validation_failed": {
+		Remediation:     "Fix the invalid done artifact named in the failure detail, then re-run finalization.",
+		CommandTemplate: "slipway validate",
 		Class:           RecoveryClassSatisfyControl,
 	},
 	"assurance_structure_invalid": {
@@ -161,6 +176,11 @@ var blockerRemediations = map[string]blockerRemediation{
 		CommandTemplate: "slipway run",
 		Class:           RecoveryClassRerunSkill,
 		Priority:        15,
+	},
+	"change_not_active": {
+		Remediation:     "Inspect active changes and ignore or remove skipped non-active records before re-running bulk finalization.",
+		CommandTemplate: "slipway status",
+		Class:           RecoveryClassSatisfyControl,
 	},
 	"dedicated_worktree_branch_mismatch": {
 		Remediation:     "Run `slipway run` to reconcile the recorded branch to the bound worktree's actual branch and continue.",
@@ -222,6 +242,21 @@ var blockerRemediations = map[string]blockerRemediation{
 		CommandTemplate: "slipway repair",
 		Class:           RecoveryClassSatisfyControl,
 	},
+	"lifecycle_event_write_failed": {
+		Remediation:     "Repair lifecycle event logging or filesystem permissions, then re-run finalization.",
+		CommandTemplate: "slipway repair",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"list_changes_failed": {
+		Remediation:     "Repair change state so active changes can be listed, then re-run bulk finalization.",
+		CommandTemplate: "slipway repair",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"load_change_failed": {
+		Remediation:     "Repair the governed change state named in the failure detail, then re-run bulk finalization.",
+		CommandTemplate: "slipway repair",
+		Class:           RecoveryClassSatisfyControl,
+	},
 	"manifest_r0_invalid": {
 		Remediation:     "Fix the R0 review manifest evidence and re-run review.",
 		CommandTemplate: "slipway review",
@@ -246,6 +281,11 @@ var blockerRemediations = map[string]blockerRemediation{
 		Remediation:     "Resolve the failing task evidence for task {subject}, then re-run wave-orchestration.",
 		CommandTemplate: "slipway run",
 		Class:           RecoveryClassRefreshWave,
+	},
+	"not_done_ready": {
+		Remediation:     "Complete the governed workflow gates before finalizing this change.",
+		CommandTemplate: "slipway next",
+		Class:           RecoveryClassRerunSkill,
 	},
 	"orphaned_change_bundle": {
 		// Emitted as orphaned_change_bundle:<slug>. The governed bundle directory
@@ -528,8 +568,83 @@ var blockerRemediations = map[string]blockerRemediation{
 		CommandTemplate: "slipway validate",
 		Class:           RecoveryClassFixScope,
 	},
+	"unknown_reason_code": {
+		Remediation:     "A blocker used an unrecognized reason code. Inspect the original token in the blocker detail, update the producer to emit a canonical reason code, then re-run validation.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"wave_execution_blocked": {
+		Remediation:     "Resolve the reported wave execution blocker, then re-run wave-orchestration.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRefreshWave,
+	},
+	"wave_execution_unavailable": {
+		Remediation:     "Repair the wave execution context before re-running wave-orchestration.",
+		CommandTemplate: "slipway repair",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"wave_plan_drift": {
+		Remediation:     "Refresh the wave plan from the current tasks.md before continuing execution.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRefreshWave,
+	},
+	"wave_plan_load_failed": {
+		Remediation:     "Repair wave-plan.yaml so status can load the authoritative wave plan.",
+		CommandTemplate: "slipway repair",
+		Class:           RecoveryClassSatisfyControl,
+	},
 	"wave_plan_missing": {
 		Remediation:     "Materialize the wave plan from tasks.md before wave execution.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRefreshWave,
+	},
+	"wave_plan_repair_blocked": {
+		Remediation:     "Fix the blocking wave plan issue before attempting repair again.",
+		CommandTemplate: "slipway repair",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"wave_plan_unreadable": {
+		Remediation:     "Fix wave-plan.yaml so it is readable, then re-run validation.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassFixScope,
+	},
+	"wave_run_missing": {
+		Remediation:     "Record passing wave run evidence by re-running wave-orchestration.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRefreshWave,
+	},
+	"wave_run_version_mismatch": {
+		Remediation:     "Repair or regenerate wave run evidence so its run_summary_version matches the requested execution summary.",
+		CommandTemplate: "slipway repair",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"wave_runs_incomplete": {
+		Remediation:     "Complete missing wave run evidence by re-running wave-orchestration.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRefreshWave,
+	},
+	"wave_runs_invalid_count": {
+		Remediation:     "Repair wave run evidence so the recorded run count matches the execution summary.",
+		CommandTemplate: "slipway repair",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"wave_runs_load_failed": {
+		Remediation:     "Repair wave run evidence so status can load the authoritative run records.",
+		CommandTemplate: "slipway repair",
+		Class:           RecoveryClassSatisfyControl,
+	},
+	"wave_runs_missing": {
+		Remediation:     "Re-run wave-orchestration to record wave run evidence for the latest execution summary.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRefreshWave,
+	},
+	"wave_runs_unreadable": {
+		Remediation:     "Fix unreadable wave run evidence, then re-run wave-orchestration.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRefreshWave,
+	},
+	"wave_task_linkage_mismatch": {
+		Remediation:     "Re-run wave-orchestration so wave run task linkage matches wave-plan.yaml.",
 		CommandTemplate: "slipway run",
 		Class:           RecoveryClassRefreshWave,
 	},

--- a/internal/model/recovery_test.go
+++ b/internal/model/recovery_test.go
@@ -109,9 +109,13 @@ func TestInScopeProducedBlockersResolveToCanonicalRecovery(t *testing.T) {
 	// that can reach an in-scope user surface before it is added to the canonical
 	// reason and remediation tables.
 	for _, spec := range inScopeProducedRecoverySpecs() {
+		producedCode, _, _ := strings.Cut(spec, ":")
+		producedCode = normalizeReasonCode(producedCode)
+		definition, hasCanonical := canonicalReasonDefinitions[producedCode]
+		require.Truef(t, hasCanonical, "produced blocker %q must have a canonical reason message", producedCode)
+
 		rc := ReasonCodeFromSpec(spec)
-		_, hasCanonical := canonicalReasonDefinitions[rc.Code]
-		assert.Truef(t, hasCanonical, "produced blocker %q must have a canonical reason message", rc.Code)
+		require.Equalf(t, producedCode, rc.Code, "produced blocker %q must not collapse to %q", spec, unknownReasonCode)
 
 		step, ok := recoveryStepFor(rc)
 		require.Truef(t, ok, "produced blocker %q must produce a recovery step", rc.Key())
@@ -119,7 +123,7 @@ func TestInScopeProducedBlockersResolveToCanonicalRecovery(t *testing.T) {
 		assert.NotEmptyf(t, strings.TrimSpace(step.Command), "produced blocker %q must produce a command", rc.Key())
 		assert.NotContainsf(t, step.Remediation, "{", "produced blocker %q remediation must not leak a placeholder", rc.Key())
 		assert.NotContainsf(t, step.Command, "{", "produced blocker %q command must not leak a placeholder", rc.Key())
-		assert.NotEqualf(t, humanizeReasonCode(rc.Code), strings.TrimSuffix(rc.Message, ": "+rc.Detail),
+		assert.NotEqualf(t, testHumanizeReasonCode(rc.Code), definition.Message,
 			"produced blocker %q must not render through humanize fallthrough", rc.Key())
 	}
 }
@@ -141,19 +145,27 @@ func inScopeProducedRecoverySpecs() []string {
 		"high_risk_check_missing:external_api_contracts.safety_baseline",
 		"high_risk_check_failed:external_api_contracts.safety_baseline",
 		"closeout_goal_verification_reuse_invalid:goal-verification evidence was produced before final-closeout input changed; rerun goal-verification, then rerun final-closeout",
+		"manifest_r0_invalid:manifest_missing",
+		"manifest_r0_invalid:manifest_parse_invalid",
+		"manifest_r0_invalid:manifest_slug_mismatch",
+		"manifest_r0_invalid:manifest_base_ref_missing",
 		"worktree_metadata_persist_failed:permission denied",
 	}
 }
 
 func recoveryRelevantCanonicalCodes() []string {
 	exact := map[string]bool{
+		"archive_failed":                           true,
 		"assurance_structure_invalid":              true,
 		"assurance_contract_missing":               true,
 		"assurance_contract_path_invalid":          true,
 		"assurance_contract_unreadable":            true,
 		"assurance_section_placeholder":            true,
 		"artifact_not_ready":                       true,
+		"artifact_reconcile_failed":                true,
 		"artifact_schema_missing":                  true,
+		"artifact_validation_failed":               true,
+		"change_not_active":                        true,
 		"closeout_assurance_attestation_missing":   true,
 		"closeout_goal_verification_reuse_invalid": true,
 		"dedicated_worktree_branch_mismatch":       true,
@@ -172,6 +184,9 @@ func recoveryRelevantCanonicalCodes() []string {
 		"intake_clarification_incomplete":          true,
 		"intake_confirmation_incomplete":           true,
 		"intake_substep_invalid":                   true,
+		"lifecycle_event_write_failed":             true,
+		"list_changes_failed":                      true,
+		"load_change_failed":                       true,
 		"manifest_r0_invalid":                      true,
 		"missing_discovery_evidence":               true,
 		"missing_required_artifact":                true,
@@ -179,6 +194,7 @@ func recoveryRelevantCanonicalCodes() []string {
 		"missing_worktree_branch":                  true,
 		"missing_worktree_path":                    true,
 		"non_pass_task":                            true,
+		"not_done_ready":                           true,
 		"preset_confirmation_required":             true,
 		"research_structure_invalid":               true,
 		"research_section_placeholder":             true,
@@ -186,6 +202,7 @@ func recoveryRelevantCanonicalCodes() []string {
 		"run_slipway_run_to_advance":               true,
 		"ship_gate_blocked":                        true,
 		"tasks_checklist_invalid_format":           true,
+		"unknown_reason_code":                      true,
 		"verification_evidence_missing":            true,
 		"worktree_metadata_persist_failed":         true,
 		"worktree_validation_error":                true,
@@ -425,7 +442,9 @@ func TestRecoveryTokensUseCanonicalMessages(t *testing.T) {
 	}
 	for _, spec := range specs {
 		rc := ReasonCodeFromSpec(spec)
-		assert.NotEqualf(t, humanizeReasonCode(rc.Code), strings.TrimSuffix(rc.Message, ": "+rc.Detail),
+		definition, ok := canonicalReasonDefinitions[rc.Code]
+		require.True(t, ok)
+		assert.NotEqualf(t, testHumanizeReasonCode(rc.Code), definition.Message,
 			"message for %q must be canonical, not the humanize fallthrough", spec)
 	}
 }
@@ -537,8 +556,10 @@ func TestCloseoutAttestationMissingResolvesToRecovery(t *testing.T) {
 		[]string{"final-closeout must record closeout:assurance_complete=pass on standard/strict"},
 		step.Details,
 		"the colon-bearing attestation token must stay intact in Details")
-	// Canonical message, not the humanizeReasonCode fallthrough.
-	assert.NotEqual(t, humanizeReasonCode(rc.Code), strings.TrimSuffix(rc.Message, ": "+rc.Detail),
+	// Canonical message, not the old humanize fallback.
+	definition, ok := canonicalReasonDefinitions[rc.Code]
+	require.True(t, ok)
+	assert.NotEqual(t, testHumanizeReasonCode(rc.Code), definition.Message,
 		"message must be the written canonical sentence")
 }
 
@@ -670,7 +691,8 @@ func TestMissingTargetFilesRecoveryAppliesToEveryTaskKind(t *testing.T) {
 	rc := NewReasonCode("plan_dimension_key_links_missing_target_files", "t-01")
 	step, ok := recoveryStepFor(rc)
 	require.True(t, ok)
-	assert.Equal(t, "A task is missing target files: t-01", rc.Message)
+	assert.Equal(t, "plan_dimension_key_links_missing_target_files", rc.Code)
+	assert.Equal(t, "t-01", rc.Detail)
 	assert.Contains(t, step.Remediation, "every task")
 	assert.NotContains(t, step.Remediation, "code task")
 }

--- a/internal/state/execution_summary_test.go
+++ b/internal/state/execution_summary_test.go
@@ -715,7 +715,7 @@ overall_verdict: fail
 non_pass_tasks:
   - task-b
 open_blockers:
-  - code: task_non_pass
+  - code: non_pass_task
     severity: error
     message: "Task did not pass: task-b"
     detail: task-b
@@ -723,18 +723,19 @@ tasks:
   - task_id: task-b
     verdict: fail
     blockers:
-      - code: lint_failed
+      - code: required_skill_missing
         severity: error
-        message: "Lint failed"
+        message: "Required governance skill evidence is missing"
+        detail: plan-audit
 `), 0o644))
 
 	loaded, err := LoadExecutionSummary(root, "demo")
 	require.NoError(t, err)
 	require.Len(t, loaded.OpenBlockers, 1)
-	assert.Equal(t, "task_non_pass", loaded.OpenBlockers[0].Code)
+	assert.Equal(t, "non_pass_task", loaded.OpenBlockers[0].Code)
 	require.Len(t, loaded.Tasks, 1)
 	require.Len(t, loaded.Tasks[0].Blockers, 1)
-	assert.Equal(t, "lint_failed", loaded.Tasks[0].Blockers[0].Code)
+	assert.Equal(t, "required_skill_missing", loaded.Tasks[0].Blockers[0].Code)
 }
 
 func TestExecutionSummaryReadyAllowsSummaryLevelBlockers(t *testing.T) {

--- a/internal/state/health_test.go
+++ b/internal/state/health_test.go
@@ -78,7 +78,7 @@ func TestCollectHealthReportReportsUnreadableChangeAuthority(t *testing.T) {
 			continue
 		}
 		found = true
-		assert.Contains(t, finding.Message, "unreadable")
+		assert.True(t, healthFindingHasReasonCode(finding, "change_bundle_unreadable"))
 		assert.False(t, finding.Repairable)
 	}
 	assert.True(t, found, "expected unreadable authority finding")
@@ -108,7 +108,7 @@ func TestCollectHealthReportReportsUnreadableHiddenWorktreeAuthority(t *testing.
 			continue
 		}
 		found = true
-		assert.Contains(t, finding.Message, "unreadable")
+		assert.True(t, healthFindingHasReasonCode(finding, "change_bundle_unreadable"))
 		assert.False(t, finding.Repairable)
 	}
 	assert.True(t, found, "expected hidden unreadable authority finding")
@@ -136,7 +136,7 @@ func TestCollectHealthReportReportsUnreadableExecutionSummary(t *testing.T) {
 			continue
 		}
 		found = true
-		assert.Contains(t, finding.Message, "Execution summary")
+		assert.True(t, healthFindingHasReasonCode(finding, "execution_summary_unreadable"))
 		assert.False(t, finding.Repairable)
 	}
 	assert.True(t, found, "expected execution summary integrity finding")
@@ -305,7 +305,7 @@ func TestCollectHealthReportBlocksWavePlanRepairWhenCurrentTasksDrifted(t *testi
 			if reason.Code == "wave_plan_repair_blocked" {
 				found = true
 				assert.False(t, finding.Repairable)
-				assert.Contains(t, finding.Message, "cannot be safely reconstructed")
+				assert.NotEmpty(t, reason.Detail)
 			}
 		}
 	}
@@ -425,7 +425,7 @@ func TestCollectHealthReportBlocksUnreadableWavePlanRepairWhenCurrentTasksDrifte
 			if reason.Code == "wave_plan_repair_blocked" {
 				found = true
 				assert.False(t, finding.Repairable)
-				assert.Contains(t, finding.Message, "cannot be safely reconstructed")
+				assert.NotEmpty(t, reason.Detail)
 			}
 		}
 	}
@@ -810,7 +810,7 @@ func TestCollectHealthReportMarksInvalidWorktreeBindingNonRepairable(t *testing.
 		}
 		found = true
 		assert.False(t, finding.Repairable, "invalid bound worktree should require explicit operator action")
-		assert.Contains(t, finding.Message, "Dedicated worktree binding is invalid")
+		assert.True(t, healthFindingHasReasonCode(finding, WorktreeReasonDedicatedRequired))
 	}
 	assert.True(t, found, "expected worktree integrity finding")
 }
@@ -846,6 +846,15 @@ func TestCollectHealthReportReportsMissingBoundWorktreeScopeConfig(t *testing.T)
 		}
 	}
 	assert.True(t, found, "expected missing bound-worktree scope config finding")
+}
+
+func healthFindingHasReasonCode(finding HealthFinding, code string) bool {
+	for _, reason := range finding.Reasons {
+		if reason.Code == code {
+			return true
+		}
+	}
+	return false
 }
 
 func TestCollectHealthReportFailsWhenWorkspaceDiscoveryFails(t *testing.T) {

--- a/internal/state/verification_test.go
+++ b/internal/state/verification_test.go
@@ -135,15 +135,15 @@ func TestLoadVerificationAcceptsStructuredReasonCodes(t *testing.T) {
 	require.NoError(t, os.MkdirAll(dir, 0o755))
 	require.NoError(t, os.WriteFile(
 		filepath.Join(dir, "plan-audit.yaml"),
-		[]byte("verdict: fail\nblockers:\n  - code: missing_coverage\n    severity: error\n    message: Missing coverage\n    detail: integration\ntimestamp: 2026-04-08T00:00:00Z\n"),
+		[]byte("verdict: fail\nblockers:\n  - code: missing_required_artifact\n    severity: error\n    message: Missing required artifact\n    detail: research.md\ntimestamp: 2026-04-08T00:00:00Z\n"),
 		0o644,
 	))
 
 	loaded, err := LoadVerification(root, slug, "plan-audit")
 	require.NoError(t, err)
 	require.Len(t, loaded.Blockers, 1)
-	assert.Equal(t, "missing_coverage", loaded.Blockers[0].Code)
-	assert.Equal(t, "integration", loaded.Blockers[0].Detail)
+	assert.Equal(t, "missing_required_artifact", loaded.Blockers[0].Code)
+	assert.Equal(t, "research.md", loaded.Blockers[0].Detail)
 }
 
 func TestListVerificationsEmpty(t *testing.T) {


### PR DESCRIPTION
## Summary
- Freeze the canonical reason-code taxonomy with snapshot and severity contract tests.
- Fail closed for unknown reason codes while preserving the original token in detail.
- Add repo-local lint coverage that rejects reason/error Message prose assertions and migrate affected tests to stable fields.
- Complete the Slipway governed lifecycle through final-closeout and archive the change bundle.

## Verification
- go test -count=1 ./...
- go vet ./...
- go build ./...
- gofmt -l cmd internal
- git --no-pager diff --check
- /tmp/slipway-issue160-closeout validate --json -> G_ship approved, evidence_freshness=fresh, scope_contract.status=pass
- /tmp/slipway-issue160-closeout done --json -> archived=true

Closes #160