### PR TITLE
feat(verify): add uncheckable trace coverage status

### DIFF
--- a/artifacts/changes/archived/resolve-github-issue-157-add-uncheckable-inconclusive-per-it/assurance.md
+++ b/artifacts/changes/archived/resolve-github-issue-157-add-uncheckable-inconclusive-per-it/assurance.md
@@ -1,0 +1,90 @@
+# Assurance
+
+## Scope Summary
+
+Resolved GitHub issue #157's remaining governed scope: the spec verification
+contract now exposes per-item uncertain statuses instead of forcing "could not
+check" mappings into covered, skipped, or drift.
+
+Delivered product changes:
+
+- `internal/tmpl/templates/skills/spec-trace/SKILL.md` now includes
+  `ambiguous` and `uncheckable` per-row statuses, reason fields, and
+  `coverage_gaps` accounting.
+- `internal/tmpl/templates/skills/spec-trace/CHECKLIST.tmpl` now instructs
+  reviewers to record uncertain rows with reasons and keep them as coverage
+  gaps.
+- `internal/tmpl/templates/skills/spec-compliance-review/SKILL.md.tmpl` now
+  rejects unresolved ambiguous or uncheckable rows as full bidirectional
+  alignment.
+- `internal/tmpl/templates_test.go` adds
+  `TestSpecTraceRecordsUncheckableCoverageGaps` to pin the contract.
+
+No runtime parser, schema, dependency, toolchain, generated skill copy, or
+external service behavior was changed.
+
+## Verification Verdict
+
+Current verification verdict is pass for the implemented scope.
+
+- Requirements contract: valid for REQ-001 through REQ-004.
+- Tasks contract: valid and completed for t-01 through t-04.
+- Scope contract: pass; changed source files are within planned targets.
+- Spec-compliance-review: pass with no blockers.
+- Code-quality-review: pass with no blockers, including required
+  `layer:IR1=pass` and `layer:IR3=pass` tokens.
+- Freshness: `go run . validate --json` reported `evidence_freshness: fresh`
+  at S3_REVIEW before this assurance file was authored.
+
+## Evidence Index
+
+- `verification/execution-summary.yaml`: run summary version 1, tasks t-01
+  through t-04 complete.
+- `verification/wave-orchestration.yaml`: RED/GREEN and verification evidence
+  for the implementation wave.
+- `verification/spec-compliance-review.yaml`: Stage 1 review pass.
+- `verification/code-quality-review.yaml`: Stage 2 review pass.
+- Runtime verification commands:
+  - `go test ./internal/tmpl -run TestSpecTraceRecordsUncheckableCoverageGaps -count=1`
+  - `go test ./internal/tmpl ./internal/toolgen -count=1`
+  - `go test -count=1 ./...`
+  - `go build ./...`
+  - `go vet ./...`
+  - `git diff --check`
+
+## Requirement Coverage
+
+- REQ-001: covered by the spec-trace template status vocabulary and checklist
+  update allowing `ambiguous` and `uncheckable` rows.
+- REQ-002: covered by reason fields and coverage-gap accounting in the
+  spec-trace template and checklist.
+- REQ-003: covered by spec-compliance-review guidance that unresolved uncertain
+  rows must block or request changes.
+- REQ-004: covered by `TestSpecTraceRecordsUncheckableCoverageGaps`, including
+  RED evidence before implementation and GREEN evidence after implementation.
+
+No skipped, drift, ambiguous, or uncheckable requirement rows remain for this
+change's own implementation.
+
+## Residual Risks and Exceptions
+
+- The updated contract is authored in template source; generated skill copies
+  remain generated output and were intentionally not hand-edited.
+- The change improves review-output contract clarity but does not add a runtime
+  parser or machine validator for every future review table. That was an
+  intentional scope decision to keep Issue #157 narrow.
+- No accepted exceptions remain for the governed requirements.
+
+## Rollback Readiness
+
+Rollback is straightforward: revert the four product source files and the
+associated governed artifact bundle for this branch. There are no migrations,
+external API calls, dependency changes, persistent data writes, or irreversible
+operations.
+
+## Archive Decision
+
+Archive readiness is pending final lifecycle advancement. Active
+`validate --json` freshness proof has been captured in S3_REVIEW, but the
+change has not been marked done and this assurance does not claim archived
+bundle revalidation through the active validate gate.

--- a/artifacts/changes/archived/resolve-github-issue-157-add-uncheckable-inconclusive-per-it/change.yaml
+++ b/artifacts/changes/archived/resolve-github-issue-157-add-uncheckable-inconclusive-per-it/change.yaml
@@ -1,0 +1,51 @@
+version: 1
+slug: resolve-github-issue-157-add-uncheckable-inconclusive-per-it
+description: 'Resolve GitHub issue #157: add uncheckable/inconclusive per-item status and coverage accounting for spec verification.'
+status: done
+current_state: DONE
+needs_discovery: true
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-06-10T11:22:18.644303Z
+guardrail_domain: external_api_contracts
+quality_mode: standard
+workflow_preset: standard
+worktree_branch: feat/resolve-github-issue-157-add-uncheckable-inconclusive-per-it
+artifact_schema: expanded
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: 30289ccebf7d9e3b265c3814f155c8ad28be20ba38f62033ba7477ef97159665
+        updated_at: 2026-06-10T11:48:13.941604386Z
+    decision:
+        id: decision
+        path: decision.md
+        state: frozen
+        content_hash: fc6552d034f06da6ddd9a7532fb215f15629ebdb9bb3d4b070d3f97f679235ac
+        updated_at: 2026-06-10T11:33:22.228776529Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: e9592197c1cc36e3b2ef740044926e97b149d8db31434d25020dd671eebf4bbd
+        updated_at: 2026-06-10T11:29:14.932611108Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: 30f9082f5a856bdbede169d358e813adb552bb06c5169b4666cd813b79a5e92e
+        updated_at: 2026-06-10T11:33:22.228567821Z
+    research:
+        id: research
+        path: research.md
+        state: frozen
+        content_hash: ce67d4f7f8fc131f117b1df666b3be9ef4b6a11f340fb76149cddac0718a6280
+        updated_at: 2026-06-10T11:32:17.070886784Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: 944fdeeeeb4c8d9f11944325a40e50db6098e91f74925c37455f5c54b8a280c3
+        updated_at: 2026-06-10T11:40:34.610384329Z

--- a/artifacts/changes/archived/resolve-github-issue-157-add-uncheckable-inconclusive-per-it/decision.md
+++ b/artifacts/changes/archived/resolve-github-issue-157-add-uncheckable-inconclusive-per-it/decision.md
@@ -1,0 +1,66 @@
+# Decision
+
+## Alternatives Considered
+
+### Option 1: Extend authored skill-output contract
+Update `internal/tmpl/templates/skills/spec-trace/SKILL.md`,
+`internal/tmpl/templates/skills/spec-trace/CHECKLIST.tmpl`, and targeted
+spec-compliance-review guidance. Add focused template regressions in
+`internal/tmpl/templates_test.go`.
+
+Tradeoffs: directly satisfies the remaining Issue #157 gap with low code blast
+radius; relies on the skill-output contract rather than runtime parsing.
+
+### Option 2: Add runtime parser and validator for trace rows
+Introduce engine-owned parsing for spec-trace coverage matrices and enforce row
+statuses in validation.
+
+Tradeoffs: stronger machine enforcement, but it widens the change into runtime
+schema behavior and conflicts with the issue instruction to avoid new engine
+prose heuristics.
+
+### Option 3: Only add prose to spec-compliance-review
+Tell spec-compliance-review not to silently accept uncertain mappings without
+changing spec-trace row vocabulary.
+
+Tradeoffs: smallest edit, but it leaves the first-class per-item record gap in
+spec-trace unresolved.
+
+## Selected Approach
+
+Select Option 1. The issue's remaining real scope is the missing per-item status
+bucket and coverage accounting, and the current architecture already places that
+contract in spec-trace and spec-compliance-review authored templates. This keeps
+the change narrow while still making "could not check" auditable.
+
+## Interfaces and Data Flow
+
+- Interface changed: markdown contract exposed by `slipway-spec-trace` and used
+  by spec-compliance-review/review/validate surfaces.
+- Data flow:
+  - authored template files -> `internal/tmpl` rendering -> exported skill
+    prompts -> reviewer-authored verification reports.
+- Runtime data structures: none changed.
+- External service contracts: none changed.
+
+## Rollout and Rollback
+
+- Rollout:
+  - Add RED template test for the Issue #157 contract.
+  - Update templates to satisfy it.
+  - Run targeted and broad Go verification, then Slipway governance gates.
+- Rollback:
+  - Revert edits to the three template/test files and rerun
+    `go test ./internal/tmpl`.
+  - Because no runtime state or schema is migrated, rollback is a normal git
+    revert.
+
+## Risk
+
+- Medium governance risk if ambiguous/uncheckable rows are presented as benign
+  skips. Mitigation: explicit reason and coverage-gap accounting plus
+  spec-compliance pass-blocking guidance.
+- Low compatibility risk because existing `covered`, `skipped`, and `drift`
+  statuses remain valid.
+- Low implementation risk because no engine runtime schema or generated copies
+  are edited directly.

--- a/artifacts/changes/archived/resolve-github-issue-157-add-uncheckable-inconclusive-per-it/intent.md
+++ b/artifacts/changes/archived/resolve-github-issue-157-add-uncheckable-inconclusive-per-it/intent.md
@@ -1,0 +1,72 @@
+# Intent
+
+## Summary
+Resolve GitHub issue #157: add uncheckable/inconclusive per-item status and coverage accounting for spec verification.
+## Complexity Assessment
+complex
+Rationale: this changes an AI-facing verification contract in a guardrail
+domain. The implementation surface is narrow, but the output semantics affect
+how governed review records uncertain traceability.
+
+## Guardrail Domains
+external_api_contracts
+
+## In Scope
+- Update the authored spec-trace skill contract under
+  `internal/tmpl/templates/skills/spec-trace/` so per-mapping coverage can
+  record `covered`, `skipped`, `drift`, `ambiguous`, and `uncheckable`.
+- Require `ambiguous` and `uncheckable` rows to carry a reason and to be counted
+  as coverage gaps rather than silently treated as pass evidence.
+- Update the spec-compliance-review authored template only as needed so review
+  guidance treats "could not check" as an auditable coverage gap and blocks
+  pass claims when ambiguity is unresolved.
+- Add or update template tests that lock the Issue #157 contract in the
+  generated skill text.
+- Drive the governed change through fresh validation evidence until Slipway
+  reports `done_ready`.
+
+## Out of Scope
+- Do not rework the lifecycle engine to infer semantic uncertainty from prose.
+- Do not re-open or re-solve Issue #104; it is only a related caution about
+  explicit parseable contracts.
+- Do not copy GSD ADR-22 wholesale or introduce checker-authority machinery
+  beyond the scope needed by this skill-output contract.
+- Do not run `slipway done`; stop at `done_ready` unless the user explicitly
+  asks for finalization later.
+
+## Constraints
+- Source of truth for generated skill content is
+  `internal/tmpl/templates/skills/`, not exported/generated copies.
+- Keep the change contract-based: engine emits/hosts the checklist surface and
+  the skill judges the trace, avoiding new engine prose heuristics.
+- Sensitive or external-contract governance must fail closed: unresolved
+  `ambiguous` or `uncheckable` rows cannot falsely bless a pass verdict.
+
+## Acceptance Signals
+- Rendered spec-trace guidance exposes a mandatory coverage matrix with
+  per-item `ambiguous` and `uncheckable` statuses, reason fields, and coverage
+  gap accounting.
+- Spec-compliance-review guidance requires recording uncertain trace mappings as
+  coverage gaps and disallows pass claims when unresolved ambiguity remains.
+- Targeted template tests fail on the old `covered | skipped | drift`-only
+  contract and pass after the new contract is present.
+- Relevant Go tests, formatting/static checks, `go run . validate --json`, and
+  `go run . run --json --diagnostics` prove the governed change is `done_ready`.
+
+## Open Questions
+None.
+
+## Deferred Ideas
+- A future change can add structured machine validation for trace matrix rows if
+  the project decides that skill-output prose is no longer enough.
+- A future change can model checker-authority tiers in engine-owned evidence if
+  the workflow needs hard-block severity to vary by checker capability.
+
+## Approved Summary
+Confirmed by user delegation on 2026-06-10 after selecting the `standard`
+workflow preset and authorizing future choices to be made by best evidence. This
+change narrows Issue #157 to the remaining real gap: spec verification must be
+able to record per-item `ambiguous`/`uncheckable` coverage rows with reasons and
+coverage-gap accounting, so "could not check" is auditable and never silently
+passes. The work is limited to authored skill/template contract updates,
+regressions, and governed readiness evidence, stopping at `done_ready`.

--- a/artifacts/changes/archived/resolve-github-issue-157-add-uncheckable-inconclusive-per-it/requirements.md
+++ b/artifacts/changes/archived/resolve-github-issue-157-add-uncheckable-inconclusive-per-it/requirements.md
@@ -1,0 +1,42 @@
+# Requirements
+
+## Requirements
+
+### Requirement: Record uncertain spec-trace rows
+REQ-001: The spec-trace output contract MUST allow each coverage matrix row to
+record `ambiguous` and `uncheckable` statuses in addition to existing
+`covered`, `skipped`, and `drift` statuses.
+
+#### Scenario: Reviewer cannot determine a mapping
+GIVEN a reviewer is producing the spec-trace coverage matrix
+WHEN a spec-to-code or code-to-spec mapping cannot be determined from available evidence
+THEN the reviewer can record the row as `ambiguous` or `uncheckable` instead of omitting it or marking it `covered`
+
+### Requirement: Account for uncertain rows as coverage gaps
+REQ-002: The spec-trace contract MUST require every `ambiguous` or
+`uncheckable` row to include a reason and MUST account for those rows as
+coverage gaps rather than pass evidence.
+
+#### Scenario: Coverage matrix includes an uncheckable row
+GIVEN a coverage matrix row has status `uncheckable`
+WHEN the reviewer writes the spec-trace report
+THEN the report includes why the row could not be checked and lists it in coverage gap accounting
+
+### Requirement: Fail closed in spec-compliance review
+REQ-003: The spec-compliance-review guidance MUST prevent a `pass` verdict when
+unresolved `ambiguous` or `uncheckable` trace rows remain.
+
+#### Scenario: Stage 1 review sees unresolved ambiguity
+GIVEN spec-compliance-review reads a spec-trace matrix with unresolved `ambiguous` or `uncheckable` rows
+WHEN the reviewer determines the final verdict
+THEN the review blocks or requests changes instead of treating the uncertainty as full bidirectional alignment
+
+### Requirement: Pin the contract with tests
+REQ-004: The implementation MUST include focused template tests that fail on
+the old `covered | skipped | drift`-only contract and pass only when the new
+uncertain-status and coverage-gap wording is present.
+
+#### Scenario: Template contract regresses
+GIVEN a future edit removes `ambiguous`, `uncheckable`, required reasons, or coverage-gap accounting from the templates
+WHEN the focused template tests run
+THEN the tests fail and identify the missing contract wording

--- a/artifacts/changes/archived/resolve-github-issue-157-add-uncheckable-inconclusive-per-it/research.md
+++ b/artifacts/changes/archived/resolve-github-issue-157-add-uncheckable-inconclusive-per-it/research.md
@@ -1,0 +1,130 @@
+# Research
+
+## Alternatives Considered
+
+### Architecture
+- Affected modules:
+  - `internal/tmpl/templates/skills/spec-trace/SKILL.md:39` owns the report
+    schema that explains how trace results are recorded.
+  - `internal/tmpl/templates/skills/spec-trace/CHECKLIST.tmpl:11` owns the
+    mandatory coverage matrix and currently has no explicit uncertain-result
+    statuses.
+  - `internal/tmpl/templates/skills/spec-compliance-review/SKILL.md.tmpl:43`
+    delegates trace-edge enumeration to the attached spec-trace checklist.
+  - `internal/tmpl/templates_test.go:1041` is the focused test seam for rendered
+    review-template contract text.
+- Dependency chains:
+  - `internal/tmpl/templates/skills/spec-trace/*` -> rendered/exported
+    `slipway-spec-trace` skill -> spec-compliance-review host and review/validate
+    focus surfaces.
+  - `internal/tmpl/templates/skills/spec-compliance-review/SKILL.md.tmpl` ->
+    rendered governance host prompt -> governed Stage 1 review.
+- Blast radius:
+  - Low code blast radius if limited to authored templates and template tests.
+  - Medium governance semantics risk because reviewer instructions affect how
+    uncertain evidence is recorded.
+- Constraints:
+  - Generated surfaces are not the authoring surface.
+  - Issue #157 explicitly asks for a skill-output-contract change and to avoid
+    new engine prose heuristics.
+
+### Patterns
+- Existing conventions:
+  - Spec-trace already uses lowercase per-row statuses:
+    `covered`, `skipped`, and `drift` in
+    `internal/tmpl/templates/skills/spec-trace/CHECKLIST.tmpl:12`.
+  - Spec-compliance-review already fails closed when review evidence is missing
+    or narrower than the requirement in
+    `internal/tmpl/templates/skills/spec-compliance-review/SKILL.md.tmpl:50`.
+  - Template contract regressions live in `internal/tmpl/templates_test.go`, with
+    tests rendering the exact skill templates.
+- Reusable abstractions:
+  - Use existing markdown checklist/report-schema text; no new Go abstraction is
+    necessary.
+  - Use existing `Render` and `Content` helpers in `internal/tmpl` tests.
+- Convention deviations:
+  - None required. The change extends existing status vocabulary rather than
+    replacing the report format.
+
+### Risks
+- Technical risks:
+  - Medium: if `ambiguous` and `uncheckable` are described as benign skips, the
+    original silent-pass problem remains.
+  - Low: template wording changes can drift from generated output if tests do
+    not assert the new contract.
+  - Low: runtime compatibility risk is minimal because no engine-owned schema is
+    changed.
+- Guardrail domains:
+  - `external_api_contracts`; unresolved or uncheckable review evidence must be
+    auditable and fail closed for pass claims in sensitive domains.
+- Reversibility:
+  - High. The implementation is template/test only and can be reverted without
+    data migration or runtime state migration.
+
+### Test Strategy
+- Existing coverage:
+  - Template rendering tests cover review guidance wording but not Issue #157's
+    uncertain per-item statuses.
+  - Toolgen tests cover exported skill shape, not the semantic row statuses.
+- Infrastructure needs:
+  - No new fixtures or external tools.
+  - Add a focused `internal/tmpl` regression test that fails against the current
+    `covered | skipped | drift`-only contract.
+- Verification approach:
+  - RED: run the new focused template test before implementation and confirm it
+    fails.
+  - GREEN: update spec-trace and spec-compliance-review template text, then run
+    the focused test.
+  - BROAD: run relevant template/toolgen tests, full Go verification, and
+    Slipway governance validation through `done_ready`.
+
+### Options
+- Option 1: extend the authored skill-output contract only.
+  - Design: update spec-trace report schema/checklist to include
+    `ambiguous`/`uncheckable` statuses with reason fields and coverage-gap
+    accounting; update spec-compliance-review guidance to block unresolved
+    ambiguity from pass claims; add template tests.
+  - Tradeoffs: matches Issue #157's scoped remaining gap and keeps runtime blast
+    radius low; relies on review prompt adherence rather than machine parsing.
+- Option 2: add engine-owned parsing/validation of trace matrix rows.
+  - Design: introduce a structured trace evidence parser and hard validation of
+    row statuses.
+  - Tradeoffs: stronger machine enforcement, but substantially broader and
+    contrary to the issue's instruction to avoid new engine prose heuristics.
+- Option 3: only update prose in spec-compliance-review.
+  - Design: tell reviewers not to silently pass uncertain mappings, without
+    changing spec-trace matrix vocabulary.
+  - Tradeoffs: smallest edit, but leaves no first-class per-item status bucket,
+    so it does not satisfy the remaining real scope.
+- Selected: Option 1.
+  - Rationale: it directly adds the missing recordable per-item uncertain
+    statuses and coverage accounting while preserving existing covered/skipped/
+    drift semantics and avoiding unnecessary runtime machinery.
+
+## Unknowns
+- Resolved: Is the old codebase map relevant? -> No. It was authored for issue
+  #137 and has been re-authored inline for issue #157.
+- Resolved: Is the implementation surface engine-owned or skill-output-owned?
+  -> Skill-output-owned. The current gap is in spec-trace/checklist vocabulary
+  and spec-compliance-review guidance.
+- Remaining: None.
+
+## Assumptions
+- The final verification should stop at `done_ready`, not `slipway done` -
+  Evidence: user objective says "直到done ready" and intake out-of-scope records
+  finalization as excluded.
+- Lowercase statuses should be used in matrix examples - Evidence:
+  `internal/tmpl/templates/skills/spec-trace/CHECKLIST.tmpl:12` uses lowercase
+  `covered`, `skipped`, and `drift`.
+- Focused template tests are sufficient to prove the contract text changed -
+  Evidence: existing tests in `internal/tmpl/templates_test.go:1041` assert
+  rendered review-template contract wording.
+
+## Canonical References
+- `https://github.com/signalridge/slipway/issues/157`
+- `internal/tmpl/templates/skills/spec-trace/SKILL.md:39`
+- `internal/tmpl/templates/skills/spec-trace/CHECKLIST.tmpl:11`
+- `internal/tmpl/templates/skills/spec-compliance-review/SKILL.md.tmpl:43`
+- `internal/tmpl/templates_test.go:1041`
+- `internal/toolgen/toolgen.go:254`
+- `internal/engine/capability/registry_b2.go:72`

--- a/artifacts/changes/archived/resolve-github-issue-157-add-uncheckable-inconclusive-per-it/tasks.md
+++ b/artifacts/changes/archived/resolve-github-issue-157-add-uncheckable-inconclusive-per-it/tasks.md
@@ -1,0 +1,31 @@
+# Tasks
+
+## Task List
+
+- [x] `t-01` Add focused RED regression for Issue #157 template contract
+  - wave: 1
+  - depends_on: []
+  - target_files: [`internal/tmpl/templates_test.go`]
+  - task_kind: test
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004]
+
+- [x] `t-02` Extend spec-trace report schema and coverage matrix vocabulary
+  - wave: 2
+  - depends_on: [`t-01`]
+  - target_files: [`internal/tmpl/templates/skills/spec-trace/SKILL.md`, `internal/tmpl/templates/skills/spec-trace/CHECKLIST.tmpl`]
+  - task_kind: code
+  - covers: [REQ-001, REQ-002]
+
+- [x] `t-03` Add spec-compliance-review fail-closed uncertain-trace guidance
+  - wave: 2
+  - depends_on: [`t-01`]
+  - target_files: [`internal/tmpl/templates/skills/spec-compliance-review/SKILL.md.tmpl`]
+  - task_kind: code
+  - covers: [REQ-003]
+
+- [x] `t-04` Verify template contract and governed readiness evidence
+  - wave: 3
+  - depends_on: [`t-02`, `t-03`]
+  - target_files: [`internal/tmpl/templates_test.go`, `artifacts/changes/resolve-github-issue-157-add-uncheckable-inconclusive-per-it/verification`]
+  - task_kind: verification
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004]

--- a/artifacts/codebase/ARCHITECTURE.md
+++ b/artifacts/codebase/ARCHITECTURE.md
@@ -1,52 +1,39 @@
 # Architecture
 
-Re-authored for change `resolve-github-issue-137-add-go-source-sast-ci-and-triage-th`
-(issue #137). This map scopes to adding Go-source SAST coverage and triaging the
-reported gosec baseline.
+Re-authored for change `resolve-github-issue-157-add-uncheckable-inconclusive-per-it`
+(GitHub issue #157).
 
-- Module responsibilities:
-  - `.github/workflows/security.yaml` — existing security CI authority. It
-    currently runs `govulncheck`, Trivy filesystem scan, SBOM generation, and
-    license reporting with SARIF uploads for vulnerability scanners, but it has
-    no Go-source static application security testing job.
-  - `cmd/pivot_execution.go` — contains the reported `G703`/`G306` path/write
-    finding in `clearApprovedSummaryForPivot`, which rewrites `intent.md` under
-    the governed bundle resolved by `state.ResolveChangePaths`.
-  - `internal/state/lifecycle.go` — contains archive/copy helpers and the
-    reported `G122`/`G301`/`G304` findings around recursive bundle copy and
-    archive migration.
-  - `cmd/done.go` — contains the reported `G122`/`G304` finding while scanning
-    governed-bundle remediation references during finalization.
-  - `internal/state`, `cmd`, `internal/model`, `internal/toolgen`, and
-    `internal/tmpl` — the issue's changed-package gosec baseline scope.
+Question: where should per-item ambiguous/uncheckable spec verification status
+be expressed so "could not check" is auditable and never silently passes?
+
+- Affected modules:
+  - `internal/tmpl/templates/skills/spec-trace/SKILL.md:39` defines the
+    spec-trace report schema consumed by review users.
+  - `internal/tmpl/templates/skills/spec-trace/CHECKLIST.tmpl:11` defines the
+    mandatory coverage matrix and currently limits item status to
+    `covered`, `skipped`, and `drift`.
+  - `internal/tmpl/templates/skills/spec-compliance-review/SKILL.md.tmpl:43`
+    tells reviewers to use the attached spec-trace checklist while performing
+    Stage 1 governed review.
+  - `internal/tmpl/templates_test.go:1041` already pins review-template contract
+    wording, making it the focused regression-test seam for this change.
+  - `internal/toolgen/toolgen.go:254` and `internal/toolgen/toolgen.go:369`
+    export governance/technique skills; spec-trace is an exported technique
+    helper rather than a lifecycle-owned host.
 - Dependency flow:
-  - CLI commands resolve project/change paths through `state.ResolveChangePaths`
-    before reading/writing governed artifacts.
-  - Security workflow jobs use GitHub Actions permissions at the workflow level
-    (`actions: read`, `contents: read`, `security-events: write`) and upload
-    SARIF through `github/codeql-action/upload-sarif@v4`.
-  - Gosec and CodeQL should remain CI/reporting additions; they must not alter
-    Slipway runtime lifecycle behavior.
+  - Authored templates under `internal/tmpl/templates/skills/...` are the source
+    of truth.
+  - Template rendering tests read authored content directly or render `.tmpl`
+    files and assert required contract text.
+  - Tool generation exports the authored skill surfaces; this change should not
+    edit generated copies directly.
 - Coupling hotspots:
-  - Path-handling fixes in archive/finalization code can affect `slipway done`,
-    archive migration, and governed bundle recovery.
-  - Broad permission changes from `0755`/`0644` to private modes can change
-    whether generated user-facing artifacts remain inspectable; permission
-    triage must distinguish repository artifacts from git-scoped runtime state.
-  - Adding CodeQL to the existing Security workflow shares the same
-    `security-events: write` permission used by current SARIF upload jobs.
-- Current change blast radius:
-  - Expected implementation files: `.github/workflows/security.yaml`, targeted
-    Go files carrying full-repository gosec findings, and local triage comments
-    or narrow suppressions for every current unsuppressed full-repository
-    finding.
-  - Expected governed files: this codebase map, `research.md`,
-    `requirements.md`, `decision.md`, `tasks.md`, `assurance.md`, and
-    verification evidence under the active bundle.
-- Notes / source references:
-  - `.github/workflows/security.yaml`
-  - `cmd/pivot_execution.go`
-  - `cmd/done.go`
-  - `internal/state/lifecycle.go`
-  - `/tmp/slipway-issue137-gosec-changed-packages.json`
-  - `/tmp/slipway-issue137-gosec-full.json`
+  - `spec-compliance-review` depends on spec-trace for the trace matrix contract,
+    so changing spec-trace wording is the main architectural fix.
+  - Adding runtime parsing or schema validation would widen the blast radius into
+    engine capability and verification-state code; Issue #157 explicitly steers
+    away from engine prose heuristics.
+- Blast radius:
+  - Low implementation blast radius: authored skill templates and focused tests.
+  - Higher workflow semantics sensitivity: the wording controls how review
+    agents classify uncertain mappings in governed review.

--- a/artifacts/codebase/CONCERNS.md
+++ b/artifacts/codebase/CONCERNS.md
@@ -1,50 +1,22 @@
 # Concerns
 
-Re-authored for change `resolve-github-issue-137-add-go-source-sast-ci-and-triage-th`
-(issue #137). This map scopes to SAST CI and gosec baseline triage.
+Re-authored for change `resolve-github-issue-157-add-uncheckable-inconclusive-per-it`
+(GitHub issue #157).
 
-- Architectural pressure points:
-  - A gosec job that exits non-zero on the current full repository baseline would
-    make the Security workflow fail immediately on historical findings. User
-    clarified all findings must be resolved, so the implementation must fix or
-    locally suppress the full baseline before enabling failure.
-  - The issue's concrete baseline began as the changed-package scan over `cmd/`,
-    `internal/state`, `internal/model`, `internal/toolgen`, and `internal/tmpl`.
-    Full `./...` finds additional packages, and those are now in scope because
-    the user clarified that all current findings must be resolved.
-  - CodeQL for Go is complementary to gosec. It should be added with the
-    official CodeQL action path, while gosec remains the baseline-rule authority
-    for the issue's named findings.
-- Brittle areas:
-  - `filepath.WalkDir` callbacks that read or write `path` values are flagged by
-    `G122`; blindly changing them can break archive semantics. Fix only when the
-    scoped root and symlink behavior remain clear, otherwise suppress with a
-    local rationale.
-  - `G304` path reads are common in Slipway because the CLI intentionally reads
-    artifacts from the current repository/worktree; suppressions must explain
-    the authority boundary instead of hiding the rule globally.
-  - `G204` git subprocess calls are expected for a git-governance CLI. They
-    should use literal executable names and bounded argument construction, with
-    local suppressions where gosec cannot infer the boundary.
-  - Permission changes must distinguish user-facing tracked artifacts from
-    git-scoped runtime state. Private modes are appropriate for local runtime
-    evidence/config; repository artifacts may intentionally remain readable.
-- Migration traps:
-  - Do not edit generated skill copies under `.codex/` or `.claude/` for this
-    issue.
-  - Do not use global `-exclude=G304,G204,...` rules without rationale; that
-    would add a SAST job while preserving an untriaged baseline.
-  - Do not make `slipway done` archive/finalize this change; the requested end
-    state is `done-ready`.
-- Fail-closed requirement:
-  - Because this change supports the `irreversible_operations.safety_baseline`
-    path, goal verification must include real SAST command evidence and a
-    domain/security review. Missing, stale, or inconclusive SAST evidence is a
-    blocker.
-- Recheck routing:
-  - Re-run full-repository gosec after triage and require no unsuppressed
-    findings.
-  - Re-run full gosec SARIF generation to prove CI upload artifacts can be
-    produced by the same policy.
-  - Run `go test -count=1 ./...`, then governance `validate` and
-    `health --governance` before final closeout.
+- Load-bearing invariant: review guidance must not allow unverifiable trace
+  mappings to be converted into `pass` evidence. Current
+  `spec-trace/CHECKLIST.tmpl:12` only names `covered`, `skipped`, and `drift`,
+  which leaves no explicit bucket for a mapping the reviewer could not check.
+- Guardrail risk: the change is classified as `external_api_contracts`; review
+  evidence must fail closed. `spec-compliance-review/SKILL.md.tmpl:103` already
+  has an R3 review layer for guardrail domains, so new guidance should align
+  with that stage rather than bypass it.
+- Compatibility risk: changing vocabulary too broadly could invalidate existing
+  review habits. The safer path is to extend the matrix with `ambiguous` and
+  `uncheckable` while keeping existing `covered`, `skipped`, and `drift`
+  semantics.
+- Overengineering risk: runtime row parsing would add engine behavior that
+  Issue #157 says to avoid. Keep this change at the skill-output-contract layer.
+- Testing risk: tests that only assert one phrase can miss the full contract.
+  Regression assertions should cover the new statuses, required reasons,
+  coverage-gap accounting, and pass-blocking semantics.

--- a/artifacts/codebase/CONVENTIONS.md
+++ b/artifacts/codebase/CONVENTIONS.md
@@ -1,24 +1,15 @@
 # Conventions
 
-- Naming:
-  - Governed host skills use `slipway-<skill-name>` in generated surfaces and
-    keep the engine skill ID as the lifecycle authority.
-  - References to parseable evidence tokens must stay literal, especially
-    `high_risk_check:<domain>.safety_baseline=pass` and `baseline_verify_cmd:`.
-- File organization:
-  - Keep host SKILL.md bodies concise and move long examples or dispatch details
-    into `references/` files where the existing skill already supports that
-    pattern.
-  - Prefer editing `internal/tmpl/templates/skills/...` over generated surfaces.
-- Error handling:
-  - Gate-bearing instructions should fail closed when delegated evidence is
-    missing, stale, inconclusive, or reports blockers.
-- Configuration:
-  - Do not introduce runtime-specific model or subagent assumptions unless the
-    template names a fallback for tools without subagent support.
-- State management:
-  - Runtime-owned evidence files and task evidence must be written through
-    supported commands, not by hand.
-- Notes:
-  - Current change favors template contract wording and tests over engine schema
-    changes.
+- Source of truth:
+  - Edit authored skill templates under `internal/tmpl/templates/skills/...`.
+  - Do not edit exported/generated skill copies directly.
+- Wording:
+  - Gate-bearing instructions should use explicit, parseable vocabulary.
+  - Keep new terms lowercase in markdown examples (`ambiguous`, `uncheckable`)
+    to match existing `covered`, `skipped`, and `drift` status style.
+- Testing:
+  - Use package-local Go template tests in `internal/tmpl/templates_test.go`.
+  - Assert behaviorally meaningful phrases, not incidental formatting.
+- Scope control:
+  - Prefer contract text and tests over new runtime/schema machinery when the
+    issue is about AI-facing review instructions.

--- a/artifacts/codebase/INTEGRATIONS.md
+++ b/artifacts/codebase/INTEGRATIONS.md
@@ -1,19 +1,12 @@
 # Integrations
 
-- External APIs:
-  - GitHub issue #114 is the external problem statement and acceptance context.
-- Infrastructure bindings:
-  - Generated skill surfaces target multiple agent runtimes; Codex, Claude,
-    Cursor, Gemini, and other supported tools may expose different subagent
-    mechanics.
-- Datastores and queues:
-  - Not applicable.
-- File formats and protocols:
-  - Governance verification artifacts are YAML files under
-    `artifacts/changes/<slug>/verification/`.
-  - Runtime task evidence is recorded through `slipway evidence task` and
-    referenced from wave verification.
-- Notes:
-  - Runtime portability is part of the design constraint: instructions should
-    describe delegated verifier/executor context without requiring a
-    Claude-only API name as the only satisfy path.
+- No external network, database, or service integration is expected.
+- User-facing integration surface:
+  - Generated/exported skill prompts for `spec-trace` and
+    `spec-compliance-review`.
+  - Governed review flows that embed spec-trace during spec-compliance review.
+- Internal integration surface:
+  - Template rendering (`internal/tmpl`) and tool generation (`internal/toolgen`)
+    consume authored skill files.
+  - Capability registry bindings in `internal/engine/capability/registry_b2.go:72`
+    identify spec-trace as a host-embedded checklist for spec-compliance review.

--- a/artifacts/codebase/STACK.md
+++ b/artifacts/codebase/STACK.md
@@ -1,7 +1,10 @@
 # Stack
 
-- Languages: Go, Python
-- Frameworks and runtimes: Go module github.com/signalridge/slipway
-- Build and test tooling: go build ./...; go test ./...
-- Key dependencies: github.com/davecgh/go-spew, github.com/gofrs/flock, github.com/google/uuid, github.com/inconshreveable/mousetrap, github.com/kr/text, github.com/pmezard/go-difflib
-- Notes: go.mod declares Go 1.26.3
+- Language: Go.
+- Template/content layer: markdown skill files and Go template rendering under
+  `internal/tmpl`.
+- Test framework: Go `testing` plus `testify` assertions already used in
+  `internal/tmpl/templates_test.go`.
+- Verification commands expected for this change: targeted `go test` for
+  `internal/tmpl`, broader Go tests, `go test -count=1 ./...`, `go build ./...`,
+  `go vet ./...`, `git diff --check`, and Slipway governance validation.

--- a/artifacts/codebase/STRUCTURE.md
+++ b/artifacts/codebase/STRUCTURE.md
@@ -1,36 +1,16 @@
 # Structure
 
-Re-authored for change `resolve-github-issue-137-add-go-source-sast-ci-and-triage-th`
-(issue #137). This map scopes to Go-source SAST CI and full-repository gosec
-baseline triage.
-
-- Directory layout:
-  - `.github/workflows/` owns repository CI workflow definitions. The Security
-    workflow is the only workflow expected to change.
-  - `cmd/` contains Cobra command implementations that resolve governed paths,
-    run git commands, and read/write lifecycle artifacts.
-  - `internal/state/` owns Slipway state path resolution, archive/copy helpers,
-    worktree/git subprocess helpers, and local runtime path handling.
-  - `internal/engine/` owns governance, artifact, intake, progression, status,
-    and skill-loading flows that intentionally read repository/governed paths.
-  - `internal/model/`, `internal/toolgen/`, `internal/tmpl/`, and `internal/fsutil/`
-    contain additional full-repository gosec findings that must be triaged.
-- Entry points:
-  - `main.go` and `cmd/*` are CLI execution entry points.
-  - `.github/workflows/security.yaml` is the CI entry point for SAST coverage.
-  - `go.mod` controls the Go module used by Actions setup and local tests.
-- Generated versus handwritten boundaries:
-  - `internal/tmpl/templates/**` are source templates and may carry findings in
-    test fixture/template loading code; generated copies outside these sources
-    are not the authoring surface for this change.
-  - `artifacts/changes/*` and `artifacts/codebase/*` are governed planning,
-    review, and evidence artifacts. Verification outputs for this change live
-    under the active bundle's `verification/` directory.
-- Ownership hints:
-  - Workflow SARIF upload conventions live in `.github/workflows/security.yaml`
-    and should be mirrored for gosec.
-  - Runtime path authority lives in `internal/state` helpers; call-site
-    suppressions should cite that authority instead of introducing parallel path
-    parsing.
-  - Git subprocess findings should stay local to `cmd/`, `internal/state/`, and
-    `internal/fsutil/` call sites with bounded executable/argument rationale.
+- `internal/tmpl/templates/skills/spec-trace/`
+  - `SKILL.md`: frontmatter, purpose, report schema, anti-patterns.
+  - `CHECKLIST.tmpl`: attached checklist and coverage matrix.
+- `internal/tmpl/templates/skills/spec-compliance-review/`
+  - `SKILL.md.tmpl`: Stage 1 review host instructions that embed spec-trace
+    guidance.
+  - `references/checklist-quality.md`: adjacent reference read by the host.
+- `internal/tmpl/templates_test.go`
+  - Existing focused regression area for template contract wording.
+- `internal/toolgen/`
+  - Exports governance and technique skill surfaces; expected to remain
+    structurally unchanged for this issue.
+- `artifacts/changes/resolve-github-issue-157-add-uncheckable-inconclusive-per-it/`
+  - Governed artifact bundle and verification evidence for this change.

--- a/artifacts/codebase/TESTING.md
+++ b/artifacts/codebase/TESTING.md
@@ -1,37 +1,21 @@
 # Testing
 
-Re-authored for change `resolve-github-issue-137-add-go-source-sast-ci-and-triage-th`
-(issue #137). This map scopes to SAST workflow coverage and gosec baseline
-triage.
-
-- Test layout:
-  - Go unit tests live in package-local `*_test.go` files.
-  - Workflow changes are YAML-only and should be validated by static inspection,
-    current GitHub Actions conventions, and branch/PR CI after push.
-- Baseline security scans:
-  - Changed-package baseline command used during research:
-    `go run github.com/securego/gosec/v2/cmd/gosec@v2.27.1 -fmt=json -out=/tmp/slipway-issue137-gosec-changed-packages.json ./cmd ./internal/state ./internal/model ./internal/toolgen ./internal/tmpl`
-  - Current changed-package result: 72 findings across `G122`, `G703`, `G304`,
-    `G301`, `G204`, and `G306`.
-  - Full-repo visibility command used during research:
-    `go run github.com/securego/gosec/v2/cmd/gosec@v2.27.1 -fmt=json -out=/tmp/slipway-issue137-gosec-full.json ./...`
-  - Current full-repo result: 136 findings. User clarified that all current
-    findings must be resolved in this change, so final gosec verification is
-    full-repository.
-- Verification commands expected before closeout:
-  - `go test -count=1 ./...`
-  - `go run github.com/securego/gosec/v2/cmd/gosec@v2.27.1 -fmt=json -out=<path> ./...`
-  - `go run github.com/securego/gosec/v2/cmd/gosec@v2.27.1 -fmt=sarif -out=<path> ./...`
-  - `go run . validate --json`
-  - `go run . health --governance --json`
-- Coverage hotspots:
-  - `cmd/done.go` and `internal/state/lifecycle.go` for symlink/WalkDir
-    high-severity findings.
-  - `cmd/pivot_execution.go` and `internal/engine/intake/intake.go` for gosec
-    taint/path write findings in full-repo scans.
-  - `.github/workflows/security.yaml` for gosec/CodeQL job configuration and
-    SARIF/code-scanning upload behavior.
-- Residual risk:
-  - Local CodeQL analysis is not normally runnable without the GitHub CodeQL
-    action environment; verification is workflow-structure inspection plus CI
-    execution after push.
+- Existing coverage:
+  - `internal/tmpl/templates_test.go:1041` verifies review-template guidance for
+    negative-path evidence.
+  - `internal/tmpl/templates_test.go:1063` verifies spec-compliance-review and
+    spec-trace contract wording around literal clause coverage.
+  - `internal/tmpl/templates_test.go:1082` verifies pending-decision guidance.
+  - `internal/toolgen/toolgen_test.go:1718` verifies generated skill typed parts
+    include the expected spec-trace checklist section.
+- Gap for Issue #157:
+  - No focused regression currently asserts `ambiguous` or `uncheckable` item
+    statuses, required reasons, or coverage-gap accounting in spec-trace.
+  - No focused regression currently asserts spec-compliance-review blocks pass
+    claims when unresolved ambiguity remains.
+- Planned verification:
+  - Add a targeted failing test in `internal/tmpl/templates_test.go` before
+    template edits.
+  - Run the targeted test after edits.
+  - Run broader relevant tests (`go test ./internal/tmpl ./internal/toolgen`),
+    then full repository verification before closeout.

--- a/internal/tmpl/templates/skills/spec-compliance-review/SKILL.md.tmpl
+++ b/internal/tmpl/templates/skills/spec-compliance-review/SKILL.md.tmpl
@@ -42,7 +42,9 @@ and the top-level `confirmation_requirement` object for stop boundaries. Those
 fields are the source of truth for this handoff.
 Apply the shared requirements checklist from `references/checklist-quality.md`
 (shipped next to this skill). Use the attached `spec-trace` checklist to
-enumerate the forward and reverse trace edges you must verify.
+enumerate the forward and reverse trace edges you must verify. Any
+`ambiguous` or `uncheckable` spec-trace row must be recorded with a reason and
+must not be treated as full bidirectional alignment.
 Use `slipway-coding-discipline` as a posture check when judging whether the
 implemented change stayed simple, surgical, and goal-driven.
 
@@ -59,6 +61,9 @@ implemented change stayed simple, surgical, and goal-driven.
   code gap or require the requirement prose to be tightened to match the built
   behavior. "Related tests exist" does not close this gap.
 - no spec requirement is silently dropped or deferred without explicit tracking
+- no uncertain mapping is silently accepted: unresolved `ambiguous` or
+  `uncheckable` spec-trace rows must remain coverage gaps and block or request
+  changes until resolved
 
 ### Reverse Alignment (Code -> Spec)
 - no undocumented features or behaviors
@@ -149,3 +154,5 @@ After confirmation, advance with `slipway run`; the engine re-resolves S3_REVIEW
 - Locked decisions are violated.
 - Claimed-complete work is still stubbed, placeholder-only, or assertion-free.
 - Requirement-named negative/error paths lack tests or runtime evidence.
+- Unresolved `ambiguous` or `uncheckable` trace rows remain in the spec-trace
+  matrix; they must not be treated as full bidirectional alignment.

--- a/internal/tmpl/templates/skills/spec-trace/CHECKLIST.tmpl
+++ b/internal/tmpl/templates/skills/spec-trace/CHECKLIST.tmpl
@@ -11,12 +11,25 @@
 ## Coverage matrix
 Produce one row per mapping, direction explicit. `status` is `covered`
 (spec item realized / hunk approved), `skipped` (spec item intentionally
-deferred with justification), or `drift` (hunk has no plan item).
+deferred with justification), `drift` (hunk has no plan item), `ambiguous`
+(available evidence points to multiple plausible mappings), or `uncheckable`
+(the reviewer cannot verify the mapping from available evidence).
 
-| direction | spec_item / diff_hunk | realized_by / plan_item | status |
-|-----------|------------------------|--------------------------|--------|
-| spec-to-code | "<quoted plan line>" | "<path:line or test>" | covered / skipped |
-| code-to-spec | "<path:line-range>" | "<quoted plan line>" | covered / drift |
+Rows marked `ambiguous` or `uncheckable` must include a reason and must be
+listed as coverage gaps, not counted as pass evidence. Use `ambiguous` when the
+evidence conflicts or maps to more than one plausible target. Use `uncheckable`
+when the reviewer cannot determine the mapping from accessible artifacts, code,
+or test output.
+
+| direction | spec_item / diff_hunk | realized_by / plan_item | status | reason |
+|-----------|------------------------|--------------------------|--------|--------|
+| spec-to-code | "<quoted plan line>" | "<path:line or test>" | covered / skipped / ambiguous / uncheckable | "<required for skipped, ambiguous, or uncheckable>" |
+| code-to-spec | "<path:line-range>" | "<quoted plan line>" | covered / drift / ambiguous / uncheckable | "<required for drift, ambiguous, or uncheckable>" |
+
+## Coverage gaps
+List every skipped, drift, ambiguous, or uncheckable row that is not full pass
+coverage. `ambiguous` and `uncheckable` gaps must stay visible until resolved;
+they are never silently promoted to `covered`.
 
 The matrix is the reviewable primary artifact; prose summaries substitute
 for it only when no rows would change after write-up.

--- a/internal/tmpl/templates/skills/spec-trace/SKILL.md
+++ b/internal/tmpl/templates/skills/spec-trace/SKILL.md
@@ -42,14 +42,24 @@ verdict: pass | changes-requested | blocked
 bottom_line: "<one-sentence summary>"
 spec_to_code:
   - spec_item: "<quoted plan line>"
+    status: covered | skipped | drift | ambiguous | uncheckable
     realized_by: "<path:line or test name>"
+    reason: "<why this mapping is ambiguous or uncheckable>"
   - spec_item: "<quoted plan line>"
+    status: skipped
     skipped_justification: "<reason reviewer accepted>"
 code_to_spec:
   - diff_hunk: "<path:line-range>"
+    status: covered | skipped | drift | ambiguous | uncheckable
     plan_item: "<quoted plan line>"
+    reason: "<why this mapping is ambiguous or uncheckable>"
   - diff_hunk: "<path:line-range>"
+    status: drift
     drift: "<why this is outside scope>"
+coverage_gaps:
+  - item: "<spec item or diff hunk>"
+    status: ambiguous | uncheckable
+    reason: "<why this mapping could not be verified>"
 scope_contract:
   status: pass | fail | not_applicable
   reference: "scope_contract:pass or scope_contract:fail:<reason>"
@@ -61,3 +71,5 @@ scope_contract:
 - Diff hunks accepted as "refactor" without a plan line to cite.
 - Changed files accepted despite `scope_contract:fail:<reason>` evidence.
 - Verdict `pass` when a skipped spec item has no justification.
+- Verdict `pass` when `ambiguous` or `uncheckable` rows remain unresolved or
+  are missing from `coverage_gaps`.

--- a/internal/tmpl/templates_test.go
+++ b/internal/tmpl/templates_test.go
@@ -1075,6 +1075,36 @@ func TestSpecComplianceReviewGuardsAgainstTestPresenceOverTrust(t *testing.T) {
 	assert.Contains(t, specTrace, "exercises the literal clause it maps to")
 }
 
+// TestSpecTraceRecordsUncheckableCoverageGaps pins issue #157: spec-trace must
+// provide a per-item uncertain status instead of forcing "could not check"
+// mappings into covered/skipped/drift, and spec-compliance-review must not pass
+// unresolved uncertainty as full bidirectional alignment.
+func TestSpecTraceRecordsUncheckableCoverageGaps(t *testing.T) {
+	t.Parallel()
+
+	data := map[string]string{"ToolID": "claude", "Trigger": "/slipway:test", "Description": "test"}
+
+	specTrace, err := Content("skills/spec-trace/SKILL.md")
+	require.NoError(t, err)
+	assert.Contains(t, specTrace, "status: covered | skipped | drift | ambiguous | uncheckable")
+	assert.Contains(t, specTrace, "reason: \"<why this mapping is ambiguous or uncheckable>\"")
+	assert.Contains(t, specTrace, "coverage_gaps:")
+
+	checklist, err := Content("skills/spec-trace/CHECKLIST.tmpl")
+	require.NoError(t, err)
+	assert.Contains(t, checklist, "`ambiguous`")
+	assert.Contains(t, checklist, "`uncheckable`")
+	assert.Contains(t, checklist, "must include a reason")
+	assert.Contains(t, checklist, "coverage gaps")
+
+	specCompliance, err := Render("skills/spec-compliance-review/SKILL.md.tmpl", data)
+	require.NoError(t, err)
+	normalizedSpecCompliance := strings.Join(strings.Fields(specCompliance), " ")
+	assert.Contains(t, specCompliance, "ambiguous` or `uncheckable`")
+	assert.Contains(t, specCompliance, "must not be treated as full bidirectional alignment")
+	assert.Contains(t, normalizedSpecCompliance, "block or request changes")
+}
+
 // TestSpecComplianceReviewTreatsPendingDecisionsAsAdvisory pins issue #140:
 // the Decision Fidelity Check must enforce fidelity only against
 // locked_decisions and treat pending_decisions (a recommended-but-unconfirmed


### PR DESCRIPTION
## Summary
- add spec-trace per-item ambiguous/uncheckable statuses with required reasons
- account uncertain rows as coverage gaps instead of pass evidence
- make spec-compliance-review fail closed when unresolved uncertainty remains
- archive governed change evidence for issue #157

Closes #157

## Verification
- go test ./internal/tmpl -run TestSpecTraceRecordsUncheckableCoverageGaps -count=1
- go test ./internal/tmpl ./internal/toolgen -count=1
- go test -count=1 ./...
- go build ./...
- go vet ./...
- git diff --check
- go run . validate --json
- go run . health --governance --json
- go run . done --json