### PR TITLE
feat(robustness): add transactional multi-file writes

### DIFF
--- a/artifacts/changes/archived/resolve-github-issue-164-implement-transactional-multi-file/assurance.md
+++ b/artifacts/changes/archived/resolve-github-issue-164-implement-transactional-multi-file/assurance.md
@@ -1,0 +1,129 @@
+# Assurance
+
+## Scope Summary
+
+This change implements issue #164 for transactional governed multi-file
+mutations. The selected option was the focused `internal/fsutil` file
+transaction helper, applied to the governed transition surfaces identified in
+research:
+
+- S1 planning bundle scaffold before `change.yaml` authority persistence.
+- S1-to-S2 `wave-plan.yaml` materialization before `change.yaml` authority
+  persistence.
+- Stale-evidence recovery removals and digest pruning before reopened
+  `change.yaml` authority persistence.
+
+The implementation also includes the S3 review fix for scaffold-owned artifact
+paths: direct symlink artifact paths are rejected before transaction-backed
+atomic writes can replace them.
+
+Out of scope remains unchanged from the approved decision: directory archive,
+bundle relocation, crash-recovery journaling, and broader lifecycle redesign.
+
+## Verification Verdict
+
+Pass. The governed execution, spec-compliance review, and code-quality review
+all report pass for run version 1. `go run . validate --json` currently reports
+state `S4_VERIFY`, freshness `fresh`, and scope contract `pass`; after
+goal-verification, the remaining blocker is final-closeout evidence and its
+standard-preset assurance attestation.
+
+Fresh verification evidence recorded through S4 verification:
+
+- `go test ./internal/fsutil ./internal/engine/artifact ./internal/engine/progression ./internal/state`: pass
+- `go test ./cmd -count=1`: pass
+- `go test ./... -count=1`: pass
+- `git diff --check`: pass
+- `go run github.com/securego/gosec/v2/cmd/gosec@v2.27.1 -fmt=sarif -out=artifacts/changes/resolve-github-issue-164-implement-transactional-multi-file/verification/gosec.sarif ./...`: pass; SARIF result count is 0
+- `go test ./internal/fsutil ./internal/engine/artifact ./internal/engine/progression ./internal/state -coverprofile=artifacts/changes/resolve-github-issue-164-implement-transactional-multi-file/verification/coverage.out -count=1`: pass; combined profile total is 70.3%
+- `go run . validate --json`: fresh, scope contract pass
+
+Post-archive PR lint cleanup:
+
+- GitHub PR #181 initially reported `Lint Go` failure for unused helper
+  functions left behind after the transactional recovery path replaced the
+  older direct-delete helpers.
+- The cleanup removes only those unused helpers; the transaction behavior and
+  rollback call sites are unchanged.
+- GitHub PR #181 then reported a Windows-only test assertion mismatch because
+  POSIX permission bits are not reported the same way on Windows. The test keeps
+  the restored-file content assertion on every OS and limits the exact
+  permission-bit assertion to non-Windows platforms.
+- Fresh local verification after the cleanup: `golangci-lint run --timeout=5m`
+  pass and `go test ./... -count=1` pass.
+
+## Evidence Index
+
+- `verification/execution-summary.yaml`: run_summary_version 1, tasks `t-01`
+  through `t-03` pass.
+- `verification/wave-orchestration.yaml` and
+  `verification/wave-orchestration-notes.md`: S2 execution pass with TDD red and
+  green evidence for all planned tasks.
+- `verification/spec-compliance-review.yaml` and
+  `verification/spec-compliance-review-notes.md`: pass; forward and reverse
+  trace cover REQ-001 through REQ-005 and all changed implementation/test files.
+- `verification/code-quality-review.yaml` and
+  `verification/code-quality-review-notes.md`: pass; implementation quality,
+  test quality, IR3 guardrail safety, and consistency checks have no open
+  blockers.
+- `verification/goal-verification.yaml` and
+  `verification/goal-verification-notes.md`: pass; acceptance criteria are
+  verified with fresh full-suite, SAST, placeholder-scan, coverage, and scope
+  evidence, including
+  `high_risk_check:irreversible_operations.safety_baseline=pass`.
+- `verification/gosec.sarif`: current SAST artifact with 0 results.
+- `verification/coverage.out`: current target-package coverage profile.
+- `requirements.md`, `decision.md`, and `tasks.md`: approved contract, selected
+  approach, and completed task coverage.
+
+## Requirement Coverage
+
+- REQ-001 is covered by `internal/fsutil/transaction.go` and regression tests
+  proving created-file cleanup and original-byte restoration after later
+  failures.
+- REQ-002 is covered by transactional stale-evidence recovery in
+  `internal/engine/progression/stale_evidence_recovery.go`, including tests that
+  restore evidence files, digest state, and lifecycle authority when reopened
+  state save fails.
+- REQ-003 is covered by `FileTransactionError`, which preserves the original
+  operation error and rollback errors with affected file paths, with tests for
+  rollback-failure diagnostics.
+- REQ-004 is covered by applying the shared file-set transaction boundary to S1
+  bundle scaffold, S1-to-S2 wave-plan materialization, and stale-evidence
+  reopen recovery.
+- REQ-005 is covered by deterministic injected-failure tests for core helper
+  rollback, governed scaffold rollback, wave-plan rollback, and stale-evidence
+  recovery rollback.
+
+## Residual Risks and Exceptions
+
+No open readiness blocker is known after the review fixes and verification
+commands above.
+
+Accepted residual limits:
+
+- The transaction helper is synchronous and process-local; it does not add a
+  durable crash-recovery journal.
+- Directory archive and bundle relocation remain outside this issue's scope.
+- If rollback itself fails at runtime, the command fails closed and reports the
+  affected path for manual inspection before normal Slipway validation and
+  gates continue.
+
+## Rollback Readiness
+
+Code rollback is straightforward: revert the `internal/fsutil` transaction
+helper, the transaction-op call-site changes, and the regression tests added for
+issue #164. After a revert, rerun the targeted package tests and
+`go run . validate --json` to refresh the governed bundle state.
+
+Runtime rollback readiness is built into the implementation: failed file-set
+operations restore previously applied writes/removes in reverse order; rollback
+failures are not hidden and do not allow a governed transition to report
+success.
+
+## Archive Decision
+
+The active worktree reached `done_ready` through Slipway's public lifecycle
+output, and `go run . done --json` archived the governed bundle as a terminal
+record. Post-archive PR lint cleanup is documented above rather than restamping
+engine-owned evidence.

--- a/artifacts/changes/archived/resolve-github-issue-164-implement-transactional-multi-file/change.yaml
+++ b/artifacts/changes/archived/resolve-github-issue-164-implement-transactional-multi-file/change.yaml
@@ -1,0 +1,61 @@
+version: 1
+slug: resolve-github-issue-164-implement-transactional-multi-file
+description: 'Resolve GitHub issue #164: implement transactional multi-file writes with rollback for Slipway stage transitions so simulated mid-transition failure leaves no partial bundle; reference local gsd-core src/phase.cts writePlanningFileSet during implementation.'
+status: done
+current_state: DONE
+needs_discovery: true
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-06-11T04:37:08.438498Z
+guardrail_domain: irreversible_operations
+quality_mode: full
+workflow_profile: code
+workflow_preset: standard
+worktree_branch: feat/resolve-github-issue-164-implement-transactional-multi-file
+artifact_schema: expanded
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: 8e854923d38db5c4e27b7b7a95a0868c8d33a490cb8290920abe253b0943e82d
+        updated_at: 2026-06-11T12:28:32.445915125Z
+    decision:
+        id: decision
+        path: decision.md
+        state: frozen
+        content_hash: b6aaea98156d2f68de06edd36bbd134f4ba83830ac80476f2ba4bb10bd919888
+        updated_at: 2026-06-11T05:27:44.350806442Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: a9a428ff29011050b3ff04b97f29d46ff3e652c14f8753be74844723d89106d1
+        updated_at: 2026-06-11T05:19:25.270941227Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: 4bfcf997d022beeaa9d6de46ba59594c1055cbe28e2f2f07a2683a212bb42db7
+        updated_at: 2026-06-11T05:27:44.350545818Z
+    research:
+        id: research
+        path: research.md
+        state: frozen
+        content_hash: c8550b72265310fb5a17ba561b7fa9c070da8f0a21fad596496480192423c881
+        updated_at: 2026-06-11T05:22:32.955339427Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: 322bb3fcf739dddc3fb13525c5262679932f88ff685146463da12e5878b7afc9
+        updated_at: 2026-06-11T11:44:55.958211651Z
+evidence_refs:
+    code-quality-review: .worktrees/resolve-github-issue-164-implement-transactional-multi-file/artifacts/changes/resolve-github-issue-164-implement-transactional-multi-file/verification/code-quality-review.yaml
+    final-closeout: .worktrees/resolve-github-issue-164-implement-transactional-multi-file/artifacts/changes/resolve-github-issue-164-implement-transactional-multi-file/verification/final-closeout.yaml
+    goal-verification: .worktrees/resolve-github-issue-164-implement-transactional-multi-file/artifacts/changes/resolve-github-issue-164-implement-transactional-multi-file/verification/goal-verification.yaml
+    intake-clarification: .worktrees/resolve-github-issue-164-implement-transactional-multi-file/artifacts/changes/resolve-github-issue-164-implement-transactional-multi-file/verification/intake-clarification.yaml
+    plan-audit: .worktrees/resolve-github-issue-164-implement-transactional-multi-file/artifacts/changes/resolve-github-issue-164-implement-transactional-multi-file/verification/plan-audit.yaml
+    research-orchestration: .worktrees/resolve-github-issue-164-implement-transactional-multi-file/artifacts/changes/resolve-github-issue-164-implement-transactional-multi-file/verification/research-orchestration.yaml
+    spec-compliance-review: .worktrees/resolve-github-issue-164-implement-transactional-multi-file/artifacts/changes/resolve-github-issue-164-implement-transactional-multi-file/verification/spec-compliance-review.yaml
+    wave-orchestration: .worktrees/resolve-github-issue-164-implement-transactional-multi-file/artifacts/changes/resolve-github-issue-164-implement-transactional-multi-file/verification/wave-orchestration.yaml

--- a/artifacts/changes/archived/resolve-github-issue-164-implement-transactional-multi-file/decision.md
+++ b/artifacts/changes/archived/resolve-github-issue-164-implement-transactional-multi-file/decision.md
@@ -1,0 +1,72 @@
+# Decision
+
+## Alternatives Considered
+
+1. Add a focused `internal/fsutil` file transaction helper and route issue #164 transition file sets through it.
+   This keeps the existing single-file `fsutil.WriteFileAtomic` durability primitive, adds one reusable all-or-nothing boundary for write/remove sets, and gives tests a deterministic failure seam. It matches the local GSD reference pattern of recording applied file writes and rolling them back in reverse order without porting the TypeScript implementation.
+
+2. Add custom rollback code directly to each transition path.
+   This would minimize new abstraction, but each path would need separate snapshot, restore, newly-created-file cleanup, and rollback-failure reporting. That increases the chance that future governed transitions drift from the irreversible-operations guardrail.
+
+3. Build a durable journal or recovery daemon for every governed filesystem mutation.
+   This would provide stronger crash recovery, but it is larger than issue #164 requires. The current issue is about synchronous multi-file stage-transition failure, not process-crash recovery or a database-style transaction log.
+
+Selected direction: option 1.
+
+## Selected Approach
+
+Add a small file-oriented transaction primitive under `internal/fsutil` and adapt the identified governed transition surfaces to use it when a transition mutates more than one lifecycle artifact or authority file.
+
+The transaction helper will snapshot existing files before mutation, track newly-created files, apply operations in order, and roll back in reverse order if a later operation fails. Write operations will continue to rely on the existing atomic single-file primitive where possible. Remove operations will snapshot file bytes before deletion so stale-evidence recovery can restore removed evidence when the reopened state save fails.
+
+The first implementation scope is limited to the issue #164 file-set surfaces found in research:
+
+- S1 planning bundle materialization before `change.yaml` persistence.
+- Stale-evidence reopen removals before reopened `change.yaml` persistence.
+- S1-to-S2 `wave-plan.yaml` materialization before `change.yaml` persistence.
+
+Directory archive, bundle relocation, and broad lifecycle-state redesign remain out of scope because they are not the file-set write/delete failure class requested by the issue.
+
+## Interfaces and Data Flow
+
+New or changed interfaces:
+
+- `internal/fsutil` will expose a file transaction API for ordered write and remove operations. Exact type names may change during implementation, but the API must carry operation path, file bytes for writes, file mode when relevant, and deterministic test failure injection.
+- Artifact scaffolding will either build transaction write operations for missing scaffold-owned artifacts or accept a transaction-aware writer from progression code. The resulting behavior must not leave a partially scaffolded bundle if a later transition save fails.
+- Progression code will wrap transition-specific file sets so artifact or evidence mutations and the following `change.yaml` save succeed or fail together.
+- State and wave-plan persistence will continue to use existing state-store semantics, but wave-plan materialization before an S2 transition must participate in the same all-or-nothing boundary as the transition state save.
+
+Data flow:
+
+1. The transition code determines the concrete file mutations required for the lifecycle move.
+2. It passes those mutations to the `fsutil` transaction helper.
+3. The helper snapshots current file state, applies each operation in order, and records what has been applied.
+4. On success, the transition reports advancement normally.
+5. On operation failure, the helper rolls back applied operations in reverse order and returns an error.
+6. On rollback failure, the helper returns an error that includes the original operation error and the affected file paths needing inspection.
+
+## Rollout and Rollback
+
+Rollout is internal to the Slipway CLI and is gated by the governed plan, wave execution, domain review, and final readiness checks. The implementation should land as a narrow code change with package-level regression tests before any broader workflow behavior is touched.
+
+Verification commands:
+
+- `go test ./internal/fsutil ./internal/engine/artifact ./internal/engine/progression ./internal/state`
+- `go run . validate --json`
+- Additional governed `go run . run --json --diagnostics` / evidence commands selected by the current lifecycle.
+
+Rollback path:
+
+- Revert the new `internal/fsutil` transaction helper and the transition call-site changes.
+- Revert the new regression tests tied to those interfaces.
+- Re-run the targeted package tests and `go run . validate --json` to confirm the governed bundle reflects the reverted scope.
+
+If a runtime rollback failure is observed during execution, the command must fail closed. Operators should inspect the paths named in the error, rerun validation after manual repair if needed, and continue only through normal Slipway gates.
+
+## Risk
+
+- A naive helper could preserve only newly-created files and miss replacing original bytes. The helper must snapshot existing file contents before applying writes or removes.
+- Rollback itself can fail. That path must report both the original failure and the rollback file path rather than hiding the partial state.
+- Wrapping `change.yaml` persistence together with artifact operations may require careful call-site boundaries so machine-local worktree binding writes are not treated as governed artifact state.
+- Scope creep into directory archive or bundle relocation would increase blast radius without directly addressing issue #164. Those paths stay excluded unless a test proves they share the same file-set failure class.
+- The codebase map for this worktree was generated for an earlier issue, so direct source inspection and current-worktree tests are the authority for this plan.

--- a/artifacts/changes/archived/resolve-github-issue-164-implement-transactional-multi-file/intent.md
+++ b/artifacts/changes/archived/resolve-github-issue-164-implement-transactional-multi-file/intent.md
@@ -1,0 +1,60 @@
+# Intent
+
+## Summary
+Resolve GitHub issue #164: implement transactional multi-file writes with rollback for Slipway stage transitions so simulated mid-transition failure leaves no partial bundle; reference local gsd-core src/phase.cts writePlanningFileSet during implementation.
+## Complexity Assessment
+complex
+<!-- Rationale: provide justification for the assessed complexity level -->
+
+## Guardrail Domains
+irreversible_operations
+
+## In Scope
+- Add an all-or-nothing apply/rollback mechanism for Slipway governed multi-file lifecycle mutations where a stage transition writes more than one artifact or authority file.
+- Apply that mechanism to stage-transition paths that can currently leave a governed bundle partially materialized or partially reopened if a later write fails.
+- Preserve the existing single-file atomic write behavior; the new scope is the multi-file transaction boundary around those writes.
+- Surface rollback failure as a fail-closed blocker/error that names the affected files to inspect, following the behavior pattern in local `gsd-core/src/phase.cts::writePlanningFileSet` without copying its TypeScript implementation.
+- Add a regression test that simulates a mid-transition write failure and proves no partial governed bundle/artifact state remains.
+
+## Out of Scope
+- No broad redesign of the lifecycle state machine or artifact schema.
+- No durable database-style journal, background recovery daemon, or cross-process transaction manager.
+- No change to `slipway done` final archive semantics unless research proves the issue #164 failure class is in that path.
+- No vendoring or direct port of GSD code.
+
+## Constraints
+- Use the current worktree's Slipway CLI and governed lifecycle as authority.
+- Keep changes small and rooted in the issue #164 failure class: stage-transition multi-file artifact/authority writes.
+- Preserve fail-closed behavior for irreversible-operations guardrails.
+- Use existing Go repository style, `fsutil.WriteFileAtomic`, and current test helpers where possible.
+
+## Acceptance Signals
+- A test simulates a failure after at least one transition file write has been attempted and before the transition completes.
+- After that simulated failure, pre-existing files are restored and newly-created transition files are absent; the governed change is not left with partial bundle materialization.
+- Rollback failure handling names the file(s) that may require inspection and fails closed instead of reporting success.
+- Targeted package tests covering the transactional path pass.
+- Final governed readiness reaches `done-ready` through current-worktree `go run . validate --json` / governance health evidence.
+
+## Open Questions
+<!-- Track real unknowns as a checklist. An unchecked `- [ ]` item is unresolved
+     and routes intake to S0_INTAKE/research; mark `- [x]` once resolved. Leave the
+     section empty (or write `None`) when there are none. Prose here is
+     documentation, not a blocker — a genuine open question must be a `- [ ]`. -->
+- [x] Which current Slipway stage-transition paths perform multi-file governed artifact/authority mutations and need the transactional wrapper for issue #164?
+
+  Resolved from current code inspection plus local GSD reference:
+  - Primary issue #164 surface: file-level governed transition mutations where a first artifact/evidence write or delete can succeed before a later `change.yaml`/verification write fails.
+  - Cover S1 planning bundle materialization: `AdvanceGoverned` advances to `S1_PLAN/bundle`, `artifact.ScaffoldGovernedBundleForChange` may create artifact files, then `state.SaveChange` persists `change.yaml`.
+  - Cover stale-evidence reopen: `reopenToStaleStage` removes verification/wave/execution summary files, mutates change state/evidence refs, then saves `change.yaml`.
+  - Keep directory archive/relocation out of the first issue #164 wrapper unless tests prove they share the same file-set failure class; `ArchiveChange` already has explicit directory rollback, while `RelocateGovernedBundle` is a directory move path rather than the GSD-style multi-file write set.
+
+## Deferred Ideas
+- General-purpose filesystem journaling for arbitrary user edits.
+- Automatic repair of every historical partially-mutated bundle shape.
+
+## Approved Summary
+- Confirmed by user on 2026-06-11 14:19:09 JST with response `确认推进`.
+- Implement transactional, all-or-nothing file-set handling for governed stage-transition mutations that can currently leave a partial bundle when a later artifact, verification, or `change.yaml` write fails.
+- First implementation scope covers S1 planning bundle materialization and stale-evidence reopen file mutations; directory archive/relocation semantics are excluded unless implementation tests prove they share the same issue #164 failure class.
+- Rollback failures must fail closed and name the files requiring inspection, following the behavior of local `gsd-core/src/phase.cts::writePlanningFileSet` as a reference pattern without copying the implementation.
+- Primary acceptance signal: a regression test simulates mid-transition failure after at least one file mutation and proves pre-existing files are restored, newly-created files are absent, and no partial governed bundle state remains.

--- a/artifacts/changes/archived/resolve-github-issue-164-implement-transactional-multi-file/requirements.md
+++ b/artifacts/changes/archived/resolve-github-issue-164-implement-transactional-multi-file/requirements.md
@@ -1,0 +1,59 @@
+# Requirements
+
+## Requirements
+
+### Requirement: Transactional governed file sets
+REQ-001: Governed stage transitions that mutate more than one lifecycle artifact or authority file MUST apply those file mutations all-or-nothing: if any write or remove operation in the transition fails after an earlier operation succeeded, the system MUST restore pre-transition file contents and remove files created by the failed transaction.
+
+#### Scenario: failed write after a created artifact
+GIVEN a governed transition that creates a missing artifact file and then persists another lifecycle file
+WHEN the second file mutation fails after the first file has been created
+THEN the created artifact file is absent after the command returns
+AND the lifecycle authority remains at the pre-transition state
+AND the command reports failure instead of advancing the change.
+
+#### Scenario: failed write after replacing existing content
+GIVEN a governed transition that replaces an existing file before a later file mutation
+WHEN the later file mutation fails
+THEN the existing file is restored to its original bytes
+AND no partially updated file-set state is reported as successful.
+
+### Requirement: Transactional deletes for stale evidence recovery
+REQ-002: Governed stale-evidence recovery MUST treat evidence-file removals and the reopened lifecycle state save as one file-set transaction, so a failure to save the reopened state SHALL restore any verification, wave-plan, or execution-summary files removed earlier in the same recovery attempt.
+
+#### Scenario: failed reopen after evidence removal
+GIVEN a governed change with verification evidence that must be removed during stale-evidence recovery
+WHEN the recovery removes one or more evidence files but then fails to save the reopened `change.yaml`
+THEN the removed evidence files are restored
+AND the change remains in its pre-recovery lifecycle state
+AND governance reports a failure requiring rerun rather than a successful reopen.
+
+### Requirement: Fail-closed rollback diagnostics
+REQ-003: If rollback after a failed multi-file transition cannot fully restore or remove a file, the system MUST fail closed and include the original operation error plus the path of each file that may require inspection.
+
+#### Scenario: rollback cannot restore a file
+GIVEN a governed file-set transaction where a later operation fails
+AND rollback of an earlier operation also fails
+WHEN the command returns the transaction error
+THEN the error names the file path that could not be rolled back
+AND the command does not report the transition as successful
+AND no bypass, force-pass, or private attestation path is accepted for the irreversible-operations guardrail.
+
+### Requirement: Covered transition surfaces
+REQ-004: The implementation SHALL apply the transactional file-set mechanism to the issue #164 transition surfaces identified in research: S1 planning bundle scaffold before state save, stale-evidence reopen file removals before state save, and S1-to-S2 wave-plan materialization before state save.
+
+#### Scenario: covered transitions use the shared guardrail
+GIVEN tests or code inspection of the identified transition surfaces
+WHEN any of those paths performs multiple file mutations before reporting advancement
+THEN the path uses the shared transaction mechanism or an equivalent wrapper with the same all-or-nothing and rollback diagnostic behavior
+AND targeted tests cover at least one mid-transition injected failure for artifact creation and one for evidence removal.
+
+### Requirement: Regression proof
+REQ-005: The change MUST include deterministic regression tests that simulate a mid-transition failure after at least one file mutation and prove no partial governed bundle or evidence state remains.
+
+#### Scenario: injected mid-transition failure
+GIVEN a test seam that fails a file mutation after one operation in a governed transition has succeeded
+WHEN the transition is executed under that injected failure
+THEN assertions verify newly-created files are absent
+AND assertions verify pre-existing files are restored
+AND assertions verify the persisted lifecycle authority did not advance.

--- a/artifacts/changes/archived/resolve-github-issue-164-implement-transactional-multi-file/research.md
+++ b/artifacts/changes/archived/resolve-github-issue-164-implement-transactional-multi-file/research.md
@@ -1,0 +1,96 @@
+# Research
+
+## Alternatives Considered
+
+### Architecture
+- Question: which governed stage-transition file mutations can leave partial state if a later write fails?
+- Affected modules:
+  - `internal/engine/progression/advance_governed.go:337` through `internal/engine/progression/advance_governed.go:355` advances the S1 planning substep, scaffolds bundle artifacts when entering `bundle`, then persists `change.yaml`.
+  - `internal/engine/artifact/manager.go:283` through `internal/engine/artifact/manager.go:306` loops over required scaffold-owned artifacts and writes missing files with `os.WriteFile`.
+  - `internal/state/store.go:511` through `internal/state/store.go:550` persists `change.yaml` through `fsutil.WriteFileAtomic` and then records the machine-local worktree binding.
+  - `internal/engine/progression/stale_evidence_recovery.go:137` through `internal/engine/progression/stale_evidence_recovery.go:182` deletes stale verification, wave-plan, and execution-summary files before `internal/engine/progression/stale_evidence_recovery.go:238` saves the reopened `change.yaml`.
+  - `internal/engine/progression/advance_governed.go:403` through `internal/engine/progression/advance_governed.go:424` materializes `wave-plan.yaml` before persisting the S2 transition state.
+- Dependency chains:
+  - S1 research -> S1 bundle: `AdvanceGoverned` -> `ensureGovernedBundleScaffolded` -> `artifact.ScaffoldGovernedBundleForChange` -> `state.SaveChange`.
+  - Stale reopen: `AdvanceGoverned` -> `reopenToStaleStage` -> `clearRecoveryEvidence` / `removeVerificationRecordAndDigest` -> `state.SaveChange`.
+  - S1 audit -> S2 execute: `AdvanceGoverned` -> `state.MaterializeWavePlan` -> `state.SaveChange`.
+- Blast radius:
+  - File mutation utilities under `internal/fsutil`.
+  - Governed transition code in `internal/engine/progression`.
+  - Artifact scaffolding in `internal/engine/artifact`.
+  - Tests in `internal/engine/progression` and/or `internal/engine/artifact`.
+- Constraints:
+  - Preserve `fsutil.WriteFileAtomic` as the single-file durability primitive; it already uses temp-in-dir, sync, rename, and parent sync (`internal/fsutil/atomic.go:14` through `internal/fsutil/atomic.go:73`).
+  - Preserve fail-closed irreversible-operations governance; no force-close or bypass path.
+  - Do not move directory archive/relocation into this issue unless file-set tests prove the same failure class. `ArchiveChange` already has explicit directory rollback tests, while this issue targets multi-file stage-transition writes.
+
+### Patterns
+- Existing convention: single-file persistence routes through `fsutil.WriteFileAtomic` for `change.yaml` (`internal/state/store.go:542`), wave plans (`internal/state/wave_execution.go:89`), skill verification records, and execution summaries.
+- Existing non-transactional gap: scaffold-owned artifacts are written by a loop with direct `os.WriteFile` (`internal/engine/artifact/manager.go:283` through `internal/engine/artifact/manager.go:306`), and the caller saves `change.yaml` only after the loop returns (`internal/engine/progression/advance_governed.go:353`).
+- Existing stale reopen deletes files before saving reopened state: `clearRecoveryEvidence` removes verification files and prunes digests (`internal/engine/progression/advance_governed.go:521` through `internal/engine/progression/advance_governed.go:541`), while the state save happens later (`internal/engine/progression/stale_evidence_recovery.go:238`).
+- GSD reference pattern: local `gsd-core/src/phase.cts:1302` records successfully applied writes, and on error reverses them in reverse order; if rollback itself fails, it names the affected file and warns that planning files may be inconsistent (`/Users/yixianlu/ghq/github.com/open-gsd/gsd-core/src/phase.cts:1302` through `/Users/yixianlu/ghq/github.com/open-gsd/gsd-core/src/phase.cts:1323`).
+- Codebase-map advisory: `artifacts/codebase/ARCHITECTURE.md:3`, `artifacts/codebase/TESTING.md:3`, and `artifacts/codebase/CONCERNS.md:3` show the populated map was authored for issue #156, so direct source citations are the planning authority for issue #164.
+
+### Risks
+- High: A failed post-scaffold `change.yaml` write can leave newly-created artifact files while the lifecycle state remains pre-transition, creating a partial bundle class issue #164 explicitly targets.
+- High: A failed stale-reopen `change.yaml` write can remove verification evidence while the lifecycle state still points past the reopened stage.
+- Medium: A transaction helper that snapshots files naively can accidentally preserve stale temp files or directory metadata; keep the helper file-oriented and explicit about create, write, and remove operations.
+- Medium: Rollback can fail. The error must include the original failure plus file names that may need inspection, matching the GSD warning behavior while using Go error wrapping.
+- Low: Directory archive/relocation could be confused with file-set transaction work. Keep it excluded unless a regression proves it belongs.
+- Guardrail domains: irreversible_operations. The rollback path is itself a guardrail and must fail closed.
+- Reversibility: The proposed helper restores prior file bytes or removes files that did not exist before the transaction; if rollback fails, the command returns an error naming the affected files and no success state is reported.
+
+### Test Strategy
+- Existing coverage:
+  - `cmd/preset_test.go:315` covers preset scaffold rollback at command level but relies on preset-specific recovery, not a generic stage-transition file-set transaction.
+  - `internal/state/lifecycle_test.go:398` and nearby tests cover archive rollback failure for directory promotion, which is a different failure class.
+  - `internal/fsutil/atomic.go:14` through `internal/fsutil/atomic.go:73` covers the production primitive used by single-file writes, but not multi-file all-or-nothing semantics.
+- Infrastructure needs:
+  - Add a small test seam around the new transaction helper so tests can inject a failure after the first mutation without depending on chmod behavior.
+  - Prefer package-level tests in `internal/fsutil` for helper semantics, then progression-level tests proving the helper wraps the issue #164 transition surfaces.
+- Verification approach:
+  - Unit test: write two files in one transaction, inject failure after the first write, assert the pre-existing file content is restored and the newly-created file is absent.
+  - Unit test: remove and write in one transaction, inject failure, assert deleted files are restored.
+  - Unit test: force rollback failure, assert the error includes the failed rollback file path.
+  - Progression regression: simulate S1 bundle scaffold materialization failure after a scaffold file write and before `change.yaml` persistence, assert no partial scaffold file remains and lifecycle authority is unchanged.
+  - Progression regression: simulate stale reopen failure after verification removal and before `change.yaml` persistence, assert verification files are restored and lifecycle authority is unchanged.
+
+### Options
+- Option 1: Add a focused `internal/fsutil` file transaction helper and update the issue #164 transition call sites.
+  - Tradeoffs: Small reusable primitive, aligns with GSD's applied/reverse-rollback model, keeps single-file atomic writes intact, and gives deterministic test seams.
+  - Cost: Requires adapting scaffold and stale-reopen paths to express file operations before applying them.
+- Option 2: Add ad hoc rollback code directly in each transition path.
+  - Tradeoffs: Lowest abstraction count for two call sites.
+  - Cost: Duplicates rollback logic, makes rollback failure reporting inconsistent, and makes future multi-file transitions likely to miss the guardrail.
+- Option 3: Add a durable journal/recovery layer for all governance mutations.
+  - Tradeoffs: Strongest crash-recovery model.
+  - Cost: Larger state-machine and repair-surface redesign, outside issue #164's requested GSD-style apply/rollback mechanism.
+- Selected: Option 1. It is the smallest contract-correct solution that matches issue #164 and GSD's core mechanism while preserving Slipway's existing single-file atomic primitive.
+
+## Unknowns
+- Resolved: Which current transition paths need the transactional wrapper? -> S1 planning bundle materialization, stale-evidence reopen, and S1-to-S2 wave-plan materialization before `change.yaml` save are the file-level transition surfaces found in current source.
+- Resolved: Should directory archive/relocation be in scope? -> Not for first implementation; current evidence points to file-set transition writes/deletes, while archive/relocation is directory movement with existing rollback/repair-forward semantics.
+- Remaining: None.
+
+## Assumptions
+- A file-oriented transaction helper is sufficient for issue #164 because the acceptance text names multi-artifact stage transitions and the GSD reference is file-content write rollback, not directory promotion.
+- Tests can rely on injected write/remove failure seams rather than platform-specific permission failures; this keeps rollback behavior deterministic across macOS/Linux/Windows.
+- Scope may include S1-to-S2 `wave-plan.yaml` materialization because it writes a verification artifact before saving the transition state, the same file-set ordering risk as the named S1 bundle and stale reopen surfaces.
+
+## Canonical References
+- `https://github.com/signalridge/slipway/issues/164`
+- `/Users/yixianlu/ghq/github.com/open-gsd/gsd-core/src/phase.cts:1302`
+- `internal/engine/progression/advance_governed.go:337`
+- `internal/engine/progression/advance_governed.go:403`
+- `internal/engine/progression/stale_evidence_recovery.go:137`
+- `internal/engine/progression/stale_evidence_recovery.go:238`
+- `internal/engine/artifact/manager.go:283`
+- `internal/engine/artifact/manager.go:304`
+- `internal/state/store.go:511`
+- `internal/state/store.go:542`
+- `internal/state/wave_execution.go:72`
+- `internal/state/wave_execution.go:89`
+- `internal/fsutil/atomic.go:14`
+- `artifacts/codebase/ARCHITECTURE.md:3`
+- `artifacts/codebase/TESTING.md:3`
+- `artifacts/codebase/CONCERNS.md:3`

--- a/artifacts/changes/archived/resolve-github-issue-164-implement-transactional-multi-file/tasks.md
+++ b/artifacts/changes/archived/resolve-github-issue-164-implement-transactional-multi-file/tasks.md
@@ -1,0 +1,30 @@
+# Tasks
+
+## Task List
+
+- [x] `t-01` Add and unit-test a reusable file-set transaction helper for ordered write/remove operations, rollback, and rollback-failure diagnostics.
+  - wave: 1
+  - depends_on: []
+  - target_files: ["internal/fsutil/transaction.go", "internal/fsutil/transaction_test.go"]
+  - task_kind: code
+  - covers: [REQ-001, REQ-003, REQ-005]
+  - evidence: artifact: `go test ./internal/fsutil`
+  - acceptance: injected write/remove failures restore original file bytes, remove newly-created files, and report rollback-failure paths
+
+- [x] `t-02` Route S1 planning bundle scaffold and S1-to-S2 wave-plan materialization through the file-set transaction boundary, including injected-failure regression coverage.
+  - wave: 2
+  - depends_on: ["t-01"]
+  - target_files: ["internal/engine/artifact/manager.go", "internal/engine/artifact/transaction_test.go", "internal/engine/progression/advance_governed.go", "internal/engine/progression/advance_transaction_test.go", "internal/state/store.go", "internal/state/wave_execution.go", "internal/state/wave_execution_transaction_test.go", "internal/state/worktree_binding.go"]
+  - task_kind: code
+  - covers: [REQ-001, REQ-004, REQ-005]
+  - evidence: artifact: `go test ./internal/engine/artifact ./internal/engine/progression ./internal/state`
+  - acceptance: injected failure after scaffold or wave-plan mutation leaves no partial generated artifact and does not advance lifecycle authority
+
+- [x] `t-03` Route stale-evidence reopen removals and reopened state save through the same transaction boundary, including evidence-restoration regression coverage.
+  - wave: 2
+  - depends_on: ["t-01"]
+  - target_files: ["internal/engine/progression/stale_evidence_recovery.go", "internal/engine/progression/stale_evidence_recovery_transaction_test.go"]
+  - task_kind: code
+  - covers: [REQ-002, REQ-003, REQ-004, REQ-005]
+  - evidence: artifact: `go test ./internal/engine/progression`
+  - acceptance: injected failure after evidence removal restores verification files and reports any rollback-failure path

--- a/artifacts/codebase/ARCHITECTURE.md
+++ b/artifacts/codebase/ARCHITECTURE.md
@@ -1,61 +1,60 @@
 # Architecture
 
-Re-authored for change `resolve-github-issue-156-add-a-change-implies-evidence-gate`
-(GitHub issue #156).
+Re-authored for change `resolve-github-issue-164-implement-transactional-multi-file`
+(GitHub issue #164).
 
-Question: where should "sensitive file changed implies owning evidence" be
-checked so it complements freshness and scope-contract readiness without
-creating a bypass path?
+Question: where should transactional multi-file stage-transition writes live so
+Slipway cannot leave partial governed bundle or evidence state when a later
+write fails?
 
 - Affected modules:
-  - `internal/engine/progression/readiness.go:184` resolves the bound governed
-    bundle path before computing readiness.
-  - `internal/engine/progression/readiness.go:211` loads passing required skill
-    verification records.
-  - `internal/engine/progression/readiness.go:275` only invokes the current
-    scope-contract gate after an execution summary exists.
-  - `internal/engine/progression/advance_governed.go:146` enforces the same
-    sensitive-evidence result on mutating advancement so S2 cannot advance past
-    missing sensitive proof and later stages reopen to S2 for repair.
-  - `internal/engine/progression/stale_evidence_recovery.go:477` builds the
-    S2 recovery target for sensitive-evidence failures.
-  - `internal/engine/scopecontract/evaluate.go:41` evaluates planned targets
-    versus changed files but has no sensitive-evidence category logic.
-  - `internal/engine/sensitiveevidence/evaluate.go:49` classifies sensitive
-    changed files and checks passed task evidence references for category
-    markers.
-  - `internal/state/verification.go` owns validated skill-verification record
-    persistence under the authoritative governed bundle.
-  - `internal/model/execution_summary.go:28` stores task evidence fields,
-    including `ChangedFiles`, `TargetFiles`, `EvidenceRef`, and `TaskKind`.
-  - `cmd/evidence.go` writes runtime task evidence from
-    `slipway evidence task` and governance skill verification from
-    `slipway evidence skill`.
-  - `internal/toolgen/toolgen.go` and
-    `internal/tmpl/templates/_partials/command-evidence-body.tmpl` publish the
-    same `evidence task` and `evidence skill` surfaces to generated command
-    references and prompts.
+  - `internal/fsutil/atomic.go:14` exposes the current single-file durability
+    primitive, `WriteFileAtomic`, using temp-in-dir, fsync, rename, and parent
+    sync. The new work should compose with this primitive rather than weaken it.
+  - `internal/engine/progression/advance_governed.go:337` through
+    `internal/engine/progression/advance_governed.go:355` advances S1 plan
+    substeps, scaffolds the governed bundle when entering `bundle`, and only
+    then persists `change.yaml`.
+  - `internal/engine/artifact/manager.go:241` through
+    `internal/engine/artifact/manager.go:309` resolves required artifacts and
+    writes missing scaffold-owned files in a loop with direct file writes.
+  - `internal/state/store.go:511` through `internal/state/store.go:550`
+    persists `change.yaml` and then records the machine-local worktree binding.
+  - `internal/engine/progression/advance_governed.go:403` through
+    `internal/engine/progression/advance_governed.go:424` materializes
+    `wave-plan.yaml` before the S1-to-S2 transition state is saved.
+  - `internal/state/wave_execution.go:72` through
+    `internal/state/wave_execution.go:90` writes `wave-plan.yaml`; lines 133
+    through 181 build and save that plan from `tasks.md`.
+  - `internal/engine/progression/stale_evidence_recovery.go:137` through
+    `internal/engine/progression/stale_evidence_recovery.go:182` removes stale
+    skill verification, wave plan, and execution-summary files before
+    `internal/engine/progression/stale_evidence_recovery.go:238` saves the
+    reopened lifecycle state.
+  - `internal/engine/progression/advance_governed.go:521` through
+    `internal/engine/progression/advance_governed.go:541` owns evidence removal
+    helpers that also prune digest records.
 - Dependency flow:
-  - `slipway evidence task` records runtime task evidence.
-  - Runtime task evidence materializes into `verification/execution-summary.yaml`.
-  - Host verification evidence is recorded through `slipway evidence skill`,
-    which writes `verification/<skill>.yaml` and records the change evidence
-    reference without advancing lifecycle state.
-  - `EvaluateGovernanceReadiness` consumes that summary, existing skill
-    verifications, and artifact state to produce blockers for `status`,
-    `validate`, `next`, `run`, and review surfaces.
-  - `AdvanceGoverned` reuses the same evaluator before normal state transition,
-    preserving the read-only and mutating contract.
+  - S1 bundle progression: `AdvanceGoverned` changes the plan substep,
+    scaffolds non-deferred governed artifacts, then saves `change.yaml`.
+  - S1-to-S2 progression: `AdvanceGoverned` materializes a wave plan, changes
+    lifecycle state, then saves `change.yaml`.
+  - Stale reopen: `reopenToStaleStage` removes evidence files and digest
+    entries, mutates change state, then saves `change.yaml`.
+  - Single-file persistence already routes through `fsutil.WriteFileAtomic`;
+    issue #164 needs an all-or-nothing boundary around ordered sets of those
+    file mutations.
 - Architectural boundary:
-  - Scope-contract should continue to own planned-target and changed-file drift.
-  - Sensitive evidence should be a sibling readiness evaluator that reuses the
-    same execution-summary changed files but reports its own reason code and
-    remediation.
-  - Generated host instructions must record skill verification through public
-    CLI commands, not hand-edited verification YAML.
+  - Add a focused file transaction helper in `internal/fsutil`.
+  - Adapt transition call sites to express file writes/removes inside a
+    transaction boundary.
+  - Keep directory archive and bundle relocation outside this change unless
+    tests prove the same file-set failure class; archive already has directory
+    rollback coverage.
 - Blast radius:
-  - Runtime readiness and reason-code/remediation contracts.
-  - Public evidence command surface for skill verification.
-  - Generated adapter command metadata for the `evidence` command.
-  - Unit tests in a new focused evaluator package plus a narrow progression
-    integration test if wiring requires it.
+  - `internal/fsutil` for transaction mechanics and rollback diagnostics.
+  - `internal/engine/progression` for transition wrapping.
+  - `internal/engine/artifact` for scaffold-owned artifact write integration.
+  - `internal/state` only where wave-plan materialization needs a transaction
+    seam or operation builder.
+  - Targeted tests in the same packages.

--- a/artifacts/codebase/CONCERNS.md
+++ b/artifacts/codebase/CONCERNS.md
@@ -1,33 +1,32 @@
 # Concerns
 
-Re-authored for change `resolve-github-issue-156-add-a-change-implies-evidence-gate`
-(GitHub issue #156).
+Re-authored for change `resolve-github-issue-164-implement-transactional-multi-file`
+(GitHub issue #164).
 
-- Stale map risk: populated codebase-map documents only help when their seams,
-  blast radius, and risks match the active change; stale map content is not
-  planning authority for this change.
-- Load-bearing invariant: freshness proves "when" evidence was produced, while
-  issue #156 requires proving that the right owning evidence exists for touched
-  sensitive files. The new gate must not replace existing freshness or
-  scope-contract checks.
-- Guardrail risk: sensitive-domain checks must fail closed. A missing marker for
-  migration-applied, auth-review, or contract-test evidence should block with a
-  canonical error reason and precise remediation.
-- Deadlock risk: requiring review-stage skill evidence during S2 execution could
-  strand the lifecycle before review can run. The first implementation should
-  use execution-summary task evidence markers, not post-review skill evidence,
-  for the change-implies-evidence proof.
-- Lifecycle bypass risk: read-only readiness alone is insufficient because
-  mutating advancement can otherwise move S2 evidence into review. The gate must
-  run inside `AdvanceGoverned` before normal state transition, reopening S3/S4
-  to S2 when repair requires `slipway evidence task`.
-- Compatibility risk: broad filename patterns can overmatch ordinary files. Keep
-  initial built-in patterns explicit and test category examples rather than
-  attempting a complete ecosystem catalog.
-- Recovery risk: new readiness blockers need entries in the canonical reason
-  code and recovery-remediation maps. The public recovery command must be
-  `slipway run`, because `slipway evidence task` is only legal from S2_EXECUTE.
-- Public-surface dead-end risk: generated host instructions require
-  `slipway evidence skill` to record verification evidence. If the command is
-  missing or accepts evidence in the wrong lifecycle state, agents either
-  hand-edit engine-owned YAML or get stranded before plan-audit can complete.
+- Load-bearing invariant: a governed lifecycle transition must not report
+  success unless its artifact/evidence side effects and authoritative
+  `change.yaml` state agree.
+- Partial scaffold risk: `advance_governed.go` can scaffold bundle artifacts
+  before saving `change.yaml`. If the save fails after a file is created, the
+  bundle can look partially materialized while the lifecycle authority remains
+  behind.
+- Partial stale-reopen risk: `stale_evidence_recovery.go` removes verification,
+  wave-plan, and execution-summary files before saving reopened state. A save
+  failure can otherwise remove evidence while the lifecycle still points past
+  the reopened stage.
+- Partial S2-entry risk: `wave_execution.go` writes `wave-plan.yaml` before the
+  transition to S2 is saved. A later save failure can otherwise leave a generated
+  plan that belongs to a transition that did not complete.
+- Rollback risk: rollback can fail too. Error reporting must include the
+  original failure and the file path requiring inspection, and irreversible
+  operations must fail closed without a force-pass path.
+- Scope risk: directory archive/relocation logic is tempting to fold into the
+  same abstraction, but the current issue and GSD reference are file-set
+  write/delete rollback. Keep directory movement out unless a failing regression
+  proves it belongs.
+- Durability boundary: the helper should compose with `fsutil.WriteFileAtomic`
+  for writes. It should not replace atomic single-file persistence with direct
+  best-effort writes.
+- Test reliability risk: chmod-based failures are platform-sensitive. Prefer a
+  deterministic failure seam in the transaction helper for cross-platform
+  regression tests.

--- a/artifacts/codebase/STRUCTURE.md
+++ b/artifacts/codebase/STRUCTURE.md
@@ -1,46 +1,39 @@
 # Structure
 
-Re-authored for change `resolve-github-issue-156-add-a-change-implies-evidence-gate`
-(GitHub issue #156).
+Re-authored for change `resolve-github-issue-164-implement-transactional-multi-file`
+(GitHub issue #164).
 
-- `internal/engine/sensitiveevidence/`
-  - `evaluate.go`: focused evaluator for sensitive changed-file categories,
-    marker extraction, and `sensitive_evidence_missing` blockers.
-  - `evaluate_test.go`: category, marker, separate-verification, and no-bypass
-    regressions.
+- `internal/fsutil/`
+  - `atomic.go`: existing atomic single-file write helper and temp artifact
+    cleanup. Planned transaction work belongs here as a small sibling helper,
+    likely `transaction.go` plus package tests.
+- `internal/engine/artifact/`
+  - `manager.go`: governed artifact schema resolution and scaffold-owned file
+    materialization. The current scaffold loop creates missing non-deferred
+    artifacts before the caller persists lifecycle state.
+  - Planned tests should prove scaffold writes participate in a transaction
+    when used from governed progression.
 - `internal/engine/progression/`
-  - `readiness.go`: read-only governance readiness aggregation, now exposing
-    `SensitiveEvidence` and appending sensitive-evidence blockers after
-    execution-summary readiness.
-  - `advance_governed.go`: mutating lifecycle transition path, now blocking in
-    S2_EXECUTE or reopening later stages to S2 when sensitive evidence is
-    missing.
-  - `stale_evidence_recovery.go`: recovery target construction for stale and
-    S2-owned evidence failures.
-  - `readiness_test.go` and `scope_contract_gate_test.go`: integration
-    regressions for readiness, S2 blocking, and S3-to-S2 reopen behavior.
-- `internal/model/`
-  - `reason_code.go`: canonical reason-code taxonomy entry.
-  - `recovery.go`: operator recovery mapping to `slipway run`, with
-    evidence-task marker guidance once the workflow is in S2.
-  - Contract tests pin canonical reason-code and recovery behavior.
+  - `advance_governed.go`: primary mutating lifecycle transition function.
+    It owns S1 plan substep progression, S1-to-S2 wave-plan materialization,
+    and evidence/digest removal helpers.
+  - `stale_evidence_recovery.go`: recovery reopen path that removes stale
+    evidence and then saves reopened lifecycle state.
+  - Planned tests should cover injected failure after at least one transition
+    file mutation for both artifact creation and evidence removal.
 - `internal/state/`
-  - `verification.go`: load and save verified skill records from the
-    authoritative governed bundle.
-  - `verification_test.go`: persistence regressions for validated
-    `SaveVerification` records.
+  - `store.go`: `SaveChange` persists the governed `change.yaml` authority
+    with `fsutil.WriteFileAtomic`.
+  - `wave_execution.go`: wave-plan generation and persistence from `tasks.md`.
+    The implementation may need a transaction-aware save path or operation
+    builder so `wave-plan.yaml` and the following state save are atomic as a
+    file set.
+  - `lifecycle_test.go`: existing archive rollback tests cover directory
+    promotion, which is related evidence but not the issue #164 file-set class.
 - `cmd/`
-  - `evidence.go`: public evidence command surface, now including
-    `evidence task` for runtime task evidence and `evidence skill` for
-    governance skill verification.
-  - `evidence_skill_test.go`: Cobra-level regressions for plan-audit recording,
-    wrong-state rejection, run-summary-bound skill rejection, and notes-source
-    conflict handling.
-  - `template_flag_contract_test.go`: generated command reference to Cobra flag
-    drift check covering both `evidence` subcommands.
-- `internal/toolgen/` and `internal/tmpl/templates/_partials/`
-  - `toolgen.go` and `command-evidence-body.tmpl`: adapter-facing command
-    metadata and prompt body for `slipway evidence task` plus
-    `slipway evidence skill`.
-- `artifacts/changes/resolve-github-issue-156-add-a-change-implies-evidence-gate/`
-  - Governed artifact bundle and verification evidence for this change.
+  - `preset_test.go`: contains a preset-specific scaffold rollback regression,
+    useful as prior art but not sufficient for generic governed stage
+    transition file-set rollback.
+- `artifacts/changes/resolve-github-issue-164-implement-transactional-multi-file/`
+  - Governed artifact bundle for this change. The plan targets code and tests;
+    `assurance.md` remains deferred until review/verify stages.

--- a/artifacts/codebase/TESTING.md
+++ b/artifacts/codebase/TESTING.md
@@ -1,39 +1,41 @@
 # Testing
 
-Re-authored for change `resolve-github-issue-156-add-a-change-implies-evidence-gate`
-(GitHub issue #156).
+Re-authored for change `resolve-github-issue-164-implement-transactional-multi-file`
+(GitHub issue #164).
 
 - Existing coverage:
-  - `internal/engine/scopecontract/evaluate_test.go:14` proves changed files
-    inside planned targets pass.
-  - `internal/engine/scopecontract/evaluate_test.go:40` proves out-of-scope
-    changed files block deterministically.
-  - `internal/engine/scopecontract/evaluate_test.go:91` proves missing
-    changed-file evidence is already a blocker.
-  - `internal/model/reason_code_contract_test.go:22` keeps canonical reason
-    code coverage stable.
-  - `internal/model/recovery_test.go:91` catches recovery-relevant reason codes
-    without remediation.
-- Gaps for issue #156:
-  - No test asserts that a sensitive changed file requires category-specific
-    owning evidence.
-  - No test asserts that matching owning evidence clears the sensitive blocker.
-  - No test asserts that sensitive blockers have precise remediation and no
-    bypass path.
-  - No test asserts that generated host verification can be recorded through the
-    public `slipway evidence skill` command.
+  - `internal/fsutil/atomic.go:14` through `internal/fsutil/atomic.go:73`
+    implements the single-file atomic write primitive but does not test
+    multi-file all-or-nothing semantics.
+  - `cmd/preset_test.go:315` through `cmd/preset_test.go:340` covers a
+    preset-command scaffold failure rollback, but that is command-specific and
+    not a reusable governed stage-transition transaction.
+  - `internal/state/lifecycle_test.go:396` through
+    `internal/state/lifecycle_test.go:430` covers archive rollback when
+    persisting archived authority fails, but that path is directory promotion,
+    not ordered file writes/removes inside an active stage transition.
+- Gaps for issue #164:
+  - No package-level test proves an ordered file transaction restores original
+    bytes and removes newly-created files when a later operation fails.
+  - No test proves rollback-failure errors include the path requiring
+    inspection.
+  - No progression regression simulates failure after governed bundle scaffold
+    writes but before `change.yaml` persistence.
+  - No progression regression simulates failure after stale evidence deletion
+    but before reopened `change.yaml` persistence.
+  - No test proves S1-to-S2 `wave-plan.yaml` materialization is part of the same
+    file-set boundary as transition state persistence.
 - Planned verification:
-  - Add table-driven unit tests for a sensitive-evidence evaluator covering
-    schema migration, auth/authz, and API contract categories.
-  - Add progression tests for mutating lifecycle enforcement: block in
-    S2_EXECUTE when marker evidence is missing, reopen S3_REVIEW to S2_EXECUTE,
-    and pass when the category marker exists.
-  - Add reason-code and recovery-contract assertions for the new blocker.
-  - Add Cobra command tests for `slipway evidence skill`, including plan-audit
-    recording, wrong-state rejection, run-summary-bound skill rejection, and
-    notes-source conflict handling.
-  - Add state persistence coverage for `state.SaveVerification`.
-  - Extend command-template flag coverage so the generated `evidence` command
-    reference includes the new `evidence skill` flags.
-  - Run the targeted package tests first, then broader `go test ./internal/...`
-    and governed `validate --json` after implementation.
+  - Add `internal/fsutil` table-driven tests for write/write, remove/write, and
+    rollback-failure paths using deterministic injected failures.
+  - Add progression or artifact tests that trigger S1 bundle scaffold under an
+    injected later write failure and assert no scaffold-owned partial file
+    remains.
+  - Add stale-evidence recovery tests that delete verification evidence under an
+    injected later save failure and assert removed files and digest state are
+    restored.
+  - Add wave-plan transition coverage or state-level coverage proving a failed
+    state save does not leave a visible `wave-plan.yaml` from the failed S2
+    transition.
+  - Run targeted package tests first, then `go run . validate --json` and the
+    governed evidence commands selected by the current lifecycle.

--- a/internal/engine/artifact/manager.go
+++ b/internal/engine/artifact/manager.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"text/template"
 
+	"github.com/signalridge/slipway/internal/fsutil"
 	"github.com/signalridge/slipway/internal/model"
 	"github.com/signalridge/slipway/internal/state"
 	"github.com/signalridge/slipway/internal/stringutil"
@@ -239,13 +240,19 @@ func ScaffoldIntentForChange(root string, change model.Change) error {
 // change. The engine owns structure only; project context is persisted on the
 // change and surfaced through `slipway instructions`, not copied into bodies.
 func ScaffoldGovernedBundleForChange(root string, change model.Change, preset model.WorkflowPreset, schema ...[]ArtifactSpec) error {
-	return scaffoldGovernedBundleForChange(root, change, preset, schema...)
+	ops, err := ScaffoldGovernedBundleTransactionOpsForChange(root, change, preset, schema...)
+	if err != nil {
+		return err
+	}
+	return fsutil.ApplyFileTransaction(ops)
 }
 
-func scaffoldGovernedBundleForChange(root string, change model.Change, preset model.WorkflowPreset, schema ...[]ArtifactSpec) error {
+// ScaffoldGovernedBundleTransactionOpsForChange returns the file operations
+// needed to create scaffold-owned governed artifacts without applying them.
+func ScaffoldGovernedBundleTransactionOpsForChange(root string, change model.Change, preset model.WorkflowPreset, schema ...[]ArtifactSpec) ([]fsutil.FileTransactionOp, error) {
 	slug := strings.TrimSpace(change.Slug)
 	if slug == "" {
-		return fmt.Errorf("slug is required")
+		return nil, fmt.Errorf("slug is required")
 	}
 
 	// Use provided schema or default to expanded.
@@ -265,12 +272,13 @@ func scaffoldGovernedBundleForChange(root string, change model.Change, preset mo
 
 	base, err := state.GovernedBundleDir(root, change)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if err := os.MkdirAll(base, 0o755); err != nil { // #nosec G301 -- directory is a user-facing project or governance artifact location where executable/searchable mode is intentional.
-		return err
+		return nil, err
 	}
 	data := buildTemplateData(change)
+	ops := make([]fsutil.FileTransactionOp, 0, len(files))
 
 	// Build a lookup from artifact name to template source path for custom schemas.
 	templatePaths := map[string]string{}
@@ -288,25 +296,34 @@ func scaffoldGovernedBundleForChange(root string, change model.Change, preset mo
 			continue
 		}
 		path := ResolveArtifactPath(base, file)
-		if _, err := os.Stat(path); err == nil {
+		if shouldWrite, err := shouldScaffoldArtifactPath(path); err != nil {
+			return nil, err
+		} else if !shouldWrite {
 			continue
-		} else if !errors.Is(err, fs.ErrNotExist) {
-			return err
 		}
 
 		rendered, err := renderTemplateWithFallback(root, file, templatePaths[file], data)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil { // #nosec G301 -- directory is a user-facing project or governance artifact location where executable/searchable mode is intentional.
-			return err
-		}
-		if err := os.WriteFile(path, []byte(rendered), 0o644); err != nil { // #nosec G306 -- file is a user-facing project or governance artifact where operator-readable mode is intentional.
-			return err
-		}
+		ops = append(ops, fsutil.WriteFileTransactionOp(path, []byte(rendered), 0o644))
 	}
 
-	return nil
+	return ops, nil
+}
+
+func shouldScaffoldArtifactPath(path string) (bool, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return true, nil
+		}
+		return false, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return false, fmt.Errorf("refuse scaffold artifact symlink %s", path)
+	}
+	return false, nil
 }
 
 // deferredToSkillAuthoring reports whether an artifact's body is authored

--- a/internal/engine/artifact/transaction_test.go
+++ b/internal/engine/artifact/transaction_test.go
@@ -1,0 +1,46 @@
+package artifact
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/signalridge/slipway/internal/fsutil"
+	"github.com/signalridge/slipway/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScaffoldGovernedBundleTransactionOpsDeferWritesUntilApplied(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	change := model.NewChange("transactional-scaffold")
+
+	ops, err := ScaffoldGovernedBundleTransactionOpsForChange(root, change, model.WorkflowPresetStandard)
+	require.NoError(t, err)
+	require.NotEmpty(t, ops)
+
+	intentPath := filepath.Join(root, "artifacts", "changes", change.Slug, "intent.md")
+	_, err = os.Stat(intentPath)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+
+	require.NoError(t, fsutil.ApplyFileTransaction(ops))
+
+	_, err = os.Stat(intentPath)
+	require.NoError(t, err)
+}
+
+func TestScaffoldGovernedBundleTransactionOpsRejectDanglingSymlink(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	change := model.NewChange("transactional-scaffold-symlink")
+	bundleDir := filepath.Join(root, "artifacts", "changes", change.Slug)
+	require.NoError(t, os.MkdirAll(bundleDir, 0o755))
+	require.NoError(t, os.Symlink(filepath.Join(bundleDir, "missing-parent", "intent.md"), filepath.Join(bundleDir, "intent.md")))
+
+	_, err := ScaffoldGovernedBundleTransactionOpsForChange(root, change, model.WorkflowPresetStandard)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "refuse scaffold artifact symlink")
+}

--- a/internal/engine/progression/advance_governed.go
+++ b/internal/engine/progression/advance_governed.go
@@ -13,11 +13,14 @@ import (
 	"github.com/signalridge/slipway/internal/engine/artifact"
 	"github.com/signalridge/slipway/internal/engine/gate"
 	"github.com/signalridge/slipway/internal/engine/governance"
+	"github.com/signalridge/slipway/internal/fsutil"
 	"github.com/signalridge/slipway/internal/model"
 	"github.com/signalridge/slipway/internal/state"
 )
 
 const planAuditLastCheckerFeedbackKey = "plan_audit.last_checker_feedback"
+
+var applyGovernedFileTransaction = fsutil.ApplyFileTransaction
 
 func AdvanceGoverned(root, slug string, opts ...AdvanceOptions) (summary AdvanceSummary, err error) {
 	var options AdvanceOptions
@@ -341,16 +344,19 @@ func AdvanceGoverned(root, slug string, opts ...AdvanceOptions) (summary Advance
 			// Advance substep within S1_PLAN.
 			change.AdvancePlanSubStep(nextSub)
 			var sideEffects []SideEffect
+			transactionOps := make([]fsutil.FileTransactionOp, 0, 2)
 			if nextSub == model.PlanSubStepBundle {
-				if err := ensureGovernedBundleScaffolded(root, &change); err != nil {
+				scaffoldOps, err := governedBundleScaffoldTransactionOps(root, &change)
+				if err != nil {
 					return AdvanceSummary{}, err
 				}
+				transactionOps = append(transactionOps, scaffoldOps...)
 				sideEffects = append(sideEffects, SideEffect{
 					Kind:   "scaffolded_bundle",
 					Detail: "governed bundle artifacts created or verified",
 				})
 			}
-			if err := state.SaveChange(root, change); err != nil {
+			if err := applyGovernedChangeTransaction(root, change, transactionOps); err != nil {
 				return AdvanceSummary{}, err
 			}
 			sideEffects = append(append([]SideEffect(nil), preTransitionSideEffects...), sideEffects...)
@@ -401,10 +407,17 @@ func AdvanceGoverned(root, slug string, opts ...AdvanceOptions) (summary Advance
 	}
 
 	sideEffects := append([]SideEffect(nil), preTransitionSideEffects...)
+	transactionOps := make([]fsutil.FileTransactionOp, 0, 2)
 	if toState == model.StateS2Execute {
-		if _, err := state.MaterializeWavePlan(root, change); err != nil {
+		generatedAt := change.CreatedAt
+		if planAudit, ok := passingSkills[SkillPlanAudit]; ok && !planAudit.Timestamp.IsZero() {
+			generatedAt = planAudit.Timestamp
+		}
+		_, wavePlanOp, err := state.MaterializeWavePlanTransactionOpAt(root, change, generatedAt)
+		if err != nil {
 			return AdvanceSummary{}, err
 		}
+		transactionOps = append(transactionOps, wavePlanOp)
 		sideEffects = append(sideEffects, SideEffect{
 			Kind:   "materialized_wave_plan",
 			Detail: "wave plan materialized from tasks.md",
@@ -420,8 +433,14 @@ func AdvanceGoverned(root, slug string, opts ...AdvanceOptions) (summary Advance
 	if change.ClearAutoPassHistory() {
 		cleared = append(cleared, "last_auto_passed_states")
 	}
-	if err := state.SaveChange(root, change); err != nil {
-		return AdvanceSummary{}, err
+	if len(transactionOps) > 0 {
+		if err := applyGovernedChangeTransaction(root, change, transactionOps); err != nil {
+			return AdvanceSummary{}, err
+		}
+	} else {
+		if err := state.SaveChange(root, change); err != nil {
+			return AdvanceSummary{}, err
+		}
 	}
 
 	return AdvanceSummary{
@@ -497,16 +516,6 @@ func computeNextPlanSubStep(current model.PlanSubStep) model.PlanSubStep {
 	return planSubStepOrder[idx+1]
 }
 
-func removeFileIfExists(path string) (bool, error) {
-	if err := os.Remove(path); err != nil {
-		if os.IsNotExist(err) {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
-}
-
 // recoveryEvidenceFile pairs a verification artifact path with the skill that
 // owns it. The skill is empty for non-skill artifacts (wave-plan.yaml,
 // execution-summary.yaml), which have no evidence-digest entry of their own.
@@ -515,45 +524,30 @@ type recoveryEvidenceFile struct {
 	skill string
 }
 
-// clearRecoveryEvidence deletes a recovery evidence file. When the file is a
-// skill verification record, its evidence-digest entry is pruned in the same
-// step so a digest never outlives its record.
-func clearRecoveryEvidence(root string, change model.Change, ev recoveryEvidenceFile) (bool, error) {
-	if strings.TrimSpace(ev.skill) != "" {
-		return removeVerificationRecordAndDigest(root, change, ev.path, ev.skill)
-	}
-	return removeFileIfExists(ev.path)
-}
-
-// removeVerificationRecordAndDigest deletes a skill's verification record file
-// and, when the file existed, prunes its evidence-digest entry so a digest entry
-// never outlives the record it certifies.
-func removeVerificationRecordAndDigest(root string, change model.Change, path, skillName string) (bool, error) {
-	removed, err := removeFileIfExists(path)
-	if err != nil {
-		return false, err
-	}
-	if removed {
-		if err := pruneEvidenceDigestForSkill(root, change, skillName); err != nil {
-			return false, err
-		}
-	}
-	return removed, nil
-}
-
-func ensureGovernedBundleScaffolded(root string, change *model.Change) error {
+func governedBundleScaffoldTransactionOps(root string, change *model.Change) ([]fsutil.FileTransactionOp, error) {
 	if change == nil {
-		return fmt.Errorf("change is required")
+		return nil, fmt.Errorf("change is required")
 	}
 	resolution := ResolveChangeSchemaDiagnostics(*change)
 	if len(resolution.Blockers) > 0 {
-		return fmt.Errorf("resolve artifact schema: %s", strings.Join(resolution.Blockers, ","))
+		return nil, fmt.Errorf("resolve artifact schema: %s", strings.Join(resolution.Blockers, ","))
 	}
 	policy, err := governance.ResolvePresetPolicy(root, *change)
 	if err != nil {
+		return nil, err
+	}
+	return artifact.ScaffoldGovernedBundleTransactionOpsForChange(root, *change, policy.EffectivePreset, resolution.Schema)
+}
+
+func applyGovernedChangeTransaction(root string, change model.Change, ops []fsutil.FileTransactionOp) error {
+	changeOps, err := state.SaveChangeTransactionOps(root, change)
+	if err != nil {
 		return err
 	}
-	return artifact.ScaffoldGovernedBundleForChange(root, *change, policy.EffectivePreset, resolution.Schema)
+	transactionOps := make([]fsutil.FileTransactionOp, 0, len(ops)+len(changeOps))
+	transactionOps = append(transactionOps, ops...)
+	transactionOps = append(transactionOps, changeOps...)
+	return applyGovernedFileTransaction(transactionOps)
 }
 
 // ComputeNextGovernedState determines the next workflow state for a governed change.

--- a/internal/engine/progression/advance_transaction_test.go
+++ b/internal/engine/progression/advance_transaction_test.go
@@ -1,0 +1,200 @@
+package progression
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/signalridge/slipway/internal/engine/artifact"
+	"github.com/signalridge/slipway/internal/fsutil"
+	"github.com/signalridge/slipway/internal/model"
+	"github.com/signalridge/slipway/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdvanceGovernedRollsBackBundleScaffoldWhenAuthorityWriteFails(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, model.SaveConfig(state.ConfigPath(root), model.DefaultConfig()))
+
+	change := model.NewChange("bundle-transaction-rollback")
+	change.CurrentState = model.StateS1Plan
+	change.PlanSubStep = model.PlanSubStepResearch
+	change.WorkflowPreset = model.WorkflowPresetStandard
+	require.NoError(t, state.SaveChange(root, change))
+
+	bundleDir, err := state.GovernedBundleDir(root, change)
+	require.NoError(t, err)
+	intentPath := filepath.Join(bundleDir, "intent.md")
+
+	writeErr := errors.New("change authority write failed")
+	withFailingGovernedTransactionWrite(t, "change.yaml", writeErr)
+
+	_, err = AdvanceGoverned(root, change.Slug)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, writeErr)
+
+	_, statErr := os.Stat(intentPath)
+	assert.ErrorIs(t, statErr, os.ErrNotExist)
+
+	reloaded, loadErr := state.LoadChange(root, change.Slug)
+	require.NoError(t, loadErr)
+	assert.Equal(t, model.PlanSubStepResearch, reloaded.PlanSubStep)
+}
+
+func TestAdvanceGovernedTransactionRefreshesWorktreeBinding(t *testing.T) {
+	root, worktreeRoot := setupTransactionRepoWithWorktree(t)
+
+	change := model.NewChange("transaction-refreshes-binding")
+	change.CurrentState = model.StateS1Plan
+	change.PlanSubStep = model.PlanSubStepResearch
+	change.WorkflowPreset = model.WorkflowPresetStandard
+	change.WorktreePath = worktreeRoot
+	change.WorktreeBranch = "transaction-binding"
+	require.NoError(t, state.SaveChange(root, change))
+	require.NoError(t, os.Remove(state.WorktreeBindingPath(root, change.Slug)))
+
+	_, err := AdvanceGoverned(root, change.Slug)
+	require.NoError(t, err)
+
+	require.FileExists(t, state.WorktreeBindingPath(root, change.Slug))
+	loaded, err := state.LoadChange(root, change.Slug)
+	require.NoError(t, err)
+	wantWorktree, err := state.NormalizePath(worktreeRoot)
+	require.NoError(t, err)
+	assert.Equal(t, wantWorktree, loaded.WorktreePath)
+}
+
+func TestAdvanceGovernedRollsBackWavePlanWhenAuthorityWriteFails(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, model.SaveConfig(state.ConfigPath(root), model.DefaultConfig()))
+
+	change := model.NewChange("wave-plan-transaction-rollback")
+	change.CurrentState = model.StateS1Plan
+	change.PlanSubStep = model.PlanSubStepAudit
+	change.WorkflowPreset = model.WorkflowPresetLight
+	require.NoError(t, state.SaveChange(root, change))
+	writeValidPlanningBundleForTransactionTest(t, root, change)
+
+	record := model.VerificationRecord{
+		Verdict:    model.VerificationVerdictPass,
+		Timestamp:  time.Now().UTC(),
+		RunVersion: 0,
+	}
+	writeVerificationForTest(t, root, change.Slug, SkillPlanAudit, record)
+
+	bundleDir, err := state.GovernedBundleDir(root, change)
+	require.NoError(t, err)
+	wavePlanPath := filepath.Join(bundleDir, "verification", state.WavePlanFileName)
+
+	writeErr := errors.New("change authority write failed")
+	withFailingGovernedTransactionWrite(t, "change.yaml", writeErr)
+
+	_, err = AdvanceGoverned(root, change.Slug)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, writeErr)
+
+	_, statErr := os.Stat(wavePlanPath)
+	assert.ErrorIs(t, statErr, os.ErrNotExist)
+
+	reloaded, loadErr := state.LoadChange(root, change.Slug)
+	require.NoError(t, loadErr)
+	assert.Equal(t, model.StateS1Plan, reloaded.CurrentState)
+	assert.Equal(t, model.PlanSubStepAudit, reloaded.PlanSubStep)
+}
+
+func withFailingGovernedTransactionWrite(t *testing.T, suffix string, failErr error) {
+	t.Helper()
+
+	original := applyGovernedFileTransaction
+	applyGovernedFileTransaction = func(ops []fsutil.FileTransactionOp) error {
+		return fsutil.ApplyFileTransactionWithHooks(ops, fsutil.FileTransactionHooks{
+			WriteFile: func(path string, data []byte, perm os.FileMode) error {
+				if strings.HasSuffix(filepath.ToSlash(path), suffix) {
+					return failErr
+				}
+				return fsutil.WriteFileAtomic(path, data, perm)
+			},
+		})
+	}
+	t.Cleanup(func() {
+		applyGovernedFileTransaction = original
+	})
+}
+
+func setupTransactionRepoWithWorktree(t *testing.T) (repoRoot string, worktreePath string) {
+	t.Helper()
+
+	root := t.TempDir()
+	runTransactionGit(t, root, "init", "-b", "main")
+	runTransactionGit(t, root, "config", "user.email", "transaction@example.com")
+	runTransactionGit(t, root, "config", "user.name", "Transaction Test")
+	require.NoError(t, model.SaveConfig(state.ConfigPath(root), model.DefaultConfig()))
+	runTransactionGit(t, root, "add", ".slipway.yaml")
+	runTransactionGit(t, root, "commit", "-m", "init")
+
+	worktreeRoot := filepath.Join(t.TempDir(), "transaction-binding")
+	runTransactionGit(t, root, "worktree", "add", worktreeRoot, "-b", "transaction-binding")
+	return root, worktreeRoot
+}
+
+func runTransactionGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...) // #nosec G204 -- test helper executes fixed git commands with test-controlled args.
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "git %v: %s", args, string(out))
+}
+
+func writeValidPlanningBundleForTransactionTest(t *testing.T, root string, change model.Change) {
+	t.Helper()
+
+	require.NoError(t, artifact.ScaffoldGovernedBundleForChange(root, change, change.WorkflowPreset))
+	bundleDir, err := state.GovernedBundleDir(root, change)
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "requirements.md"), []byte(`# Requirements
+
+## Requirements
+
+### Requirement: Transactional transition
+REQ-001: The system MUST keep transition files all-or-nothing.
+
+#### Scenario: Rollback
+GIVEN a transition file is written
+WHEN a later authority write fails
+THEN the first file is rolled back.
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "decision.md"), []byte(`# Decision
+
+## Alternatives Considered
+- Use per-call rollback.
+- Use a shared file transaction.
+
+## Selected Approach
+Use a shared file transaction.
+
+## Interfaces and Data Flow
+Progression builds file operations and applies them together.
+
+## Rollout and Rollback
+Revert the transaction wrapper if needed.
+
+## Risk
+Rollback failure must be visible.
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "tasks.md"), []byte(`# Tasks
+
+## Task List
+
+- [ ] `+"`t-01`"+` implement transaction
+  - wave: 1
+  - target_files: ["internal/fsutil/transaction.go"]
+  - task_kind: code
+  - covers: [REQ-001]
+`), 0o644))
+}

--- a/internal/engine/progression/stale_evidence_recovery.go
+++ b/internal/engine/progression/stale_evidence_recovery.go
@@ -14,9 +14,11 @@ import (
 	"github.com/signalridge/slipway/internal/engine/scopecontract"
 	"github.com/signalridge/slipway/internal/engine/sensitiveevidence"
 	"github.com/signalridge/slipway/internal/engine/skill"
+	"github.com/signalridge/slipway/internal/fsutil"
 	"github.com/signalridge/slipway/internal/model"
 	"github.com/signalridge/slipway/internal/state"
 	"github.com/signalridge/slipway/internal/stringutil"
+	"gopkg.in/yaml.v3"
 )
 
 type StaleEvidenceTarget struct {
@@ -134,18 +136,20 @@ func reopenToStaleStage(
 	verificationDir := filepath.Join(paths.GovernedBundleDir, "verification")
 	sideEffects := []SideEffect{}
 	clearedSkills := []string{}
+	transactionOps := make([]fsutil.FileTransactionOp, 0, len(authorities)+3)
 	for _, authority := range authorities {
 		if compareStaleEvidencePosition(authority.position, targetPosition) < 0 {
 			continue
 		}
 		path := filepath.Join(verificationDir, authority.SkillName+".yaml")
-		removed, err := clearRecoveryEvidence(root, *change, recoveryEvidenceFile{
+		removed, ops, err := recoveryEvidenceTransactionOps(root, *change, recoveryEvidenceFile{
 			path:  path,
 			skill: authority.SkillName,
 		})
 		if err != nil {
 			return AdvanceSummary{}, err
 		}
+		transactionOps = append(transactionOps, ops...)
 		if removed {
 			clearedSkills = append(clearedSkills, authority.SkillName)
 			sideEffects = append(sideEffects, SideEffect{
@@ -156,10 +160,11 @@ func reopenToStaleStage(
 	}
 	if shouldClearWavePlan(targetPosition) {
 		path := filepath.Join(verificationDir, state.WavePlanFileName)
-		removed, err := clearRecoveryEvidence(root, *change, recoveryEvidenceFile{path: path})
+		removed, ops, err := recoveryEvidenceTransactionOps(root, *change, recoveryEvidenceFile{path: path})
 		if err != nil {
 			return AdvanceSummary{}, err
 		}
+		transactionOps = append(transactionOps, ops...)
 		if removed {
 			sideEffects = append(sideEffects, SideEffect{
 				Kind:   "cleared_stale_generated_evidence",
@@ -169,10 +174,11 @@ func reopenToStaleStage(
 	}
 	if shouldClearExecutionSummary(targetPosition) {
 		path := filepath.Join(verificationDir, state.ExecutionSummaryFileName)
-		removed, err := clearRecoveryEvidence(root, *change, recoveryEvidenceFile{path: path})
+		removed, ops, err := recoveryEvidenceTransactionOps(root, *change, recoveryEvidenceFile{path: path})
 		if err != nil {
 			return AdvanceSummary{}, err
 		}
+		transactionOps = append(transactionOps, ops...)
 		if removed {
 			sideEffects = append(sideEffects, SideEffect{
 				Kind:   "cleared_stale_generated_evidence",
@@ -235,7 +241,15 @@ func reopenToStaleStage(
 		}
 	}
 
-	if err := state.SaveChange(root, *change); err != nil {
+	digestOp, digestChanged, err := pruneEvidenceDigestsTransactionOp(root, *change, clearedSkills)
+	if err != nil {
+		return AdvanceSummary{}, err
+	}
+	if digestChanged {
+		transactionOps = append(transactionOps, digestOp)
+	}
+
+	if err := applyGovernedChangeTransaction(root, *change, transactionOps); err != nil {
 		return AdvanceSummary{}, err
 	}
 	return AdvanceSummary{
@@ -250,6 +264,75 @@ func reopenToStaleStage(
 		Message:       "Reopened " + target.Label() + " for stale evidence recovery.",
 		Blockers:      target.Blockers,
 	}, nil
+}
+
+func recoveryEvidenceTransactionOps(
+	root string,
+	change model.Change,
+	ev recoveryEvidenceFile,
+) (bool, []fsutil.FileTransactionOp, error) {
+	exists, err := recoveryEvidenceFileExists(ev.path)
+	if err != nil {
+		return false, nil, err
+	}
+	if !exists {
+		return false, nil, nil
+	}
+
+	return true, []fsutil.FileTransactionOp{fsutil.RemoveFileTransactionOp(ev.path)}, nil
+}
+
+func recoveryEvidenceFileExists(path string) (bool, error) {
+	if _, err := os.Stat(path); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func pruneEvidenceDigestsTransactionOp(
+	root string,
+	change model.Change,
+	skillNames []string,
+) (fsutil.FileTransactionOp, bool, error) {
+	skills := stringutil.UniqueSorted(skillNames)
+	if len(skills) == 0 {
+		return fsutil.FileTransactionOp{}, false, nil
+	}
+	digests, err := state.LoadOptionalEvidenceDigestsForChange(root, change)
+	if err != nil {
+		return fsutil.FileTransactionOp{}, false, err
+	}
+	if digests == nil {
+		return fsutil.FileTransactionOp{}, false, nil
+	}
+	digests.Normalize()
+	changed := false
+	for _, skillName := range skills {
+		if _, ok := digests.Skills[skillName]; !ok {
+			continue
+		}
+		delete(digests.Skills, skillName)
+		changed = true
+	}
+	if !changed {
+		return fsutil.FileTransactionOp{}, false, nil
+	}
+	if err := digests.Validate(); err != nil {
+		return fsutil.FileTransactionOp{}, false, err
+	}
+	raw, err := yaml.Marshal(*digests)
+	if err != nil {
+		return fsutil.FileTransactionOp{}, false, err
+	}
+	paths, err := state.ResolveChangePaths(root, change)
+	if err != nil {
+		return fsutil.FileTransactionOp{}, false, err
+	}
+	path := filepath.Join(paths.GovernedBundleDir, "verification", state.EvidenceDigestsFileName)
+	return fsutil.WriteFileTransactionOp(path, raw, 0o644), true, nil
 }
 
 func staleEvidenceAuthorities(root string, change model.Change, requiredOnly bool) ([]staleEvidenceAuthority, error) {

--- a/internal/engine/progression/stale_evidence_recovery_transaction_test.go
+++ b/internal/engine/progression/stale_evidence_recovery_transaction_test.go
@@ -1,0 +1,69 @@
+package progression
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/signalridge/slipway/internal/model"
+	"github.com/signalridge/slipway/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStaleEvidenceRecoveryRestoresEvidenceWhenAuthorityWriteFails(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, model.SaveConfig(state.ConfigPath(root), model.DefaultConfig()))
+
+	change := model.NewChange("stale-reopen-transaction-rollback")
+	change.CurrentState = model.StateS3Review
+	change.WorkflowPreset = model.WorkflowPresetLight
+	require.NoError(t, state.SaveChange(root, change))
+	writeValidPlanningBundleForTransactionTest(t, root, change)
+
+	record := model.VerificationRecord{
+		Verdict:    model.VerificationVerdictPass,
+		Timestamp:  time.Now().UTC(),
+		RunVersion: 0,
+	}
+	writeVerificationForTest(t, root, change.Slug, SkillPlanAudit, record)
+	require.NoError(t, StampEvidenceDigestForSkill(root, change, SkillPlanAudit, record, nil))
+
+	bundleDir, err := state.GovernedBundleDir(root, change)
+	require.NoError(t, err)
+	verificationPath := filepath.Join(bundleDir, "verification", SkillPlanAudit+".yaml")
+	digestsPath := filepath.Join(bundleDir, "verification", state.EvidenceDigestsFileName)
+
+	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "tasks.md"), []byte(`# Tasks
+
+## Task List
+
+- [ ] `+"`t-01`"+` changed task plan
+  - wave: 1
+  - target_files: ["internal/fsutil/transaction.go"]
+  - task_kind: code
+  - covers: [REQ-001]
+`), 0o644))
+
+	writeErr := errors.New("change authority write failed")
+	withFailingGovernedTransactionWrite(t, "change.yaml", writeErr)
+
+	_, err = AdvanceGoverned(root, change.Slug)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, writeErr)
+
+	_, statErr := os.Stat(verificationPath)
+	require.NoError(t, statErr)
+	_, statErr = os.Stat(digestsPath)
+	require.NoError(t, statErr)
+
+	digests, loadErr := state.LoadEvidenceDigestsForChange(root, change)
+	require.NoError(t, loadErr)
+	assert.Contains(t, digests.Skills, SkillPlanAudit)
+
+	reloaded, loadErr := state.LoadChange(root, change.Slug)
+	require.NoError(t, loadErr)
+	assert.Equal(t, model.StateS3Review, reloaded.CurrentState)
+}

--- a/internal/fsutil/transaction.go
+++ b/internal/fsutil/transaction.go
@@ -1,0 +1,257 @@
+package fsutil
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"slices"
+	"strings"
+)
+
+type fileTransactionOpKind string
+
+const (
+	fileTransactionOpWrite  fileTransactionOpKind = "write"
+	fileTransactionOpRemove fileTransactionOpKind = "remove"
+)
+
+// FileTransactionOp describes one ordered file mutation in a file transaction.
+type FileTransactionOp struct {
+	kind fileTransactionOpKind
+	path string
+	data []byte
+	perm os.FileMode
+}
+
+// WriteFileTransactionOp returns a transaction operation that atomically writes
+// one file when the transaction is applied.
+func WriteFileTransactionOp(path string, data []byte, perm os.FileMode) FileTransactionOp {
+	return FileTransactionOp{
+		kind: fileTransactionOpWrite,
+		path: path,
+		data: slices.Clone(data),
+		perm: perm,
+	}
+}
+
+// RemoveFileTransactionOp returns a transaction operation that removes one file
+// when it exists.
+func RemoveFileTransactionOp(path string) FileTransactionOp {
+	return FileTransactionOp{
+		kind: fileTransactionOpRemove,
+		path: path,
+	}
+}
+
+// ApplyFileTransaction applies ordered file writes/removes. If an operation
+// fails after earlier operations succeeded, earlier files are restored or
+// removed so callers do not observe a partial file set.
+func ApplyFileTransaction(ops []FileTransactionOp) error {
+	return applyFileTransaction(ops, fileTransactionHooks{})
+}
+
+// FileTransactionHooks overrides file IO for deterministic tests.
+type FileTransactionHooks struct {
+	WriteFile  func(path string, data []byte, perm os.FileMode) error
+	RemoveFile func(path string) error
+}
+
+// ApplyFileTransactionWithHooks applies a file transaction with caller-supplied
+// file IO hooks. Production callers should normally use ApplyFileTransaction.
+func ApplyFileTransactionWithHooks(ops []FileTransactionOp, hooks FileTransactionHooks) error {
+	return applyFileTransaction(ops, fileTransactionHooks{
+		writeFile:  hooks.WriteFile,
+		removeFile: hooks.RemoveFile,
+	})
+}
+
+type fileTransactionHooks struct {
+	writeFile  func(path string, data []byte, perm os.FileMode) error
+	removeFile func(path string) error
+}
+
+func (hooks fileTransactionHooks) withDefaults() fileTransactionHooks {
+	if hooks.writeFile == nil {
+		hooks.writeFile = WriteFileAtomic
+	}
+	if hooks.removeFile == nil {
+		hooks.removeFile = removeTransactionFileIfExists
+	}
+	return hooks
+}
+
+type fileSnapshot struct {
+	existed bool
+	data    []byte
+	perm    os.FileMode
+}
+
+type appliedFileTransactionOp struct {
+	path   string
+	before fileSnapshot
+}
+
+type rollbackPathError struct {
+	path string
+	err  error
+}
+
+func (err rollbackPathError) Error() string {
+	return fmt.Sprintf("%s: %v", err.path, err.err)
+}
+
+func (err rollbackPathError) Unwrap() error {
+	return err.err
+}
+
+// FileTransactionError reports the operation failure and any rollback failures.
+type FileTransactionError struct {
+	OperationErr error
+	RollbackErrs []error
+}
+
+func (err *FileTransactionError) Error() string {
+	if err == nil {
+		return ""
+	}
+	if len(err.RollbackErrs) == 0 {
+		return fmt.Sprintf("apply file transaction: %v", err.OperationErr)
+	}
+	paths := make([]string, 0, len(err.RollbackErrs))
+	for _, rollbackErr := range err.RollbackErrs {
+		var pathErr rollbackPathError
+		if errors.As(rollbackErr, &pathErr) {
+			paths = append(paths, pathErr.path)
+		}
+	}
+	slices.Sort(paths)
+	return fmt.Sprintf(
+		"apply file transaction: %v; rollback incomplete for %s: %v",
+		err.OperationErr,
+		strings.Join(paths, ", "),
+		errors.Join(err.RollbackErrs...),
+	)
+}
+
+func (err *FileTransactionError) Unwrap() error {
+	if err == nil {
+		return nil
+	}
+	joined := make([]error, 0, 1+len(err.RollbackErrs))
+	if err.OperationErr != nil {
+		joined = append(joined, err.OperationErr)
+	}
+	joined = append(joined, err.RollbackErrs...)
+	return errors.Join(joined...)
+}
+
+func applyFileTransaction(ops []FileTransactionOp, hooks fileTransactionHooks) error {
+	hooks = hooks.withDefaults()
+	if err := validateFileTransactionOps(ops); err != nil {
+		return err
+	}
+
+	applied := make([]appliedFileTransactionOp, 0, len(ops))
+	for _, op := range ops {
+		before, err := snapshotFileForTransaction(op.path)
+		if err != nil {
+			if len(applied) > 0 {
+				return newFileTransactionError(err, rollbackFileTransaction(applied, hooks))
+			}
+			return err
+		}
+		if err := applyFileTransactionOp(op, hooks); err != nil {
+			return newFileTransactionError(err, rollbackFileTransaction(applied, hooks))
+		}
+		applied = append(applied, appliedFileTransactionOp{
+			path:   op.path,
+			before: before,
+		})
+	}
+	return nil
+}
+
+func validateFileTransactionOps(ops []FileTransactionOp) error {
+	for _, op := range ops {
+		if strings.TrimSpace(op.path) == "" {
+			return errors.New("file transaction path is required")
+		}
+		switch op.kind {
+		case fileTransactionOpWrite, fileTransactionOpRemove:
+		default:
+			return fmt.Errorf("unknown file transaction operation %q for %s", op.kind, op.path)
+		}
+	}
+	return nil
+}
+
+func snapshotFileForTransaction(path string) (fileSnapshot, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return fileSnapshot{}, nil
+		}
+		return fileSnapshot{}, fmt.Errorf("snapshot %s: %w", path, err)
+	}
+	if info.IsDir() {
+		return fileSnapshot{}, fmt.Errorf("snapshot %s: path is a directory", path)
+	}
+	data, err := os.ReadFile(path) // #nosec G304 -- transaction paths are supplied by governed artifact/state code or tests.
+	if err != nil {
+		return fileSnapshot{}, fmt.Errorf("snapshot %s: %w", path, err)
+	}
+	return fileSnapshot{
+		existed: true,
+		data:    data,
+		perm:    info.Mode().Perm(),
+	}, nil
+}
+
+func applyFileTransactionOp(op FileTransactionOp, hooks fileTransactionHooks) error {
+	switch op.kind {
+	case fileTransactionOpWrite:
+		if err := hooks.writeFile(op.path, op.data, op.perm); err != nil {
+			return fmt.Errorf("write %s: %w", op.path, err)
+		}
+	case fileTransactionOpRemove:
+		if err := hooks.removeFile(op.path); err != nil {
+			return fmt.Errorf("remove %s: %w", op.path, err)
+		}
+	}
+	return nil
+}
+
+func rollbackFileTransaction(applied []appliedFileTransactionOp, hooks fileTransactionHooks) []error {
+	rollbackErrs := make([]error, 0)
+	for i := len(applied) - 1; i >= 0; i-- {
+		item := applied[i]
+		var err error
+		if item.before.existed {
+			err = hooks.writeFile(item.path, item.before.data, item.before.perm)
+		} else {
+			err = hooks.removeFile(item.path)
+		}
+		if err != nil {
+			rollbackErrs = append(rollbackErrs, rollbackPathError{
+				path: item.path,
+				err:  err,
+			})
+		}
+	}
+	return rollbackErrs
+}
+
+func newFileTransactionError(operationErr error, rollbackErrs []error) error {
+	return &FileTransactionError{
+		OperationErr: operationErr,
+		RollbackErrs: rollbackErrs,
+	}
+}
+
+func removeTransactionFileIfExists(path string) error {
+	if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) { // #nosec G122 -- transaction paths are supplied by governed artifact/state code or tests.
+		return err
+	}
+	return nil
+}

--- a/internal/fsutil/transaction_test.go
+++ b/internal/fsutil/transaction_test.go
@@ -1,0 +1,137 @@
+package fsutil
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyFileTransactionRollsBackAppliedWriteOnLaterFailure(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	existingPath := filepath.Join(dir, "existing.yaml")
+	newPath := filepath.Join(dir, "new.yaml")
+	require.NoError(t, os.WriteFile(existingPath, []byte("old"), 0o644))
+
+	writeErr := errors.New("write failed")
+	ops := []FileTransactionOp{
+		WriteFileTransactionOp(existingPath, []byte("new"), 0o644),
+		WriteFileTransactionOp(newPath, []byte("created"), 0o644),
+	}
+
+	err := applyFileTransaction(ops, fileTransactionHooks{
+		writeFile: func(path string, data []byte, perm os.FileMode) error {
+			if path == newPath {
+				return writeErr
+			}
+			return WriteFileAtomic(path, data, perm)
+		},
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, writeErr)
+
+	got, readErr := os.ReadFile(existingPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, "old", string(got))
+
+	_, statErr := os.Stat(newPath)
+	assert.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+func TestApplyFileTransactionRestoresRemovedFileOnLaterFailure(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	removedPath := filepath.Join(dir, "verification.yaml")
+	laterPath := filepath.Join(dir, "change.yaml")
+	require.NoError(t, os.WriteFile(removedPath, []byte("evidence"), 0o640))
+
+	writeErr := errors.New("state save failed")
+	ops := []FileTransactionOp{
+		RemoveFileTransactionOp(removedPath),
+		WriteFileTransactionOp(laterPath, []byte("state"), 0o644),
+	}
+
+	err := applyFileTransaction(ops, fileTransactionHooks{
+		writeFile: func(path string, data []byte, perm os.FileMode) error {
+			if path == laterPath {
+				return writeErr
+			}
+			return WriteFileAtomic(path, data, perm)
+		},
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, writeErr)
+
+	got, readErr := os.ReadFile(removedPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, "evidence", string(got))
+
+	info, statErr := os.Stat(removedPath)
+	require.NoError(t, statErr)
+	if runtime.GOOS != "windows" {
+		assert.Equal(t, os.FileMode(0o640), info.Mode().Perm())
+	}
+}
+
+func TestApplyFileTransactionRollsBackAppliedWriteOnLaterSnapshotFailure(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	createdPath := filepath.Join(dir, "created.yaml")
+	directoryPath := filepath.Join(dir, "not-a-file")
+	require.NoError(t, os.Mkdir(directoryPath, 0o755))
+
+	err := ApplyFileTransaction([]FileTransactionOp{
+		WriteFileTransactionOp(createdPath, []byte("created"), 0o644),
+		WriteFileTransactionOp(directoryPath, []byte("later"), 0o644),
+	})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "path is a directory")
+
+	_, statErr := os.Stat(createdPath)
+	assert.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+func TestApplyFileTransactionReportsRollbackFailurePath(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	createdPath := filepath.Join(dir, "created.yaml")
+	laterPath := filepath.Join(dir, "change.yaml")
+
+	writeErr := errors.New("state save failed")
+	rollbackErr := errors.New("rollback remove failed")
+	ops := []FileTransactionOp{
+		WriteFileTransactionOp(createdPath, []byte("created"), 0o644),
+		WriteFileTransactionOp(laterPath, []byte("state"), 0o644),
+	}
+
+	err := applyFileTransaction(ops, fileTransactionHooks{
+		writeFile: func(path string, data []byte, perm os.FileMode) error {
+			if path == laterPath {
+				return writeErr
+			}
+			return WriteFileAtomic(path, data, perm)
+		},
+		removeFile: func(path string) error {
+			if path == createdPath {
+				return rollbackErr
+			}
+			return os.Remove(path)
+		},
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, writeErr)
+	assert.ErrorIs(t, err, rollbackErr)
+	assert.ErrorContains(t, err, createdPath)
+}

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -509,47 +509,56 @@ func changeVisibleFromRoot(root, workspaceRoot string, change model.Change, arch
 // SaveChange persists the change state for the given change (keyed by slug).
 // The governed bundle copy is the single authority.
 func SaveChange(root string, st model.Change) error {
+	ops, err := SaveChangeTransactionOps(root, st)
+	if err != nil {
+		return err
+	}
+	return fsutil.ApplyFileTransaction(ops)
+}
+
+// SaveChangeTransactionOps returns the file operations needed to persist the
+// governed bundle authority and its machine-local worktree binding.
+func SaveChangeTransactionOps(root string, st model.Change) ([]fsutil.FileTransactionOp, error) {
 	if st.Slug == "" {
-		return errors.New("slug is required")
+		return nil, errors.New("slug is required")
 	}
 
 	st.Normalize()
 	if err := st.Validate(); err != nil {
-		return err
+		return nil, err
 	}
 	if strings.TrimSpace(st.WorktreePath) != "" {
 		if err := EnsureWorkspaceScopeMarker(root, st.WorktreePath); err != nil {
-			return err
+			return nil, err
 		}
 		if err := EnsureWorkspaceScopeConfig(root, st.WorktreePath); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
 	b, err := yaml.Marshal(st)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Write to bundle directory (canonical authority alongside plan artifacts).
 	bundlePath, err := bundleChangeFilePathForChange(root, st)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	if err := os.MkdirAll(filepath.Dir(bundlePath), 0o755); err != nil { // #nosec G301 -- directory is a user-facing project or governance artifact location where executable/searchable mode is intentional.
-		return err
-	}
-	if err := fsutil.WriteFileAtomic(bundlePath, b, 0o644); err != nil {
-		return err
-	}
+
 	// Record the machine-local worktree binding in git-local runtime state.
 	// The tracked bundle above carries no absolute path (Change.MarshalYAML
 	// strips it); this runtime record is the authority for resolving the bound
 	// worktree, with the bundle's own location as a self-healing fallback.
-	if err := writeWorktreeBinding(root, st); err != nil {
-		return err
+	bindingOp, err := worktreeBindingTransactionOp(root, st)
+	if err != nil {
+		return nil, err
 	}
-	return nil
+	return []fsutil.FileTransactionOp{
+		fsutil.WriteFileTransactionOp(bundlePath, b, 0o644),
+		bindingOp,
+	}, nil
 }
 
 func decodeChangeStrict(raw []byte, change *model.Change) error {

--- a/internal/state/wave_execution.go
+++ b/internal/state/wave_execution.go
@@ -70,23 +70,28 @@ func LoadOptionalWavePlanForChange(root string, change model.Change) (*model.Wav
 }
 
 func SaveWavePlan(root, slug string, plan model.WavePlan) error {
+	op, err := SaveWavePlanTransactionOp(root, slug, plan)
+	if err != nil {
+		return err
+	}
+	return fsutil.ApplyFileTransaction([]fsutil.FileTransactionOp{op})
+}
+
+func SaveWavePlanTransactionOp(root, slug string, plan model.WavePlan) (fsutil.FileTransactionOp, error) {
 	plan.Normalize()
 	if err := plan.Validate(); err != nil {
-		return err
+		return fsutil.FileTransactionOp{}, err
 	}
 	dir, err := resolveVerificationDirForWrite(root, slug)
 	if err != nil {
-		return fmt.Errorf("resolve wave plan dir for %q: %w", slug, err)
+		return fsutil.FileTransactionOp{}, fmt.Errorf("resolve wave plan dir for %q: %w", slug, err)
 	}
 	path := filepath.Join(dir, WavePlanFileName)
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil { // #nosec G301 -- directory is a user-facing project or governance artifact location where executable/searchable mode is intentional.
-		return err
-	}
 	raw, err := yaml.Marshal(plan)
 	if err != nil {
-		return err
+		return fsutil.FileTransactionOp{}, err
 	}
-	return fsutil.WriteFileAtomic(path, raw, 0o644)
+	return fsutil.WriteFileTransactionOp(path, raw, 0o644), nil
 }
 
 func MaterializeWavePlan(root string, change model.Change) (model.WavePlan, error) {
@@ -131,13 +136,24 @@ func cloneWavePlanForEffectiveParallel(plan model.WavePlan) model.WavePlan {
 }
 
 func MaterializeWavePlanAt(root string, change model.Change, generatedAt time.Time) (model.WavePlan, error) {
-	hashes, nodes, err := currentTaskPlanHashesAndNodes(root, change)
+	plan, op, err := MaterializeWavePlanTransactionOpAt(root, change, generatedAt)
 	if err != nil {
 		return model.WavePlan{}, err
 	}
+	if err := fsutil.ApplyFileTransaction([]fsutil.FileTransactionOp{op}); err != nil {
+		return model.WavePlan{}, err
+	}
+	return plan, nil
+}
+
+func MaterializeWavePlanTransactionOpAt(root string, change model.Change, generatedAt time.Time) (model.WavePlan, fsutil.FileTransactionOp, error) {
+	hashes, nodes, err := currentTaskPlanHashesAndNodes(root, change)
+	if err != nil {
+		return model.WavePlan{}, fsutil.FileTransactionOp{}, err
+	}
 	waves, err := wave.PlanWaves(nodes)
 	if err != nil {
-		return model.WavePlan{}, err
+		return model.WavePlan{}, fsutil.FileTransactionOp{}, err
 	}
 	plan := model.WavePlan{
 		Version:                 model.WavePlanVersion,
@@ -175,10 +191,11 @@ func MaterializeWavePlanAt(root string, change model.Change, generatedAt time.Ti
 	// and file-disjoint. The flag is derived here and is not part of the
 	// freshness hashes above (which derive from tasks.md).
 	plan = ApplyEffectiveParallel(plan, forcedParallel)
-	if err := SaveWavePlan(root, change.Slug, plan); err != nil {
-		return model.WavePlan{}, err
+	op, err := SaveWavePlanTransactionOp(root, change.Slug, plan)
+	if err != nil {
+		return model.WavePlan{}, fsutil.FileTransactionOp{}, err
 	}
-	return plan, nil
+	return plan, op, nil
 }
 
 func CurrentTasksPlanStructuralState(root string, change model.Change) (string, error) {

--- a/internal/state/wave_execution_transaction_test.go
+++ b/internal/state/wave_execution_transaction_test.go
@@ -1,0 +1,49 @@
+package state
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/signalridge/slipway/internal/fsutil"
+	"github.com/signalridge/slipway/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMaterializeWavePlanTransactionOpDefersWriteUntilApplied(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, model.SaveConfig(ConfigPath(root), model.DefaultConfig()))
+
+	change := model.NewChange("transactional-wave-plan")
+	require.NoError(t, SaveChange(root, change))
+
+	bundleDir, err := GovernedBundleDir(root, change)
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(bundleDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "tasks.md"), []byte(`# Tasks
+
+- [ ] `+"`t-01`"+` implement transaction
+  - wave: 1
+  - target_files: ["internal/fsutil/transaction.go"]
+  - task_kind: code
+`), 0o644))
+
+	generatedAt := time.Date(2026, 6, 11, 1, 2, 3, 0, time.UTC)
+	plan, op, err := MaterializeWavePlanTransactionOpAt(root, change, generatedAt)
+	require.NoError(t, err)
+	assert.Equal(t, 1, plan.TotalTasks)
+
+	wavePlanPath := filepath.Join(bundleDir, "verification", WavePlanFileName)
+	_, err = os.Stat(wavePlanPath)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+
+	require.NoError(t, fsutil.ApplyFileTransaction([]fsutil.FileTransactionOp{op}))
+
+	loaded, err := LoadWavePlanForChange(root, change)
+	require.NoError(t, err)
+	assert.Equal(t, generatedAt, loaded.GeneratedAt)
+}

--- a/internal/state/worktree_binding.go
+++ b/internal/state/worktree_binding.go
@@ -3,7 +3,6 @@ package state
 import (
 	"errors"
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -38,24 +37,21 @@ func WorktreeBindingPath(root, slug string) string {
 	return filepath.Join(ChangeDir(root, slug), worktreeBindingFileName)
 }
 
-// writeWorktreeBinding persists (or clears) the git-local worktree binding for a
-// change. An empty WorktreePath removes any existing record so an unbound change
-// leaves no stale binding behind.
-func writeWorktreeBinding(root string, change model.Change) error {
+// worktreeBindingTransactionOp persists or clears the git-local worktree
+// binding. An empty WorktreePath removes any existing record so an unbound
+// change leaves no stale binding behind.
+func worktreeBindingTransactionOp(root string, change model.Change) (fsutil.FileTransactionOp, error) {
 	slug := strings.TrimSpace(change.Slug)
 	if slug == "" {
-		return errors.New("slug is required")
+		return fsutil.FileTransactionOp{}, errors.New("slug is required")
 	}
 	path := WorktreeBindingPath(root, slug)
 	if strings.TrimSpace(change.WorktreePath) == "" {
-		if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
-			return err
-		}
-		return nil
+		return fsutil.RemoveFileTransactionOp(path), nil
 	}
 	normalizedWorktreePath, err := NormalizePath(change.WorktreePath)
 	if err != nil {
-		return fmt.Errorf("normalize worktree binding path: %w", err)
+		return fsutil.FileTransactionOp{}, fmt.Errorf("normalize worktree binding path: %w", err)
 	}
 
 	binding := worktreeBinding{
@@ -65,12 +61,9 @@ func writeWorktreeBinding(root string, change model.Change) error {
 	}
 	raw, err := yaml.Marshal(binding)
 	if err != nil {
-		return err
+		return fsutil.FileTransactionOp{}, err
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil { // #nosec G301 -- directory is a user-facing project or governance artifact location where executable/searchable mode is intentional.
-		return err
-	}
-	return fsutil.WriteFileAtomic(path, raw, 0o644)
+	return fsutil.WriteFileTransactionOp(path, raw, 0o644), nil
 }
 
 // readWorktreeBinding returns the recorded worktree binding for slug. The second


### PR DESCRIPTION
## Summary
- add a reusable fsutil transaction helper for staged multi-file writes with rollback on failure
- wire transactional writes through artifact persistence, governed advancement, stale-evidence recovery, and state/worktree stores
- add failure-injection regressions proving partial writes are rolled back across affected stage transitions
- archive the governed Slipway change bundle after successful `slipway done`
- remove obsolete unused helper code caught by PR lint after the transactional path replaced it
- make the restored-file permission assertion POSIX-only while keeping restored content checks on every OS

## Verification
- `go run . validate --json`
- `go run . run --json --diagnostics`
- `go run . done --json`
- `golangci-lint run --timeout=5m`
- `go test ./internal/fsutil -count=1`
- `go test ./... -count=1`
- `git diff --check`
- `git diff --cached --check`
- governed closeout gosec SARIF result count: 0

Resolves #164