### PR TITLE
feat(context): add thin-host disk handoff evidence

### DIFF
--- a/artifacts/changes/archived/resolve-github-issue-151-thin-host-disk-handoff-return-contr/change.yaml
+++ b/artifacts/changes/archived/resolve-github-issue-151-thin-host-disk-handoff-return-contr/change.yaml
@@ -1,0 +1,31 @@
+version: 1
+slug: resolve-github-issue-151-thin-host-disk-handoff-return-contr
+description: 'Resolve GitHub issue #151: thin-host disk-handoff return contract for heavy stages, with CLI-owned ingest/stamping and measurable host-context reduction'
+status: done
+current_state: DONE
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-06-10T12:12:57.572742Z
+quality_mode: standard
+workflow_preset: light
+worktree_branch: feat/resolve-github-issue-151-thin-host-disk-handoff-return-contr
+artifact_schema: core
+artifacts:
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: eab34f21d3961cc63e144ae93437572cb3314b24891660b0d9d3716fb8865efa
+        updated_at: 2026-06-10T12:14:49.067438119Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: 55568889893f77ad97b3554bd612b5209b24b56cbe15a0d24caa4997e70becb5
+        updated_at: 2026-06-10T12:55:41.10454884Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: ba7d23393e0a727662ee75e0ad7848a4b6bcd5c16cc238a3f9bee65107d872ba
+        updated_at: 2026-06-10T13:09:07.112578668Z

--- a/artifacts/changes/archived/resolve-github-issue-151-thin-host-disk-handoff-return-contr/intent.md
+++ b/artifacts/changes/archived/resolve-github-issue-151-thin-host-disk-handoff-return-contr/intent.md
@@ -1,0 +1,77 @@
+# Intent
+
+## Summary
+Resolve GitHub issue #151: thin-host disk-handoff return contract for heavy stages, with CLI-owned ingest/stamping and measurable host-context reduction
+## Complexity Assessment
+complex
+
+Issue #151 affects governed host instructions, evidence ingestion semantics,
+and fail-closed freshness guarantees across heavy lifecycle stages. The change
+is not sensitive-domain work, but it touches AI-facing workflow contracts and
+must keep engine-owned stamping authority intact.
+
+## Guardrail Domains
+None detected.
+
+## In Scope
+- Resolve the remaining issue #151 scope for heavy stages not already covered
+  by issue #114: `research-orchestration`, `plan-audit`,
+  `intake-clarification`, `spec-compliance-review`, and
+  `code-quality-review`.
+- Introduce or extend a disk-handoff contract where a subagent writes bulky
+  artifacts under `artifacts/changes/<slug>/` and returns only a short
+  confirmation to the thin host.
+- Keep evidence freshness, run versions, timestamps, and pass/fail stamping
+  owned by Slipway CLI ingestion/verification flows rather than by subagent
+  self-attestation.
+- Pass heavy context by paths or required-reading references instead of
+  inlining large artifact bodies where the stage can operate through a
+  disk-handoff.
+- Use the local `ghq` checkout of `gsd` as an implementation reference during
+  coding, without copying its workflow wholesale.
+- Add focused regression coverage proving the contract wording and
+  fail-closed ingest/stamping boundary.
+
+## Out of Scope
+- Reworking stages already covered by issue #114 unless needed for shared
+  consistency.
+- Copying GSD command or agent prompts directly into Slipway.
+- Replacing the existing governed lifecycle, stage model, or freshness engine.
+- Running `slipway done`; this goal stops at `done-ready`.
+
+## Constraints
+- Source-of-truth edits for generated skill surfaces belong under
+  `internal/tmpl/templates/skills/`.
+- Host-facing text must remain thin and path-oriented; detailed per-stage
+  instructions should stay in adjacent references or generated command/skill
+  surfaces.
+- The plan does not need a separate GSD research artifact; the local GSD
+  checkout is an implementation reference.
+- Any evidence ingest/stamp path must fail closed when evidence is stale,
+  forged, or missing CLI-owned freshness fields.
+
+## Acceptance Signals
+- At least one remaining heavy stage is refactored to an explicit
+  disk-handoff thin-host contract, with tests pinning the contract.
+- The relevant host context is measurably reduced or bounded by path references
+  instead of pasted artifact bodies.
+- Regression coverage proves subagent confirmation is only a claim and that
+  CLI-owned ingestion/verification remains the evidence authority.
+- Fresh `go test -count=1 ./...` passes.
+- Fresh `go run . validate --json` and lifecycle checks advance the governed
+  change to `done_ready`.
+
+## Open Questions
+None.
+
+## Deferred Ideas
+- Generalized multi-stage digest surfaces beyond the minimum needed to resolve
+  issue #151.
+- Broad host-token telemetry outside the changed stage contracts.
+
+## Approved Summary
+Confirmed by the user objective on 2026-06-10: use the governed Slipway flow to
+resolve all problems in GitHub issue #151 through `done-ready`; when blocked,
+make the best scope-preserving choice; reference the local `ghq` checkout of
+`gsd` during implementation, while keeping the governed plan independent of a
+separate GSD planning exercise.

--- a/artifacts/changes/archived/resolve-github-issue-151-thin-host-disk-handoff-return-contr/requirements.md
+++ b/artifacts/changes/archived/resolve-github-issue-151-thin-host-disk-handoff-return-contr/requirements.md
@@ -1,0 +1,68 @@
+# Requirements
+
+## Requirements
+
+### Requirement: Remaining heavy stages expose a disk-handoff contract
+REQ-001: The system MUST update the remaining heavy governed host stages from
+issue #151 (`research-orchestration`, `plan-audit`, `intake-clarification`,
+`spec-compliance-review`, and `code-quality-review`) so their authored skill
+surfaces describe a thin-host disk-handoff contract for bulky artifacts.
+
+#### Scenario: Heavy stage delegates bulky artifact authoring by path
+GIVEN a governed host stage needs research notes, plan audit notes, intake
+summary, or review findings that may be large
+WHEN an AI agent follows the generated host skill surface
+THEN the host is instructed to keep bulky content out of the coordinator
+context and use path-based disk handoff under `artifacts/changes/<slug>/`.
+
+### Requirement: Subagent confirmations are not evidence
+REQ-002: The system MUST state that a subagent's short return is only a claim
+and that evidence verdicts, run versions, timestamps, freshness inputs, and
+stamping remain owned by Slipway CLI ingestion or verification flows.
+
+#### Scenario: Forged or stale handoff cannot pass by prose
+GIVEN a subagent writes an artifact and returns a short completion line
+WHEN the host records governed evidence for that stage
+THEN the host is required to use the supported Slipway evidence/review or
+verification path, and must not treat the subagent line as a pass verdict.
+
+#### Scenario: CLI stamps skill verification evidence
+GIVEN a host has inspected a delegated artifact and needs to record a governance
+skill verdict
+WHEN it records the result through `slipway evidence skill`
+THEN Slipway writes the verification record with CLI-owned timestamp and
+`run_version` fields and refreshes the evidence digest for passing records.
+
+### Requirement: Host context stays bounded through required-reading paths
+REQ-003: The system MUST direct hosts to pass context as required-reading paths
+or structured summaries instead of pasted artifact bodies wherever disk handoff
+is available.
+
+#### Scenario: Review host receives large diff or artifact context
+GIVEN a review host needs to inspect a large diff, governed artifact bundle, or
+command output
+WHEN it prepares work for an isolated reviewer or subagent
+THEN the handoff names the relevant files or commands to read and keeps the
+coordinator response bounded to a short digest or confirmation.
+
+### Requirement: Regression coverage pins the issue #151 contract
+REQ-004: The system MUST include focused regression coverage that fails when
+the remaining heavy stage templates omit the disk-handoff, short-confirmation,
+or CLI-owned stamping boundary required by issue #151.
+
+#### Scenario: Template contract drifts back to inline-heavy instructions
+GIVEN a future edit removes disk-handoff guidance from one of the remaining
+heavy stage templates
+WHEN the focused template tests run
+THEN the tests fail before generated surfaces can regress silently.
+
+### Requirement: Governed readiness proves completion
+REQ-005: The change MUST reach Slipway `done_ready` with fresh current-worktree
+evidence and without running `slipway done`.
+
+#### Scenario: Issue #151 implementation is ready but not finalized
+GIVEN the implementation and regression tests are complete
+WHEN `go test -count=1 ./...` and governed lifecycle checks are run from the
+active worktree
+THEN the repository tests pass and Slipway reports the active change as
+`done_ready`.

--- a/artifacts/changes/archived/resolve-github-issue-151-thin-host-disk-handoff-return-contr/tasks.md
+++ b/artifacts/changes/archived/resolve-github-issue-151-thin-host-disk-handoff-return-contr/tasks.md
@@ -1,0 +1,31 @@
+# Tasks
+
+## Task List
+
+- [x] `t-01` Add failing template regressions for remaining heavy-stage disk handoff.
+  - wave: 1
+  - depends_on: []
+  - target_files: [cmd/evidence_task_test.go, internal/tmpl/thin_host_content_test.go, internal/tmpl/templates_test.go]
+  - task_kind: test
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004]
+
+- [x] `t-02` Update remaining heavy stage authored skill surfaces with path-based disk-handoff and short-confirmation guidance.
+  - wave: 2
+  - depends_on: [t-01]
+  - target_files: [cmd/evidence.go, internal/state/verification.go, internal/tmpl/templates/skills/research-orchestration/SKILL.md, internal/tmpl/templates/skills/plan-audit/SKILL.md, internal/tmpl/templates/skills/intake-clarification/SKILL.md, internal/tmpl/templates/skills/spec-compliance-review/SKILL.md.tmpl, internal/tmpl/templates/skills/code-quality-review/SKILL.md.tmpl, internal/toolgen/toolgen.go]
+  - task_kind: code
+  - covers: [REQ-001, REQ-002, REQ-003]
+
+- [x] `t-03` Prove the template contract and generated-surface behavior with targeted and package-level tests.
+  - wave: 3
+  - depends_on: [t-02]
+  - target_files: [cmd/evidence_task_test.go, internal/state/verification_test.go, internal/tmpl/thin_host_content_test.go, internal/tmpl/templates_test.go, internal/toolgen/toolgen_test.go]
+  - task_kind: test
+  - covers: [REQ-004]
+
+- [x] `t-04` Run implementation verification commands and record execution evidence for governed review handoff.
+  - wave: 4
+  - depends_on: [t-03]
+  - target_files: [cmd/evidence_task_test.go, internal/state/verification_test.go, internal/tmpl/thin_host_content_test.go, internal/tmpl/templates_test.go, artifacts/codebase/ARCHITECTURE.md, artifacts/codebase/CONCERNS.md, artifacts/codebase/STRUCTURE.md, artifacts/codebase/TESTING.md, artifacts/changes/resolve-github-issue-151-thin-host-disk-handoff-return-contr/verification/execution-summary.yaml]
+  - task_kind: test
+  - covers: [REQ-005]

--- a/artifacts/codebase/ARCHITECTURE.md
+++ b/artifacts/codebase/ARCHITECTURE.md
@@ -1,39 +1,39 @@
 # Architecture
 
-Re-authored for change `resolve-github-issue-157-add-uncheckable-inconclusive-per-it`
-(GitHub issue #157).
+Re-authored for change
+`resolve-github-issue-151-thin-host-disk-handoff-return-contr`
+(GitHub issue #151).
 
-Question: where should per-item ambiguous/uncheckable spec verification status
-be expressed so "could not check" is auditable and never silently passes?
+Question: how should remaining heavy governed hosts adopt a disk-handoff
+contract without letting subagents self-stamp evidence?
 
-- Affected modules:
-  - `internal/tmpl/templates/skills/spec-trace/SKILL.md:39` defines the
-    spec-trace report schema consumed by review users.
-  - `internal/tmpl/templates/skills/spec-trace/CHECKLIST.tmpl:11` defines the
-    mandatory coverage matrix and currently limits item status to
-    `covered`, `skipped`, and `drift`.
-  - `internal/tmpl/templates/skills/spec-compliance-review/SKILL.md.tmpl:43`
-    tells reviewers to use the attached spec-trace checklist while performing
-    Stage 1 governed review.
-  - `internal/tmpl/templates_test.go:1041` already pins review-template contract
-    wording, making it the focused regression-test seam for this change.
-  - `internal/toolgen/toolgen.go:254` and `internal/toolgen/toolgen.go:369`
-    export governance/technique skills; spec-trace is an exported technique
-    helper rather than a lifecycle-owned host.
+- Affected host surfaces:
+  - `internal/tmpl/templates/skills/research-orchestration/SKILL.md:23`
+    currently asks the host to read governed artifacts directly and later
+    author `research.md`.
+  - `internal/tmpl/templates/skills/plan-audit/SKILL.md:18` owns S1 plan bundle
+    audit and writes `verification/plan-audit.yaml`.
+  - `internal/tmpl/templates/skills/intake-clarification/SKILL.md:20` owns
+    intent clarification and writes `verification/intake-clarification.yaml`.
+  - `internal/tmpl/templates/skills/spec-compliance-review/SKILL.md.tmpl` and
+    `internal/tmpl/templates/skills/code-quality-review/SKILL.md.tmpl` are the
+    S3 review hosts that produce review certificates.
+- Established thin-host precedent:
+  - `internal/tmpl/thin_host_content_test.go:11` already pins
+    goal-verification delegation for bulky evidence.
+  - `internal/tmpl/thin_host_content_test.go:37` pins worktree-preflight bounded
+    baseline summaries.
+  - `internal/tmpl/thin_host_content_test.go:56` pins wave-orchestration
+    path-based delegation and executor-owned codebase-map reads.
 - Dependency flow:
   - Authored templates under `internal/tmpl/templates/skills/...` are the source
     of truth.
-  - Template rendering tests read authored content directly or render `.tmpl`
-    files and assert required contract text.
-  - Tool generation exports the authored skill surfaces; this change should not
-    edit generated copies directly.
-- Coupling hotspots:
-  - `spec-compliance-review` depends on spec-trace for the trace matrix contract,
-    so changing spec-trace wording is the main architectural fix.
-  - Adding runtime parsing or schema validation would widen the blast radius into
-    engine capability and verification-state code; Issue #157 explicitly steers
-    away from engine prose heuristics.
+  - `internal/tmpl` renders static and templated skill content for tests and
+    generated exports.
+  - Evidence authority remains in Slipway CLI and governed verification files;
+    template prose must not introduce a bypass where a subagent return line
+    becomes evidence.
 - Blast radius:
-  - Low implementation blast radius: authored skill templates and focused tests.
-  - Higher workflow semantics sensitivity: the wording controls how review
-    agents classify uncertain mappings in governed review.
+  - Medium to high workflow semantics: five host surfaces are touched, but the
+    implementation should stay in template contracts and tests rather than
+    runtime lifecycle state.

--- a/artifacts/codebase/CONCERNS.md
+++ b/artifacts/codebase/CONCERNS.md
@@ -1,22 +1,20 @@
 # Concerns
 
-Re-authored for change `resolve-github-issue-157-add-uncheckable-inconclusive-per-it`
-(GitHub issue #157).
+Re-authored for change
+`resolve-github-issue-151-thin-host-disk-handoff-return-contr`
+(GitHub issue #151).
 
-- Load-bearing invariant: review guidance must not allow unverifiable trace
-  mappings to be converted into `pass` evidence. Current
-  `spec-trace/CHECKLIST.tmpl:12` only names `covered`, `skipped`, and `drift`,
-  which leaves no explicit bucket for a mapping the reviewer could not check.
-- Guardrail risk: the change is classified as `external_api_contracts`; review
-  evidence must fail closed. `spec-compliance-review/SKILL.md.tmpl:103` already
-  has an R3 review layer for guardrail domains, so new guidance should align
-  with that stage rather than bypass it.
-- Compatibility risk: changing vocabulary too broadly could invalidate existing
-  review habits. The safer path is to extend the matrix with `ambiguous` and
-  `uncheckable` while keeping existing `covered`, `skipped`, and `drift`
-  semantics.
-- Overengineering risk: runtime row parsing would add engine behavior that
-  Issue #157 says to avoid. Keep this change at the skill-output-contract layer.
-- Testing risk: tests that only assert one phrase can miss the full contract.
-  Regression assertions should cover the new statuses, required reasons,
-  coverage-gap accounting, and pass-blocking semantics.
+- Load-bearing invariant: Slipway CLI owns evidence freshness, run versions,
+  timestamps, and pass/fail stamping. A subagent's return line must remain a
+  claim until the host records or validates evidence through supported Slipway
+  paths.
+- Context risk: updating only one host would satisfy the issue's minimum
+  acceptance but leave the named remaining heavy stages inconsistent. The plan
+  should cover all five named hosts while keeping implementation at the template
+  contract layer.
+- Overengineering risk: adding a new runtime evidence-ingest subsystem would
+  widen the change beyond the issue's acceptance signal. Prefer explicit host
+  contracts and tests unless implementation proves a runtime gap is necessary.
+- Test risk: phrase-only tests can pass while the fail-closed boundary regresses.
+  Regression coverage should assert the three-part contract: disk artifact
+  handoff, short confirmation, and CLI-owned stamping/freshness.

--- a/artifacts/codebase/STRUCTURE.md
+++ b/artifacts/codebase/STRUCTURE.md
@@ -1,16 +1,26 @@
 # Structure
 
-- `internal/tmpl/templates/skills/spec-trace/`
-  - `SKILL.md`: frontmatter, purpose, report schema, anti-patterns.
-  - `CHECKLIST.tmpl`: attached checklist and coverage matrix.
-- `internal/tmpl/templates/skills/spec-compliance-review/`
-  - `SKILL.md.tmpl`: Stage 1 review host instructions that embed spec-trace
-    guidance.
-  - `references/checklist-quality.md`: adjacent reference read by the host.
+Re-authored for change
+`resolve-github-issue-151-thin-host-disk-handoff-return-contr`
+(GitHub issue #151).
+
+- `internal/tmpl/templates/skills/research-orchestration/SKILL.md`
+  - Static governed host for discovery/research artifacts.
+- `internal/tmpl/templates/skills/plan-audit/SKILL.md`
+  - Static governed host for S1 plan readiness and plan-audit evidence.
+- `internal/tmpl/templates/skills/intake-clarification/SKILL.md`
+  - Static governed host for S0 intent clarification evidence.
+- `internal/tmpl/templates/skills/spec-compliance-review/SKILL.md.tmpl`
+  - Templated governed host for S3 spec compliance review.
+- `internal/tmpl/templates/skills/code-quality-review/SKILL.md.tmpl`
+  - Templated governed host for S3 code quality review.
+- `internal/tmpl/thin_host_content_test.go`
+  - Focused thin-host regression tests for issue #114-style bounded host
+    contracts.
 - `internal/tmpl/templates_test.go`
-  - Existing focused regression area for template contract wording.
-- `internal/toolgen/`
-  - Exports governance and technique skill surfaces; expected to remain
-    structurally unchanged for this issue.
-- `artifacts/changes/resolve-github-issue-157-add-uncheckable-inconclusive-per-it/`
+  - Broader template rendering and generated-contract regression tests.
+- `internal/toolgen/toolgen_test.go`
+  - Exported skill generation coverage; useful if issue #151 changes must be
+    proven after tool generation.
+- `artifacts/changes/resolve-github-issue-151-thin-host-disk-handoff-return-contr/`
   - Governed artifact bundle and verification evidence for this change.

--- a/artifacts/codebase/TESTING.md
+++ b/artifacts/codebase/TESTING.md
@@ -1,21 +1,30 @@
 # Testing
 
-- Existing coverage:
-  - `internal/tmpl/templates_test.go:1041` verifies review-template guidance for
-    negative-path evidence.
-  - `internal/tmpl/templates_test.go:1063` verifies spec-compliance-review and
-    spec-trace contract wording around literal clause coverage.
-  - `internal/tmpl/templates_test.go:1082` verifies pending-decision guidance.
-  - `internal/toolgen/toolgen_test.go:1718` verifies generated skill typed parts
-    include the expected spec-trace checklist section.
-- Gap for Issue #157:
-  - No focused regression currently asserts `ambiguous` or `uncheckable` item
-    statuses, required reasons, or coverage-gap accounting in spec-trace.
-  - No focused regression currently asserts spec-compliance-review blocks pass
-    claims when unresolved ambiguity remains.
+Re-authored for change
+`resolve-github-issue-151-thin-host-disk-handoff-return-contr`
+(GitHub issue #151).
+
+- Existing focused coverage:
+  - `internal/tmpl/thin_host_content_test.go:11` verifies
+    goal-verification thin-host delegation and host-owned verdict language.
+  - `internal/tmpl/thin_host_content_test.go:37` verifies worktree-preflight
+    keeps only bounded baseline summaries.
+  - `internal/tmpl/thin_host_content_test.go:56` verifies wave-orchestration
+    delegates source/map reads by path to task executors.
+  - `internal/tmpl/templates_test.go:17` verifies governance skills render and
+    keep required host sections.
+  - `internal/tmpl/templates_test.go:781` verifies run-version source language
+    for review and verification hosts.
+- Gap for issue #151:
+  - No focused regression currently asserts disk-handoff guidance for the
+    remaining heavy hosts named by the issue:
+    `research-orchestration`, `plan-audit`, `intake-clarification`,
+    `spec-compliance-review`, and `code-quality-review`.
+  - No focused regression currently asserts that a short subagent confirmation
+    is a claim, not evidence, across those remaining hosts.
 - Planned verification:
-  - Add a targeted failing test in `internal/tmpl/templates_test.go` before
-    template edits.
-  - Run the targeted test after edits.
-  - Run broader relevant tests (`go test ./internal/tmpl ./internal/toolgen`),
-    then full repository verification before closeout.
+  - Add a failing test that renders/loads the five remaining heavy host
+    surfaces and asserts path-based disk handoff, short confirmation, and
+    CLI-owned stamping/freshness language.
+  - Run the targeted test first, then `go test -count=1 ./internal/tmpl`, and
+    finish with `go test -count=1 ./...` before closeout.

--- a/cmd/evidence.go
+++ b/cmd/evidence.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/signalridge/slipway/internal/engine/progression"
+	"github.com/signalridge/slipway/internal/engine/skill"
 	"github.com/signalridge/slipway/internal/fsutil"
 	"github.com/signalridge/slipway/internal/model"
 	"github.com/signalridge/slipway/internal/state"
@@ -25,12 +26,209 @@ type evidenceTaskView struct {
 	FreshnessInputs   model.ExecutionTaskFreshnessInputs `json:"freshness_inputs"`
 }
 
+type evidenceSkillView struct {
+	Slug       string   `json:"slug"`
+	Skill      string   `json:"skill"`
+	RunVersion int      `json:"run_version"`
+	Path       string   `json:"path"`
+	Recorded   bool     `json:"recorded"`
+	Stamped    bool     `json:"stamped"`
+	References []string `json:"references,omitempty"`
+}
+
 func makeEvidenceCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "evidence",
 		Short: desc("evidence"),
 	}
 	cmd.AddCommand(makeEvidenceTaskCmd())
+	cmd.AddCommand(makeEvidenceSkillCmd())
+	return cmd
+}
+
+func makeEvidenceSkillCmd() *cobra.Command {
+	var (
+		jsonOutput bool
+		changeSlug string
+		skillName  string
+		verdictRaw string
+		references []string
+		blockers   []string
+		notes      string
+		notesFile  string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "skill",
+		Short: "Record CLI-stamped governance skill verification evidence",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			root, err := projectRootFromCommand(cmd)
+			if err != nil {
+				return err
+			}
+			ref, err := resolveActiveChangeRef(root, changeSlug)
+			if err != nil {
+				return err
+			}
+
+			return withChangeStateLock(root, ref.Slug, "evidence skill", func() error {
+				change, err := loadActiveChange(
+					root,
+					ref.Slug,
+					"cannot record skill evidence for governed status %q",
+					"Skill evidence can only be recorded for an active governed change.",
+				)
+				if err != nil {
+					return err
+				}
+
+				skillName = strings.TrimSpace(skillName)
+				def, err := validateEvidenceSkillName(root, skillName)
+				if err != nil {
+					return err
+				}
+				if err := validateEvidenceSkillStage(change, def); err != nil {
+					return err
+				}
+
+				verdict := strings.TrimSpace(verdictRaw)
+				switch verdict {
+				case model.VerificationVerdictPass, model.VerificationVerdictFail:
+				case "":
+					return newInvalidUsageError(
+						"evidence_skill_verdict_required",
+						"--verdict is required",
+						"Pass pass or fail.",
+						nil,
+					)
+				default:
+					return newInvalidUsageError(
+						"evidence_skill_verdict_invalid",
+						fmt.Sprintf("invalid skill verdict: %q", verdict),
+						"Pass pass or fail.",
+						map[string]any{"verdict": verdict},
+					)
+				}
+
+				blockerCodes := model.ReasonCodesFromSpecs(blockers)
+				for i, blocker := range blockerCodes {
+					if err := blocker.Validate(); err != nil {
+						return newInvalidUsageError(
+							"evidence_skill_blocker_invalid",
+							fmt.Sprintf("blocker %d is invalid: %v", i, err),
+							"Pass blockers as code or code:detail values.",
+							nil,
+						)
+					}
+				}
+				if verdict == model.VerificationVerdictPass && len(blockerCodes) > 0 {
+					return newInvalidUsageError(
+						"evidence_skill_pass_with_blockers",
+						"pass verdict cannot include blockers",
+						"Use --verdict fail when blockers are present, or remove --blocker values.",
+						nil,
+					)
+				}
+
+				notesText, err := resolveEvidenceSkillNotes(root, notes, notesFile)
+				if err != nil {
+					return err
+				}
+				runVersion, err := evidenceSkillRunVersion(root, change, def)
+				if err != nil {
+					return err
+				}
+				references = stringutil.UniqueSorted(trimNonEmptyStrings(references))
+				record := model.VerificationRecord{
+					Verdict:    verdict,
+					Blockers:   blockerCodes,
+					Timestamp:  time.Now().UTC(),
+					RunVersion: runVersion,
+					References: references,
+					Notes:      notesText,
+				}
+				path, err := state.SaveVerification(root, change.Slug, skillName, record)
+				if err != nil {
+					return newStateIntegrityError(
+						"evidence_skill_write_failed",
+						fmt.Sprintf("failed to write %s verification evidence: %v", skillName, err),
+						"Fix the verification record inputs and rerun `slipway evidence skill`.",
+						change.Slug,
+						map[string]any{"skill": skillName},
+					)
+				}
+
+				stamped := false
+				if record.IsPassing() {
+					summary, err := state.LoadOptionalRelevantExecutionSummary(root, change)
+					if err != nil {
+						return newStateIntegrityError(
+							"evidence_skill_execution_summary_load_failed",
+							fmt.Sprintf("failed to load execution summary for %q: %v", change.Slug, err),
+							"Repair execution-summary.yaml or record non-passing skill evidence.",
+							change.Slug,
+							nil,
+						)
+					}
+					if err := progression.StampEvidenceDigestForSkill(root, change, skillName, record, summary); err != nil {
+						return newStateIntegrityError(
+							"evidence_skill_digest_stamp_failed",
+							fmt.Sprintf("failed to stamp %s evidence digest: %v", skillName, err),
+							"Resolve missing or stale digest inputs before recording passing skill evidence.",
+							change.Slug,
+							map[string]any{"skill": skillName},
+						)
+					}
+					stamped = true
+				}
+
+				if err := appendCLILifecycleEvent(root, change, state.LifecycleEvent{
+					Command:     "evidence skill",
+					EventType:   "skill.evidence_recorded",
+					Action:      "recorded",
+					Result:      verdict,
+					BeforeState: change.CurrentState,
+					AfterState:  change.CurrentState,
+					SkillID:     skillName,
+					Diagnostics: []string{
+						fmt.Sprintf("skill=%s", skillName),
+						fmt.Sprintf("run_version=%d", runVersion),
+						"path=" + state.DisplayPath(root, path),
+					},
+				}); err != nil {
+					return err
+				}
+
+				view := evidenceSkillView{
+					Slug:       change.Slug,
+					Skill:      skillName,
+					RunVersion: runVersion,
+					Path:       state.DisplayPath(root, path),
+					Recorded:   true,
+					Stamped:    stamped,
+					References: references,
+				}
+				if jsonOutput {
+					return encodeJSONResponse(cmd, view)
+				}
+
+				writer := newFormatWriter(cmd.OutOrStdout())
+				writer.Writef("Skill evidence recorded: %s\n", view.Path)
+				return writer.Err()
+			})
+		},
+	}
+
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "JSON output")
+	addChangeSelectorFlags(cmd, &changeSlug, "Explicit change slug")
+	cmd.Flags().StringVar(&skillName, "skill", "", "Governance skill name, for example spec-compliance-review (required)")
+	cmd.Flags().StringVar(&verdictRaw, "verdict", "", "Skill verdict: pass or fail (required)")
+	cmd.Flags().StringArrayVar(&references, "reference", nil, "Verification reference token; may be repeated")
+	cmd.Flags().StringArrayVar(&blockers, "blocker", nil, "Verification blocker as code or code:detail; may be repeated")
+	cmd.Flags().StringVar(&notes, "notes", "", "Bounded verification notes")
+	cmd.Flags().StringVar(&notesFile, "notes-file", "", "Workspace-relative file containing verification notes")
+
 	return cmd
 }
 
@@ -314,6 +512,145 @@ func makeEvidenceTaskCmd() *cobra.Command {
 	cmd.Flags().StringVar(&sessionID, "session-id", "", "Optional executor session identifier")
 
 	return cmd
+}
+
+func validateEvidenceSkillName(root, skillName string) (skill.Definition, error) {
+	if skillName == "" {
+		return skill.Definition{}, newInvalidUsageError(
+			"evidence_skill_required",
+			"--skill is required",
+			"Pass a governance skill name such as plan-audit or spec-compliance-review.",
+			nil,
+		)
+	}
+	if strings.ContainsAny(skillName, `/\`) || skillName == "." || skillName == ".." {
+		return skill.Definition{}, newInvalidUsageError(
+			"evidence_skill_invalid",
+			fmt.Sprintf("skill must be a safe governance skill name: %q", skillName),
+			"Pass a governance skill name without path separators.",
+			map[string]any{"skill": skillName},
+		)
+	}
+	registry, err := skill.LoadGovernanceRegistry(root)
+	if err != nil {
+		return skill.Definition{}, newStateIntegrityError(
+			"evidence_skill_registry_load_failed",
+			fmt.Sprintf("failed to load governance skill registry: %v", err),
+			"Repair generated governance skill metadata and retry.",
+			"",
+			nil,
+		)
+	}
+	def, ok := skill.LookupDefinitionInRegistry(registry, skillName)
+	if !ok {
+		return skill.Definition{}, newInvalidUsageError(
+			"evidence_skill_unknown",
+			fmt.Sprintf("unknown governance skill %q", skillName),
+			"Use a governance skill registered in the active Slipway skill registry.",
+			map[string]any{"skill": skillName},
+		)
+	}
+	return def, nil
+}
+
+func evidenceSkillRunVersion(root string, change model.Change, def skill.Definition) (int, error) {
+	if !def.RunSummaryBound {
+		return 0, nil
+	}
+	summary, err := state.LoadOptionalRelevantExecutionSummary(root, change)
+	if err != nil {
+		return 0, newStateIntegrityError(
+			"evidence_skill_execution_summary_load_failed",
+			fmt.Sprintf("failed to load execution summary for %q: %v", change.Slug, err),
+			"Repair execution-summary.yaml before recording run-summary-bound skill evidence.",
+			change.Slug,
+			nil,
+		)
+	}
+	if summary == nil || summary.RunSummaryVersion < 1 {
+		return 0, newInvalidUsageError(
+			"evidence_skill_run_summary_missing",
+			fmt.Sprintf("%s evidence requires execution-summary.yaml with run_summary_version >= 1", def.Name),
+			"Run wave execution first so Slipway can bind this verification to the current execution summary.",
+			map[string]any{"skill": def.Name},
+		)
+	}
+	return summary.RunSummaryVersion, nil
+}
+
+func validateEvidenceSkillStage(change model.Change, def skill.Definition) error {
+	if change.CurrentState != def.State {
+		return newInvalidUsageError(
+			"evidence_skill_wrong_state",
+			fmt.Sprintf("%s evidence requires %s state, current: %s", def.Name, def.State, change.CurrentState),
+			fmt.Sprintf("Run the lifecycle to %s before recording %s evidence.", def.State, def.Name),
+			map[string]any{
+				"skill":    def.Name,
+				"expected": def.State,
+				"current":  change.CurrentState,
+			},
+		)
+	}
+	if def.State == model.StateS1Plan && def.PlanSubStep != model.PlanSubStepNone && change.PlanSubStep != def.PlanSubStep {
+		return newInvalidUsageError(
+			"evidence_skill_wrong_plan_substep",
+			fmt.Sprintf("%s evidence requires S1_PLAN/%s, current substep: %s", def.Name, def.PlanSubStep, change.PlanSubStep),
+			fmt.Sprintf("Run the lifecycle to S1_PLAN/%s before recording %s evidence.", def.PlanSubStep, def.Name),
+			map[string]any{
+				"skill":    def.Name,
+				"expected": def.PlanSubStep,
+				"current":  change.PlanSubStep,
+			},
+		)
+	}
+	return nil
+}
+
+func resolveEvidenceSkillNotes(root, notes, notesFile string) (string, error) {
+	notes = strings.TrimSpace(notes)
+	notesFile = strings.TrimSpace(notesFile)
+	if notes != "" && notesFile != "" {
+		return "", newInvalidUsageError(
+			"evidence_skill_notes_conflict",
+			"pass either --notes or --notes-file, not both",
+			"Use --notes for a bounded inline summary or --notes-file for a disk handoff.",
+			nil,
+		)
+	}
+	if notesFile == "" {
+		return notes, nil
+	}
+	if err := validateEvidencePath(notesFile); err != nil {
+		return "", newInvalidUsageError(
+			"evidence_skill_notes_file_invalid",
+			err.Error(),
+			"Pass a workspace-relative notes file path without absolute paths, empty segments, or parent traversal.",
+			nil,
+		)
+	}
+	path := filepath.Join(root, filepath.FromSlash(model.NormalizePublicPath(notesFile)))
+	raw, err := os.ReadFile(path) // #nosec G304 -- path is validated as workspace-relative before reading.
+	if err != nil {
+		return "", newStateIntegrityError(
+			"evidence_skill_notes_file_read_failed",
+			fmt.Sprintf("failed to read notes file %q: %v", notesFile, err),
+			"Write the delegated review or verification notes to the referenced workspace-relative path and retry.",
+			"",
+			map[string]any{"path": notesFile},
+		)
+	}
+	return strings.TrimSpace(string(raw)), nil
+}
+
+func trimNonEmptyStrings(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
 }
 
 func validateEvidenceTaskID(taskID string) error {

--- a/cmd/evidence_task_test.go
+++ b/cmd/evidence_task_test.go
@@ -93,6 +93,136 @@ func TestEvidenceTaskRecordsRuntimeEvidenceAndBuildsExecutionSummary(t *testing.
 	})
 }
 
+func TestEvidenceSkillRecordsCLIStampedVerificationAndDigest(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		slug, change := createEvidenceTaskFixture(t, root)
+		writePassingExecutionSummary(t, root, slug, 2, "t-01")
+		writePassingWaveEvidence(t, root, slug, 2)
+		change.CurrentState = model.StateS3Review
+		require.NoError(t, state.SaveChange(root, change))
+
+		notesPath := filepath.Join(root, "review-notes.md")
+		require.NoError(t, os.WriteFile(notesPath, []byte("review notes from disk\n"), 0o644))
+
+		cmd := commandForRoot(t, root, makeEvidenceCmd())
+		cmd.SetArgs([]string{
+			"skill",
+			"--json",
+			"--skill", progression.SkillSpecComplianceReview,
+			"--verdict", "pass",
+			"--reference", "layer:R0=pass",
+			"--reference", "scope_contract:pass",
+			"--notes-file", "review-notes.md",
+		})
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		require.NoError(t, cmd.Execute())
+
+		var view evidenceSkillView
+		require.NoError(t, json.Unmarshal(out.Bytes(), &view))
+		assert.Equal(t, slug, view.Slug)
+		assert.Equal(t, progression.SkillSpecComplianceReview, view.Skill)
+		assert.Equal(t, 2, view.RunVersion)
+		assert.True(t, view.Recorded)
+		assert.True(t, view.Stamped)
+		assert.Contains(t, view.Path, "verification/"+progression.SkillSpecComplianceReview+".yaml")
+
+		rec, err := state.LoadVerification(root, slug, progression.SkillSpecComplianceReview)
+		require.NoError(t, err)
+		assert.Equal(t, model.VerificationVerdictPass, rec.Verdict)
+		assert.Equal(t, 2, rec.RunVersion)
+		assert.False(t, rec.Timestamp.IsZero())
+		assert.Equal(t, "review notes from disk", rec.Notes)
+		assert.Equal(t, []string{"layer:R0=pass", "scope_contract:pass"}, rec.References)
+
+		digests, err := state.LoadOptionalEvidenceDigestsForChange(root, change)
+		require.NoError(t, err)
+		require.NotNil(t, digests)
+		assert.Contains(t, digests.Skills, progression.SkillSpecComplianceReview)
+	})
+}
+
+func TestEvidenceSkillRejectsUnknownSkillWithoutWritingEvidence(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		slug, _ := createEvidenceTaskFixture(t, root)
+
+		cmd := commandForRoot(t, root, makeEvidenceCmd())
+		cmd.SetArgs([]string{
+			"skill",
+			"--skill", "../escape",
+			"--verdict", "pass",
+		})
+		err := cmd.Execute()
+		cliErr := asCLIError(err)
+		require.NotNil(t, cliErr)
+		assert.Equal(t, "evidence_skill_invalid", cliErr.ErrorCode)
+
+		_, statErr := os.Stat(state.VerificationFilePath(root, slug, "../escape"))
+		require.Error(t, statErr)
+	})
+}
+
+func TestEvidenceSkillRejectsRunSummaryBoundSkillWithoutExecutionSummary(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		slug := createGovernedRequest(t, root, "L2", "skill evidence command")
+		change, err := state.LoadChange(root, slug)
+		require.NoError(t, err)
+		change.CurrentState = model.StateS3Review
+		require.NoError(t, state.SaveChange(root, change))
+
+		cmd := commandForRoot(t, root, makeEvidenceCmd())
+		cmd.SetArgs([]string{
+			"skill",
+			"--skill", progression.SkillSpecComplianceReview,
+			"--verdict", "pass",
+		})
+		err = cmd.Execute()
+		cliErr := asCLIError(err)
+		require.NotNil(t, cliErr)
+		assert.Equal(t, "evidence_skill_run_summary_missing", cliErr.ErrorCode)
+	})
+}
+
+func TestEvidenceSkillRejectsWrongWorkflowStateWithoutWritingEvidence(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		slug, change := createEvidenceTaskFixture(t, root)
+		writePassingExecutionSummary(t, root, slug, 1, "t-01")
+		writePassingWaveEvidence(t, root, slug, 1)
+		change.CurrentState = model.StateS2Execute
+		require.NoError(t, state.SaveChange(root, change))
+
+		cmd := commandForRoot(t, root, makeEvidenceCmd())
+		cmd.SetArgs([]string{
+			"skill",
+			"--skill", progression.SkillSpecComplianceReview,
+			"--verdict", "pass",
+		})
+		err := cmd.Execute()
+		cliErr := asCLIError(err)
+		require.NotNil(t, cliErr)
+		assert.Equal(t, "evidence_skill_wrong_state", cliErr.ErrorCode)
+
+		_, statErr := os.Stat(state.VerificationFilePath(root, slug, progression.SkillSpecComplianceReview))
+		require.Error(t, statErr)
+	})
+}
+
 func TestEvidenceTaskRejectsUnsafeTaskID(t *testing.T) {
 	t.Parallel()
 

--- a/internal/state/verification.go
+++ b/internal/state/verification.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/signalridge/slipway/internal/fsutil"
 	"github.com/signalridge/slipway/internal/model"
 	"gopkg.in/yaml.v3"
 )
@@ -227,6 +228,36 @@ func verificationDirPathForRead(root, slug string) string {
 // path are authoritative.
 func VerificationFilePath(root, slug, skillName string) string {
 	return filepath.Join(resolveVerificationDir(root, slug), skillName+".yaml")
+}
+
+// SaveVerification writes a skill verification record to the authoritative
+// governed bundle. The caller owns the record contents; this helper owns only
+// path authority, normalization, validation, and atomic persistence.
+func SaveVerification(root, slug, skillName string, rec model.VerificationRecord) (string, error) {
+	skillName = strings.TrimSpace(skillName)
+	if skillName == "" || strings.ContainsAny(skillName, `/\`) || skillName == "." || skillName == ".." {
+		return "", fmt.Errorf("skill name must be a safe flat filename: %q", skillName)
+	}
+	rec.Normalize()
+	if err := rec.Validate(); err != nil {
+		return "", err
+	}
+	dir, err := resolveVerificationDirForWrite(root, slug)
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil { // #nosec G301 -- governed artifact directories are intentionally user-readable/searchable.
+		return "", err
+	}
+	raw, err := yaml.Marshal(rec)
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(dir, skillName+".yaml")
+	if err := fsutil.WriteFileAtomic(path, raw, 0o644); err != nil {
+		return "", err
+	}
+	return path, nil
 }
 
 // LoadVerification reads a skill verification record.

--- a/internal/state/verification_test.go
+++ b/internal/state/verification_test.go
@@ -6,11 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/signalridge/slipway/internal/fsutil"
 	"github.com/signalridge/slipway/internal/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
 )
 
 func testVerificationReason(code, detail string) model.ReasonCode {
@@ -20,16 +18,8 @@ func testVerificationReason(code, detail string) model.ReasonCode {
 func writeVerificationForTest(t *testing.T, root, slug, skillName string, rec model.VerificationRecord) {
 	t.Helper()
 
-	rec.Normalize()
-	require.NoError(t, rec.Validate())
-
-	dir, err := resolveVerificationDirForWrite(root, slug)
+	_, err := SaveVerification(root, slug, skillName, rec)
 	require.NoError(t, err)
-	require.NoError(t, os.MkdirAll(dir, 0o755))
-
-	raw, err := yaml.Marshal(rec)
-	require.NoError(t, err)
-	require.NoError(t, fsutil.WriteFileAtomic(filepath.Join(dir, skillName+".yaml"), raw, 0o644))
 }
 
 func TestSaveLoadVerificationRoundTrip(t *testing.T) {

--- a/internal/tmpl/templates/skills/code-quality-review/SKILL.md.tmpl
+++ b/internal/tmpl/templates/skills/code-quality-review/SKILL.md.tmpl
@@ -37,13 +37,26 @@ verification. Use fresh context; do not carry assumptions from Stage 1.
 Run `slipway next --json`. Read `verification/spec-compliance-review.yaml` and
 verify it has `verdict: pass` with empty `blockers` (this per-skill file — NOT
 `execution-summary.yaml` — is the authority for the prior Stage 1 verdict). Read
-`verification/execution-summary.yaml` only for the current `run_summary_version`
-(the value your verification's `run_version` must equal). Read
+`verification/execution-summary.yaml` only for the current `run_summary_version`;
+`slipway evidence skill` will stamp the verification record with that value. Read
 `next_skill.review_context.required_implementation_layers` for required review
 tokens and the top-level `confirmation_requirement` object for stop boundaries.
 Those fields are the source of truth for this handoff.
 Use `slipway-coding-discipline` as the baseline review posture for simplicity,
 small diffs, and goal-driven execution.
+
+## Disk-Handoff Contract
+For bulky review artifacts, keep the coordinator thin:
+- Pass required-reading paths from `slipway next --json`; do not paste artifact
+  bodies, diffs, or command output into the host context.
+- An isolated subagent writes bulky artifacts directly to disk under
+  `artifacts/changes/<slug>/` and returns only a short confirmation naming the
+  paths written and any blockers.
+- The confirmation is a claim, not evidence. The review host must inspect the
+  written files and record the verdict through `slipway evidence skill`; do not
+  hand-edit verification YAML into a pass state.
+- Slipway CLI owns `run_version`, timestamps, freshness inputs, and verdict
+  stamping; subagents must not self-stamp freshness or final verdicts.
 
 ## Required Checks
 ### Code Quality
@@ -87,21 +100,21 @@ Do not use `layer:QUALITY=pass` as a gate-satisfying substitute. It may be a
 prose category in notes, but governance gates consume the exact `IR*` layer
 tokens.
 
-## Write Verification
-```yaml
-# Write to: artifacts/changes/{slug}/verification/code-quality-review.yaml
-verdict: pass
-blockers: []
-timestamp: "<ISO-8601-UTC>"
-run_version: <run_summary_version from verification/execution-summary.yaml>  # must equal the current execution-summary run_summary_version, not a literal 1
-references:
-  - "layer:IR1=pass"
-  - "layer:IR3=pass" # include only when review_context requires IR3
-  - "toolchain_compat:pass" # include when dependency/toolchain files changed
-notes: |
-  Gaps (code_to_artifact): <code patterns not reflected in artifacts>
-  Gaps (artifact_to_code): <artifact expectations not met by code>
+## Record Verification
+Write bulky review notes to disk, then record the verdict through the CLI so
+Slipway owns the timestamp, `run_version`, freshness inputs, and digest stamp.
+Do not hand-edit `verification/code-quality-review.yaml`.
+
+```bash
+slipway evidence skill \
+  --skill code-quality-review \
+  --verdict pass \
+  --reference "layer:IR1=pass" \
+  --notes-file artifacts/changes/{slug}/verification/code-quality-review-notes.md
 ```
+
+Add `--reference "toolchain_compat:pass"` when dependency, manifest, lockfile,
+or generated tool-surface changes required compatibility verification.
 
 The `notes` field SHOULD include gap analysis. Empty gaps indicate full
 cross-artifact consistency.

--- a/internal/tmpl/templates/skills/intake-clarification/SKILL.md
+++ b/internal/tmpl/templates/skills/intake-clarification/SKILL.md
@@ -21,6 +21,19 @@ over-scoping.
 Use `slipway next --json` for the current state and governed bundle path, then
 read `intent.md`.
 
+### Disk-Handoff Contract
+For bulky intake artifacts, keep the coordinator thin:
+- Pass required-reading paths from `slipway next --json`; do not paste artifact
+  bodies into the host context.
+- An isolated subagent writes bulky artifacts directly to disk under
+  `artifacts/changes/<slug>/` and returns only a short confirmation naming the
+  paths written and any blockers.
+- The confirmation is a claim, not evidence. The host must inspect the written
+  files and record the verdict through `slipway evidence skill`; do not
+  hand-edit verification YAML into a pass state.
+- Slipway CLI owns `run_version`, timestamps, freshness inputs, and verdict
+  stamping; subagents must not self-stamp freshness or final verdicts.
+
 Carry this scope posture while reading:
 - surface the unspoken assumption before the next question
 - prefer one well-targeted question over scattered batches
@@ -71,16 +84,17 @@ Once scope is clear:
 3. Confirm it names at least one out-of-scope item and keeps unresolved technical unknowns under `## Open Questions`.
 4. <HARD-GATE>Wait for explicit user confirmation before writing the approved summary.</HARD-GATE>
 
-### 6. Write Verification
-```yaml
-# Write to: artifacts/changes/{slug}/verification/intake-clarification.yaml
-verdict: pass
-blockers: []
-timestamp: "<ISO-8601-UTC>"
-run_version: 0
-references: []
-notes: |
-  <verification notes>
+### 6. Record Verification
+Write bulky clarification notes to disk, then record the verdict through the CLI
+so Slipway owns the timestamp, `run_version`, freshness inputs, and digest
+stamp. Do not hand-edit `verification/intake-clarification.yaml`.
+
+```bash
+slipway evidence skill \
+  --skill intake-clarification \
+  --verdict pass \
+  --reference "intake:pass" \
+  --notes-file artifacts/changes/{slug}/verification/intake-clarification-notes.md
 ```
 
 ### 7. Advance

--- a/internal/tmpl/templates/skills/plan-audit/SKILL.md
+++ b/internal/tmpl/templates/skills/plan-audit/SKILL.md
@@ -53,6 +53,19 @@ Populated is not the same as relevant. For a `partial` map, also inspect
 Use `slipway-coding-discipline` as the execution-shape bar: plans should stay
 simple, goal-scoped, and sliced for surgical implementation.
 
+## Disk-Handoff Contract
+For bulky audit artifacts, keep the coordinator thin:
+- Pass required-reading paths from `slipway next --json`; do not paste artifact
+  bodies or codebase-map documents into the host context.
+- An isolated subagent writes bulky artifacts directly to disk under
+  `artifacts/changes/<slug>/` and returns only a short confirmation naming the
+  paths written and any blockers.
+- The confirmation is a claim, not evidence. The host must inspect the written
+  files and record the verdict through `slipway evidence skill`; do not
+  hand-edit verification YAML into a pass state.
+- Slipway CLI owns `run_version`, timestamps, freshness inputs, and verdict
+  stamping; subagents must not self-stamp freshness or final verdicts.
+
 ## Author Substance First
 The engine owns each plan artifact's structure; you own its substance. Author the
 real plan artifacts in schema dependency order: `requirements.md` first,
@@ -143,16 +156,17 @@ Audit tasks as execution units, not prose:
 - for guardrail-domain work, require a RED test plan before execution
 - keep non-goals explicit, including scope and rollout boundaries
 
-## Write Verification
-```yaml
-# Write to: artifacts/changes/{slug}/verification/plan-audit.yaml
-verdict: pass
-blockers: []
-timestamp: "<ISO-8601-UTC>"
-run_version: 0
-references: []
-notes: |
-  <verification notes>
+## Record Verification
+Write bulky audit notes to disk, then record the verdict through the CLI so
+Slipway owns the timestamp, `run_version`, freshness inputs, and digest stamp.
+Do not hand-edit `verification/plan-audit.yaml`.
+
+```bash
+slipway evidence skill \
+  --skill plan-audit \
+  --verdict pass \
+  --reference "plan-audit:pass" \
+  --notes-file artifacts/changes/{slug}/verification/plan-audit-notes.md
 ```
 
 ## Present and Advance

--- a/internal/tmpl/templates/skills/research-orchestration/SKILL.md
+++ b/internal/tmpl/templates/skills/research-orchestration/SKILL.md
@@ -24,6 +24,19 @@ Discovery-required governed changes only, at `S1_PLAN/research` substep.
 Run `slipway next --json` and examine the governed change artifacts.
 Read the `research.md` artifact for existing discovery notes.
 
+## Disk-Handoff Contract
+For bulky research artifacts, keep the coordinator thin:
+- Pass required-reading paths from `slipway next --json`; do not paste artifact
+  bodies into the host context.
+- An isolated subagent writes bulky artifacts directly to disk under
+  `artifacts/changes/<slug>/` and returns only a short confirmation naming the
+  paths written and any blockers.
+- The confirmation is a claim, not evidence. The host must inspect the written
+  files and record the verdict through `slipway evidence skill`; do not
+  hand-edit verification YAML into a pass state.
+- Slipway CLI owns `run_version`, timestamps, freshness inputs, and verdict
+  stamping; subagents must not self-stamp freshness or final verdicts.
+
 ## Structured Research Dimensions
 Investigate the following dimensions systematically:
 
@@ -94,16 +107,17 @@ If the codebase map is **missing** (`status: missing`), run the
 semantically stale, re-author the affected sections inline (above) — do not rerun
 the technique skill, which only scaffolds a missing or non-durable set.
 
-## Write Verification
-```yaml
-# Write to: artifacts/changes/{slug}/verification/research-orchestration.yaml
-verdict: pass
-blockers: []
-timestamp: "<ISO-8601-UTC>"
-run_version: 0
-references: []
-notes: |
-  <verification notes>
+## Record Verification
+Write bulky research notes to disk, then record the verdict through the CLI so
+Slipway owns the timestamp, `run_version`, freshness inputs, and digest stamp.
+Do not hand-edit `verification/research-orchestration.yaml`.
+
+```bash
+slipway evidence skill \
+  --skill research-orchestration \
+  --verdict pass \
+  --reference "research:pass" \
+  --notes-file artifacts/changes/{slug}/verification/research-orchestration-notes.md
 ```
 
 ## Surface Findings

--- a/internal/tmpl/templates/skills/spec-compliance-review/SKILL.md.tmpl
+++ b/internal/tmpl/templates/skills/spec-compliance-review/SKILL.md.tmpl
@@ -35,8 +35,8 @@ claiming alignment.
 
 ## Read Context
 Run `slipway next --json` and locate `verification/execution-summary.yaml`.
-Read its current `run_summary_version`; your verification's `run_version` must
-equal that value, not a literal `1`. Read
+Read its current `run_summary_version`; `slipway evidence skill` will stamp the
+verification record with that value, not a literal `1`. Read
 `next_skill.review_context.required_artifact_layers` for required review tokens
 and the top-level `confirmation_requirement` object for stop boundaries. Those
 fields are the source of truth for this handoff.
@@ -47,6 +47,19 @@ enumerate the forward and reverse trace edges you must verify. Any
 must not be treated as full bidirectional alignment.
 Use `slipway-coding-discipline` as a posture check when judging whether the
 implemented change stayed simple, surgical, and goal-driven.
+
+## Disk-Handoff Contract
+For bulky review artifacts, keep the coordinator thin:
+- Pass required-reading paths from `slipway next --json`; do not paste artifact
+  bodies, diffs, or command output into the host context.
+- An isolated subagent writes bulky artifacts directly to disk under
+  `artifacts/changes/<slug>/` and returns only a short confirmation naming the
+  paths written and any blockers.
+- The confirmation is a claim, not evidence. The review host must inspect the
+  written files and record the verdict through `slipway evidence skill`; do not
+  hand-edit verification YAML into a pass state.
+- Slipway CLI owns `run_version`, timestamps, freshness inputs, and verdict
+  stamping; subagents must not self-stamp freshness or final verdicts.
 
 ## Required Checks
 ### Forward Alignment (Spec -> Code)
@@ -115,21 +128,19 @@ Do not use `layer:CORRECTNESS=pass` or `layer:SAFETY=pass` as gate-satisfying
 substitutes. They may be prose categories in notes, but governance gates consume
 the exact `R*` layer tokens.
 
-## Write Verification
-```yaml
-# Write to: artifacts/changes/{slug}/verification/spec-compliance-review.yaml
-verdict: pass
-blockers: []
-timestamp: "<ISO-8601-UTC>"
-run_version: <run_summary_version from verification/execution-summary.yaml>  # must equal the current execution-summary run_summary_version, not a literal 1
-references:
-  - "layer:R0=pass"
-  - "layer:R3=pass" # include only when review_context requires R3
-  - "scope_contract:pass"
-  - "negative_path:pass" # include when requirements name negative/error paths
-notes: |
-  Gaps (code_to_artifact): <code behaviors not documented in spec>
-  Gaps (artifact_to_code): <spec requirements not implemented in code>
+## Record Verification
+Write bulky review notes to disk, then record the verdict through the CLI so
+Slipway owns the timestamp, `run_version`, freshness inputs, and digest stamp.
+Do not hand-edit `verification/spec-compliance-review.yaml`.
+
+```bash
+slipway evidence skill \
+  --skill spec-compliance-review \
+  --verdict pass \
+  --reference "layer:R0=pass" \
+  --reference "scope_contract:pass" \
+  --reference "negative_path:pass" \
+  --notes-file artifacts/changes/{slug}/verification/spec-compliance-review-notes.md
 ```
 
 The `notes` field SHOULD include gap analysis. Empty gaps indicate full

--- a/internal/tmpl/templates_test.go
+++ b/internal/tmpl/templates_test.go
@@ -787,39 +787,39 @@ func TestRunSummaryBoundGovernedTemplatesDoNotUseLiteralRunVersion(t *testing.T)
 		"Description": "test",
 	}
 	tests := []struct {
-		name          string
-		templatePath  string
-		wantRunSource string
+		name           string
+		templatePath   string
+		wantRunSources []string
 	}{
 		{
-			name:          "wave orchestration",
-			templatePath:  "skills/wave-orchestration/SKILL.md.tmpl",
-			wantRunSource: "run_version: <current wave-orchestration run_version>",
+			name:           "wave orchestration",
+			templatePath:   "skills/wave-orchestration/SKILL.md.tmpl",
+			wantRunSources: []string{"run_version: <current wave-orchestration run_version>"},
 		},
 		{
-			name:          "tdd governance",
-			templatePath:  "skills/tdd-governance/SKILL.md.tmpl",
-			wantRunSource: "run_version: <current wave-orchestration run_version>",
+			name:           "tdd governance",
+			templatePath:   "skills/tdd-governance/SKILL.md.tmpl",
+			wantRunSources: []string{"run_version: <current wave-orchestration run_version>"},
 		},
 		{
-			name:          "spec compliance review",
-			templatePath:  "skills/spec-compliance-review/SKILL.md.tmpl",
-			wantRunSource: "run_version: <run_summary_version from verification/execution-summary.yaml>",
+			name:           "spec compliance review",
+			templatePath:   "skills/spec-compliance-review/SKILL.md.tmpl",
+			wantRunSources: []string{"slipway evidence skill", "current `run_summary_version`"},
 		},
 		{
-			name:          "code quality review",
-			templatePath:  "skills/code-quality-review/SKILL.md.tmpl",
-			wantRunSource: "run_version: <run_summary_version from verification/execution-summary.yaml>",
+			name:           "code quality review",
+			templatePath:   "skills/code-quality-review/SKILL.md.tmpl",
+			wantRunSources: []string{"slipway evidence skill", "current `run_summary_version`"},
 		},
 		{
-			name:          "goal verification",
-			templatePath:  "skills/goal-verification/SKILL.md.tmpl",
-			wantRunSource: "run_version: <current run_summary_version from slipway status --json>",
+			name:           "goal verification",
+			templatePath:   "skills/goal-verification/SKILL.md.tmpl",
+			wantRunSources: []string{"run_version: <current run_summary_version from slipway status --json>"},
 		},
 		{
-			name:          "final closeout",
-			templatePath:  "skills/final-closeout/SKILL.md.tmpl",
-			wantRunSource: "run_version: <current run_summary_version from slipway status --json>",
+			name:           "final closeout",
+			templatePath:   "skills/final-closeout/SKILL.md.tmpl",
+			wantRunSources: []string{"run_version: <current run_summary_version from slipway status --json>"},
 		},
 	}
 
@@ -836,13 +836,15 @@ func TestRunSummaryBoundGovernedTemplatesDoNotUseLiteralRunVersion(t *testing.T)
 				"%s must not guide agents to copy a stale literal run_version",
 				tt.templatePath,
 			)
-			assert.Contains(
-				t,
-				content,
-				tt.wantRunSource,
-				"%s must name the authoritative run_version source",
-				tt.templatePath,
-			)
+			for _, want := range tt.wantRunSources {
+				assert.Contains(
+					t,
+					content,
+					want,
+					"%s must name the authoritative run_version source",
+					tt.templatePath,
+				)
+			}
 		})
 	}
 }

--- a/internal/tmpl/thin_host_content_test.go
+++ b/internal/tmpl/thin_host_content_test.go
@@ -91,6 +91,77 @@ func TestThinHostWaveOrchestrationDelegatesCodebaseMapReads(t *testing.T) {
 	assert.Contains(t, flatRef, "relevance/staleness self-check")
 }
 
+func TestRemainingHeavyHostsUseDiskHandoffContract(t *testing.T) {
+	t.Parallel()
+
+	data := map[string]string{
+		"ToolID":      "claude",
+		"Trigger":     "/slipway:test",
+		"Description": "test",
+	}
+	hosts := []struct {
+		name    string
+		content string
+		err     error
+	}{
+		{
+			name:    "research-orchestration",
+			content: mustContent(t, "skills/research-orchestration/SKILL.md"),
+		},
+		{
+			name:    "plan-audit",
+			content: mustContent(t, "skills/plan-audit/SKILL.md"),
+		},
+		{
+			name:    "intake-clarification",
+			content: mustContent(t, "skills/intake-clarification/SKILL.md"),
+		},
+		{
+			name:    "spec-compliance-review",
+			content: mustRender(t, "skills/spec-compliance-review/SKILL.md.tmpl", data),
+		},
+		{
+			name:    "code-quality-review",
+			content: mustRender(t, "skills/code-quality-review/SKILL.md.tmpl", data),
+		},
+	}
+
+	for _, host := range hosts {
+		t.Run(host.name, func(t *testing.T) {
+			t.Parallel()
+
+			flat := thinHostFlatten(host.content)
+			assert.Contains(t, flat, "Disk-Handoff Contract")
+			assert.Contains(t, flat, "writes bulky artifacts directly to disk under `artifacts/changes/<slug>/`")
+			assert.Contains(t, flat, "returns only a short confirmation")
+			assert.Contains(t, flat, "confirmation is a claim, not evidence")
+			assert.Contains(t, flat, "Slipway CLI owns `run_version`, timestamps, freshness inputs, and verdict stamping")
+			assert.Contains(t, flat, "required-reading paths")
+			assert.Contains(t, flat, "record the verdict through `slipway evidence skill`")
+			assert.Contains(t, flat, "Do not hand-edit")
+			assert.NotContains(t, flat, `timestamp: "<ISO-8601-UTC>"`)
+			assert.NotContains(t, flat, "run_version: 0")
+			assert.NotContains(t, flat, "run_version: <run_summary_version")
+		})
+	}
+}
+
+func mustContent(t *testing.T, name string) string {
+	t.Helper()
+
+	content, err := Content(name)
+	require.NoError(t, err)
+	return content
+}
+
+func mustRender(t *testing.T, name string, data map[string]string) string {
+	t.Helper()
+
+	content, err := Render(name, data)
+	require.NoError(t, err)
+	return content
+}
+
 func thinHostFlatten(s string) string {
 	return strings.Join(strings.Fields(s), " ")
 }

--- a/internal/toolgen/toolgen.go
+++ b/internal/toolgen/toolgen.go
@@ -197,8 +197,8 @@ var commandRegistry = []CommandDef{
 		Arguments:     "[--json] [--focus <alias>] [--list-focuses] [--format text|json]",
 		Prerequisites: []string{"`.slipway.yaml` must exist (run `slipway init` first)"}},
 	{ID: "evidence", Class: CommandClassMutation, Description: "Record supported runtime evidence for governed execution", Tier: "situational", HasPromptSurface: true,
-		Arguments:     "task --task-id <id> --run-summary-version <n> --task-kind <kind> --verdict <verdict> --evidence-ref <ref> [--changed-file <path> ...] [--target-file <path> ...] [--blocker <code[:detail]> ...] [--captured-at <RFC3339Nano>] [--session-id <id>] [--json] [--change <slug>]",
-		Prerequisites: []string{"`.slipway.yaml` must exist (run `slipway init` first)", "An active governed change must be in S2_EXECUTE with a materialized wave plan."}},
+		Arguments:     "task --task-id <id> --run-summary-version <n> --task-kind <kind> --verdict <verdict> --evidence-ref <ref> [--changed-file <path> ...] [--target-file <path> ...] [--blocker <code[:detail]> ...] [--captured-at <RFC3339Nano>] [--session-id <id>] [--json] [--change <slug>]; skill --skill <name> --verdict <pass|fail> [--reference <ref> ...] [--blocker <code[:detail]> ...] [--notes <text>|--notes-file <path>] [--json] [--change <slug>]",
+		Prerequisites: []string{"`.slipway.yaml` must exist (run `slipway init` first)", "`task` requires an active governed change in S2_EXECUTE with a materialized wave plan.", "`skill` requires an active governed change; run-summary-bound skills also require execution-summary.yaml."}},
 	// Diagnostics (5)
 	{ID: "learn", Class: CommandClassQuery, Description: "Preview governance learning proposals from lifecycle evidence", Tier: "diagnostics", HasPromptSurface: true,
 		Arguments:     "[--preview] [--json]",


### PR DESCRIPTION
## Summary
- add `slipway evidence skill` for CLI-owned governance skill verification stamping and digest refresh
- update the remaining heavy stage templates with disk-handoff and short-confirmation contracts
- add regressions for template drift, skill evidence stamping, notes-file handoff, and state/freshness failures
- archive the governed issue #151 change bundle

## Verification
- `go test -count=1 ./...`
- `go run . validate --json`
- `go run . next --json --diagnostics`
- `git diff --check`
- `go run . done --json`

Closes #151