### PR TITLE
feat(coherence): add generated surface manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,21 @@ Generate host-tool surfaces with `slipway init --tools <id>` (`claude`, `codex`,
 | Gemini | `.gemini/skills/slipway-*/SKILL.md`, `.gemini/commands/slipway/*.toml`, `.gemini/hooks/slipway-session-start.sh`, `.gemini/settings.json` |
 | OpenCode | `.opencode/skills/slipway-*/SKILL.md`, `.opencode/commands/slipway-*.md`, `.opencode/hooks/slipway-session-start.sh` |
 
+Exported generated skill rows are pinned by public skill directory:
+`slipway/SKILL.md`, `slipway-ci-triage/SKILL.md`,
+`slipway-code-quality-review/SKILL.md`, `slipway-codebase-mapping/SKILL.md`,
+`slipway-coding-discipline/SKILL.md`, `slipway-context-assembly/SKILL.md`,
+`slipway-coverage-analysis/SKILL.md`, `slipway-final-closeout/SKILL.md`,
+`slipway-git-recovery/SKILL.md`, `slipway-goal-verification/SKILL.md`,
+`slipway-incident-response/SKILL.md`, `slipway-independent-review/SKILL.md`,
+`slipway-intake-clarification/SKILL.md`, `slipway-plan-audit/SKILL.md`,
+`slipway-research-orchestration/SKILL.md`,
+`slipway-root-cause-tracing/SKILL.md`, `slipway-security-review/SKILL.md`,
+`slipway-spec-compliance-review/SKILL.md`, `slipway-spec-trace/SKILL.md`,
+`slipway-tdd-governance/SKILL.md`, `slipway-test-design/SKILL.md`,
+`slipway-wave-orchestration/SKILL.md`, and
+`slipway-worktree-preflight/SKILL.md`.
+
 Every tool gets the entry skill. Codex enters the lifecycle through its skill and prompt surfaces; the other four also get an auto-injecting session-start hook (Codex has no session-hook surface to attach to, so its agent pulls governed state via `slipway status --json` instead).
 
 </details>
@@ -209,6 +224,7 @@ See the [Operator Guide](docs/operator-guide.md) for state authority, freshness 
 - [Governed Workflow](docs/workflow.md): lifecycle states, read-only surfaces, mutating commands, and Open Questions semantics.
 - [Command Reference](docs/commands.md): core, situational, and diagnostics commands.
 - [AI Tool Adapters](docs/ai-tools.md): generated paths and host invocation styles.
+- [Surface Manifest](docs/SURFACE-MANIFEST.json): generated inventory of adapter, command, skill, JSON, and documentation surfaces.
 - [Operator Guide](docs/operator-guide.md): worktrees, state authority, health, repair, verification, and closeout.
 - [Contributing](docs/contributing.md): repo layout, docs build, adapter contracts, and governance tests.
 
@@ -217,6 +233,7 @@ See the [Operator Guide](docs/operator-guide.md) for state authority, freshness 
 Use focused package tests while developing, then run the full local proof before closeout:
 
 ```bash
+go run ./internal/toolgen/cmd/gen-surface-manifest --check
 go test -timeout=20m ./... -count=1
 go build ./...
 go vet ./...

--- a/artifacts/changes/archived/resolve-github-issue-158-add-a-generated-surface-inventory-m/assurance.md
+++ b/artifacts/changes/archived/resolve-github-issue-158-add-a-generated-surface-inventory-m/assurance.md
@@ -1,0 +1,131 @@
+# Assurance
+
+## Scope Summary
+
+This change resolves GitHub issue #158 by adding a generated surface inventory
+manifest and fail-closed sync checks for Slipway's public generated surfaces.
+The delivered scope includes:
+
+- a deterministic manifest builder in `internal/toolgen`
+- a committed public manifest at `docs/SURFACE-MANIFEST.json`
+- a Go regeneration entrypoint with stdout, `--check`, and `--write` modes
+- tests that fail closed when the committed manifest, docs tokens, or generated
+  surface families drift
+- public docs in `README.md`, `docs/ai-tools.md`, and `docs/commands.md`
+- two narrow lifecycle repairs required to re-certify the governed change:
+  S2 stale future-stage review evidence no longer deadlocks current-stage wave
+  evidence stamping, and S2 `wave-orchestration` evidence can bootstrap from the
+  current runtime task evidence ledger before `execution-summary.yaml` exists
+
+The committed manifest is derived from existing Slipway authorities rather than
+a new hand-maintained command or skill registry. Its current inventory contains
+74 rows: 5 adapter rows, 21 command rows, 4 documentation rows, 21 JSON contract
+rows, and 23 skill rows.
+
+## Verification Verdict
+
+Verdict: pass.
+
+Execution evidence records all planned tasks `t-01` through `t-07` as passing at
+`run_summary_version: 1`. Review evidence records `spec-compliance-review` and
+`code-quality-review` as passing, with scope contract, negative-path coverage,
+toolchain compatibility, and layer checks satisfied.
+
+Fresh S4 proof commands after the last code/test change include:
+
+- `go run ./internal/toolgen/cmd/gen-surface-manifest --check`
+- `go test ./internal/toolgen ./internal/toolgen/cmd/gen-surface-manifest ./cmd ./internal/engine/progression -count=1`
+- `go test -timeout=20m ./... -count=1`
+- `go test -coverprofile=/tmp/slipway-issue158-cover.out ./internal/toolgen ./internal/toolgen/cmd/gen-surface-manifest ./cmd ./internal/engine/progression`
+- `git diff --check`
+- `go run . validate --json --change resolve-github-issue-158-add-a-generated-surface-inventory-m`
+
+Before goal-verification/final-closeout are recorded, the expected remaining S4
+blockers are the missing `goal-verification`, missing `final-closeout`, and the
+standard-preset closeout assurance attestation.
+
+## Evidence Index
+
+- `verification/execution-summary.yaml`: all tasks passed with
+  `run_summary_version: 1`.
+- `verification/wave-orchestration.yaml`: wave execution verdict pass, recorded
+  from the current task evidence ledger.
+- `verification/spec-compliance-review.yaml`: verdict pass with `layer:R0=pass`,
+  `scope_contract:pass`, and `negative_path:pass`.
+- `verification/code-quality-review.yaml`: verdict pass with `layer:IR1=pass`
+  and `toolchain_compat:pass`.
+- `verification/evidence-digests.yaml`: current digests for review and
+  execution evidence inputs.
+- `verification/spec-compliance-review-notes.md`: forward and reverse trace for
+  REQ-001 through REQ-006.
+- `verification/code-quality-review-notes.md`: quality, safety, test, and
+  toolchain review for the manifest and lifecycle repair diff.
+- Runtime task evidence under `.git/slipway/runtime/changes/.../evidence/tasks`:
+  task evidence for `t-01` through `t-07` bound to the current task-plan hash.
+
+## Requirement Coverage
+
+- REQ-001: Covered by `internal/toolgen/surface_manifest.go`,
+  `docs/SURFACE-MANIFEST.json`, and manifest sync/docs-token tests. The builder
+  derives rows from existing command, adapter, governance-skill,
+  standalone/technique-skill, catalog/capability, JSON contract, and docs
+  authorities, then emits deterministic sorted JSON.
+- REQ-002: Covered by
+  `internal/toolgen/cmd/gen-surface-manifest/main.go` and
+  `internal/toolgen/cmd/gen-surface-manifest/main_test.go`. The entrypoint
+  supports stdout, check, and write modes, rejects `--check --write`, and
+  reports actionable stale manifest row differences.
+- REQ-003: Covered by README/docs updates and tests in
+  `internal/toolgen/surface_manifest_test.go`, `internal/toolgen/toolgen_test.go`,
+  and `cmd/template_flag_contract_test.go`. Documentation tokens are checked and
+  existing README/command contract checks remain active.
+- REQ-004: Covered by governed task evidence, focused package tests, full Go
+  tests, manifest check, diff check, review evidence, coverage evidence, and
+  active validation.
+- REQ-005: Covered by
+  `internal/engine/progression/evidence_digests.go` and
+  `TestStampPassingSkillDigestsDoesNotBlockCurrentStageOnFutureAcceptedEvidence`.
+  The repair prevents stale future-stage review/verify evidence from blocking
+  S2 current-stage re-certification before the owning future stage can refresh.
+- REQ-006: Covered by `cmd/evidence.go`, `cmd/evidence_task_test.go`, and
+  `docs/commands.md`. The repair lets S2 `wave-orchestration` derive its run
+  version from single-version task evidence before an execution summary exists,
+  while later run-summary-bound skills still fail closed without
+  `execution-summary.yaml`.
+
+## Residual Risks and Exceptions
+
+- No unresolved implementation, review, requirement coverage, quality, or
+  safety blockers are recorded.
+- The populated codebase-map docs still reflect older issue #151 context and
+  were treated as advisory only; they are not part of the current tracked diff.
+- The manifest intentionally uses stable docs tokens instead of prose snapshots,
+  so docs rewrites remain possible as long as the public surface tokens stay
+  present.
+- The new S2 evidence bootstrap is intentionally narrow: it applies only to
+  `wave-orchestration` in S2 and rejects missing, invalid, mixed-version, or
+  empty task evidence.
+
+## Rollback Readiness
+
+Rollback is straightforward because the change does not alter external APIs,
+dependencies, lockfiles, schemas, auth, credentials, persisted user data, or
+irreversible operations. Reverting the manifest builder, regeneration entrypoint,
+committed manifest, docs additions, tests, and the two S2 recovery repairs
+restores the previous surface.
+
+After rollback, rerun at least:
+
+- `go test ./internal/toolgen ./internal/toolgen/cmd/gen-surface-manifest ./cmd ./internal/engine/progression -count=1`
+- `go test -timeout=20m ./... -count=1`
+
+## Archive Decision
+
+Archive readiness decision: ready to advance toward done-ready after
+goal-verification and final-closeout are refreshed from the current worktree and
+`go run . validate --json --change resolve-github-issue-158-add-a-generated-surface-inventory-m`
+confirms the active ship gate is approved.
+
+This assurance file is authored from the current issue #158 evidence record.
+`slipway done` is not part of this decision and must not run without explicit
+user authorization.

--- a/artifacts/changes/archived/resolve-github-issue-158-add-a-generated-surface-inventory-m/change.yaml
+++ b/artifacts/changes/archived/resolve-github-issue-158-add-a-generated-surface-inventory-m/change.yaml
@@ -1,0 +1,50 @@
+version: 1
+slug: resolve-github-issue-158-add-a-generated-surface-inventory-m
+description: 'Resolve GitHub issue #158: add a generated surface inventory manifest and fail-closed sync checks so generated skills, CLI commands, JSON contracts, and docs stay represented together.'
+status: done
+current_state: DONE
+needs_discovery: true
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-06-10T13:43:01.143773Z
+quality_mode: standard
+workflow_preset: standard
+worktree_branch: feat/resolve-github-issue-158-add-a-generated-surface-inventory-m
+artifact_schema: expanded
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: d3cee9ff815ba29b3e49fab599df3993647523a9432245546a6397fee2087b0d
+        updated_at: 2026-06-10T16:57:27.033868832Z
+    decision:
+        id: decision
+        path: decision.md
+        state: frozen
+        content_hash: f89a8da86b020b1e1a8aa1c7240f6a3b5ddc1deb5a85ec2c5aef2d1a8c5439a9
+        updated_at: 2026-06-10T16:27:05.651850537Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: 9972a2d16de1aedcb0402f447477036c61d270120a9c2c4fadf2e2aaa49b3ba1
+        updated_at: 2026-06-10T13:54:06.967617035Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: 8241195d90a6365671e1503ffad89c38b34dcf81ff53d8ae0848afb842e4f91c
+        updated_at: 2026-06-10T16:27:05.651429327Z
+    research:
+        id: research
+        path: research.md
+        state: frozen
+        content_hash: 8a141e28a6ac321f648a0175c54d741fe3e131bc2386f0eca452a870bf3f7987
+        updated_at: 2026-06-10T16:27:05.652210329Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: 697a22de217d622c7108a33dde793c7a3068d22cd7135dac342467744fe46308
+        updated_at: 2026-06-10T16:27:05.651662453Z

--- a/artifacts/changes/archived/resolve-github-issue-158-add-a-generated-surface-inventory-m/decision.md
+++ b/artifacts/changes/archived/resolve-github-issue-158-add-a-generated-surface-inventory-m/decision.md
@@ -1,0 +1,92 @@
+# Decision
+
+## Alternatives Considered
+
+- Filesystem-scanning script outside the Go package: simple to run, but it would add a second toolchain path and would tend to duplicate Slipway's Go-owned command and skill registries.
+- Test-only golden manifest in `internal/toolgen/testdata`: lower public surface area, but it would not satisfy the issue's request for a committed generated-surface inventory that operators and reviewers can inspect as a product artifact.
+- Go-native public manifest implementation: adds a small amount of package code and a regeneration entrypoint, but keeps source authority in `internal/toolgen`, makes CI and maintainers use the same manifest builder, and exposes the product inventory in `docs/`.
+
+Selected: Go-native public manifest implementation.
+
+## Selected Approach
+
+Implement a surface manifest builder in `internal/toolgen` that derives rows from existing Slipway authorities:
+
+- adapter tool configs and path rules from `Registry`, `SkillPath`, `GeneratedAdapterMarkerPath`, and command surface path conventions
+- command prompt surfaces from `commandRegistry` and `commandIDs`
+- generated governance, standalone, catalog, and technique skill surfaces from existing toolgen descriptors and capability registry filtering
+- JSON/user-facing contract rows from the documented command JSON surfaces and stable model/contract authorities already used by tests
+- documentation rows from stable tokens in `README.md`, `docs/ai-tools.md`, `docs/commands.md`, and `docs/operator-guide.md`
+
+Commit the generated JSON as `docs/SURFACE-MANIFEST.json`. Add a small Go regeneration entrypoint with check and write modes that uses the same builder. Add sync tests that rebuild the manifest, compare it with the committed file, and verify docs tokens. Keep the existing README command-token/description tests active.
+
+## Interfaces and Data Flow
+
+New internal package surface:
+
+- `internal/toolgen` exposes or owns a `BuildSurfaceManifest` style helper returning deterministic manifest data.
+- The manifest writer marshals that data with stable ordering and indentation.
+- Tests and the regeneration entrypoint both call the same builder.
+
+New command/script surface:
+
+- A Go entrypoint under `internal/toolgen/cmd/gen-surface-manifest` supports check mode and write mode.
+- Check mode compares live output with `docs/SURFACE-MANIFEST.json` and prints actionable differences.
+- Write mode overwrites `docs/SURFACE-MANIFEST.json` from live authorities.
+
+Data flow:
+
+`internal/toolgen` registries and docs token definitions -> manifest builder -> JSON encoder -> committed `docs/SURFACE-MANIFEST.json` -> sync/docs tests and regeneration entrypoint.
+
+No runtime lifecycle state, evidence model, or command behavior changes are required.
+
+Review repair addendum:
+
+- While re-certifying the fixed manifest, the current lifecycle produced a
+  dead-end: S2 execution had completed, old S3/S4 review evidence was stale, and
+  `slipway run` reported the stale future evidence before the change could reach
+  S3 where `slipway evidence skill` is allowed to refresh it.
+- The narrow repair keeps digest freshness fail-closed but filters
+  previously-consumed skill evidence by lifecycle position. Directly passing
+  evidence for the current stage is still stamped. Previously consumed evidence
+  from future stages is checked only after the lifecycle reaches those stages.
+- This changes no public command shape and does not bypass review/verify gates;
+  it only prevents future-stage evidence from blocking the current S2 gate before
+  the owning S3/S4 stage can re-certify it.
+- A second S2 command-surface dead-end appeared after task evidence was refreshed:
+  `slipway run` requires passing `wave-orchestration` evidence before it can
+  build `execution-summary.yaml`, but the generic `slipway evidence skill` path
+  required `execution-summary.yaml` before recording any run-summary-bound skill.
+- The selected repair is a narrow bootstrap in `slipway evidence skill` for
+  `wave-orchestration` while the change is in S2. It derives the run version
+  from the current flat task evidence ledger, rejects missing, invalid, or
+  mixed-version task evidence, and leaves S3/S4 run-summary-bound skills
+  fail-closed until `execution-summary.yaml` exists.
+
+## Rollout and Rollback
+
+Rollout:
+
+1. Add the manifest builder, regeneration entrypoint, committed manifest, tests, and docs links.
+2. Run focused tests: `go test ./internal/toolgen ./cmd`.
+3. Run full verification: `go test ./...`.
+4. Complete governed review and validation.
+
+Rollback:
+
+1. Revert the manifest builder, regeneration entrypoint, committed manifest, docs additions, and tests.
+2. Run `go test ./internal/toolgen ./cmd` and `go test ./...` to verify existing generated-surface tests still pass.
+
+## Risk
+
+- Duplicate-authority risk: mitigated by deriving rows from existing `internal/toolgen` and capability authorities rather than introducing a second command/skill list.
+- Docs brittleness risk: mitigated by checking stable tokens and table/path entries, not broad prose snapshots.
+- Scope drift risk: mitigated by keeping implementation out of runtime lifecycle state and limiting changed production code to manifest generation.
+- Maintenance risk: mitigated by using one builder for committed JSON, check mode, write mode, and tests.
+- Recovery dead-end risk: mitigated by a focused regression that proves S2 wave
+  digest stamping ignores stale evidence from future lifecycle stages while
+  preserving stale checks once those stages are reached.
+- Wave evidence bootstrap risk: mitigated by limiting the task-ledger run-version
+  bootstrap to the S2 `wave-orchestration` skill and preserving
+  `evidence_skill_run_summary_missing` for review/verify skills without an
+  execution summary.

--- a/artifacts/changes/archived/resolve-github-issue-158-add-a-generated-surface-inventory-m/intent.md
+++ b/artifacts/changes/archived/resolve-github-issue-158-add-a-generated-surface-inventory-m/intent.md
@@ -1,0 +1,49 @@
+# Intent
+
+## Summary
+Resolve GitHub issue #158: add a generated surface inventory manifest and fail-closed sync checks so generated skills, CLI commands, JSON contracts, and docs stay represented together.
+## Complexity Assessment
+complex
+Rationale: this crosses generated skill templates, CLI command surfaces, docs, JSON/API contract surfaces, committed generated artifacts, and CI-facing tests. It also needs a regenerable workflow that can fail closed without weakening existing README coverage.
+
+## Guardrail Domains
+None detected.
+
+## In Scope
+- Add a Slipway-owned generated surface inventory manifest covering at least generated skills, CLI commands, JSON/user-facing contracts, and documentation rows.
+- Add a regenerating command or script path with explicit check and write modes so the committed manifest can be verified and updated deterministically.
+- Add a Go test or equivalent CI-facing sync check that fails when a new generated command/skill/contract surface lacks the expected manifest/doc/skill representation.
+- Add docs-row/README-facing checks where they are derived from stable manifest rows and do not weaken existing tests.
+- Preserve and keep running the existing README command-token/contract checks.
+- Keep implementation grounded in Slipway's own generated-surface authorities and tests.
+
+## Out of Scope
+- Do not replace Slipway's generated-surface architecture or migrate command/skill generation to an external script model.
+- Do not remove or weaken existing README/token surface tests.
+- Do not finalize or delete unrelated active work beyond the minimal governance cleanup needed to unblock this change.
+
+## Constraints
+- Use current worktree behavior and generated templates as authority.
+- Keep the manifest additive and self-correcting: stale committed output should be fixed by a write/regeneration mode, not by hand-editing generated JSON.
+- Keep planning artifacts Slipway-specific.
+
+## Acceptance Signals
+- Adding or exposing a generated command, skill, JSON contract, or doc-facing surface without updating the surface manifest/doc row causes a test failure.
+- Running the regeneration path updates the committed manifest deterministically and leaves no diff when already synced.
+- Existing README surface/token tests still pass.
+- `go test ./...` and governed Slipway readiness reach done-ready for this change.
+
+## Open Questions
+<!-- Track real unknowns as a checklist. An unchecked `- [ ]` item is unresolved
+     and routes intake to S0_INTAKE/research; mark `- [x]` once resolved. Leave the
+     section empty (or write `None`) when there are none. Prose here is
+     documentation, not a blocker — a genuine open question must be a `- [ ]`. -->
+- [x] Which existing Slipway files own generated skills, command metadata, JSON/user-facing contracts, and docs rows, and which should be manifest inputs?
+- [x] What inventory-manifest mechanics are worth adapting without importing an external product model?
+- [x] Where should the committed manifest live, and what generator/test entrypoint best matches existing Slipway conventions?
+
+## Deferred Ideas
+- README prose count contract tests beyond the minimum issue acceptance can be added only if they stay low-maintenance and align with existing docs.
+
+## Approved Summary
+Confirmed by the user objective on 2026-06-10 and refined on 2026-06-10: use the Slipway governed flow to resolve every issue in GitHub #158 until done-ready, make best choices when blocked, keep artifacts Slipway-specific, and fully implement the issue rather than a narrow subset. This change will add a regenerable generated-surface inventory manifest plus fail-closed sync coverage for commands, skills, JSON/contracts, docs rows, and stable README-facing coverage, while explicitly preserving existing README token checks and leaving unrelated worktrees/code outside scope.

--- a/artifacts/changes/archived/resolve-github-issue-158-add-a-generated-surface-inventory-m/requirements.md
+++ b/artifacts/changes/archived/resolve-github-issue-158-add-a-generated-surface-inventory-m/requirements.md
@@ -1,0 +1,83 @@
+# Requirements
+
+## Requirements
+
+### Requirement: Deterministic Surface Manifest
+REQ-001: The system MUST generate a deterministic public surface manifest that represents Slipway-owned generated skills, CLI command prompt surfaces, JSON/user-facing contract surfaces, and documentation rows from existing Slipway authorities rather than a duplicated hand-maintained registry.
+
+#### Scenario: Manifest is rebuilt from current authorities
+GIVEN the repository contains the current `internal/toolgen` command and skill registries, generated adapter path rules, capability surfaces, and public docs
+WHEN the surface manifest builder runs
+THEN it emits stable JSON rows for the current generated product surfaces with deterministic ordering and no volatile timestamp-only drift.
+
+#### Scenario: New surface lacks inventory coverage
+GIVEN a developer adds a new generated command, skill, JSON contract surface, or docs-facing surface authority
+WHEN the manifest sync test rebuilds the live manifest
+THEN the test fails until the committed manifest and required documentation representation are updated.
+
+### Requirement: Check And Write Regeneration
+REQ-002: The system MUST provide a regeneration entrypoint with check and write modes so maintainers can verify the committed manifest or update it without hand-editing JSON.
+
+#### Scenario: Synced manifest passes check mode
+GIVEN `docs/SURFACE-MANIFEST.json` matches the live generated-surface authorities
+WHEN the regeneration entrypoint runs in check mode
+THEN it exits successfully and reports that the manifest is up to date.
+
+#### Scenario: Stale manifest fails check mode
+GIVEN `docs/SURFACE-MANIFEST.json` is stale relative to the live generated-surface authorities
+WHEN the regeneration entrypoint runs in check mode
+THEN it exits non-zero with actionable additions or removals so the maintainer can regenerate intentionally.
+
+#### Scenario: Write mode updates the committed manifest
+GIVEN the live generated-surface authorities differ from the committed manifest
+WHEN the regeneration entrypoint runs in write mode
+THEN it rewrites `docs/SURFACE-MANIFEST.json` deterministically from live authorities.
+
+### Requirement: Documentation And README Coverage
+REQ-003: The system MUST keep manifest rows tied to stable documentation coverage and MUST preserve the existing README command-token/contract tests.
+
+#### Scenario: Documentation row is missing
+GIVEN a manifest row requires a stable docs or README token
+WHEN the docs coverage test scans the repository documentation
+THEN it fails if the token is missing from the expected docs file.
+
+#### Scenario: Existing README checks remain active
+GIVEN the generated-surface manifest checks are added
+WHEN `go test ./internal/toolgen` runs
+THEN the existing README command-token and command-description contract tests still execute and pass.
+
+### Requirement: Governed Verification
+REQ-004: The system MUST verify the manifest implementation with focused tests, full Go tests, and governed readiness evidence before done-ready.
+
+#### Scenario: Focused and full verification succeed
+GIVEN the implementation and manifest have been updated
+WHEN the focused package tests and `go test ./...` run
+THEN they pass and provide task evidence for the governed workflow.
+
+#### Scenario: Governed readiness reaches done-ready
+GIVEN code, docs, manifest, and tests satisfy the requirements
+WHEN Slipway validation and review/verification gates run
+THEN the governed change reaches done-ready without bypassing lifecycle gates.
+
+### Requirement: Review Re-Certification Recovery
+REQ-005: The lifecycle MUST allow a change that has completed S2 execution to advance back to S3 review after legitimate S2 inputs are refreshed, without being blocked in S2 by stale evidence from future review or verify stages.
+
+#### Scenario: Future-stage stale evidence does not deadlock S2
+GIVEN S2 execution evidence is being refreshed after S3/S4 review evidence was previously consumed
+AND a later edit makes the old S3/S4 evidence stale
+WHEN S2 stamps the current wave-orchestration evidence
+THEN stale future-stage review or verify evidence does not block S2 from reaching the S3 review handoff where it can be re-certified.
+
+### Requirement: Wave Evidence Bootstrap
+REQ-006: The evidence command surface MUST allow the S2 wave-orchestration host to record its run-summary-bound verification evidence from the current task evidence ledger before `execution-summary.yaml` exists, while later run-summary-bound review and verification skills remain fail-closed until an execution summary exists.
+
+#### Scenario: Wave evidence is bootstrapped from task evidence
+GIVEN an active S2 change has passing task evidence for a single `run_summary_version`
+AND `execution-summary.yaml` has not been generated yet
+WHEN `slipway evidence skill --skill wave-orchestration --verdict pass` records the S2 host verdict
+THEN the command binds the wave-orchestration record to that task evidence `run_summary_version` and stamps its digest without requiring a pre-existing execution summary.
+
+#### Scenario: Review skill still requires execution summary
+GIVEN an active review-stage change has no `execution-summary.yaml`
+WHEN `slipway evidence skill --skill spec-compliance-review --verdict pass` is attempted
+THEN the command fails closed with `evidence_skill_run_summary_missing` instead of inventing a run version.

--- a/artifacts/changes/archived/resolve-github-issue-158-add-a-generated-surface-inventory-m/research.md
+++ b/artifacts/changes/archived/resolve-github-issue-158-add-a-generated-surface-inventory-m/research.md
@@ -1,0 +1,98 @@
+# Research
+
+## Alternatives Considered
+
+### Architecture
+- Affected modules:
+  - `internal/toolgen/toolgen.go`: adapter registry, command registry, governance skill descriptors, generated skill/command paths, deterministic `Generate`.
+  - `internal/tmpl/templates/`: authored command/skill templates and support files embedded by `internal/tmpl/templates.go`.
+  - `internal/engine/capability/`: public focus/skill surface metadata used by skill indexes and route surfaces.
+  - `cmd/`: Cobra command/flag definitions and JSON-emitting command implementations.
+  - `README.md`, `docs/ai-tools.md`, `docs/commands.md`, `docs/operator-guide.md`: public docs rows for generated and JSON surfaces.
+- Dependency chains:
+  - `commandRegistry` -> command descriptions/arguments -> command reference and adapter prompt surfaces.
+  - `governanceSurfaceDescriptors` plus capability registry -> generated host skills and skill index.
+  - Cobra command constructors -> generated template flag contracts and JSON command behavior.
+  - docs tables/prose -> public operator contract for generated adapter paths and JSON contracts.
+- Blast radius: medium, bounded to `internal/toolgen`, a small regeneration entrypoint, docs, and tests if the generator reads existing registries rather than changing runtime lifecycle code.
+- Constraints:
+  - Do not weaken existing README/token tests.
+  - Do not introduce a second command or skill registry.
+  - Keep regenerated output deterministic and diffable.
+
+### Patterns
+- Existing conventions:
+  - `internal/toolgen` is the local source for generated adapter surfaces and already owns package-local tests for registry drift.
+  - `internal/toolgen/support_files_test.go` already uses a generated inventory/golden pattern for the Codex skill tree.
+  - `cmd/template_flag_contract_test.go` already enforces generated-template/Cobra drift in both directions.
+  - Docs already centralize generated adapter paths in `README.md` and `docs/ai-tools.md`, and JSON contracts in `docs/operator-guide.md`.
+- Reusable abstractions:
+  - `Registry`, `GeneratedAdapterMarkerPath`, `SkillPath`, `commandIDs`, command metadata, governance descriptors, and capability registry helpers can supply manifest rows.
+  - Existing generated-output tests can continue proving renderability while the new manifest proves inventory and docs coverage.
+- Convention deviations:
+  - A committed JSON manifest is new for this repo, but it matches the existing golden-manifest testing style and the issue's requested fail-closed behavior.
+
+### Risks
+- Technical risks:
+  - Medium: duplicate source lists could drift from command/skill registries. Mitigation: derive rows from existing registries and expose package-local helpers only where needed.
+  - Medium: docs-row checks can become brittle if they parse broad prose. Mitigation: use stable row/table tokens and path references, not whole-document snapshots.
+  - Low: generated JSON ordering/dates can create noisy diffs. Mitigation: deterministic sort and avoid volatile timestamps in check comparisons.
+- Guardrail domains: none detected.
+- Reversibility: high. The change adds generator/test/docs artifacts and can be reverted without data migration or runtime state changes.
+
+### Test Strategy
+- Existing coverage:
+  - `internal/toolgen/toolgen_test.go` checks command registry completeness, generated command surfaces, generated skill command references, and README command descriptions.
+  - `internal/toolgen/adapter_contract_test.go` freezes per-tool command path contracts.
+  - `internal/toolgen/support_files_test.go` freezes generated Codex skill tree structure.
+  - `cmd/template_flag_contract_test.go` checks generated template flag usage against real Cobra commands and the reverse flag-to-registry coverage.
+- Infrastructure needs:
+  - A Go-native manifest builder in `internal/toolgen`.
+  - A small regeneration entrypoint with explicit check and write modes that produces the same JSON as the tests.
+  - A committed public manifest under `docs/` because the inventory represents operator-facing product surfaces, not only package internals.
+- Verification approach:
+  - Test stale manifest by rebuilding live rows and comparing against the committed file.
+  - Test check/write behavior through the regeneration entrypoint or shared builder path.
+  - Test docs coverage by making each manifest row include the stable docs reference/token expected for that surface family.
+  - Preserve the existing README token/description test and add stable README/docs coverage derived from the manifest where practical.
+  - Run targeted `go test ./internal/toolgen ./cmd`, then full `go test ./...`.
+
+### Options
+- Option A: filesystem-scanning script outside the Go package.
+  - Tradeoffs: Simple to run, but adds a non-Go toolchain path and duplicates Slipway registries by filesystem scanning.
+- Option B: Go-native `internal/toolgen` manifest builder, committed public JSON, check/write regeneration entrypoint, and package tests.
+  - Tradeoffs: Best fit for Slipway because it reads the existing Go registries, remains deterministic in normal `go test`, keeps generator logic near adapter generation, and still gives maintainers an explicit regeneration surface.
+- Option C: Runtime `slipway surface-manifest` CLI command.
+  - Tradeoffs: More discoverable for operators, but wider public CLI surface and command docs burden before the internal contract is proven.
+- Selected: Option B in full. This satisfies issue #158 while keeping source authority in the package that already owns generated surfaces and giving CI and maintainers the same deterministic manifest contract.
+
+## Unknowns
+- Resolved: Which existing Slipway files own generated skills, command metadata, JSON/user-facing contracts, and docs rows? -> `internal/toolgen/toolgen.go`, `internal/tmpl/templates/`, `internal/engine/capability/`, `cmd/`, `README.md`, `docs/ai-tools.md`, `docs/commands.md`, and `docs/operator-guide.md`.
+- Resolved: What inventory-manifest mechanics are worth adapting? -> Build live inventory, support deterministic write/check behavior, commit JSON, and make tests fail with useful additions/removals. Do not import an external script implementation or surface family model.
+- Resolved: Where should the committed manifest live, and what generator/test entrypoint matches Slipway? -> Use `docs/SURFACE-MANIFEST.json` because the file describes public/operator-facing product surfaces. Implement a Go-native builder in `internal/toolgen` plus a deterministic check/write regeneration entrypoint used by tests.
+- Resolved: How should S2 wave evidence be recorded when `execution-summary.yaml` does not exist yet? -> `wave-orchestration` is the bootstrap stage that creates execution-summary evidence, so its `slipway evidence skill` path derives the run version from a single-version task evidence ledger. Later run-summary-bound skills continue to require an existing execution summary.
+- Remaining: None.
+
+## Assumptions
+- A manifest row is useful only if it names the source authority and expected docs representation for the surface. Evidence: issue #158 asks for generated skills, CLI commands, JSON contracts, and docs to stay one product surface.
+- `internal/toolgen` is the lowest-risk implementation home. Evidence: `toolgen.Generate` and the existing toolgen tests already own generated adapter outputs and contract drift checks.
+- Codebase-map docs are semantically stale for this change and are treated as advisory only during this recovery audit. Evidence: `artifacts/codebase/ARCHITECTURE.md`, `artifacts/codebase/STRUCTURE.md`, `artifacts/codebase/TESTING.md`, and `artifacts/codebase/CONCERNS.md` still name issue #151, while the issue #158 plan authority lives in this governed bundle and the current implementation diff.
+- S2 wave-orchestration evidence is the only run-summary-bound skill evidence that can be recorded before `execution-summary.yaml`; its run version comes from runtime task evidence. Evidence: `cmd/evidence.go` and `cmd/evidence_task_test.go`.
+- User confirmation for selecting the recommended approach and full implementation scope is covered by the objective's instruction to make the best choice when blocked plus the later instruction to fully implement the issue rather than a narrow subset. Evidence: active thread objective and follow-up scope refinement.
+
+## Canonical References
+- `https://github.com/signalridge/slipway/issues/158`
+- `internal/toolgen/toolgen.go`
+- `internal/toolgen/toolgen_test.go`
+- `internal/toolgen/adapter_contract_test.go`
+- `internal/toolgen/support_files_test.go`
+- `cmd/template_flag_contract_test.go`
+- `README.md`
+- `docs/ai-tools.md`
+- `docs/commands.md`
+- `docs/operator-guide.md`
+- `cmd/evidence.go`
+- `cmd/evidence_task_test.go`
+- `artifacts/codebase/ARCHITECTURE.md` (advisory; stale issue #151 map)
+- `artifacts/codebase/TESTING.md` (advisory; stale issue #151 map)
+- `artifacts/codebase/CONCERNS.md` (advisory; stale issue #151 map)

--- a/artifacts/changes/archived/resolve-github-issue-158-add-a-generated-surface-inventory-m/tasks.md
+++ b/artifacts/changes/archived/resolve-github-issue-158-add-a-generated-surface-inventory-m/tasks.md
@@ -1,0 +1,52 @@
+# Tasks
+
+## Task List
+
+- [x] `t-01` Implement deterministic surface manifest builder and committed public manifest.
+  - wave: 1
+  - depends_on: []
+  - target_files: [`internal/toolgen/surface_manifest.go`, `docs/SURFACE-MANIFEST.json`]
+  - task_kind: code
+  - covers: [REQ-001]
+
+- [x] `t-02` Add check/write regeneration entrypoint backed by the shared manifest builder.
+  - wave: 2
+  - depends_on: [`t-01`]
+  - target_files: [`internal/toolgen/cmd/gen-surface-manifest/main.go`, `internal/toolgen/surface_manifest.go`]
+  - task_kind: code
+  - covers: [REQ-002]
+
+- [x] `t-03` Add fail-closed manifest sync, regeneration, and docs-token tests while preserving existing README checks.
+  - wave: 3
+  - depends_on: [`t-01`, `t-02`]
+  - target_files: [`internal/toolgen/surface_manifest_test.go`, `internal/toolgen/cmd/gen-surface-manifest/main_test.go`, `internal/toolgen/toolgen_test.go`, `cmd/template_flag_contract_test.go`]
+  - task_kind: test
+  - covers: [REQ-001, REQ-002, REQ-003]
+
+- [x] `t-04` Document the committed surface manifest and regeneration path in public docs.
+  - wave: 3
+  - depends_on: [`t-01`, `t-02`]
+  - target_files: [`README.md`, `docs/ai-tools.md`, `docs/commands.md`, `docs/SURFACE-MANIFEST.json`]
+  - task_kind: doc
+  - covers: [REQ-003]
+
+- [x] `t-05` Verify focused packages, full Go test suite, manifest check mode, and governed readiness.
+  - wave: 4
+  - depends_on: [`t-03`, `t-04`]
+  - target_files: [`artifacts/changes/resolve-github-issue-158-add-a-generated-surface-inventory-m/verification/execution-summary.yaml`, `artifacts/changes/resolve-github-issue-158-add-a-generated-surface-inventory-m/verification/evidence-digests.yaml`, `artifacts/changes/resolve-github-issue-158-add-a-generated-surface-inventory-m/verification/wave-orchestration.yaml`]
+  - task_kind: verification
+  - covers: [REQ-004]
+
+- [x] `t-06` Repair S2 review re-certification dead-end discovered during stale review evidence recovery.
+  - wave: 5
+  - depends_on: [`t-05`]
+  - target_files: [`internal/engine/progression/evidence_digests.go`, `internal/engine/progression/evidence_digests_test.go`]
+  - task_kind: code
+  - covers: [REQ-005]
+
+- [x] `t-07` Repair S2 wave-orchestration evidence bootstrap dead-end discovered after refreshing task evidence.
+  - wave: 6
+  - depends_on: [`t-06`]
+  - target_files: [`cmd/evidence.go`, `cmd/evidence_task_test.go`, `docs/commands.md`]
+  - task_kind: code
+  - covers: [REQ-006]

--- a/cmd/evidence.go
+++ b/cmd/evidence.go
@@ -135,7 +135,7 @@ func makeEvidenceSkillCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				runVersion, err := evidenceSkillRunVersion(root, change, def)
+				runVersion, digestSummary, err := evidenceSkillRunContext(root, change, def)
 				if err != nil {
 					return err
 				}
@@ -161,17 +161,7 @@ func makeEvidenceSkillCmd() *cobra.Command {
 
 				stamped := false
 				if record.IsPassing() {
-					summary, err := state.LoadOptionalRelevantExecutionSummary(root, change)
-					if err != nil {
-						return newStateIntegrityError(
-							"evidence_skill_execution_summary_load_failed",
-							fmt.Sprintf("failed to load execution summary for %q: %v", change.Slug, err),
-							"Repair execution-summary.yaml or record non-passing skill evidence.",
-							change.Slug,
-							nil,
-						)
-					}
-					if err := progression.StampEvidenceDigestForSkill(root, change, skillName, record, summary); err != nil {
+					if err := progression.StampEvidenceDigestForSkill(root, change, skillName, record, digestSummary); err != nil {
 						return newStateIntegrityError(
 							"evidence_skill_digest_stamp_failed",
 							fmt.Sprintf("failed to stamp %s evidence digest: %v", skillName, err),
@@ -553,13 +543,13 @@ func validateEvidenceSkillName(root, skillName string) (skill.Definition, error)
 	return def, nil
 }
 
-func evidenceSkillRunVersion(root string, change model.Change, def skill.Definition) (int, error) {
+func evidenceSkillRunContext(root string, change model.Change, def skill.Definition) (int, *model.ExecutionSummary, error) {
 	if !def.RunSummaryBound {
-		return 0, nil
+		return 0, nil, nil
 	}
 	summary, err := state.LoadOptionalRelevantExecutionSummary(root, change)
 	if err != nil {
-		return 0, newStateIntegrityError(
+		return 0, nil, newStateIntegrityError(
 			"evidence_skill_execution_summary_load_failed",
 			fmt.Sprintf("failed to load execution summary for %q: %v", change.Slug, err),
 			"Repair execution-summary.yaml before recording run-summary-bound skill evidence.",
@@ -567,15 +557,134 @@ func evidenceSkillRunVersion(root string, change model.Change, def skill.Definit
 			nil,
 		)
 	}
-	if summary == nil || summary.RunSummaryVersion < 1 {
-		return 0, newInvalidUsageError(
-			"evidence_skill_run_summary_missing",
-			fmt.Sprintf("%s evidence requires execution-summary.yaml with run_summary_version >= 1", def.Name),
-			"Run wave execution first so Slipway can bind this verification to the current execution summary.",
-			map[string]any{"skill": def.Name},
+	if summary != nil && summary.RunSummaryVersion >= 1 {
+		return summary.RunSummaryVersion, summary, nil
+	}
+	if def.Name == progression.SkillWaveOrchestration && change.CurrentState == model.StateS2Execute {
+		runVersion, err := waveOrchestrationTaskEvidenceRunVersion(root, change)
+		if err != nil {
+			return 0, nil, err
+		}
+		return runVersion, &model.ExecutionSummary{
+			Version:           model.ExecutionSummaryVersion,
+			RunSummaryVersion: runVersion,
+			CapturedAt:        time.Now().UTC(),
+		}, nil
+	}
+	return 0, nil, newInvalidUsageError(
+		"evidence_skill_run_summary_missing",
+		fmt.Sprintf("%s evidence requires execution-summary.yaml with run_summary_version >= 1", def.Name),
+		"Run wave execution first so Slipway can bind this verification to the current execution summary.",
+		map[string]any{"skill": def.Name},
+	)
+}
+
+func waveOrchestrationTaskEvidenceRunVersion(root string, change model.Change) (int, error) {
+	dir := state.EvidenceTasksDir(root, change.Slug)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, newInvalidUsageError(
+				"evidence_skill_run_summary_missing",
+				"wave-orchestration evidence requires task evidence before execution-summary.yaml exists",
+				"Record task evidence with `slipway evidence task --run-summary-version <n>` before recording wave-orchestration evidence.",
+				map[string]any{"skill": progression.SkillWaveOrchestration},
+			)
+		}
+		return 0, newStateIntegrityError(
+			"evidence_skill_task_evidence_load_failed",
+			fmt.Sprintf("failed to read task evidence for %q: %v", change.Slug, err),
+			"Repair the runtime task evidence directory before recording wave-orchestration evidence.",
+			change.Slug,
+			map[string]any{"path": state.DisplayPath(root, dir)},
 		)
 	}
-	return summary.RunSummaryVersion, nil
+
+	versions := map[int]bool{}
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		raw, err := os.ReadFile(path) // #nosec G304 -- path is resolved from Slipway runtime evidence authority.
+		if err != nil {
+			return 0, newStateIntegrityError(
+				"evidence_skill_task_evidence_load_failed",
+				fmt.Sprintf("failed to read task evidence %q: %v", state.DisplayPath(root, path), err),
+				"Repair the runtime task evidence file before recording wave-orchestration evidence.",
+				change.Slug,
+				map[string]any{"path": state.DisplayPath(root, path)},
+			)
+		}
+		var payload struct {
+			RunSummaryVersion int `json:"run_summary_version"`
+		}
+		if err := json.Unmarshal(raw, &payload); err != nil {
+			return 0, newStateIntegrityError(
+				"evidence_skill_task_evidence_invalid",
+				fmt.Sprintf("failed to parse task evidence %q: %v", state.DisplayPath(root, path), err),
+				"Regenerate task evidence with `slipway evidence task` before recording wave-orchestration evidence.",
+				change.Slug,
+				map[string]any{"path": state.DisplayPath(root, path)},
+			)
+		}
+		if payload.RunSummaryVersion < 1 {
+			return 0, newStateIntegrityError(
+				"evidence_skill_task_evidence_invalid",
+				fmt.Sprintf("task evidence %q has invalid run_summary_version %d", state.DisplayPath(root, path), payload.RunSummaryVersion),
+				"Regenerate task evidence with a run_summary_version >= 1 before recording wave-orchestration evidence.",
+				change.Slug,
+				map[string]any{"path": state.DisplayPath(root, path)},
+			)
+		}
+		versions[payload.RunSummaryVersion] = true
+	}
+	if len(versions) == 0 {
+		return 0, newInvalidUsageError(
+			"evidence_skill_run_summary_missing",
+			"wave-orchestration evidence requires task evidence before execution-summary.yaml exists",
+			"Record task evidence with `slipway evidence task --run-summary-version <n>` before recording wave-orchestration evidence.",
+			map[string]any{"skill": progression.SkillWaveOrchestration},
+		)
+	}
+	if len(versions) > 1 {
+		return 0, newInvalidUsageError(
+			"evidence_skill_task_evidence_run_summary_ambiguous",
+			"task evidence contains multiple run_summary_version values",
+			"Re-record task evidence for a single wave-orchestration run_version before recording wave-orchestration evidence.",
+			map[string]any{"skill": progression.SkillWaveOrchestration},
+		)
+	}
+
+	runVersion := 0
+	for version := range versions {
+		runVersion = version
+	}
+	if tasks, issues, err := progression.LoadExecutionTasksFromEvidence(root, change.Slug, runVersion); err != nil {
+		return 0, newStateIntegrityError(
+			"evidence_skill_task_evidence_load_failed",
+			fmt.Sprintf("failed to load task evidence for run_summary_version=%d: %v", runVersion, err),
+			"Repair runtime task evidence before recording wave-orchestration evidence.",
+			change.Slug,
+			map[string]any{"run_summary_version": runVersion},
+		)
+	} else if len(issues) > 0 {
+		return 0, newStateIntegrityError(
+			"evidence_skill_task_evidence_invalid",
+			fmt.Sprintf("task evidence for run_summary_version=%d is invalid: %s", runVersion, strings.Join(issues, "; ")),
+			"Regenerate invalid task evidence before recording wave-orchestration evidence.",
+			change.Slug,
+			map[string]any{"run_summary_version": runVersion},
+		)
+	} else if len(tasks) == 0 {
+		return 0, newInvalidUsageError(
+			"evidence_skill_run_summary_missing",
+			"wave-orchestration evidence requires task evidence before execution-summary.yaml exists",
+			"Record task evidence with `slipway evidence task --run-summary-version <n>` before recording wave-orchestration evidence.",
+			map[string]any{"skill": progression.SkillWaveOrchestration},
+		)
+	}
+	return runVersion, nil
 }
 
 func validateEvidenceSkillStage(change model.Change, def skill.Definition) error {

--- a/cmd/evidence_task_test.go
+++ b/cmd/evidence_task_test.go
@@ -195,6 +195,68 @@ func TestEvidenceSkillRejectsRunSummaryBoundSkillWithoutExecutionSummary(t *test
 	})
 }
 
+func TestEvidenceSkillRecordsWaveOrchestrationBeforeExecutionSummary(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		slug, _ := createEvidenceTaskFixture(t, root)
+
+		taskCmd := commandForRoot(t, root, makeEvidenceCmd())
+		taskCmd.SetArgs([]string{
+			"task",
+			"--json",
+			"--task-id", "t-01",
+			"--run-summary-version", "1",
+			"--task-kind", "verification",
+			"--verdict", "pass",
+			"--evidence-ref", "test:wave-bootstrap-task",
+			"--changed-file", "cmd/lifecycle_commands_test.go",
+			"--target-file", "cmd/lifecycle_commands_test.go",
+		})
+		require.NoError(t, taskCmd.Execute())
+
+		summary, err := state.LoadOptionalExecutionSummary(root, slug)
+		require.NoError(t, err)
+		require.Nil(t, summary)
+
+		notesPath := filepath.Join(root, "wave-notes.md")
+		require.NoError(t, os.WriteFile(notesPath, []byte("wave evidence from task ledger\n"), 0o644))
+		skillCmd := commandForRoot(t, root, makeEvidenceCmd())
+		skillCmd.SetArgs([]string{
+			"skill",
+			"--json",
+			"--skill", progression.SkillWaveOrchestration,
+			"--verdict", "pass",
+			"--reference", "wave-orchestration:pass",
+			"--notes-file", "wave-notes.md",
+		})
+		var out bytes.Buffer
+		skillCmd.SetOut(&out)
+		require.NoError(t, skillCmd.Execute())
+
+		var view evidenceSkillView
+		require.NoError(t, json.Unmarshal(out.Bytes(), &view))
+		assert.Equal(t, slug, view.Slug)
+		assert.Equal(t, progression.SkillWaveOrchestration, view.Skill)
+		assert.Equal(t, 1, view.RunVersion)
+		assert.True(t, view.Recorded)
+		assert.True(t, view.Stamped)
+
+		rec, err := state.LoadVerification(root, slug, progression.SkillWaveOrchestration)
+		require.NoError(t, err)
+		assert.Equal(t, model.VerificationVerdictPass, rec.Verdict)
+		assert.Equal(t, 1, rec.RunVersion)
+		assert.Equal(t, "wave evidence from task ledger", rec.Notes)
+
+		digests, err := state.LoadOptionalEvidenceDigestsForChange(root, model.NewChange(slug))
+		require.NoError(t, err)
+		require.NotNil(t, digests)
+		assert.Contains(t, digests.Skills, progression.SkillWaveOrchestration)
+	})
+}
+
 func TestEvidenceSkillRejectsWrongWorkflowStateWithoutWritingEvidence(t *testing.T) {
 	t.Parallel()
 

--- a/docs/SURFACE-MANIFEST.json
+++ b/docs/SURFACE-MANIFEST.json
@@ -1,0 +1,523 @@
+{
+  "version": 1,
+  "rows": [
+    {
+      "kind": "adapter",
+      "name": "claude",
+      "source": "internal/toolgen/toolgen.go:toolRegistry",
+      "docs": "docs/ai-tools.md",
+      "token": "`claude`"
+    },
+    {
+      "kind": "adapter",
+      "name": "codex",
+      "source": "internal/toolgen/toolgen.go:toolRegistry",
+      "docs": "docs/ai-tools.md",
+      "token": "`codex`"
+    },
+    {
+      "kind": "adapter",
+      "name": "cursor",
+      "source": "internal/toolgen/toolgen.go:toolRegistry",
+      "docs": "docs/ai-tools.md",
+      "token": "`cursor`"
+    },
+    {
+      "kind": "adapter",
+      "name": "gemini",
+      "source": "internal/toolgen/toolgen.go:toolRegistry",
+      "docs": "docs/ai-tools.md",
+      "token": "`gemini`"
+    },
+    {
+      "kind": "adapter",
+      "name": "opencode",
+      "source": "internal/toolgen/toolgen.go:toolRegistry",
+      "docs": "docs/ai-tools.md",
+      "token": "`opencode`"
+    },
+    {
+      "kind": "command",
+      "name": "abort",
+      "source": "internal/toolgen/toolgen.go:commandRegistry",
+      "docs": "docs/commands.md",
+      "token": "slipway abort"
+    },
+    {
+      "kind": "command",
+      "name": "cancel",
+      "source": "internal/toolgen/toolgen.go:commandRegistry",
+      "docs": "docs/commands.md",
+      "token": "slipway cancel"
+    },
+    {
+      "kind": "command",
+      "name": "checkpoint",
+      "source": "internal/toolgen/toolgen.go:commandRegistry",
+      "docs": "docs/commands.md",
+      "token": "slipway checkpoint"
+    },
+    {
+      "kind": "command",
+      "name": "codebase-map",
+      "source": "internal/toolgen/toolgen.go:commandRegistry",
+      "docs": "docs/commands.md",
+      "token": "slipway codebase-map"
+    },
+    {
+      "kind": "command",
+      "name": "delete",
+      "source": "internal/toolgen/toolgen.go:commandRegistry",
+      "docs": "docs/commands.md",
+      "token": "slipway delete"
+    },
+    {
+      "kind": "command",
+      "name": "done",
+      "source": "internal/toolgen/toolgen.go:commandRegistry",
+      "docs": "docs/commands.md",
+      "token": "slipway done"
+    },
+    {
+      "kind": "command",
+      "name": "evidence",
+      "source": "internal/toolgen/toolgen.go:commandRegistry",
+      "docs": "docs/commands.md",
+      "token": "slipway evidence"
+    },
+    {
+      "kind": "command",
+      "name": "health",
+      "source": "internal/toolgen/toolgen.go:commandRegistry",
+      "docs": "docs/commands.md",
+      "token": "slipway health"
+    },
+    {
+      "kind": "command",
+      "name": "init",
+      "source": "internal/toolgen/toolgen.go:commandRegistry",
+      "docs": "docs/commands.md",
+      "token": "slipway init"
+    },
+    {
+      "kind": "command",
+      "name": "instructions",
+      "source": "internal/toolgen/toolgen.go:commandRegistry",
+      "docs": "docs/commands.md",
+      "token": "slipway instructions"
+    },
+    {
+      "kind": "command",
+      "name": "learn",
+      "source": "internal/toolgen/toolgen.go:commandRegistry",
+      "docs": "docs/commands.md",
+      "token": "slipway learn"
+    },
+    {
+      "kind": "command",
+      "name": "new",
+      "source": "internal/toolgen/toolgen.go:commandRegistry",
+      "docs": "docs/commands.md",
+      "token": "slipway new"
+    },
+    {
+      "kind": "command",
+      "name": "next",
+      "source": "internal/toolgen/toolgen.go:commandRegistry",
+      "docs": "docs/commands.md",
+      "token": "slipway next"
+    },
+    {
+      "kind": "command",
+      "name": "pivot",
+      "source": "internal/toolgen/toolgen.go:commandRegistry",
+      "docs": "docs/commands.md",
+      "token": "slipway pivot"
+    },
+    {
+      "kind": "command",
+      "name": "preset",
+      "source": "internal/toolgen/toolgen.go:commandRegistry",
+      "docs": "docs/commands.md",
+      "token": "slipway preset"
+    },
+    {
+      "kind": "command",
+      "name": "repair",
+      "source": "internal/toolgen/toolgen.go:commandRegistry",
+      "docs": "docs/commands.md",
+      "token": "slipway repair"
+    },
+    {
+      "kind": "command",
+      "name": "review",
+      "source": "internal/toolgen/toolgen.go:commandRegistry",
+      "docs": "docs/commands.md",
+      "token": "slipway review"
+    },
+    {
+      "kind": "command",
+      "name": "run",
+      "source": "internal/toolgen/toolgen.go:commandRegistry",
+      "docs": "docs/commands.md",
+      "token": "slipway run"
+    },
+    {
+      "kind": "command",
+      "name": "stats",
+      "source": "internal/toolgen/toolgen.go:commandRegistry",
+      "docs": "docs/commands.md",
+      "token": "slipway stats"
+    },
+    {
+      "kind": "command",
+      "name": "status",
+      "source": "internal/toolgen/toolgen.go:commandRegistry",
+      "docs": "docs/commands.md",
+      "token": "slipway status"
+    },
+    {
+      "kind": "command",
+      "name": "validate",
+      "source": "internal/toolgen/toolgen.go:commandRegistry",
+      "docs": "docs/commands.md",
+      "token": "slipway validate"
+    },
+    {
+      "kind": "documentation",
+      "name": "README.md",
+      "source": "README.md",
+      "docs": "README.md",
+      "token": "Generated surfaces"
+    },
+    {
+      "kind": "documentation",
+      "name": "docs/ai-tools.md",
+      "source": "docs/ai-tools.md",
+      "docs": "docs/ai-tools.md",
+      "token": "Generated Command Surface"
+    },
+    {
+      "kind": "documentation",
+      "name": "docs/commands.md",
+      "source": "docs/commands.md",
+      "docs": "docs/commands.md",
+      "token": "Command Reference"
+    },
+    {
+      "kind": "documentation",
+      "name": "docs/operator-guide.md",
+      "source": "docs/operator-guide.md",
+      "docs": "docs/operator-guide.md",
+      "token": "Diagnostic JSON"
+    },
+    {
+      "kind": "json-contract",
+      "name": "abort-json",
+      "source": "cmd/abort.go",
+      "docs": "docs/commands.md",
+      "token": "slipway abort --json"
+    },
+    {
+      "kind": "json-contract",
+      "name": "cancel-json",
+      "source": "cmd/cancel.go",
+      "docs": "docs/commands.md",
+      "token": "slipway cancel --json"
+    },
+    {
+      "kind": "json-contract",
+      "name": "checkpoint-json",
+      "source": "cmd/checkpoint.go",
+      "docs": "docs/commands.md",
+      "token": "slipway checkpoint --task-id \u003cid\u003e --json"
+    },
+    {
+      "kind": "json-contract",
+      "name": "codebase-map-json",
+      "source": "cmd/codebase_map.go",
+      "docs": "docs/commands.md",
+      "token": "slipway codebase-map --json"
+    },
+    {
+      "kind": "json-contract",
+      "name": "delete-json",
+      "source": "cmd/delete.go",
+      "docs": "docs/commands.md",
+      "token": "slipway delete --change \u003cslug\u003e --json"
+    },
+    {
+      "kind": "json-contract",
+      "name": "done-json",
+      "source": "cmd/done.go",
+      "docs": "docs/commands.md",
+      "token": "slipway done --json"
+    },
+    {
+      "kind": "json-contract",
+      "name": "evidence-skill-json",
+      "source": "cmd/evidence.go",
+      "docs": "docs/commands.md",
+      "token": "slipway evidence skill --skill \u003cname\u003e --verdict pass --json"
+    },
+    {
+      "kind": "json-contract",
+      "name": "evidence-task-json",
+      "source": "cmd/evidence.go",
+      "docs": "docs/commands.md",
+      "token": "slipway evidence task --task-id t-01 --run-summary-version 1 --task-kind code --verdict pass --evidence-ref \"test:go-test\" --json"
+    },
+    {
+      "kind": "json-contract",
+      "name": "health-json",
+      "source": "cmd/health.go",
+      "docs": "docs/commands.md",
+      "token": "slipway health --json"
+    },
+    {
+      "kind": "json-contract",
+      "name": "instructions-json",
+      "source": "cmd/instructions.go",
+      "docs": "docs/commands.md",
+      "token": "slipway instructions \u003cartifact\u003e --json"
+    },
+    {
+      "kind": "json-contract",
+      "name": "learn-json",
+      "source": "cmd/learn.go",
+      "docs": "docs/commands.md",
+      "token": "slipway learn --json"
+    },
+    {
+      "kind": "json-contract",
+      "name": "new-json",
+      "source": "cmd/new.go",
+      "docs": "docs/commands.md",
+      "token": "slipway new --json"
+    },
+    {
+      "kind": "json-contract",
+      "name": "next-json",
+      "source": "cmd/next.go",
+      "docs": "docs/commands.md",
+      "token": "slipway next --json"
+    },
+    {
+      "kind": "json-contract",
+      "name": "pivot-json",
+      "source": "cmd/pivot.go",
+      "docs": "docs/commands.md",
+      "token": "slipway pivot --json"
+    },
+    {
+      "kind": "json-contract",
+      "name": "preset-json",
+      "source": "cmd/preset.go",
+      "docs": "docs/commands.md",
+      "token": "slipway preset \u003clevel\u003e --json"
+    },
+    {
+      "kind": "json-contract",
+      "name": "repair-json",
+      "source": "cmd/repair.go",
+      "docs": "docs/commands.md",
+      "token": "slipway repair --json"
+    },
+    {
+      "kind": "json-contract",
+      "name": "review-json",
+      "source": "cmd/review.go",
+      "docs": "docs/commands.md",
+      "token": "slipway review --json"
+    },
+    {
+      "kind": "json-contract",
+      "name": "run-json",
+      "source": "cmd/run.go",
+      "docs": "docs/commands.md",
+      "token": "slipway run --json"
+    },
+    {
+      "kind": "json-contract",
+      "name": "stats-json",
+      "source": "cmd/stats.go",
+      "docs": "docs/commands.md",
+      "token": "slipway stats --json"
+    },
+    {
+      "kind": "json-contract",
+      "name": "status-json",
+      "source": "cmd/status.go",
+      "docs": "docs/commands.md",
+      "token": "slipway status --json"
+    },
+    {
+      "kind": "json-contract",
+      "name": "validate-json",
+      "source": "cmd/validate.go",
+      "docs": "docs/commands.md",
+      "token": "slipway validate --json"
+    },
+    {
+      "kind": "skill",
+      "name": "slipway",
+      "source": "internal/toolgen/toolgen.go:hostSkillExportAllowlist",
+      "docs": "README.md",
+      "token": "`slipway/SKILL.md`"
+    },
+    {
+      "kind": "skill",
+      "name": "slipway-ci-triage",
+      "source": "internal/engine/capability.DefaultRegistry",
+      "docs": "README.md",
+      "token": "`slipway-ci-triage/SKILL.md`"
+    },
+    {
+      "kind": "skill",
+      "name": "slipway-code-quality-review",
+      "source": "internal/toolgen/toolgen.go:governanceSurfaceDescriptors",
+      "docs": "README.md",
+      "token": "`slipway-code-quality-review/SKILL.md`"
+    },
+    {
+      "kind": "skill",
+      "name": "slipway-codebase-mapping",
+      "source": "internal/toolgen/toolgen.go:hostSkillExportAllowlist",
+      "docs": "README.md",
+      "token": "`slipway-codebase-mapping/SKILL.md`"
+    },
+    {
+      "kind": "skill",
+      "name": "slipway-coding-discipline",
+      "source": "internal/toolgen/toolgen.go:hostSkillExportAllowlist",
+      "docs": "README.md",
+      "token": "`slipway-coding-discipline/SKILL.md`"
+    },
+    {
+      "kind": "skill",
+      "name": "slipway-context-assembly",
+      "source": "internal/engine/capability.DefaultRegistry",
+      "docs": "README.md",
+      "token": "`slipway-context-assembly/SKILL.md`"
+    },
+    {
+      "kind": "skill",
+      "name": "slipway-coverage-analysis",
+      "source": "internal/engine/capability.DefaultRegistry",
+      "docs": "README.md",
+      "token": "`slipway-coverage-analysis/SKILL.md`"
+    },
+    {
+      "kind": "skill",
+      "name": "slipway-final-closeout",
+      "source": "internal/toolgen/toolgen.go:governanceSurfaceDescriptors",
+      "docs": "README.md",
+      "token": "`slipway-final-closeout/SKILL.md`"
+    },
+    {
+      "kind": "skill",
+      "name": "slipway-git-recovery",
+      "source": "internal/engine/capability.DefaultRegistry",
+      "docs": "README.md",
+      "token": "`slipway-git-recovery/SKILL.md`"
+    },
+    {
+      "kind": "skill",
+      "name": "slipway-goal-verification",
+      "source": "internal/toolgen/toolgen.go:governanceSurfaceDescriptors",
+      "docs": "README.md",
+      "token": "`slipway-goal-verification/SKILL.md`"
+    },
+    {
+      "kind": "skill",
+      "name": "slipway-incident-response",
+      "source": "internal/engine/capability.DefaultRegistry",
+      "docs": "README.md",
+      "token": "`slipway-incident-response/SKILL.md`"
+    },
+    {
+      "kind": "skill",
+      "name": "slipway-independent-review",
+      "source": "internal/engine/capability.DefaultRegistry",
+      "docs": "README.md",
+      "token": "`slipway-independent-review/SKILL.md`"
+    },
+    {
+      "kind": "skill",
+      "name": "slipway-intake-clarification",
+      "source": "internal/toolgen/toolgen.go:governanceSurfaceDescriptors",
+      "docs": "README.md",
+      "token": "`slipway-intake-clarification/SKILL.md`"
+    },
+    {
+      "kind": "skill",
+      "name": "slipway-plan-audit",
+      "source": "internal/toolgen/toolgen.go:governanceSurfaceDescriptors",
+      "docs": "README.md",
+      "token": "`slipway-plan-audit/SKILL.md`"
+    },
+    {
+      "kind": "skill",
+      "name": "slipway-research-orchestration",
+      "source": "internal/toolgen/toolgen.go:governanceSurfaceDescriptors",
+      "docs": "README.md",
+      "token": "`slipway-research-orchestration/SKILL.md`"
+    },
+    {
+      "kind": "skill",
+      "name": "slipway-root-cause-tracing",
+      "source": "internal/engine/capability.DefaultRegistry",
+      "docs": "README.md",
+      "token": "`slipway-root-cause-tracing/SKILL.md`"
+    },
+    {
+      "kind": "skill",
+      "name": "slipway-security-review",
+      "source": "internal/engine/capability.DefaultRegistry",
+      "docs": "README.md",
+      "token": "`slipway-security-review/SKILL.md`"
+    },
+    {
+      "kind": "skill",
+      "name": "slipway-spec-compliance-review",
+      "source": "internal/toolgen/toolgen.go:governanceSurfaceDescriptors",
+      "docs": "README.md",
+      "token": "`slipway-spec-compliance-review/SKILL.md`"
+    },
+    {
+      "kind": "skill",
+      "name": "slipway-spec-trace",
+      "source": "internal/engine/capability.DefaultRegistry",
+      "docs": "README.md",
+      "token": "`slipway-spec-trace/SKILL.md`"
+    },
+    {
+      "kind": "skill",
+      "name": "slipway-tdd-governance",
+      "source": "internal/toolgen/toolgen.go:governanceSurfaceDescriptors",
+      "docs": "README.md",
+      "token": "`slipway-tdd-governance/SKILL.md`"
+    },
+    {
+      "kind": "skill",
+      "name": "slipway-test-design",
+      "source": "internal/engine/capability.DefaultRegistry",
+      "docs": "README.md",
+      "token": "`slipway-test-design/SKILL.md`"
+    },
+    {
+      "kind": "skill",
+      "name": "slipway-wave-orchestration",
+      "source": "internal/toolgen/toolgen.go:governanceSurfaceDescriptors",
+      "docs": "README.md",
+      "token": "`slipway-wave-orchestration/SKILL.md`"
+    },
+    {
+      "kind": "skill",
+      "name": "slipway-worktree-preflight",
+      "source": "internal/toolgen/toolgen.go:governanceSurfaceDescriptors",
+      "docs": "README.md",
+      "token": "`slipway-worktree-preflight/SKILL.md`"
+    }
+  ]
+}

--- a/docs/ai-tools.md
+++ b/docs/ai-tools.md
@@ -78,6 +78,21 @@ Diagnostics prompt-backed commands:
 Every CLI command ships a prompt-backed surface, so an agent never has to fall
 back to guessing one; the workflow skill's command reference indexes them all.
 
+## Surface Manifest
+
+`docs/SURFACE-MANIFEST.json` is the committed inventory for generated adapter,
+command, skill, JSON, and documentation surfaces. It is regenerated from
+Slipway-owned Go authorities, not hand-edited:
+
+```bash
+go run ./internal/toolgen/cmd/gen-surface-manifest --write
+go run ./internal/toolgen/cmd/gen-surface-manifest --check
+```
+
+Run `--write` after adding a generated tool, command, skill, JSON contract, or
+documentation surface, then keep the matching documentation token in the file
+named by the manifest row.
+
 ## OpenCode Notes
 
 OpenCode stores project commands as Markdown files under `.opencode/commands/`. Slipway generates flat OpenCode command files under:

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -117,6 +117,19 @@ map-consuming planning skill (research-orchestration or plan-audit) is next and
 the status is `scaffold_only` or `baseline`, `warnings` carries a non-blocking
 codebase-map advisory.
 
+`docs/SURFACE-MANIFEST.json` is the committed generated-surface inventory for
+adapter, command, skill, JSON, and documentation rows. The manifest is rebuilt
+from Slipway-owned Go authorities and checked in CI-facing Go tests:
+
+```bash
+go run ./internal/toolgen/cmd/gen-surface-manifest --check
+go run ./internal/toolgen/cmd/gen-surface-manifest --write
+```
+
+When adding a command, skill, JSON output contract, or docs-facing surface, run
+`--write` and keep the manifest row's documentation token present in the named
+docs file. A stale manifest or missing docs token fails `go test ./internal/toolgen`.
+
 ## Output And Hydration Flags
 
 Query and review commands share a consistent output-and-hydration surface, kept
@@ -160,6 +173,32 @@ slipway evidence task --task-id t-01 --run-summary-version 1 --task-kind code --
 slipway health --doctor --json
 ```
 
+Stable manifest tokens for JSON contract coverage:
+
+| Contract | Token |
+| --- | --- |
+| abort JSON | `slipway abort --json` |
+| cancel JSON | `slipway cancel --json` |
+| checkpoint JSON | `slipway checkpoint --task-id <id> --json` |
+| codebase-map JSON | `slipway codebase-map --json` |
+| delete JSON | `slipway delete --change <slug> --json` |
+| done JSON | `slipway done --json` |
+| evidence skill JSON | `slipway evidence skill --skill <name> --verdict pass --json` |
+| evidence task JSON | `slipway evidence task --task-id t-01 --run-summary-version 1 --task-kind code --verdict pass --evidence-ref "test:go-test" --json` |
+| health JSON | `slipway health --json` |
+| instructions JSON | `slipway instructions <artifact> --json` |
+| learn JSON | `slipway learn --json` |
+| new JSON | `slipway new --json` |
+| next JSON | `slipway next --json` |
+| pivot JSON | `slipway pivot --json` |
+| preset JSON | `slipway preset <level> --json` |
+| repair JSON | `slipway repair --json` |
+| review JSON | `slipway review --json` |
+| run JSON | `slipway run --json` |
+| stats JSON | `slipway stats --json` |
+| status JSON | `slipway status --json` |
+| validate JSON | `slipway validate --json` |
+
 `next --json` includes `next_skill.name` for AI-tool handoff. The host tool derives the local `SKILL.md` path from its own adapter conventions.
 
 When diagnostics are enabled, review-state handoff JSON can also include:
@@ -199,6 +238,15 @@ validates task kind/verdict/blockers, and refuses unknown or path-unsafe task ID
 instead of relying on hand-written JSON.
 `freshness_inputs` includes the current wave-plan `tasks_plan_hash` so task
 evidence cannot be reused after `tasks.md` semantically changes.
+
+`slipway evidence skill --skill wave-orchestration` is the S2 bootstrap for
+execution-summary evidence. Before `execution-summary.yaml` exists, it derives
+the wave run version from the current flat task evidence ledger, requires all
+task evidence to use a single valid `run_summary_version`, and stamps the
+wave-orchestration digest from that ledger. Later run-summary-bound skills such
+as `spec-compliance-review`, `code-quality-review`, `goal-verification`, and
+`final-closeout` still require an existing execution summary and fail closed
+with `evidence_skill_run_summary_missing` when it is absent.
 
 Accepted governance skill evidence is additionally bound by
 `verification/evidence-digests.yaml`, an engine-owned local file that records the

--- a/internal/engine/progression/evidence_digests.go
+++ b/internal/engine/progression/evidence_digests.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/signalridge/slipway/internal/engine/skill"
 	"github.com/signalridge/slipway/internal/engine/wave"
 	"github.com/signalridge/slipway/internal/model"
 	"github.com/signalridge/slipway/internal/state"
@@ -286,6 +287,11 @@ func passingAndPreviouslyAcceptedSkillRecords(
 	if err != nil {
 		return nil, err
 	}
+	currentPosition := currentStaleEvidencePosition(change)
+	recordedPositions, err := recordedSkillEvidencePositions(root)
+	if err != nil {
+		return nil, err
+	}
 	for skillName, record := range verifications {
 		skillName = strings.TrimSpace(skillName)
 		if skillName == SkillIntakeClarification {
@@ -297,11 +303,31 @@ func passingAndPreviouslyAcceptedSkillRecords(
 		if skillName == "" || !recorded[skillName] || !record.IsPassing() {
 			continue
 		}
+		position, ok := recordedPositions[skillName]
+		if ok && compareStaleEvidencePosition(position, currentPosition) > 0 {
+			continue
+		}
 		if _, exists := out[skillName]; !exists {
 			out[skillName] = record
 		}
 	}
 	return out, nil
+}
+
+func recordedSkillEvidencePositions(root string) (map[string]staleEvidencePosition, error) {
+	registry, err := skill.LoadGovernanceRegistry(root)
+	if err != nil {
+		return nil, err
+	}
+	positions := map[string]staleEvidencePosition{}
+	for _, def := range registry {
+		position, ok := staleEvidencePositionForDefinition(def)
+		if !ok {
+			continue
+		}
+		positions[strings.TrimSpace(def.Name)] = position
+	}
+	return positions, nil
 }
 
 func recordedSkillEvidenceSet(root string, change model.Change) (map[string]bool, error) {

--- a/internal/engine/progression/evidence_digests_test.go
+++ b/internal/engine/progression/evidence_digests_test.go
@@ -345,6 +345,66 @@ func TestMissingWaveDigestEntryStampsCurrentRuntimeTaskEvidenceWithoutTimestampR
 	assert.Contains(t, digests.Skills[SkillWaveOrchestration].Inputs, "runtime_task_evidence")
 }
 
+func TestStampPassingSkillDigestsDoesNotBlockCurrentStageOnFutureAcceptedEvidence(t *testing.T) {
+	t.Parallel()
+
+	root, change := createReviewInputDigestFixture(t)
+	change.CurrentState = model.StateS2Execute
+	require.NoError(t, state.SaveChange(root, change))
+	writeDigestPlanningBundle(t, root, change, uncheckedDigestTasks())
+	writeTasksAndMaterializeWavePlan(t, root, change, uncheckedDigestTasks())
+	plan, err := state.LoadWavePlanForChange(root, change)
+	require.NoError(t, err)
+
+	capturedAt := time.Date(2026, 6, 4, 3, 0, 0, 0, time.UTC)
+	writeWaveDigestTaskEvidence(t, root, change, plan.TasksPlanHash, "test:wave", capturedAt)
+	tasks, issues, err := LoadExecutionTasksFromEvidence(root, change.Slug, 1)
+	require.NoError(t, err)
+	require.Empty(t, issues)
+	summary := &model.ExecutionSummary{
+		Version:           model.ExecutionSummaryVersion,
+		RunSummaryVersion: 1,
+		CapturedAt:        capturedAt,
+		OverallVerdict:    model.ExecutionVerdictPass,
+		TasksPlanHash:     plan.TasksPlanHash,
+		Tasks:             tasks,
+	}
+	summary.SyncDerivedFields()
+	require.NoError(t, state.SaveExecutionSummary(root, change.Slug, *summary))
+
+	waveRecord := model.VerificationRecord{
+		Verdict:    model.VerificationVerdictPass,
+		Blockers:   []model.ReasonCode{},
+		Timestamp:  capturedAt.Add(time.Minute),
+		RunVersion: 1,
+	}
+	writeVerificationForTest(t, root, change.Slug, SkillWaveOrchestration, waveRecord)
+
+	reviewRecord := model.VerificationRecord{
+		Verdict:    model.VerificationVerdictPass,
+		Blockers:   []model.ReasonCode{},
+		Timestamp:  capturedAt.Add(2 * time.Minute),
+		RunVersion: 1,
+		References: []string{"layer:R0=pass"},
+	}
+	writeVerificationForTest(t, root, change.Slug, SkillSpecComplianceReview, reviewRecord)
+	require.NoError(t, StampEvidenceDigestForSkill(root, change, SkillSpecComplianceReview, reviewRecord, summary))
+	_, err = state.AppendLifecycleEvent(root, change, state.LifecycleEvent{
+		EventType: "skill.evidence_recorded",
+		SkillID:   SkillSpecComplianceReview,
+		Result:    "recorded",
+		Reason:    "verification_evidence_consumed",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(filepath.Join(root, "tracked.go"), []byte("package main\n\nconst changedForFutureReview = true\n"), 0o644))
+	result, err := stampPassingSkillDigests(root, change, map[string]model.VerificationRecord{
+		SkillWaveOrchestration: waveRecord,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, result.Blockers, "future-stage review evidence must not block S2 wave digest stamping")
+}
+
 func TestStampPassingSkillDigestsStampsPreviouslyConsumedEvidenceWithoutLegacyEvent(t *testing.T) {
 	t.Parallel()
 

--- a/internal/toolgen/cmd/gen-surface-manifest/main.go
+++ b/internal/toolgen/cmd/gen-surface-manifest/main.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/signalridge/slipway/internal/toolgen"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	var check bool
+	var write bool
+	flag.BoolVar(&check, "check", false, "fail if docs/SURFACE-MANIFEST.json is stale")
+	flag.BoolVar(&write, "write", false, "rewrite docs/SURFACE-MANIFEST.json")
+	flag.Parse()
+
+	repoRoot, err := findRepoRoot()
+	if err != nil {
+		return err
+	}
+	return runWithOptions(repoRoot, manifestCommandOptions{
+		check:  check,
+		write:  write,
+		stdout: os.Stdout,
+	})
+}
+
+type manifestCommandOptions struct {
+	check  bool
+	write  bool
+	stdout io.Writer
+}
+
+func runWithOptions(repoRoot string, opts manifestCommandOptions) error {
+	if opts.check && opts.write {
+		return errors.New("choose only one of --check or --write")
+	}
+	if opts.stdout == nil {
+		opts.stdout = io.Discard
+	}
+	manifestPath := filepath.Join(repoRoot, toolgen.SurfaceManifestPath)
+
+	live, err := toolgen.EncodeSurfaceManifest(toolgen.BuildSurfaceManifest())
+	if err != nil {
+		return fmt.Errorf("encode surface manifest: %w", err)
+	}
+
+	switch {
+	case opts.write:
+		if err := os.MkdirAll(filepath.Dir(manifestPath), 0o755); err != nil {
+			return fmt.Errorf("create manifest directory: %w", err)
+		}
+		if err := os.WriteFile(manifestPath, live, 0o644); err != nil { // #nosec G306 -- committed docs artifact.
+			return fmt.Errorf("write %s: %w", toolgen.SurfaceManifestPath, err)
+		}
+		fmt.Fprintf(opts.stdout, "wrote %s\n", toolgen.SurfaceManifestPath)
+		return nil
+	case opts.check:
+		committed, err := os.ReadFile(manifestPath)
+		if err != nil {
+			return fmt.Errorf("%s is missing or unreadable; run `go run ./internal/toolgen/cmd/gen-surface-manifest --write`: %w",
+				toolgen.SurfaceManifestPath,
+				err)
+		}
+		if bytes.Equal(committed, live) {
+			fmt.Fprintf(opts.stdout, "%s is up to date\n", toolgen.SurfaceManifestPath)
+			return nil
+		}
+		return fmt.Errorf("%s is stale; run `go run ./internal/toolgen/cmd/gen-surface-manifest --write`\n%s",
+			toolgen.SurfaceManifestPath,
+			surfaceManifestDiff(committed, live))
+	default:
+		_, err := opts.stdout.Write(live)
+		return err
+	}
+}
+
+func findRepoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("get working directory: %w", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", errors.New("could not find repository root containing go.mod")
+		}
+		dir = parent
+	}
+}
+
+func surfaceManifestDiff(committed, live []byte) string {
+	committedRows := decodeRows(committed)
+	liveRows := decodeRows(live)
+
+	committedSet := map[string]struct{}{}
+	for _, row := range committedRows {
+		committedSet[surfaceManifestRowKey(row)] = struct{}{}
+	}
+	liveSet := map[string]struct{}{}
+	for _, row := range liveRows {
+		liveSet[surfaceManifestRowKey(row)] = struct{}{}
+	}
+
+	var lines []string
+	for _, row := range liveRows {
+		key := surfaceManifestRowKey(row)
+		if _, ok := committedSet[key]; !ok {
+			lines = append(lines, "+ "+key)
+		}
+	}
+	for _, row := range committedRows {
+		key := surfaceManifestRowKey(row)
+		if _, ok := liveSet[key]; !ok {
+			lines = append(lines, "- "+key)
+		}
+	}
+	if len(lines) == 0 {
+		return "manifest row keys are unchanged; committed JSON differs in metadata or ordering"
+	}
+	return strings.Join(lines, "\n")
+}
+
+func decodeRows(raw []byte) []toolgen.SurfaceManifestRow {
+	var manifest toolgen.SurfaceManifest
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		return nil
+	}
+	return manifest.Rows
+}
+
+func surfaceManifestRowKey(row toolgen.SurfaceManifestRow) string {
+	return row.Kind + "/" + row.Name
+}

--- a/internal/toolgen/cmd/gen-surface-manifest/main.go
+++ b/internal/toolgen/cmd/gen-surface-manifest/main.go
@@ -61,7 +61,7 @@ func runWithOptions(repoRoot string, opts manifestCommandOptions) error {
 
 	switch {
 	case opts.write:
-		if err := os.MkdirAll(filepath.Dir(manifestPath), 0o755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(manifestPath), 0o755); err != nil { // #nosec G301 -- docs directory is a committed project artifact location.
 			return fmt.Errorf("create manifest directory: %w", err)
 		}
 		if err := os.WriteFile(manifestPath, live, 0o644); err != nil { // #nosec G306 -- committed docs artifact.
@@ -70,7 +70,7 @@ func runWithOptions(repoRoot string, opts manifestCommandOptions) error {
 		fmt.Fprintf(opts.stdout, "wrote %s\n", toolgen.SurfaceManifestPath)
 		return nil
 	case opts.check:
-		committed, err := os.ReadFile(manifestPath)
+		committed, err := os.ReadFile(manifestPath) // #nosec G304 -- manifestPath is repo root plus docs/SURFACE-MANIFEST.json.
 		if err != nil {
 			return fmt.Errorf("%s is missing or unreadable; run `go run ./internal/toolgen/cmd/gen-surface-manifest --write`: %w",
 				toolgen.SurfaceManifestPath,

--- a/internal/toolgen/cmd/gen-surface-manifest/main_test.go
+++ b/internal/toolgen/cmd/gen-surface-manifest/main_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/signalridge/slipway/internal/toolgen"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunWithOptionsWritesChecksAndPrintsSurfaceManifest(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	var stdout bytes.Buffer
+
+	require.NoError(t, runWithOptions(repoRoot, manifestCommandOptions{
+		write:  true,
+		stdout: &stdout,
+	}))
+	assert.Contains(t, stdout.String(), "wrote docs/SURFACE-MANIFEST.json")
+
+	manifestPath := filepath.Join(repoRoot, toolgen.SurfaceManifestPath)
+	committed, err := os.ReadFile(manifestPath)
+	require.NoError(t, err)
+
+	live, err := toolgen.EncodeSurfaceManifest(toolgen.BuildSurfaceManifest())
+	require.NoError(t, err)
+	assert.Equal(t, string(live), string(committed))
+
+	stdout.Reset()
+	require.NoError(t, runWithOptions(repoRoot, manifestCommandOptions{
+		check:  true,
+		stdout: &stdout,
+	}))
+	assert.Contains(t, stdout.String(), "docs/SURFACE-MANIFEST.json is up to date")
+
+	stdout.Reset()
+	require.NoError(t, runWithOptions(repoRoot, manifestCommandOptions{
+		stdout: &stdout,
+	}))
+	assert.JSONEq(t, string(live), stdout.String())
+}
+
+func TestRunWithOptionsCheckFailsOnStaleSurfaceManifest(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	manifestPath := filepath.Join(repoRoot, toolgen.SurfaceManifestPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(manifestPath), 0o755))
+	require.NoError(t, os.WriteFile(manifestPath, []byte(`{"version":1,"rows":[]}`+"\n"), 0o644))
+
+	err := runWithOptions(repoRoot, manifestCommandOptions{check: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "docs/SURFACE-MANIFEST.json is stale")
+	assert.Contains(t, err.Error(), "go run ./internal/toolgen/cmd/gen-surface-manifest --write")
+	assert.Contains(t, err.Error(), "+ command/new")
+}
+
+func TestRunWithOptionsRejectsCheckAndWriteTogether(t *testing.T) {
+	t.Parallel()
+
+	err := runWithOptions(t.TempDir(), manifestCommandOptions{
+		check: true,
+		write: true,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "choose only one")
+}

--- a/internal/toolgen/surface_manifest.go
+++ b/internal/toolgen/surface_manifest.go
@@ -221,7 +221,7 @@ func documentationRows() []SurfaceManifestRow {
 			Name:   "docs/commands.md",
 			Source: "docs/commands.md",
 			Docs:   "docs/commands.md",
-			Token:  "Command Reference",
+			Token:  "Command Reference", // #nosec G101 -- manifest token is a docs search string, not a credential.
 		},
 		{
 			Kind:   "documentation",

--- a/internal/toolgen/surface_manifest.go
+++ b/internal/toolgen/surface_manifest.go
@@ -1,0 +1,234 @@
+package toolgen
+
+import (
+	"bytes"
+	"encoding/json"
+	"slices"
+	"strings"
+)
+
+// SurfaceManifestPath is the committed generated-surface inventory location.
+const SurfaceManifestPath = "docs/SURFACE-MANIFEST.json"
+
+// SurfaceManifest is a deterministic public inventory of Slipway product
+// surfaces derived from the same authorities that generate skills, command
+// prompts, JSON contracts, and documentation.
+type SurfaceManifest struct {
+	Version int                  `json:"version"`
+	Rows    []SurfaceManifestRow `json:"rows"`
+}
+
+// SurfaceManifestRow ties one generated or documented public surface to the
+// authority that creates it and the documentation token that keeps it visible.
+type SurfaceManifestRow struct {
+	Kind   string `json:"kind"`
+	Name   string `json:"name"`
+	Source string `json:"source"`
+	Docs   string `json:"docs"`
+	Token  string `json:"token"`
+}
+
+// BuildSurfaceManifest derives the public surface inventory from Slipway-owned
+// registries and stable documentation contracts.
+func BuildSurfaceManifest() SurfaceManifest {
+	rows := []SurfaceManifestRow{}
+
+	for _, def := range commandRegistry {
+		rows = append(rows, SurfaceManifestRow{
+			Kind:   "command",
+			Name:   def.ID,
+			Source: "internal/toolgen/toolgen.go:commandRegistry",
+			Docs:   "docs/commands.md",
+			Token:  "slipway " + def.ID,
+		})
+	}
+
+	for _, cfg := range Registry() {
+		rows = append(rows, SurfaceManifestRow{
+			Kind:   "adapter",
+			Name:   cfg.ID,
+			Source: "internal/toolgen/toolgen.go:toolRegistry",
+			Docs:   "docs/ai-tools.md",
+			Token:  "`" + cfg.ID + "`",
+		})
+	}
+
+	seenSkills := map[string]struct{}{}
+	for _, desc := range governanceSurfaceDescriptors {
+		name := adapterSkillName(desc.ID)
+		rows = append(rows, SurfaceManifestRow{
+			Kind:   "skill",
+			Name:   name,
+			Source: "internal/toolgen/toolgen.go:governanceSurfaceDescriptors",
+			Docs:   "README.md",
+			Token:  skillDocsToken(name),
+		})
+		seenSkills[name] = struct{}{}
+	}
+	for _, id := range append(append([]string{}, standaloneNames...), techniqueNames...) {
+		if !shouldExportAsHostSkill(id) {
+			continue
+		}
+		name := adapterSkillName(id)
+		if _, ok := seenSkills[name]; ok {
+			continue
+		}
+		rows = append(rows, SurfaceManifestRow{
+			Kind:   "skill",
+			Name:   name,
+			Source: "internal/toolgen/toolgen.go:hostSkillExportAllowlist",
+			Docs:   "README.md",
+			Token:  skillDocsToken(name),
+		})
+		seenSkills[name] = struct{}{}
+	}
+	for _, id := range catalogSkillIDs {
+		if !shouldExportAsHostSkill(id) {
+			continue
+		}
+		name := adapterSkillName(id)
+		if _, ok := seenSkills[name]; ok {
+			continue
+		}
+		rows = append(rows, SurfaceManifestRow{
+			Kind:   "skill",
+			Name:   name,
+			Source: "internal/engine/capability.DefaultRegistry",
+			Docs:   "README.md",
+			Token:  skillDocsToken(name),
+		})
+		seenSkills[name] = struct{}{}
+	}
+
+	rows = append(rows, jsonContractRows()...)
+	rows = append(rows, documentationRows()...)
+
+	slices.SortFunc(rows, compareSurfaceManifestRows)
+	return SurfaceManifest{
+		Version: 1,
+		Rows:    rows,
+	}
+}
+
+// EncodeSurfaceManifest renders stable, newline-terminated JSON for the
+// committed manifest and check-mode comparisons.
+func EncodeSurfaceManifest(manifest SurfaceManifest) ([]byte, error) {
+	raw, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	buf.Write(raw)
+	buf.WriteByte('\n')
+	return buf.Bytes(), nil
+}
+
+func compareSurfaceManifestRows(a, b SurfaceManifestRow) int {
+	switch {
+	case a.Kind < b.Kind:
+		return -1
+	case a.Kind > b.Kind:
+		return 1
+	case a.Name < b.Name:
+		return -1
+	case a.Name > b.Name:
+		return 1
+	case a.Source < b.Source:
+		return -1
+	case a.Source > b.Source:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func jsonContractRows() []SurfaceManifestRow {
+	rows := []SurfaceManifestRow{}
+	for _, def := range commandRegistry {
+		if !strings.Contains(def.Arguments, "--json") {
+			continue
+		}
+		if def.ID == "evidence" {
+			rows = append(rows,
+				SurfaceManifestRow{
+					Kind:   "json-contract",
+					Name:   "evidence-task-json",
+					Source: commandSourcePath(def.ID),
+					Docs:   "docs/commands.md",
+					Token:  "slipway evidence task --task-id t-01 --run-summary-version 1 --task-kind code --verdict pass --evidence-ref \"test:go-test\" --json",
+				},
+				SurfaceManifestRow{
+					Kind:   "json-contract",
+					Name:   "evidence-skill-json",
+					Source: commandSourcePath(def.ID),
+					Docs:   "docs/commands.md",
+					Token:  "slipway evidence skill --skill <name> --verdict pass --json",
+				},
+			)
+			continue
+		}
+		rows = append(rows, SurfaceManifestRow{
+			Kind:   "json-contract",
+			Name:   def.ID + "-json",
+			Source: commandSourcePath(def.ID),
+			Docs:   "docs/commands.md",
+			Token:  jsonContractDocsToken(def.ID),
+		})
+	}
+	return rows
+}
+
+func commandSourcePath(commandID string) string {
+	return "cmd/" + strings.ReplaceAll(commandID, "-", "_") + ".go"
+}
+
+func jsonContractDocsToken(commandID string) string {
+	switch commandID {
+	case "checkpoint":
+		return "slipway checkpoint --task-id <id> --json"
+	case "delete":
+		return "slipway delete --change <slug> --json"
+	case "instructions":
+		return "slipway instructions <artifact> --json"
+	case "preset":
+		return "slipway preset <level> --json"
+	}
+	return "slipway " + commandID + " --json"
+}
+
+func skillDocsToken(name string) string {
+	return "`" + name + "/SKILL.md`"
+}
+
+func documentationRows() []SurfaceManifestRow {
+	return []SurfaceManifestRow{
+		{
+			Kind:   "documentation",
+			Name:   "README.md",
+			Source: "README.md",
+			Docs:   "README.md",
+			Token:  "Generated surfaces",
+		},
+		{
+			Kind:   "documentation",
+			Name:   "docs/ai-tools.md",
+			Source: "docs/ai-tools.md",
+			Docs:   "docs/ai-tools.md",
+			Token:  "Generated Command Surface",
+		},
+		{
+			Kind:   "documentation",
+			Name:   "docs/commands.md",
+			Source: "docs/commands.md",
+			Docs:   "docs/commands.md",
+			Token:  "Command Reference",
+		},
+		{
+			Kind:   "documentation",
+			Name:   "docs/operator-guide.md",
+			Source: "docs/operator-guide.md",
+			Docs:   "docs/operator-guide.md",
+			Token:  "Diagnostic JSON",
+		},
+	}
+}

--- a/internal/toolgen/surface_manifest_test.go
+++ b/internal/toolgen/surface_manifest_test.go
@@ -1,0 +1,153 @@
+package toolgen
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildSurfaceManifestDerivesRowsFromSlipwayAuthorities(t *testing.T) {
+	t.Parallel()
+
+	manifest := BuildSurfaceManifest()
+	raw, err := EncodeSurfaceManifest(manifest)
+	require.NoError(t, err)
+
+	var decoded SurfaceManifest
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+	assert.Equal(t, manifest, decoded)
+
+	assert.Equal(t, 1, manifest.Version)
+	assert.NotEmpty(t, manifest.Rows)
+	assert.True(t, slices.IsSortedFunc(manifest.Rows, compareSurfaceManifestRows),
+		"manifest rows must be sorted for deterministic JSON")
+
+	rowsByKey := map[string]SurfaceManifestRow{}
+	for _, row := range manifest.Rows {
+		require.NotEmpty(t, row.Kind)
+		require.NotEmpty(t, row.Name)
+		require.NotEmpty(t, row.Source)
+		require.NotEmpty(t, row.Docs)
+		require.NotEmpty(t, row.Token)
+		rowsByKey[row.Kind+"/"+row.Name] = row
+	}
+
+	for _, id := range commandIDs() {
+		row, ok := rowsByKey["command/"+id]
+		require.Truef(t, ok, "missing command row for %s", id)
+		assert.Equal(t, "internal/toolgen/toolgen.go:commandRegistry", row.Source)
+		assert.Equal(t, "docs/commands.md", row.Docs)
+		assert.Equal(t, "slipway "+id, row.Token)
+	}
+
+	for _, cfg := range Registry() {
+		row, ok := rowsByKey["adapter/"+cfg.ID]
+		require.Truef(t, ok, "missing adapter row for %s", cfg.ID)
+		assert.Equal(t, "internal/toolgen/toolgen.go:toolRegistry", row.Source)
+		assert.Equal(t, "docs/ai-tools.md", row.Docs)
+		assert.Equal(t, "`"+cfg.ID+"`", row.Token)
+	}
+
+	for _, id := range governanceSurfaceIDs(func(governanceSurfaceDescriptor) bool { return true }) {
+		row, ok := rowsByKey["skill/"+adapterSkillName(id)]
+		require.Truef(t, ok, "missing governance skill row for %s", id)
+		assert.Equal(t, "internal/toolgen/toolgen.go:governanceSurfaceDescriptors", row.Source)
+		assert.Equal(t, "README.md", row.Docs)
+		assert.Equal(t, skillDocsToken(adapterSkillName(id)), row.Token)
+	}
+
+	for _, id := range append(append([]string{}, standaloneNames...), techniqueNames...) {
+		if !shouldExportAsHostSkill(id) {
+			continue
+		}
+		row, ok := rowsByKey["skill/"+adapterSkillName(id)]
+		require.Truef(t, ok, "missing standalone or technique skill row for %s", id)
+		assert.Equal(t, "internal/toolgen/toolgen.go:hostSkillExportAllowlist", row.Source)
+		assert.Equal(t, "README.md", row.Docs)
+		assert.Equal(t, skillDocsToken(adapterSkillName(id)), row.Token)
+	}
+
+	for _, id := range catalogSkillIDs {
+		if !shouldExportAsHostSkill(id) {
+			continue
+		}
+		row, ok := rowsByKey["skill/"+adapterSkillName(id)]
+		require.Truef(t, ok, "missing exported catalog skill row for %s", id)
+		assert.Equal(t, "internal/engine/capability.DefaultRegistry", row.Source)
+	}
+
+	for _, def := range commandRegistry {
+		if !strings.Contains(def.Arguments, "--json") {
+			continue
+		}
+		if def.ID == "evidence" {
+			for _, id := range []string{"evidence-task-json", "evidence-skill-json"} {
+				row, ok := rowsByKey["json-contract/"+id]
+				require.Truef(t, ok, "missing json contract row for %s", id)
+				assert.Equal(t, "cmd/evidence.go", row.Source)
+				assert.Equal(t, "docs/commands.md", row.Docs)
+				assert.Contains(t, row.Token, "json")
+			}
+			continue
+		}
+		row, ok := rowsByKey["json-contract/"+def.ID+"-json"]
+		require.Truef(t, ok, "missing json contract row for %s", def.ID)
+		assert.Equal(t, commandSourcePath(def.ID), row.Source)
+		assert.Equal(t, "docs/commands.md", row.Docs)
+		assert.Contains(t, row.Token, "json")
+	}
+
+	for _, path := range []string{"README.md", "docs/ai-tools.md", "docs/commands.md", "docs/operator-guide.md"} {
+		key := "documentation/" + path
+		row, ok := rowsByKey[key]
+		require.Truef(t, ok, "missing documentation row for %s", path)
+		assert.Equal(t, path, row.Docs)
+		assert.Equal(t, path, row.Name)
+	}
+}
+
+func TestCommittedSurfaceManifestMatchesBuilder(t *testing.T) {
+	t.Parallel()
+
+	live, err := EncodeSurfaceManifest(BuildSurfaceManifest())
+	require.NoError(t, err)
+
+	committedPath := filepath.Join(toolgenRepoRoot(t), SurfaceManifestPath)
+	committed := readSurfaceManifestFixture(t, committedPath)
+	if string(live) != committed {
+		t.Fatalf("%s is stale; run `go run ./internal/toolgen/cmd/gen-surface-manifest --write`.\n--- diff sample ---\n%s",
+			SurfaceManifestPath,
+			firstNDiffLines(committed, string(live), 20))
+	}
+}
+
+func TestSurfaceManifestDocsTokensExist(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := toolgenRepoRoot(t)
+	docsCache := map[string]string{}
+
+	for _, row := range BuildSurfaceManifest().Rows {
+		content, ok := docsCache[row.Docs]
+		if !ok {
+			content = readSurfaceManifestFixture(t, filepath.Join(repoRoot, row.Docs))
+			docsCache[row.Docs] = content
+		}
+		assert.Containsf(t, content, row.Token,
+			"%s/%s expects token %q in %s", row.Kind, row.Name, row.Token, row.Docs)
+	}
+}
+
+func readSurfaceManifestFixture(t *testing.T, path string) string {
+	t.Helper()
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return strings.ReplaceAll(string(raw), "\r\n", "\n")
+}


### PR DESCRIPTION
## Summary
- add a deterministic generated surface manifest at `docs/SURFACE-MANIFEST.json`
- add `gen-surface-manifest` with stdout, `--check`, and `--write` modes
- add fail-closed manifest/docs-token tests for generated command, adapter, skill, JSON, and docs surfaces
- repair the S2 evidence re-certification and wave-orchestration bootstrap dead ends found during governed closeout
- archive the governed change record for issue #158

## Verification
- `go run ./internal/toolgen/cmd/gen-surface-manifest --check`
- `git diff --check origin/main...HEAD`
- `go build ./...`
- `go test -timeout=20m ./... -count=1`

Closes #158