### PR TITLE
fix(progression): prevent S4 evidence self-stale

### DIFF
--- a/artifacts/changes/archived/resolve-github-issue-185-prevent-s4-goal-verification-from-s/assurance.md
+++ b/artifacts/changes/archived/resolve-github-issue-185-prevent-s4-goal-verification-from-s/assurance.md
@@ -1,0 +1,80 @@
+# Assurance
+
+## Scope Summary
+
+Delivered GitHub issue #185 by changing S4 digest input construction so
+`goal-verification` and `final-closeout` do not self-stale when recording
+engine-owned `EvidenceRefs` mutates the current
+`artifacts/changes/<slug>/change.yaml`.
+
+Implementation stayed scoped to:
+
+- `internal/engine/progression/evidence_digests.go`
+- `internal/engine/progression/evidence_digests_test.go`
+
+The governed bundle and codebase map were refreshed for #185.
+
+## Verification Verdict
+
+Current verification evidence is pass:
+
+- Focused regressions passed after failing coverage gaps were identified:
+  S4 goal/final evidence-ref normalization and the default raw-content path.
+- Full `internal/engine/progression` package test passed.
+- Full repository `go test -count=1 ./...` passed.
+- Progression package coverage profile passed with 70.6% statement coverage;
+  the changed digest helpers are covered, including
+  `goalVerificationContentPathInputHash` at 100.0%.
+- `git diff --check` passed.
+- Runtime task evidence exists for `t-01`, `t-02`, and `t-03`.
+
+## Evidence Index
+
+- `go test -count=1 ./internal/engine/progression -run 'Test(GoalAndCloseoutDigestIgnoresEvidenceRefOnlyChangeYAMLMutation|DefaultContentDigestKeepsRawChangeYAMLHash)'`
+- `go test -count=1 ./internal/engine/progression`
+- `go test -count=1 ./...`
+- `go test -count=1 -coverprofile=/tmp/slipway-185-progression.cover ./internal/engine/progression`
+- `go tool cover -func=/tmp/slipway-185-progression.cover`
+- `git diff --check`
+- `go run . validate --json`
+- `verification/wave-orchestration.yaml`
+- `verification/spec-compliance-review.yaml`
+- `verification/code-quality-review.yaml`
+- Runtime task evidence:
+  - `.git/slipway/runtime/changes/resolve-github-issue-185-prevent-s4-goal-verification-from-s/evidence/tasks/t-01.json`
+  - `.git/slipway/runtime/changes/resolve-github-issue-185-prevent-s4-goal-verification-from-s/evidence/tasks/t-02.json`
+  - `.git/slipway/runtime/changes/resolve-github-issue-185-prevent-s4-goal-verification-from-s/evidence/tasks/t-03.json`
+
+## Requirement Coverage
+
+- REQ-001: covered by
+  `TestGoalAndCloseoutDigestIgnoresEvidenceRefOnlyChangeYAMLMutation`, which
+  records `EvidenceRefs` for both `goal-verification` and `final-closeout` and
+  expects no `change.yaml` stale blocker.
+- REQ-002: covered by the same test mutating `Description` after evidence and
+  expecting `required_skill_stale:<skill>:artifacts/changes/<slug>/change.yaml`.
+- REQ-003: covered by path scoping in `currentChangeAuthorityInput` and the
+  `TestDefaultContentDigestKeepsRawChangeYAMLHash` regression for non-goal raw
+  content hashing, plus the existing
+  `TestStoredGoalDigestStalesWhenInputContentChanges` behavior for a normal
+  target file.
+
+## Residual Risks and Exceptions
+
+- Existing digests stamped before this code change may stale once because the
+  current-change `change.yaml` digest format changed from raw bytes to
+  structured authority-without-`EvidenceRefs`. Re-recording evidence through the
+  supported CLI is the expected recovery.
+- No manual Lattice artifact edits or public restamp command are included in
+  this change.
+
+## Rollback Readiness
+
+Rollback is source-only: revert the helper and regression test changes, then run
+`go test -count=1 ./internal/engine/progression` to confirm the previous
+behavior is restored. No data migration or cleanup command is required.
+
+## Archive Decision
+
+Not archived yet. Active validation and review evidence must be refreshed after
+S3 review and S4 verification before `slipway done` is appropriate.

--- a/artifacts/changes/archived/resolve-github-issue-185-prevent-s4-goal-verification-from-s/change.yaml
+++ b/artifacts/changes/archived/resolve-github-issue-185-prevent-s4-goal-verification-from-s/change.yaml
@@ -1,0 +1,60 @@
+version: 1
+slug: resolve-github-issue-185-prevent-s4-goal-verification-from-s
+description: 'Resolve GitHub issue #185: prevent S4 goal-verification from self-staling when evidence_refs updates change.yaml'
+status: done
+current_state: DONE
+needs_discovery: true
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-06-11T15:50:00.041427Z
+quality_mode: standard
+workflow_profile: code
+workflow_preset: standard
+worktree_branch: feat/resolve-github-issue-185-prevent-s4-goal-verification-from-s
+artifact_schema: expanded
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: 98bbcf47eaf1a32924ac403a0df1a15c51f3cc30ca23fda0ff6db75cb0b8845c
+        updated_at: 2026-06-11T16:23:18.872334636Z
+    decision:
+        id: decision
+        path: decision.md
+        state: frozen
+        content_hash: 68f28ec6e858b98546b14874c3de432787431bb27d59d1f2e6ac43edf6587e5f
+        updated_at: 2026-06-11T16:01:42.01157463Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: 2c23e6a943c3f5dfd130fcf58fc247a86ad2cc23bd75993c671c7b0fda2986e3
+        updated_at: 2026-06-11T15:57:42.193787591Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: 4abcdb53d3f2384db9049df6f62ece9cf248d21c607f2764eb546c7b356b9e7b
+        updated_at: 2026-06-11T16:01:42.011121879Z
+    research:
+        id: research
+        path: research.md
+        state: frozen
+        content_hash: 0d3436aa1697d822697078fffe10b6538469caba2d0e4b8f9235d08dbf1acba9
+        updated_at: 2026-06-11T16:00:25.198954598Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: 4e2b958367b1238b8d566dae49c9efa95d6f8785e48b718e079c7e37437c929a
+        updated_at: 2026-06-11T16:06:09.158785071Z
+evidence_refs:
+    code-quality-review: .worktrees/resolve-github-issue-185-prevent-s4-goal-verification-from-s/artifacts/changes/resolve-github-issue-185-prevent-s4-goal-verification-from-s/verification/code-quality-review.yaml
+    final-closeout: .worktrees/resolve-github-issue-185-prevent-s4-goal-verification-from-s/artifacts/changes/resolve-github-issue-185-prevent-s4-goal-verification-from-s/verification/final-closeout.yaml
+    goal-verification: .worktrees/resolve-github-issue-185-prevent-s4-goal-verification-from-s/artifacts/changes/resolve-github-issue-185-prevent-s4-goal-verification-from-s/verification/goal-verification.yaml
+    intake-clarification: .worktrees/resolve-github-issue-185-prevent-s4-goal-verification-from-s/artifacts/changes/resolve-github-issue-185-prevent-s4-goal-verification-from-s/verification/intake-clarification.yaml
+    plan-audit: .worktrees/resolve-github-issue-185-prevent-s4-goal-verification-from-s/artifacts/changes/resolve-github-issue-185-prevent-s4-goal-verification-from-s/verification/plan-audit.yaml
+    research-orchestration: .worktrees/resolve-github-issue-185-prevent-s4-goal-verification-from-s/artifacts/changes/resolve-github-issue-185-prevent-s4-goal-verification-from-s/verification/research-orchestration.yaml
+    spec-compliance-review: .worktrees/resolve-github-issue-185-prevent-s4-goal-verification-from-s/artifacts/changes/resolve-github-issue-185-prevent-s4-goal-verification-from-s/verification/spec-compliance-review.yaml
+    wave-orchestration: .worktrees/resolve-github-issue-185-prevent-s4-goal-verification-from-s/artifacts/changes/resolve-github-issue-185-prevent-s4-goal-verification-from-s/verification/wave-orchestration.yaml

--- a/artifacts/changes/archived/resolve-github-issue-185-prevent-s4-goal-verification-from-s/decision.md
+++ b/artifacts/changes/archived/resolve-github-issue-185-prevent-s4-goal-verification-from-s/decision.md
@@ -1,0 +1,68 @@
+# Decision
+
+## Alternatives Considered
+
+- Normalize current `change.yaml` before S4 goal/closeout content hashing.
+  - Pros: fixes the root self-stale loop at the input semantics boundary,
+    preserves the public `evidence skill` write order, and keeps meaningful
+    authority fields covered.
+  - Cons: introduces a special structured hash for the current change authority
+    instead of raw bytes.
+- Save `EvidenceRefs` before stamping the digest.
+  - Pros: the digest would see the post-pointer `change.yaml`.
+  - Cons: expands command transaction complexity across verification YAML,
+    digest state, lifecycle events, and `change.yaml`; it solves this case by
+    ordering rather than by defining which authority content matters.
+- Add a public restamp command for this Tier-0 stale evidence case.
+  - Pros: gives operators a recovery escape hatch.
+  - Cons: leaves the default S4 recovery path capable of looping and broadens
+    command surface beyond the reported root cause.
+
+## Selected Approach
+
+Use the first approach. `goal-verification` and `final-closeout` digest input
+generation now detects the current
+`artifacts/changes/<slug>/change.yaml`, strict-decodes it as `model.Change`,
+clears `EvidenceRefs`, and computes a structured input hash. All other content
+paths keep the existing raw file or directory hash behavior.
+
+This selection matches the issue's expected behavior: evidence-ref-only
+`change.yaml` mutations do not stale S4 evidence, but meaningful authority
+changes still do.
+
+## Interfaces and Data Flow
+
+- Public CLI interfaces: none changed.
+- Data flow before:
+  - `slipway evidence skill` stamps a digest over raw `change.yaml` bytes.
+  - The same command writes `EvidenceRefs` into `change.yaml`.
+  - The next freshness check sees different raw bytes and reports stale.
+- Data flow after:
+  - S4 goal/closeout digest construction routes the current `change.yaml` path
+    through `changeAuthorityInputHash`.
+  - `changeAuthorityInputHash` validates the authority, clears `EvidenceRefs`,
+    and hashes the structured change.
+  - The next freshness check sees the same structured authority for
+    evidence-ref-only mutations, but different hashes for non-pointer authority
+    changes.
+
+## Rollout and Rollback
+
+- Rollout:
+  - Source-only Go change in `internal/engine/progression/evidence_digests.go`.
+  - Regression coverage in
+    `internal/engine/progression/evidence_digests_test.go`.
+- Rollback:
+  - Revert the helper and regression test changes.
+  - Re-run `go test -count=1 ./internal/engine/progression` to confirm the
+    previous behavior is restored if rollback is required.
+
+## Risk
+
+- Over-normalization risk is controlled by clearing only `EvidenceRefs`.
+- Path matching risk is controlled by requiring the exact current
+  `artifacts/changes/<slug>/change.yaml` path.
+- Malformed `change.yaml` now fails during digest input construction for this
+  path; this is fail-closed and consistent with authority validation.
+- Existing stale digest records that used raw `change.yaml` bytes may need normal
+  evidence re-recording once; no migration is required.

--- a/artifacts/changes/archived/resolve-github-issue-185-prevent-s4-goal-verification-from-s/intent.md
+++ b/artifacts/changes/archived/resolve-github-issue-185-prevent-s4-goal-verification-from-s/intent.md
@@ -1,0 +1,76 @@
+# Intent
+
+## Summary
+Resolve GitHub issue #185: prevent S4 goal-verification from self-staling when evidence_refs updates change.yaml
+## Complexity Assessment
+complex
+Rationale: the bug sits in governed evidence freshness for S4 verification and
+can block `G_ship`; a fix must preserve fail-closed stale evidence behavior
+while excluding only engine-owned evidence pointer churn.
+
+## Guardrail Domains
+None detected. This does not touch auth, credentials, PII, financial flows,
+schema migrations, irreversible operations, or external API contracts.
+
+## In Scope
+- Fix GitHub issue #185: an S4 required skill must not become stale solely
+  because `slipway evidence skill` records its own `evidence_refs` pointer in
+  `artifacts/changes/<slug>/change.yaml`.
+- Cover the `goal-verification` and `final-closeout` S4 evidence path enough to
+  prove the public recovery flow can reach `done_ready` without editing
+  engine-owned evidence by hand.
+- Add regression coverage in the existing Go test surface for evidence digest
+  freshness and recovery behavior.
+- Keep normal stale detection for real `change.yaml` content changes.
+
+## Out of Scope
+- Adding a new manual `slipway evidence restamp` command.
+- Editing Lattice governed artifacts or runtime evidence manually as a
+  workaround.
+- Weakening stale evidence checks for ordinary target files or unrelated skill
+  inputs.
+- Retiring existing recovery behavior outside the self-stale `change.yaml`
+  evidence-reference case.
+
+## Constraints
+- Use the current Slipway CLI behavior as authority and keep verification
+  records engine-owned.
+- The fix must be narrow enough that stale evidence still fails closed when
+  user-authored artifacts or implementation files change.
+- Codebase map files in this worktree appear stale from previous issues, so
+  research must verify the actual #185 code paths directly.
+
+## Acceptance Signals
+- A focused regression proves recording `goal-verification` evidence does not
+  immediately produce `required_skill_stale:goal-verification:.../change.yaml`
+  when the only `change.yaml` delta is the evidence pointer.
+- A companion assertion proves a meaningful `change.yaml` change still makes
+  the required skill stale.
+- Targeted package tests for the touched evidence/freshness code pass.
+- `go test -count=1 ./...`, `git diff --check`, and `go run . validate --json`
+  pass from the #185 worktree.
+
+## Open Questions
+<!-- Track real unknowns as a checklist. An unchecked `- [ ]` item is unresolved
+     and routes intake to S0_INTAKE/research; mark `- [x]` once resolved. Leave the
+     section empty (or write `None`) when there are none. Prose here is
+     documentation, not a blocker — a genuine open question must be a `- [ ]`. -->
+- [x] `certifiedSkillInputDigest` in
+  `internal/engine/progression/evidence_digests.go` owns the S4 digest inputs.
+  The fix normalizes current-change `change.yaml` inputs by hashing a strict
+  decoded `model.Change` with `EvidenceRefs` cleared, preserving stale detection
+  for meaningful authority changes without changing `evidence skill` write
+  order.
+
+## Deferred Ideas
+- A public restamp/recovery command for broader Tier-0 stale evidence cases can
+  be considered separately if the narrow self-stale fix is insufficient.
+
+## Approved Summary
+Approved from the user-provided objective to fix GitHub issue #185 and the live
+issue body. The change will repair the S4 `goal-verification`/`final-closeout`
+self-stale loop caused by `change.yaml` evidence pointer updates, preserve
+fail-closed stale detection for real input changes, and prove the behavior with
+focused Go regression tests plus normal repo verification. Out of scope: manual
+Lattice artifact edits, adding a new restamp command, and weakening unrelated
+stale evidence gates.

--- a/artifacts/changes/archived/resolve-github-issue-185-prevent-s4-goal-verification-from-s/requirements.md
+++ b/artifacts/changes/archived/resolve-github-issue-185-prevent-s4-goal-verification-from-s/requirements.md
@@ -1,0 +1,57 @@
+# Requirements
+
+## Requirements
+
+### Requirement: Evidence refs do not self-stale S4 verification
+
+REQ-001: The system MUST keep `goal-verification` and `final-closeout` evidence
+fresh when the only current-change `change.yaml` mutation after stamping is an
+engine-owned `evidence_refs` update for that skill.
+
+#### Scenario: Goal verification evidence pointer is recorded
+
+GIVEN a governed change is in `S4_VERIFY` and the execution summary target files
+include `artifacts/changes/<slug>/change.yaml`
+WHEN `goal-verification` evidence is stamped and the CLI records
+`evidence_refs.goal-verification` in `change.yaml`
+THEN required-skill freshness MUST NOT report
+`required_skill_stale:goal-verification:artifacts/changes/<slug>/change.yaml`
+for that evidence-ref-only mutation.
+
+#### Scenario: Final closeout evidence pointer is recorded
+
+GIVEN a governed change is in `S4_VERIFY` and the execution summary target files
+include `artifacts/changes/<slug>/change.yaml`
+WHEN `final-closeout` evidence is stamped and the CLI records
+`evidence_refs.final-closeout` in `change.yaml`
+THEN required-skill freshness MUST NOT report
+`required_skill_stale:final-closeout:artifacts/changes/<slug>/change.yaml` for
+that evidence-ref-only mutation.
+
+### Requirement: Meaningful change authority drift still fails closed
+
+REQ-002: The system MUST continue to stale required S4 skill evidence when any
+meaningful non-`evidence_refs` field in the current `change.yaml` authority
+changes after the skill is stamped.
+
+#### Scenario: Change description mutates after S4 evidence
+
+GIVEN a stored `goal-verification` or `final-closeout` digest includes the
+current `artifacts/changes/<slug>/change.yaml`
+WHEN a non-`evidence_refs` field such as `description` changes in that file
+THEN required-skill freshness MUST report
+`required_skill_stale:<skill>:artifacts/changes/<slug>/change.yaml`.
+
+### Requirement: The fix stays scoped to the current change authority
+
+REQ-003: The system SHALL apply evidence-ref normalization only to the current
+change authority path `artifacts/changes/<slug>/change.yaml` while preserving
+normal content hashing for all other target files and directories.
+
+#### Scenario: Normal target file changes
+
+GIVEN stored `goal-verification` evidence includes a normal target file such as
+`tracked.go`
+WHEN that file content changes
+THEN required-skill freshness MUST continue reporting
+`required_skill_stale:goal-verification:tracked.go`.

--- a/artifacts/changes/archived/resolve-github-issue-185-prevent-s4-goal-verification-from-s/research.md
+++ b/artifacts/changes/archived/resolve-github-issue-185-prevent-s4-goal-verification-from-s/research.md
@@ -1,0 +1,160 @@
+# Research
+
+Question: how should Slipway prevent S4 `goal-verification` and
+`final-closeout` evidence from self-staling when recording evidence pointers
+mutates the same `change.yaml` file that the skill digest includes?
+
+## Alternatives Considered
+
+### Architecture
+
+- Affected modules:
+  - `cmd/evidence.go:151` through `cmd/evidence.go:218` validates digest
+    inputs, writes verification YAML, stamps `evidence-digests.yaml`, then writes
+    `EvidenceRefs` into `change.yaml`.
+  - `internal/engine/progression/evidence_digests.go:36` through
+    `internal/engine/progression/evidence_digests.go:84` dispatches
+    engine-owned digest inputs by governance skill.
+  - `internal/engine/progression/evidence_digests.go:497` through
+    `internal/engine/progression/evidence_digests.go:564` builds S4
+    `goal-verification` inputs from execution-summary changed and target files.
+  - `internal/engine/progression/authority.go:361` through
+    `internal/engine/progression/authority.go:382` feeds S4 digest content paths
+    from task `ChangedFiles` and `TargetFiles`.
+  - `internal/engine/progression/evidence_digests.go:829` through
+    `internal/engine/progression/evidence_digests.go:869` is the generic file
+    and directory content hashing path.
+- Dependency chain:
+  - `slipway evidence skill` -> `CheckEvidenceDigestInputsForSkill` ->
+    `certifiedSkillInputDigest`.
+  - `slipway evidence skill` -> `StampEvidenceDigestForSkill` ->
+    `state.SaveEvidenceDigests`.
+  - `slipway evidence skill` then calls `change.RecordEvidenceRef` and
+    `state.SaveChange`, mutating `change.yaml` after the digest has been
+    stamped.
+- Blast radius:
+  - S4 digest inputs for `goal-verification` and `final-closeout`.
+  - Existing review, plan-audit, wave, and generic digest paths should remain
+    unchanged.
+- Constraints:
+  - Verification records and freshness state must remain engine-owned.
+  - Meaningful `change.yaml` authority changes must still stale required skills.
+  - Verification directory paths are already skipped by S4 content path reuse;
+    the issue is the active `change.yaml` authority itself.
+
+### Patterns
+
+- Existing conventions:
+  - Digest input construction is centralized in
+    `certifiedSkillInputDigest`, with one branch per governance skill.
+  - File inputs normally use raw content hashes, and special cases are kept close
+    to the digest helper rather than in command code.
+  - `change.yaml` is strict-decoded elsewhere with known fields before being
+    treated as authority.
+- Reusable abstractions:
+  - `model.ComputeInputHash` provides canonical hashing over structured payloads.
+  - `model.Change.Normalize` and `model.Change.Validate` preserve existing
+    authority validation semantics.
+- Convention deviations:
+  - The current change authority needs a structured hash instead of raw bytes,
+    but only for S4 goal/closeout content hashing and only with `EvidenceRefs`
+    cleared.
+
+### Risks
+
+- Technical risks:
+  - High: normalizing too much of `change.yaml` could hide real lifecycle or
+    scope drift.
+  - Medium: parsing `change.yaml` during digest creation could expose malformed
+    authority earlier than raw hashing did; this is acceptable because malformed
+    authority should fail closed.
+  - Low: digest format changes for the current `change.yaml` input can stale
+    already-stamped evidence once, but future stamps become stable across
+    evidence-ref-only mutations.
+- Guardrail domains:
+  - None of the explicit sensitive domains apply. The change is governance
+    engine behavior, not auth, credentials, PII, financial flow, schema
+    migration, irreversible operations, or external API contracts.
+- Reversibility:
+  - The code change is source-only and can be reverted. No migration of existing
+    evidence files is required.
+
+### Test Strategy
+
+- Existing coverage:
+  - `internal/engine/progression/evidence_digests_test.go:809` through
+    `internal/engine/progression/evidence_digests_test.go:831` proves
+    `goal-verification` stales when a normal target file changes.
+  - Existing S4 digest tests cover execution-summary metadata exclusion,
+    deleted target files, assurance handling, and review digest stale reopen
+    behavior.
+- Infrastructure needs:
+  - No new fixtures are needed beyond the existing `createReviewInputDigestFixture`
+    and `digestPolicyExecutionSummary` helpers.
+- Verification approach:
+  - Add a regression where the execution summary target is
+    `artifacts/changes/<slug>/change.yaml`.
+  - Stamp `goal-verification` and `final-closeout`.
+  - Mutate only `EvidenceRefs` and prove no stale blocker is emitted.
+  - Mutate a meaningful authority field and prove the stale blocker still
+    appears.
+  - Run the focused test, the full progression package, then repo-wide checks.
+
+### Options
+
+- Option 1: Normalize the current change authority before S4 content hashing.
+  - Design: detect `artifacts/changes/<slug>/change.yaml`, strict-decode it as
+    `model.Change`, clear `EvidenceRefs`, then compute a structured input hash.
+  - Tradeoffs: narrow root-cause fix; preserves stale checks for all non-pointer
+    fields; changes digest semantics only for the current change authority in
+    S4 goal/closeout hashing.
+- Option 2: Change `slipway evidence skill` write order so evidence refs are
+  saved before the digest is stamped.
+  - Tradeoffs: may require rollback choreography across verification YAML,
+    digest store, lifecycle event, and `change.yaml`; makes digest stability
+    depend on command persistence sequencing rather than input semantics.
+- Option 3: Add a supported restamp/recovery command for this Tier-0 case.
+  - Tradeoffs: provides an escape hatch but leaves the default public recovery
+    path looping and broadens the command surface beyond the reported root cause.
+- Selected: Option 1.
+  - Rationale: the issue is caused by engine-owned `EvidenceRefs` churn, not by
+    operator-authored content changing. Normalizing only that field at the
+    digest-input boundary keeps the command flow and fail-closed stale checks
+    intact.
+
+## Unknowns
+
+- Resolved: which function owns skill digest inputs for `change.yaml`? ->
+  `certifiedSkillInputDigest` routes `goal-verification` and `final-closeout`
+  through `addGoalVerificationInputs` and `addContentPathInputs`.
+- Resolved: should the fix normalize evidence-ref-only mutations or stamp after
+  evidence pointer update? -> normalize the current `change.yaml` input with
+  `EvidenceRefs` cleared; do not alter `evidence skill` persistence ordering.
+- Remaining: None.
+
+## Assumptions
+
+- The reported Lattice loop is represented by an execution summary whose changed
+  or target file list contains `artifacts/changes/<slug>/change.yaml` -
+  Evidence: issue #185 body and `authority.go:361` through `authority.go:382`.
+- `EvidenceRefs` is engine-owned runtime pointer state, not the substantive
+  authority being certified by `goal-verification` - Evidence:
+  `cmd/evidence.go:216` through `cmd/evidence.go:218` writes it after
+  verification/digest stamping.
+- Meaningful changes to other `change.yaml` fields should remain digest inputs -
+  Evidence: the new regression mutates `Description` and still expects
+  `required_skill_stale`.
+
+## Canonical References
+
+- `https://github.com/signalridge/slipway/issues/185`
+- `cmd/evidence.go:151`
+- `cmd/evidence.go:181`
+- `cmd/evidence.go:193`
+- `cmd/evidence.go:216`
+- `internal/engine/progression/evidence_digests.go:36`
+- `internal/engine/progression/evidence_digests.go:497`
+- `internal/engine/progression/evidence_digests.go:539`
+- `internal/engine/progression/evidence_digests.go:871`
+- `internal/engine/progression/authority.go:361`
+- `internal/engine/progression/evidence_digests_test.go:833`

--- a/artifacts/changes/archived/resolve-github-issue-185-prevent-s4-goal-verification-from-s/tasks.md
+++ b/artifacts/changes/archived/resolve-github-issue-185-prevent-s4-goal-verification-from-s/tasks.md
@@ -1,0 +1,24 @@
+# Tasks
+
+## Task List
+
+- [x] `t-01` Implement structured S4 hashing for current change authority.
+  - wave: 1
+  - depends_on: []
+  - target_files: ["internal/engine/progression/evidence_digests.go"]
+  - task_kind: code
+  - covers: [REQ-001, REQ-002, REQ-003]
+
+- [x] `t-02` Add regression coverage for evidence-ref-only `change.yaml` mutations and meaningful authority drift.
+  - wave: 1
+  - depends_on: []
+  - target_files: ["internal/engine/progression/evidence_digests_test.go"]
+  - task_kind: test
+  - covers: [REQ-001, REQ-002, REQ-003]
+
+- [x] `t-03` Verify the #185 fix with targeted and repository-wide checks.
+  - wave: 2
+  - depends_on: ["t-01", "t-02"]
+  - target_files: ["internal/engine/progression/evidence_digests.go", "internal/engine/progression/evidence_digests_test.go"]
+  - task_kind: verification
+  - covers: [REQ-001, REQ-002, REQ-003]

--- a/artifacts/codebase/ARCHITECTURE.md
+++ b/artifacts/codebase/ARCHITECTURE.md
@@ -1,46 +1,42 @@
 # Architecture
 
-Re-authored for change `resolve-issue-163-decisions-gate` (GitHub issue #163).
+Re-authored for change
+`resolve-github-issue-185-prevent-s4-goal-verification-from-s`
+(GitHub issue #185).
 
-Question: where should Slipway parse `decision.md` status and fail closed when a
-stage would build on a superseded or deprecated decision?
+Question: where should S4 governance-skill digest logic ignore
+evidence-ref-only `change.yaml` mutations without weakening stale detection for
+real authority changes?
 
-- Affected modules:
-  - `internal/engine/artifact/decision_contract.go:34` through
-    `internal/engine/artifact/decision_contract.go:64` evaluates decision
-    artifact substance for `validate --json` and instruction-readiness surfaces.
-  - `internal/engine/artifact/decision_contract.go:78` through
-    `internal/engine/artifact/decision_contract.go:96` enforces required
-    decision sections and template-placeholder rejection.
-  - `internal/engine/artifact/manager.go:463` through
-    `internal/engine/artifact/manager.go:488` parses selected direction and
-    selected approach text from `decision.md`.
-  - `cmd/next_skill.go:20` through `cmd/next_skill.go:40` injects parsed
-    decision text into next-skill constraints as pending or locked depending on
-    `G_plan`.
-  - `internal/engine/progression/validation.go:587` through
-    `internal/engine/progression/validation.go:610` wires decision contract
-    blockers into plan-audit and post-plan readiness.
-  - `internal/model/reason_code.go` and `internal/model/recovery.go` own the
-    canonical diagnostics and recovery guidance for new fail-closed blockers.
-- Dependency flow:
-  - Artifact parsing belongs in `internal/engine/artifact` so `cmd` and
-    progression can share the same structured decision result.
-  - Progression readiness should consume the parsed decision contract to block
-    `S1_PLAN/audit` and later when status is dead.
-  - Next-skill constraints should stop surfacing pending or locked decisions when
-    the decision status is dead, and should use the same parser as readiness.
-- Architectural boundary:
-  - Keep status parsing independent from lifecycle gate approval. Status answers
-    whether the decision is usable; `G_plan` still answers whether an otherwise
-    usable decision is pending or locked.
-  - Preserve #119 behavior: missing, unreadable, structurally empty, and
-    template-only decisions stay on existing contract paths.
-  - Do not move decision authoring into research; `research.md` remains upstream
-    input and `decision.md` is authored by plan-audit.
-- GSD reference:
-  - Local GSD Core has a status reject set for `superseded`, `rejected`, and
-    `deprecated`, status-heading aliases, and a normalizing
-    `shouldRejectAdrStatus` helper in
-    `/Users/yixianlu/ghq/github.com/open-gsd/gsd-core/src/adr-parser.cts`.
-  - Slipway should borrow the pattern, not the ADR file model.
+- Entry point:
+  - `cmd/evidence.go:151` through `cmd/evidence.go:218` records passing skill
+    evidence. It checks digest inputs, writes verification YAML, stamps
+    `evidence-digests.yaml`, then records the skill pointer in
+    `change.EvidenceRefs` and saves `change.yaml`.
+- Digest authority:
+  - `internal/engine/progression/evidence_digests.go:36` through
+    `internal/engine/progression/evidence_digests.go:84` centralizes
+    skill-specific input digest construction.
+  - `internal/engine/progression/evidence_digests.go:539` through
+    `internal/engine/progression/evidence_digests.go:564` is the
+    `goal-verification` branch; `final-closeout` reuses it before adding
+    assurance input.
+  - `internal/engine/progression/evidence_digests.go:497` through
+    `internal/engine/progression/evidence_digests.go:536` hashes task changed
+    and target paths reused for S4 verification.
+- Content path source:
+  - `internal/engine/progression/authority.go:361` through
+    `internal/engine/progression/authority.go:382` collects changed and target
+    files from execution-summary tasks and only skips verification-directory
+    paths. The current change `change.yaml` is therefore a valid S4 input.
+- Fix boundary:
+  - Keep command sequencing unchanged.
+  - Special-case only the current `artifacts/changes/<slug>/change.yaml` input
+    while building S4 goal/closeout content hashes.
+  - Strict-decode the authority as `model.Change`, clear `EvidenceRefs`, and use
+    a structured `model.ComputeInputHash` payload.
+- Blast radius:
+  - `internal/engine/progression/evidence_digests.go`
+  - `internal/engine/progression/evidence_digests_test.go`
+  - No public CLI syntax, generated command surface, model schema, or Lattice
+    artifact changes are required.

--- a/artifacts/codebase/CONCERNS.md
+++ b/artifacts/codebase/CONCERNS.md
@@ -1,27 +1,24 @@
 # Concerns
 
-Re-authored for change `resolve-issue-163-decisions-gate` (GitHub issue #163).
+Re-authored for change
+`resolve-github-issue-185-prevent-s4-goal-verification-from-s`
+(GitHub issue #185).
 
-- Load-bearing invariant: a decision that is explicitly superseded or deprecated
-  must not be treated as a usable planning authority, even if its required
-  sections contain authored prose.
-- Status-vs-locking risk: `G_plan` currently controls pending-vs-locked
-  decision visibility. The new status gate must not conflate "not yet locked"
-  with "dead decision"; these are separate axes.
-- Silent continuation risk: `parseDecisionItems` currently returns only strings
-  and has no way to report "decision exists but is rejected". If this remains
-  string-only, `next` can silently omit or surface decision text instead of
-  emitting an actionable blocker.
-- Unknown status risk: issue #163 asks for a defined status taxonomy. Treating an
-  unrecognized explicit status as accepted would be unsafe because a misspelled
-  dead status could bypass the gate.
-- Compatibility risk: older `decision.md` files may omit any status section. A
-  missing status should remain compatible while still allowing authored selected
-  approaches; explicit unknown statuses should be blocked once status parsing is
-  introduced.
-- Recovery risk: a new blocker requires canonical reason-code and recovery prose
-  so operators get a clear path: revise or replace the dead decision before
-  continuing.
-- Scope risk: GSD's issue-number ADR filenames and append-only amendments are
-  useful but optional in issue #163. Combining them with the status gate would
-  broaden the change and make the acceptance signal harder to verify.
+- Load-bearing invariant: required skill evidence must stale when certified
+  inputs materially change, but must not stale itself because the engine records
+  where that same evidence lives.
+- Self-stale risk: `cmd/evidence.go` stamps the digest before it writes the
+  evidence pointer to `change.yaml`; raw-byte hashing of current `change.yaml`
+  therefore makes a freshly-recorded S4 skill stale immediately.
+- Over-normalization risk: clearing more than `EvidenceRefs` could hide real
+  lifecycle, scope, preset, or artifact-state changes. The fix must clear only
+  `EvidenceRefs`.
+- Path scoping risk: a generic `change.yaml` filename elsewhere in the repo must
+  still use raw content hashing. The special case applies only to
+  `artifacts/changes/<current-slug>/change.yaml`.
+- Corruption risk: strict-decoding the current change authority during hashing
+  means malformed `change.yaml` fails the digest path. That is acceptable because
+  malformed authority should block governed progression.
+- Compatibility risk: old stored digests that used raw `change.yaml` bytes may
+  stale once after this change. Restamping through the normal evidence path is
+  acceptable; no migration or manual evidence editing is required.

--- a/artifacts/codebase/CONVENTIONS.md
+++ b/artifacts/codebase/CONVENTIONS.md
@@ -1,20 +1,18 @@
 # Conventions
 
-Re-authored for change `resolve-github-issue-156-add-a-change-implies-evidence-gate`
-(GitHub issue #156).
+Re-authored for change
+`resolve-github-issue-185-prevent-s4-goal-verification-from-s`
+(GitHub issue #185).
 
-- Gate-bearing readiness checks should use canonical `model.ReasonCode` values,
-  not free-form blocker prose.
-- Recovery text must name a legal public command for the current lifecycle
-  position. For `sensitive_evidence_missing`, recovery starts with
-  `slipway run` so the workflow stays in or reopens to S2 before using
-  `slipway evidence task`.
-- Runtime task evidence is recorded through `slipway evidence task`; governance
-  skill verification is recorded through `slipway evidence skill`. Do not
-  hand-edit engine-owned freshness state or verification records as a normal
-  workflow path.
-- Generated command surfaces are backed by `internal/toolgen/toolgen.go` and
-  command body templates. When a Cobra flag is added, update the generated
-  command metadata in the same change.
-- Sensitive evidence markers are lowercase hyphenated prefixes such as
-  `migration-applied`, `auth-review`, and `contract-test`.
+- Keep public CLI command behavior stable unless the issue requires a surface
+  change. #185 can be fixed in digest input semantics without changing flags or
+  command ordering.
+- Required skill freshness must fail closed for real input changes and report
+  canonical `required_skill_stale:<skill>:<input>` details.
+- Verification YAML, `evidence-digests.yaml`, timestamps, run versions, and
+  evidence refs remain engine-owned. Tests may use helpers, but normal workflow
+  should not hand-edit these files.
+- Use focused package tests for digest behavior before broadening to full
+  repository tests.
+- Special-case logic should be path-scoped and skill-scoped; avoid broad
+  exclusions that make unrelated content invisible to freshness checks.

--- a/artifacts/codebase/INTEGRATIONS.md
+++ b/artifacts/codebase/INTEGRATIONS.md
@@ -1,19 +1,19 @@
 # Integrations
 
-Re-authored for change `resolve-github-issue-156-add-a-change-implies-evidence-gate`
-(GitHub issue #156).
+Re-authored for change
+`resolve-github-issue-185-prevent-s4-goal-verification-from-s`
+(GitHub issue #185).
 
-- No external network, database, or service integration is expected.
-- Public CLI integration surfaces:
-  - `slipway evidence task` records runtime task evidence consumed by execution
-    summary and sensitive-evidence readiness.
-  - `slipway evidence skill` records governance skill verification consumed by
-    plan/review/verify gates.
-  - `slipway validate`, `slipway next`, and `slipway run` consume the same
-    readiness result so read-only and mutating surfaces agree.
-- Internal integration surfaces:
-  - `internal/engine/progression` integrates execution-summary freshness,
-    scope-contract, sensitive-evidence, stale-evidence recovery, and lifecycle
-    advancement.
-  - `internal/toolgen` and `internal/tmpl/templates/_partials` publish the
-    command metadata and prompt body for the evidence command family.
+- External integrations:
+  - None. The change is local CLI/governance engine behavior.
+- Public CLI surfaces involved:
+  - `slipway evidence skill` records governance verification evidence.
+  - `slipway run`, `slipway next`, `slipway status`, and `slipway validate`
+    consume required-skill freshness and surface `required_skill_stale`
+    blockers.
+- Internal integration points:
+  - `cmd/evidence.go` records verification and evidence refs.
+  - `internal/engine/progression/evidence_digests.go` stamps and evaluates
+    skill digest freshness.
+  - `internal/state` persists `change.yaml`, verification YAML, execution
+    summaries, and evidence digest records.

--- a/artifacts/codebase/STACK.md
+++ b/artifacts/codebase/STACK.md
@@ -1,17 +1,17 @@
 # Stack
 
-Re-authored for change `resolve-github-issue-156-add-a-change-implies-evidence-gate`
-(GitHub issue #156).
+Re-authored for change
+`resolve-github-issue-185-prevent-s4-goal-verification-from-s`
+(GitHub issue #185).
 
 - Language: Go.
 - CLI framework: Cobra command tree under `cmd/`.
-- Persistence: YAML governed bundle records under `artifacts/changes/<slug>/`
-  and runtime task evidence under `.git/slipway/runtime/changes/<slug>/`.
-- Template/content layer: generated command prompt bodies from
-  `internal/tmpl/templates/_partials` and command metadata from
-  `internal/toolgen`.
-- Test framework: Go `testing` plus `testify` assertions.
-- Verification commands expected for this change: focused Go package tests,
-  `go test ./cmd -count=1`, `go test ./internal/toolgen -count=1`,
-  `go test ./... -count=1`, `git diff --check`, and Slipway governance
-  validation.
+- Persistence: YAML governed bundle authority under
+  `artifacts/changes/<slug>/change.yaml`, verification YAML under
+  `artifacts/changes/<slug>/verification/`, and runtime task evidence under
+  `.git/slipway/runtime/changes/<slug>/`.
+- Serialization: `gopkg.in/yaml.v3` for strict authority decoding and
+  `encoding/json` via `model.ComputeInputHash` for canonical digest payloads.
+- Tests: Go `testing` plus `testify`.
+- Expected checks: focused progression tests, full Go test suite, `git diff
+  --check`, and Slipway `validate --json`.

--- a/artifacts/codebase/STRUCTURE.md
+++ b/artifacts/codebase/STRUCTURE.md
@@ -1,35 +1,23 @@
 # Structure
 
-Re-authored for change `resolve-issue-163-decisions-gate` (GitHub issue #163).
+Re-authored for change
+`resolve-github-issue-185-prevent-s4-goal-verification-from-s`
+(GitHub issue #185).
 
-- `internal/engine/artifact/`
-  - `decision_contract.go`: decision artifact contract status, structured
-    evaluation, substance blockers, and the planned parsed-decision status
-    helper.
-  - `decision_contract_test.go`: artifact-level tests for section substance and
-    the planned parser/status behavior.
-  - `manager.go`: existing selected-decision extraction helpers and markdown
-    section utilities reused by artifact contracts.
-  - `schemas.yaml`: authoritative required-section list for `decision.md`;
-    status parsing must remain compatible because status is not currently a
-    required schema section.
-- `internal/engine/progression/`
-  - `validation.go`: planning readiness gate that already invokes
-    `DecisionContractBlockers` and should receive dead-status blockers.
-  - `validation_test.go`: lifecycle-timing tests for decision blockers and the
-    planned superseded/deprecated/unknown status regressions.
 - `cmd/`
-  - `next_skill.go`: next-skill constraint assembly currently reads decision
-    text and routes it to pending or locked based on `G_plan`.
-  - `next_skill_constraints_test.go`: existing pending-vs-locked coverage and
-    planned dead-status handoff regressions.
+  - `evidence.go`: public `slipway evidence skill` command. It remains
+    unchanged; it demonstrates why digest stamping happens before
+    `EvidenceRefs` are written.
+- `internal/engine/progression/`
+  - `evidence_digests.go`: owned implementation surface for #185. S4
+    goal/closeout digest helpers live here.
+  - `evidence_digests_test.go`: focused regression location for the self-stale
+    and meaningful-change cases.
+  - `authority.go`: source of the changed/target paths reused by
+    goal-verification and final-closeout.
 - `internal/model/`
-  - `reason_code.go`: canonical reason-code definitions for new decision status
-    blockers.
-  - `reason_code_contract_test.go`: frozen taxonomy snapshot that must be
-    updated when new reason codes are added.
-  - `recovery.go` and `recovery_test.go`: operator remediation for the new
-    fail-closed diagnostics.
-- `artifacts/changes/resolve-issue-163-decisions-gate/`
-  - Governed artifact bundle for this change. `assurance.md` remains deferred
-    until review/verify stages.
+  - `change.go`: `Change.EvidenceRefs` is the engine-owned runtime pointer map
+    stored in `change.yaml`.
+  - `evidence.go`: `ComputeInputHash` provides canonical structured hashing.
+- `artifacts/changes/resolve-github-issue-185-prevent-s4-goal-verification-from-s/`
+  - Governed artifact bundle for #185.

--- a/artifacts/codebase/TESTING.md
+++ b/artifacts/codebase/TESTING.md
@@ -1,36 +1,34 @@
 # Testing
 
-Re-authored for change `resolve-issue-163-decisions-gate` (GitHub issue #163).
+Re-authored for change
+`resolve-github-issue-185-prevent-s4-goal-verification-from-s`
+(GitHub issue #185).
 
 - Existing coverage:
-  - `internal/engine/artifact/decision_contract_test.go` covers required
-    decision sections, placeholder rejection, missing file behavior, unreadable
-    file behavior, and authored decision acceptance.
-  - `internal/engine/progression/validation_test.go:417` through
-    `internal/engine/progression/validation_test.go:522` covers
-    `DecisionContractBlockers` at pre-audit, plan-audit, and post-plan states.
-  - `cmd/next_skill_constraints_test.go:52` through
-    `cmd/next_skill_constraints_test.go:348` covers parsing selected approach
-    text and routing it to pending or locked constraints depending on `G_plan`.
-  - `internal/model/reason_code_contract_test.go` freezes canonical reason-code
-    names and severities.
-- Gaps for issue #163:
-  - No parser test extracts lifecycle status from `decision.md`.
-  - No test proves `superseded` or `deprecated` decisions fail closed in
-    planning readiness.
-  - No test proves dead decisions are not surfaced as pending or locked skill
-    constraints.
-  - No property or fuzz-style test proves status normalization is stable across
-    casing, spacing, punctuation, and heading aliases.
-  - No reason-code snapshot entry exists for a dead/superseded decision blocker.
-- Planned verification:
-  - Add artifact-level tests for parsed decision status, selected decisions, live
-    statuses, dead statuses, unknown statuses, and malformed status sections.
-  - Add a fuzz or property-style unit test around `ShouldRejectDecisionStatus`
-    normalization, including `superseded` and `deprecated` variants.
-  - Extend progression validation tests with a superseded/deprecated authored
-    decision that otherwise satisfies all required sections.
-  - Extend next-skill constraint tests to prove dead decisions produce no
-    pending or locked decision text.
-  - Run targeted tests for `internal/engine/artifact`, `internal/engine/progression`,
-    `cmd`, and `internal/model`, then `go test -count=1 ./...`.
+  - `internal/engine/progression/evidence_digests_test.go:809` through
+    `internal/engine/progression/evidence_digests_test.go:831` proves a stored
+    `goal-verification` digest stales when a normal target file changes.
+  - Nearby tests cover review digest staleness, deleted S4 target files,
+    execution-summary metadata exclusion, and final-closeout assurance input.
+- Gap:
+  - No prior test represented the issue #185 case where the target file is the
+    current `artifacts/changes/<slug>/change.yaml` and the only subsequent
+    mutation is `EvidenceRefs`.
+- New regression:
+  - `TestGoalAndCloseoutDigestIgnoresEvidenceRefOnlyChangeYAMLMutation` covers
+    both `goal-verification` and `final-closeout`.
+  - It stamps a digest for current `change.yaml`, records only the skill
+    evidence pointer, and expects no stale blocker.
+  - It then mutates `Description` in `change.yaml` and expects
+    `required_skill_stale:<skill>:artifacts/changes/<slug>/change.yaml`.
+- Verification commands:
+  - Failing before fix:
+    `go test -count=1 ./internal/engine/progression -run TestGoalAndCloseoutDigestIgnoresEvidenceRefOnlyChangeYAMLMutation`
+  - Passing after fix:
+    `go test -count=1 ./internal/engine/progression -run TestGoalAndCloseoutDigestIgnoresEvidenceRefOnlyChangeYAMLMutation`
+  - Broader package check:
+    `go test -count=1 ./internal/engine/progression`
+- Planned final checks:
+  - `go test -count=1 ./...`
+  - `git diff --check`
+  - `go run . validate --json`

--- a/internal/engine/progression/evidence_digests.go
+++ b/internal/engine/progression/evidence_digests.go
@@ -1,6 +1,7 @@
 package progression
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -14,6 +15,7 @@ import (
 	"github.com/signalridge/slipway/internal/model"
 	"github.com/signalridge/slipway/internal/state"
 	"github.com/signalridge/slipway/internal/stringutil"
+	"gopkg.in/yaml.v3"
 )
 
 var errDigestInputsUnavailable = errors.New("evidence digest inputs unavailable")
@@ -461,7 +463,7 @@ func addExecutionAndContentInputs(
 	if err := addExecutionSummaryInputs(summary, inputs); err != nil {
 		return err
 	}
-	if err := addContentPathInputs(root, change, summary, inputs); err != nil {
+	if err := addContentPathInputs(root, change, summary, inputs, false); err != nil {
 		return err
 	}
 	if len(inputs) == 0 {
@@ -492,7 +494,13 @@ func addExecutionSummaryInputs(summary *model.ExecutionSummary, inputs map[strin
 	return nil
 }
 
-func addContentPathInputs(root string, change model.Change, summary *model.ExecutionSummary, inputs map[string]string) error {
+func addContentPathInputs(
+	root string,
+	change model.Change,
+	summary *model.ExecutionSummary,
+	inputs map[string]string,
+	normalizeCurrentChangeAuthority bool,
+) error {
 	if summary == nil {
 		return nil
 	}
@@ -524,7 +532,13 @@ func addContentPathInputs(root string, change model.Change, summary *model.Execu
 					key = filepath.ToSlash(display)
 				}
 			}
-			hash, err := workspacePathInputHash(path, key)
+			var hash string
+			var err error
+			if normalizeCurrentChangeAuthority {
+				hash, err = goalVerificationContentPathInputHash(change, path, key)
+			} else {
+				hash, err = workspacePathInputHash(path, key)
+			}
 			if err != nil {
 				return err
 			}
@@ -553,7 +567,7 @@ func addGoalVerificationInputs(
 	if err := addChangedTargetFileSetInput(change, summary, inputs); err != nil {
 		return err
 	}
-	if err := addContentPathInputs(root, change, summary, inputs); err != nil {
+	if err := addContentPathInputs(root, change, summary, inputs, true); err != nil {
 		return err
 	}
 	if len(inputs) == 0 {
@@ -863,6 +877,44 @@ func workspacePathInputHash(path, rel string) (string, error) {
 		"path":  filepath.ToSlash(strings.TrimSpace(rel)),
 		"type":  "directory",
 		"files": files,
+	})
+}
+
+func goalVerificationContentPathInputHash(change model.Change, path, rel string) (string, error) {
+	if currentChangeAuthorityInput(change, rel) {
+		return changeAuthorityInputHash(path, rel)
+	}
+	return workspacePathInputHash(path, rel)
+}
+
+func currentChangeAuthorityInput(change model.Change, rel string) bool {
+	rel = strings.Trim(strings.TrimSpace(filepath.ToSlash(rel)), "/")
+	if rel == "" || strings.TrimSpace(change.Slug) == "" {
+		return false
+	}
+	want := filepath.ToSlash(filepath.Join("artifacts", "changes", change.Slug, "change.yaml"))
+	return rel == want
+}
+
+func changeAuthorityInputHash(path, rel string) (string, error) {
+	raw, err := os.ReadFile(path) // #nosec G304 -- path is resolved from repository or governed artifact authority before this read.
+	if err != nil {
+		return "", err
+	}
+	var authority model.Change
+	decoder := yaml.NewDecoder(bytes.NewReader(raw))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&authority); err != nil {
+		return "", err
+	}
+	authority.Normalize()
+	if err := authority.Validate(); err != nil {
+		return "", err
+	}
+	authority.EvidenceRefs = nil
+	return model.ComputeInputHash(map[string]any{
+		"path":             filepath.ToSlash(strings.TrimSpace(rel)),
+		"change_authority": authority,
 	})
 }
 

--- a/internal/engine/progression/evidence_digests_test.go
+++ b/internal/engine/progression/evidence_digests_test.go
@@ -830,6 +830,69 @@ func TestStoredGoalDigestStalesWhenInputContentChanges(t *testing.T) {
 	assert.Contains(t, blockers, "required_skill_stale:goal-verification:tracked.go")
 }
 
+func TestGoalAndCloseoutDigestIgnoresEvidenceRefOnlyChangeYAMLMutation(t *testing.T) {
+	t.Parallel()
+
+	for _, skillName := range []string{SkillGoalVerification, SkillFinalCloseout} {
+		t.Run(skillName, func(t *testing.T) {
+			t.Parallel()
+
+			root, change := createReviewInputDigestFixture(t)
+			change.CurrentState = model.StateS4Verify
+			require.NoError(t, state.SaveChange(root, change))
+			changeYAMLRel := filepath.ToSlash(filepath.Join("artifacts", "changes", change.Slug, "change.yaml"))
+			summary := digestPolicyExecutionSummary(change, []string{changeYAMLRel})
+			require.NoError(t, state.SaveExecutionSummary(root, change.Slug, *summary))
+			record := model.VerificationRecord{
+				Verdict:    model.VerificationVerdictPass,
+				Blockers:   []model.ReasonCode{},
+				Timestamp:  time.Date(2026, 6, 4, 1, 0, 0, 0, time.UTC),
+				RunVersion: 1,
+			}
+			require.NoError(t, StampEvidenceDigestForSkill(root, change, skillName, record, summary))
+
+			change.RecordEvidenceRef(skillName, filepath.ToSlash(filepath.Join("artifacts", "changes", change.Slug, "verification", skillName+".yaml")))
+			require.NoError(t, state.SaveChange(root, change))
+
+			blockers, err := skillDigestFreshnessBlockersWithSummary(root, change, skillName, summary)
+			require.NoError(t, err)
+			assert.NotContains(t, blockers, "required_skill_stale:"+skillName+":"+changeYAMLRel)
+			assert.Empty(t, blockers)
+
+			change.Description = "meaningful change.yaml mutation after evidence"
+			require.NoError(t, state.SaveChange(root, change))
+
+			blockers, err = skillDigestFreshnessBlockersWithSummary(root, change, skillName, summary)
+			require.NoError(t, err)
+			assert.Contains(t, blockers, "required_skill_stale:"+skillName+":"+changeYAMLRel)
+		})
+	}
+}
+
+func TestDefaultContentDigestKeepsRawChangeYAMLHash(t *testing.T) {
+	t.Parallel()
+
+	const skillName = "custom-runtime-review"
+	root, change := createReviewInputDigestFixture(t)
+	changeYAMLRel := filepath.ToSlash(filepath.Join("artifacts", "changes", change.Slug, "change.yaml"))
+	summary := digestPolicyExecutionSummary(change, []string{changeYAMLRel})
+	require.NoError(t, state.SaveExecutionSummary(root, change.Slug, *summary))
+	record := model.VerificationRecord{
+		Verdict:    model.VerificationVerdictPass,
+		Blockers:   []model.ReasonCode{},
+		Timestamp:  time.Date(2026, 6, 4, 1, 0, 0, 0, time.UTC),
+		RunVersion: 1,
+	}
+	require.NoError(t, StampEvidenceDigestForSkill(root, change, skillName, record, summary))
+
+	change.RecordEvidenceRef(skillName, filepath.ToSlash(filepath.Join("artifacts", "changes", change.Slug, "verification", skillName+".yaml")))
+	require.NoError(t, state.SaveChange(root, change))
+
+	blockers, err := skillDigestFreshnessBlockersWithSummary(root, change, skillName, summary)
+	require.NoError(t, err)
+	assert.Contains(t, blockers, "required_skill_stale:"+skillName+":"+changeYAMLRel)
+}
+
 func TestStoredReviewDigestStalesWhenInputContentChanges(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Fixes #185 by preventing S4 `goal-verification` and `final-closeout` evidence from self-staling when the only current `change.yaml` mutation is the engine-owned `evidence_refs` pointer update.

## Root Cause

`slipway evidence skill` stamps the digest before it records the skill evidence pointer in `change.yaml`. For S4 goal/final checks, `change.yaml` can be part of the execution target set, so raw-byte hashing made the freshly recorded evidence stale immediately.

## Changes

- Normalize only the current `artifacts/changes/<slug>/change.yaml` input for S4 goal/final digest checks.
- Strict-decode that file as `model.Change`, clear `EvidenceRefs`, and hash the remaining structured authority.
- Preserve raw content hashing for default/non-goal digest paths and normal target files.
- Add regressions for goal/final evidence-ref-only mutations, meaningful `change.yaml` drift, and the default raw-hash branch.
- Archive the governed issue #185 bundle and refresh the codebase map notes for this change.

## Validation

- `go test -count=1 ./internal/engine/progression -run 'Test(GoalAndCloseoutDigestIgnoresEvidenceRefOnlyChangeYAMLMutation|DefaultContentDigestKeepsRawChangeYAMLHash)'`
- `go test -count=1 ./internal/engine/progression`
- `git diff --check`
- `go test -count=1 ./...`

## Notes

The archived change is already marked `DONE`; active validation commands for the archived slug now return `archived_change_not_validatable`, which is expected after `slipway done`.