### PR TITLE
feat(wave): add GSD-style subagent dispatch

### DIFF
--- a/artifacts/changes/archived/resolve-github-issue-184-add-gsd-style-automatic-subagent-di/assurance.md
+++ b/artifacts/changes/archived/resolve-github-issue-184-add-gsd-style-automatic-subagent-di/assurance.md
@@ -1,0 +1,141 @@
+# Assurance
+
+## Scope Summary
+
+This change resolves GitHub issue #184 by making the generated
+`wave-orchestration` surface executable for `parallel: true` waves through real
+executor fan-out where the host runtime has a subagent or fresh-session
+primitive.
+
+Delivered scope:
+
+- `wave-orchestration/SKILL.md.tmpl` now states that capable runtimes must use
+  real executor subagent fan-out for `parallel: true`; same-context inline
+  execution is not equivalent.
+- `executor-dispatch-reference.md` maps Codex to `spawn_agent` semantics with
+  deferred `tool_search` discovery, `fork_context: false`, collect/wait/parse
+  and close semantics, and a fail-closed boundary for unavailable claimed
+  isolation.
+- Incapable runtimes remain distinguishable from capable-runtime failures and
+  must report structured degraded sequential dispatch evidence.
+- Executor results now have a stable contract: `task_id`, `verdict`,
+  `changed_files`, `test_summary`, `evidence_ref`, `blockers`, and concise
+  notes.
+- Task evidence ownership remains with the coordinator through
+  `slipway evidence task`; executors must not self-stamp governed freshness or
+  write verification YAML.
+- Single worktree parallelization is explicit: executor agents share the
+  current worktree, so the coordinator must perform a target-overlap preflight
+  before dispatch and a post-result changed-file conflict check before
+  integration or the next wave.
+- Wave dispatch evidence now requires a structured parallel dispatch mode and
+  one per-task executor handle reference such as
+  `executor_agent:wave=<wave_index>:task=<task_id>:<handle>`.
+- Wait and recovery paths now fail closed for lost handles, missing parseable
+  results, and stalled executor dispatch.
+- Codex guidance now names the explicit user authorization boundary for
+  `spawn_agent`: stop and ask when authorization is required but absent.
+- Focused source and generated-output tests prevent regression to the old
+  primary `codex -q --task` dispatch wording or unsafe single-worktree fan-out.
+
+No Go runtime scheduler, persisted model schema, dependency, lockfile, public
+command flag, or external API was changed.
+
+## Verification Verdict
+
+Current governed evidence verdict: pass.
+
+Verified commands:
+
+- `go test -count=1 ./internal/tmpl ./internal/toolgen`: failed as expected
+  after adding the expanded single-worktree contract assertions, then passed
+  after updating the template/reference implementation.
+- `go run ./internal/toolgen/cmd/gen-surface-manifest --check`: pass,
+  `docs/SURFACE-MANIFEST.json is up to date`.
+- `git diff --check`: pass.
+- `go test -count=1 ./...`: pass.
+- `go run . validate --json`: fresh evidence and `scope_contract.status=pass`
+  before assurance was authored; final active validation remains the next
+  readiness proof after this assurance artifact exists.
+
+Governance review verdicts:
+
+- `spec-compliance-review`: pass with `layer:R0=pass`,
+  `scope_contract:pass`, and `negative_path:pass`.
+- `code-quality-review`: pass with `layer:IR1=pass` and
+  `toolchain_compat:pass`.
+
+## Evidence Index
+
+- `verification/execution-summary.yaml`: refreshed wave evidence covers
+  completed tasks `t-01` through `t-06`.
+- `verification/wave-orchestration.yaml`: wave execution evidence recorded.
+- `verification/spec-compliance-review.yaml`: bidirectional spec trace passed.
+- `verification/code-quality-review.yaml`: implementation quality and
+  generated-surface compatibility passed.
+- `verification/spec-compliance-review-notes.md`: forward and reverse trace
+  matrix for REQ-001 through REQ-006.
+- `verification/code-quality-review-notes.md`: Stage 2 quality, test, safety,
+  and toolchain review.
+
+## Requirement Coverage
+
+- REQ-001: covered by `SKILL.md.tmpl` fan-out wording and generated-surface
+  assertions in `internal/toolgen/toolgen_test.go`.
+- REQ-002: covered by the Codex `spawn_agent` adapter guidance and source plus
+  generated-output tests for `spawn_agent`, `tool_search`,
+  `fork_context: false`, collect/wait/parse/close semantics, and absence of the
+  old primary `codex -q --task` path.
+- REQ-003: covered by fail-closed capable-runtime wording in the template and
+  reference, plus tests for capable-runtime and non-silent inline execution
+  language.
+- REQ-004: covered by structured degraded sequential dispatch wording and tests
+  pinning `dispatch_mode:wave=<wave_index>:degraded_sequential`.
+- REQ-005: covered by the stable executor result contract and evidence
+  ownership wording, with tests for required fields and the
+  `slipway evidence task` ledger boundary.
+- REQ-006: covered by focused `internal/tmpl` and generated `internal/toolgen`
+  tests, plus focused and full-suite verification.
+- REQ-007: covered by single worktree target-overlap preflight wording in the
+  template and dispatch reference, plus source and generated-output tests.
+- REQ-008: covered by structured `dispatch_mode` and per-task
+  `executor_agent:wave=<wave_index>:task=<task_id>:<handle>` evidence wording,
+  plus source and generated-output tests.
+- REQ-009: covered by lost-handle, missing-result, and stalled-dispatch
+  recovery wording in the template/reference and tests.
+- REQ-010: covered by Codex explicit user authorization fail-closed wording and
+  generated Codex dispatch tests.
+
+## Residual Risks and Exceptions
+
+- No blocking residual risks.
+- Workspace-local generated adapter copies are not tracked by this repository.
+  Users who want refreshed local AI-tool surfaces after merge should run
+  `slipway init --tools all --refresh`.
+- Typed dispatch fields and executor-brief helpers remain deferred follow-ups
+  by decision. The internal Go scheduler approach remains intentionally
+  rejected for this issue.
+- Per-executor git worktree isolation and GSD's commit protocol remain out of
+  scope by user direction; this change implements single worktree
+  parallelization safeguards instead.
+
+## Rollback Readiness
+
+Rollback is a normal git revert of the template, reference, test, codebase-map,
+and governed artifact changes from this branch. After rollback, run:
+
+```bash
+go test -count=1 ./internal/tmpl ./internal/toolgen
+go run ./internal/toolgen/cmd/gen-surface-manifest --check
+go test -count=1 ./...
+```
+
+No data migration, dependency downgrade, or external service rollback is
+required.
+
+## Archive Decision
+
+Not archived. The requested stopping point is done-ready, not `slipway done`.
+After this assurance artifact is present, capture a fresh active
+`go run . validate --json` readiness proof before claiming done-ready. Do not
+describe the archived bundle as revalidated through the active validate gate.

--- a/artifacts/changes/archived/resolve-github-issue-184-add-gsd-style-automatic-subagent-di/change.yaml
+++ b/artifacts/changes/archived/resolve-github-issue-184-add-gsd-style-automatic-subagent-di/change.yaml
@@ -1,0 +1,59 @@
+version: 1
+slug: resolve-github-issue-184-add-gsd-style-automatic-subagent-di
+description: 'Resolve GitHub issue #184: add GSD-style automatic subagent dispatch contract for parallel waves'
+status: done
+current_state: DONE
+needs_discovery: true
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-06-12T01:20:30.812473Z
+quality_mode: standard
+workflow_preset: standard
+worktree_branch: feat/resolve-github-issue-184-add-gsd-style-automatic-subagent-di
+artifact_schema: expanded
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: 3e97e13d796aaf9d286a1ce710ebbf3db5ad40a753661c734900818ed259a8ad
+        updated_at: 2026-06-12T04:42:55.29604404Z
+    decision:
+        id: decision
+        path: decision.md
+        state: frozen
+        content_hash: 3a546ff998e071c0139fa7e4e13b03a86cdfbe83b74c09340251c2f2dfd43418
+        updated_at: 2026-06-12T04:42:38.329219Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: b23e6e06fa42764688c3e506b956f2baaca79a44f65b5974dfcd1fd6af11c0a4
+        updated_at: 2026-06-12T04:31:38.32669751Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: a89a93f1a8cb45d7bc25183b75fe140c249b9695bad87b8115d3426d25c581f5
+        updated_at: 2026-06-12T04:32:23.99223005Z
+    research:
+        id: research
+        path: research.md
+        state: frozen
+        content_hash: 29eea31c8ec37d1e40e320c27fc138c9bc49824573a836a86373feedbcc899f4
+        updated_at: 2026-06-12T04:42:10.603729035Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: b1bb3ccb065e91ca90836caa26f0a208aec6b22437819a2b48bf01f86706f539
+        updated_at: 2026-06-12T04:36:53.196105455Z
+evidence_refs:
+    code-quality-review: .worktrees/resolve-github-issue-184-add-gsd-style-automatic-subagent-di/artifacts/changes/resolve-github-issue-184-add-gsd-style-automatic-subagent-di/verification/code-quality-review.yaml
+    final-closeout: .worktrees/resolve-github-issue-184-add-gsd-style-automatic-subagent-di/artifacts/changes/resolve-github-issue-184-add-gsd-style-automatic-subagent-di/verification/final-closeout.yaml
+    goal-verification: .worktrees/resolve-github-issue-184-add-gsd-style-automatic-subagent-di/artifacts/changes/resolve-github-issue-184-add-gsd-style-automatic-subagent-di/verification/goal-verification.yaml
+    intake-clarification: .worktrees/resolve-github-issue-184-add-gsd-style-automatic-subagent-di/artifacts/changes/resolve-github-issue-184-add-gsd-style-automatic-subagent-di/verification/intake-clarification.yaml
+    plan-audit: .worktrees/resolve-github-issue-184-add-gsd-style-automatic-subagent-di/artifacts/changes/resolve-github-issue-184-add-gsd-style-automatic-subagent-di/verification/plan-audit.yaml
+    research-orchestration: .worktrees/resolve-github-issue-184-add-gsd-style-automatic-subagent-di/artifacts/changes/resolve-github-issue-184-add-gsd-style-automatic-subagent-di/verification/research-orchestration.yaml
+    spec-compliance-review: .worktrees/resolve-github-issue-184-add-gsd-style-automatic-subagent-di/artifacts/changes/resolve-github-issue-184-add-gsd-style-automatic-subagent-di/verification/spec-compliance-review.yaml
+    wave-orchestration: .worktrees/resolve-github-issue-184-add-gsd-style-automatic-subagent-di/artifacts/changes/resolve-github-issue-184-add-gsd-style-automatic-subagent-di/verification/wave-orchestration.yaml

--- a/artifacts/changes/archived/resolve-github-issue-184-add-gsd-style-automatic-subagent-di/decision.md
+++ b/artifacts/changes/archived/resolve-github-issue-184-add-gsd-style-automatic-subagent-di/decision.md
@@ -1,0 +1,104 @@
+# Decision
+
+## Alternatives Considered
+
+### Surface-contract update with contract tests
+
+Update the `wave-orchestration` template and executor dispatch reference, then
+pin the behavior with focused `internal/tmpl` tests and generated-output
+`internal/toolgen` tests. This keeps the CLI as lifecycle/evidence authority
+and directly fixes the product surface named by issue #184. The update includes
+the single worktree dispatch contract: target-overlap preflight before spawn,
+per-task executor handle evidence, bounded wait/stall recovery, and
+post-result changed-file conflict checks.
+
+### Typed runtime capability and dispatch-mode model
+
+Add new typed fields to wave-orchestration verification or `next --json` so the
+CLI can represent dispatch mode more structurally. This may be useful later, but
+it expands schema behavior beyond the minimum issue and would need broader
+consumer compatibility work.
+
+### Internal scheduler/executor
+
+Implement real executor orchestration inside Slipway's Go runtime. This would
+enforce dispatch more strongly, but it contradicts the issue non-goal and would
+turn a generated-surface contract fix into a large runtime feature.
+
+## Selected Approach
+
+Select the surface-contract update with contract tests.
+
+This approach satisfies the explicit acceptance criteria: it makes
+`parallel: true` executable for generated hosts, maps Codex to `spawn_agent`
+semantics, prevents capable runtimes from silently executing inline, preserves
+CLI-owned evidence, defines the shared-worktree safety checks, and adds tests so
+the behavior cannot drift back to `codex -q --task` prose or untracked
+single-worktree fan-out.
+
+Typed dispatch fields, executor-brief helpers, and per-executor git worktrees
+remain deferred follow-ups. The internal scheduler approach is rejected for this
+issue.
+
+## Interfaces and Data Flow
+
+- Changed source interface:
+  `internal/tmpl/templates/skills/wave-orchestration/SKILL.md.tmpl` changes the
+  host-facing dispatch contract for S2 execution.
+- Changed reference interface:
+  `internal/tmpl/templates/skills/wave-orchestration/references/executor-dispatch-reference.md`
+  changes the runtime adapter details consumed by generated host skills.
+- Test flow:
+  `internal/tmpl` tests render/read source templates and references directly;
+  `internal/toolgen` tests generate adapter output in a temporary root and
+  assert the shipped generated surface contains the same contract.
+- Runtime flow remains:
+  `slipway next --json` produces the wave plan; the host dispatches executors;
+  the coordinator first checks that the current wave's declared targets remain
+  disjoint in the shared worktree; executor handles are recorded per task;
+  executor results return to the coordinator; missing results, lost handles, or
+  stalled waits block for operator direction; the coordinator records task
+  evidence through `slipway evidence task`; post-result changed-file conflicts
+  and the post-wave integration gate run on the merged current worktree.
+
+No Go command-line syntax, persisted model schema, or external API changes are
+introduced.
+
+## Rollout and Rollback
+
+Rollout is the normal code path: commit template/reference/test changes. Users
+refresh generated AI-tool surfaces with `slipway init --tools all --refresh`
+when they want workspace-local adapters updated. This repository does not track
+those generated adapter copies.
+
+Rollback is a normal git revert of the template/reference/test changes, then:
+
+```bash
+go test -count=1 ./internal/tmpl ./internal/toolgen
+```
+
+If a new public generated surface is introduced during implementation, run:
+
+```bash
+go run ./internal/toolgen/cmd/gen-surface-manifest --write
+```
+
+Current research indicates no manifest row change is expected.
+
+## Risk
+
+- Capable-runtime fallback must be worded carefully: unable-to-spawn on a
+  capable runtime blocks or asks; genuinely incapable runtimes may report
+  degraded/unsupported mode.
+- Codex guidance must not overclaim worktree isolation. Local GSD explicitly
+  treats `Agent(... isolation="worktree")` as having no direct Codex mapping.
+- Single worktree fan-out must not imply write isolation. The generated host
+  contract must fail closed on target overlap before dispatch and on returned
+  changed-file conflicts before integration.
+- Codex runtimes may require explicit user authorization for subagent spawning;
+  the generated guidance must stop and ask instead of forcing spawn or silently
+  inlining work.
+- Tests must inspect generated output as well as template sources; otherwise
+  toolgen regressions could pass source-only checks.
+- `parallelization: off` and `parallel: false` must remain clean sequential
+  paths with no degraded-mode noise.

--- a/artifacts/changes/archived/resolve-github-issue-184-add-gsd-style-automatic-subagent-di/intent.md
+++ b/artifacts/changes/archived/resolve-github-issue-184-add-gsd-style-automatic-subagent-di/intent.md
@@ -1,0 +1,132 @@
+# Intent
+
+## Summary
+Resolve GitHub issue #184: add GSD-style automatic subagent dispatch contract for parallel waves
+## Complexity Assessment
+complex
+
+This is a generated-surface contract change with tests and sync requirements.
+It changes how the `wave-orchestration` host tells agents to dispatch
+`parallel: true` waves, including Codex-specific subagent adapter semantics,
+fallback behavior, executor result shape, evidence ownership, and single
+worktree dispatch safety.
+
+## Guardrail Domains
+None detected. The work changes generated instructions, references, and tests;
+it does not alter auth/authz, credentials/PII, financial logic, schema
+migrations, irreversible operations, or external API contracts.
+
+## In Scope
+- Resolve GitHub issue #184 as the authoritative scope.
+- Update `internal/tmpl/templates/skills/wave-orchestration/SKILL.md.tmpl` so
+  `parallel: true` means real executor subagent fan-out instead of same-context
+  inline work.
+- Update
+  `internal/tmpl/templates/skills/wave-orchestration/references/executor-dispatch-reference.md`
+  with executable runtime adapter semantics for Claude-style runtimes, Codex,
+  fallback/degraded operation, spawn/wait/collect/close, and a stable executor
+  result contract.
+- Remove or demote the old Codex `codex -q --task` path so it is not the
+  primary fan-out mechanism.
+- Preserve Slipway governance authority: task evidence is written through
+  `slipway evidence task`; executors do not self-stamp governed freshness.
+- Define the single worktree parallelization contract: executor agents share
+  the current worktree, so the coordinator must preflight the current wave's
+  target scope before dispatch, record executor handles, wait with bounded
+  recovery semantics, and run post-wave conflict/integration checks before the
+  next wave.
+- Make Codex's explicit subagent authorization boundary visible: when the
+  runtime policy requires user authorization for `spawn_agent`, the coordinator
+  must stop and ask instead of forcing a spawn or silently inlining the wave.
+- Add or update generated-surface contract tests under the existing template or
+  toolgen test surfaces.
+- Regenerate tracked generated agent surfaces if the repository expects them to
+  stay in sync with template sources.
+
+## Out of Scope
+- Building a full internal Slipway scheduler or executor runtime inside the Go
+  CLI.
+- Copying GSD project-state files, phase model, commit protocol, or fail-soft
+  skip paths wholesale.
+- Moving governed evidence stamping or verification ownership into subagents.
+- Weakening `execution.parallelization: off`; explicit sequential opt-out must
+  remain clean.
+- Running shared-worktree-wide integration commands concurrently inside every
+  executor.
+- Adding per-executor git worktree isolation, worktree merge/cleanup machinery,
+  or GSD's commit protocol.
+
+## Constraints
+- Use the current Slipway CLI and governed workflow as lifecycle authority.
+- Use local `github.com/open-gsd/gsd-core` only as an implementation reference;
+  Slipway artifacts and behavior remain repo-native.
+- Keep coordinator context thin by passing paths and bounded task briefs to
+  executors; executor source reads and implementation debugging belong in
+  executor contexts.
+- Capable runtimes must not silently inline a `parallel: true` wave in the
+  coordinator context.
+- Incapable runtimes must report degraded or unsupported dispatch explicitly and
+  stop or ask for operator direction when inline execution would pollute the
+  coordinator context.
+- Single worktree executor fan-out is allowed only for dependency-free,
+  target-disjoint tasks; the coordinator owns pre-dispatch target checks,
+  post-result changed-file conflict checks, and post-wave integration.
+
+## Acceptance Signals
+- Template/reference tests prove Codex generated guidance uses `spawn_agent`
+  or equivalent spawn/wait/collect/close semantics instead of relying on
+  `codex -q --task` as the primary fan-out path.
+- Tests require fresh-context wording such as `fork_context: false` where the
+  available Codex tool supports it.
+- Tests require coordinator stop-work wording while executor agents are active.
+- Tests require executor result fields: `task_id`, `verdict`, `changed_files`,
+  `test_summary`, `evidence_ref`, and `blockers`.
+- Tests require `slipway evidence task` to remain the task evidence writer and
+  forbid subagent self-stamping of governed freshness.
+- Tests reject silent same-context inline execution for `parallel: true` waves
+  on runtimes with a real subagent primitive.
+- Tests require single worktree preflight wording for target overlap, structured
+  executor agent/session references, wait/stall recovery, and Codex explicit
+  subagent authorization handling.
+- Focused verification passes:
+  `go test -count=1 ./internal/tmpl ./internal/toolgen`.
+- Final verification passes:
+  `go test -count=1 ./...`, `git diff --check`, and `go run . validate --json`.
+
+## Open Questions
+<!-- Track real unknowns as a checklist. An unchecked `- [ ]` item is unresolved
+     and routes intake to S0_INTAKE/research; mark `- [x]` once resolved. Leave the
+     section empty (or write `None`) when there are none. Prose here is
+     documentation, not a blocker — a genuine open question must be a `- [ ]`. -->
+- [x] Which exact GSD Codex adapter semantics should be borrowed into Slipway,
+  and which fail-soft or worktree-isolation behavior must stay out of scope?
+- [x] Which generated surfaces are tracked and must be regenerated after editing
+  the `wave-orchestration` template/reference sources?
+- [x] Which existing tests should be expanded versus where new contract tests
+  should live?
+
+## Deferred Ideas
+- A typed dispatch-mode field in wave-orchestration verification instead of
+  string references.
+- Runtime capability hints from `slipway next --json`.
+- A helper command/reference generator that emits one bounded executor brief per
+  task.
+- Typed executor dispatch records with per-task handles and wait state.
+
+## Approved Summary
+User objective received on 2026-06-12: use the Slipway governed workflow to
+resolve all issues described in GitHub issue #184 until done-ready, make the
+best choice when encountering non-sensitive blockers, and reference local GSD
+while implementing.
+
+Approved scope: strengthen Slipway's generated `wave-orchestration` contract so
+`parallel: true` waves require real executor subagent fan-out where the runtime
+supports it, Codex guidance maps dispatch to `spawn_agent`-style
+spawn/wait/collect/close behavior, capable runtimes cannot silently inline the
+wave in coordinator context, incapable runtimes report degraded or unsupported
+dispatch explicitly, single worktree fan-out carries target preflight,
+executor-handle evidence, wait/stall recovery, and post-wave conflict checks,
+and task evidence remains owned by `slipway evidence task`. Do not build an
+internal scheduler, copy GSD's lifecycle, add per-executor worktrees, or move
+governed freshness stamping into subagents. Primary acceptance is
+generated-surface contract tests plus focused and full Go/Slipway verification.

--- a/artifacts/changes/archived/resolve-github-issue-184-add-gsd-style-automatic-subagent-di/requirements.md
+++ b/artifacts/changes/archived/resolve-github-issue-184-add-gsd-style-automatic-subagent-di/requirements.md
@@ -1,0 +1,152 @@
+# Requirements
+
+## Requirements
+
+### Requirement: Parallel waves require executor fan-out
+
+REQ-001: The generated `wave-orchestration` surface MUST state that a
+`parallel: true` wave requires one executor subagent per planned task when the
+runtime has a real subagent or fresh-session primitive.
+
+#### Scenario: Capable runtime dispatches a parallel wave
+
+GIVEN `slipway next --json` marks a multi-task wave as `parallel: true`
+WHEN a host follows the generated `wave-orchestration` skill
+THEN the host attempts one executor subagent per task, collects executor handles,
+waits for the wave, parses structured results, records task evidence, and runs a
+post-wave integration gate before the next wave.
+
+### Requirement: Codex uses spawn_agent semantics
+
+REQ-002: The generated Codex dispatch guidance MUST map executor fan-out to a
+`spawn_agent`-style runtime adapter, including deferred tool discovery,
+fresh-context behavior such as `fork_context: false`, collecting agent IDs,
+waiting for all results, parsing results, and closing agents when close
+semantics exist.
+
+#### Scenario: Codex generated guidance is inspected
+
+GIVEN a generated or rendered Codex `wave-orchestration` surface
+WHEN the Codex dispatch section is read
+THEN `spawn_agent`, `tool_search`, `fork_context: false`, wait, collect, parse,
+and close semantics are present, and `codex -q --task` is not presented as the
+primary executor fan-out path.
+
+### Requirement: Capable runtimes cannot silently inline parallel waves
+
+REQ-003: The generated dispatch contract SHALL fail closed or require operator
+direction when a runtime has a subagent primitive but spawning fails, is
+unavailable after discovery, or would not provide the isolation level the
+surface claims.
+
+#### Scenario: Capable runtime cannot complete subagent dispatch
+
+GIVEN a `parallel: true` wave and a runtime that normally supports executor
+subagents
+WHEN executor spawning fails or cannot provide the claimed isolation
+THEN the generated guidance blocks or asks for operator direction instead of
+silently executing the whole wave inline in the coordinator context.
+
+### Requirement: Incapable runtimes report structured degradation
+
+REQ-004: The generated dispatch contract MUST distinguish genuinely incapable
+runtimes from capable runtime failures, and incapable runtimes MUST report
+unsupported or degraded sequential dispatch explicitly.
+
+#### Scenario: Runtime lacks a fresh executor primitive
+
+GIVEN a `parallel: true` wave and a runtime with no subagent or fresh-session
+primitive
+WHEN the host cannot dispatch isolated executors
+THEN it records structured dispatch metadata such as
+`dispatch_mode:wave=<n>:degraded_sequential`, states the limitation in notes,
+and stops for operator direction when inline execution would pollute coordinator
+context.
+
+### Requirement: Executor result and evidence ownership are stable
+
+REQ-005: The generated surface MUST name a stable executor result contract with
+`task_id`, `verdict`, `changed_files`, `test_summary`, `evidence_ref`,
+`blockers`, and concise notes, and MUST preserve `slipway evidence task` as the
+task evidence ledger writer.
+
+#### Scenario: Executor completes a planned task
+
+GIVEN an executor returns from a dispatched task
+WHEN the coordinator accepts the result
+THEN the result includes the required fields, the coordinator records evidence
+through `slipway evidence task`, and no subagent is instructed to self-stamp
+governed freshness or write verification YAML directly.
+
+### Requirement: Generated-surface tests prevent regression
+
+REQ-006: The repository MUST include contract tests covering the generated and
+rendered wave-orchestration surfaces so the Codex adapter cannot regress to
+shell/prose-only dispatch.
+
+#### Scenario: Contract tests run
+
+GIVEN the template/reference changes are implemented
+WHEN `go test -count=1 ./internal/tmpl ./internal/toolgen` runs
+THEN the tests prove the required dispatch, fallback, result-contract, and
+evidence-ownership wording is present and the old primary `codex -q --task`
+path is absent.
+
+### Requirement: Single worktree dispatch preflights target conflicts
+
+REQ-007: The generated dispatch contract MUST state that parallel executor
+agents share the current worktree and therefore require a cheap pre-dispatch
+target-overlap backstop for the current `parallel: true` wave before spawning.
+
+#### Scenario: Target overlap is detected before dispatch
+
+GIVEN a `parallel: true` wave whose tasks no longer appear target-disjoint
+WHEN the coordinator preflights the current wave's task `target_files`
+THEN it must not spawn those tasks in parallel, must record a blocking
+single-worktree dispatch conflict or rescope/replan, and must not treat notes
+alone as conflict evidence.
+
+### Requirement: Dispatch evidence names executor handles
+
+REQ-008: The generated dispatch contract MUST require per-task executor
+agent/session references for every spawned task in a `parallel: true` wave so
+review can prove which executor handled which planned task.
+
+#### Scenario: Parallel single worktree wave is dispatched
+
+GIVEN a `parallel: true` wave is dispatched through runtime subagents
+WHEN the coordinator records wave-orchestration references
+THEN the references include a structured dispatch mode and one stable
+`executor_agent:wave=<n>:task=<id>:<handle>` or equivalent per-task executor
+handle before task evidence is accepted.
+
+### Requirement: Wait and stalled-executor recovery is explicit
+
+REQ-009: The generated dispatch contract MUST define bounded wait semantics for
+spawned executors, including missing result, lost handle, and stalled executor
+recovery paths.
+
+#### Scenario: Spawned executor does not return a parseable result
+
+GIVEN one or more executor agents are active for a `parallel: true` wave
+WHEN an executor handle is lost, no parseable result is returned, or the wait
+stalls past the host's reasonable timeout
+THEN the coordinator records an executor-dispatch blocker with known handles and
+last observed state, asks for operator direction, and does not inline or mark
+the task complete without explicit authorization.
+
+### Requirement: Codex authorization boundary is fail-closed
+
+REQ-010: The generated Codex guidance MUST state that when the available Codex
+runtime requires explicit user authorization for subagent spawning and the
+current invocation lacks it, the coordinator stops and asks rather than forcing
+`spawn_agent` or silently executing inline.
+
+#### Scenario: Codex spawn requires authorization
+
+GIVEN a `parallel: true` wave in Codex and `spawn_agent` exists but runtime
+policy requires explicit user authorization
+WHEN the coordinator has not received that authorization
+THEN the coordinator asks for operator direction and records the pending
+authorization boundary instead of claiming degraded sequential execution or
+same-context completion.

--- a/artifacts/changes/archived/resolve-github-issue-184-add-gsd-style-automatic-subagent-di/research.md
+++ b/artifacts/changes/archived/resolve-github-issue-184-add-gsd-style-automatic-subagent-di/research.md
@@ -1,0 +1,174 @@
+# Research
+
+Question: how should Slipway borrow GSD-style executor fan-out for
+`parallel: true` waves while preserving Slipway's generated-surface and
+governance boundaries?
+
+## Alternatives Considered
+
+### Architecture
+
+- Affected modules:
+  `internal/tmpl/templates/skills/wave-orchestration/SKILL.md.tmpl`,
+  `internal/tmpl/templates/skills/wave-orchestration/references/executor-dispatch-reference.md`,
+  `internal/tmpl/*_test.go`, and `internal/toolgen/toolgen_test.go`.
+- Dependency chain: template/reference sources -> `internal/toolgen.Generate`
+  -> generated adapter skills and support files -> host runtime behavior during
+  governed `S2_EXECUTE`.
+- Blast radius: generated wave-orchestration instructions for all supported
+  AI tools, focused tests under `internal/tmpl` and `internal/toolgen`, and no
+  Go runtime scheduler behavior unless later scope expands.
+- Constraints: the CLI owns lifecycle and evidence; task evidence still flows
+  through `slipway evidence task`; `parallelization: off` remains an explicit
+  sequential opt-out; Codex guidance cannot claim Claude worktree isolation;
+  this issue now intentionally targets single worktree parallelization rather
+  than per-executor git worktree isolation.
+
+### Patterns
+
+- Existing generated-surface contract tests already assert rendered
+  wave-orchestration behavior in `internal/toolgen/toolgen_test.go:1069-1094`.
+- Existing thin-host tests already read the executor dispatch reference directly
+  in `internal/tmpl/thin_host_content_test.go:85-91`.
+- Existing template convention is prose contract plus contract tests, not a new
+  scheduler abstraction. This matches issue #184's minimum viable scope.
+- GSD provides useful adapter semantics: orchestrator coordinates while
+  subagents execute, runtime-specific spawning is required when available, Codex
+  maps `Task(...)` and `Agent(...)` to `spawn_agent(...)`, `fork_context: false`
+  keeps agent contexts fresh, and spawned agent IDs are collected, waited on,
+  parsed, and closed.
+- GSD's stronger worktree-isolation flow also highlights missing safeguards for
+  a single shared worktree: pre-dispatch target-overlap checks, durable
+  executor handle records, explicit wait/stall recovery, and post-result
+  changed-file conflict checks.
+- Slipway already has static wave target conflict logic in
+  `internal/engine/wave/wave.go` and tests in
+  `internal/engine/wave/wave_test.go`; the generated host contract should reuse
+  that same fail-closed idea at dispatch time instead of inventing a parallel
+  write lock.
+
+### Risks
+
+- High: leaving capable-runtime inline fallback as nonblocking would preserve
+  the reported context-pollution failure.
+- Medium: over-copying GSD worktree isolation would create a false Codex
+  contract; local GSD tests document that Codex has no direct mapping for
+  `Agent(... isolation="worktree")`.
+- Medium: weak tests could pass while generated adapter output regresses; use
+  both source/template tests and toolgen-generated output tests.
+- Medium: single worktree fan-out without a host-side target preflight could
+  let two executor agents edit overlapping files even when the planned wave no
+  longer remains target-disjoint.
+- Medium: a lost executor handle, missing parseable result, or stalled wait
+  could make the coordinator continue with incomplete wave evidence unless the
+  generated contract blocks recovery explicitly.
+- Low: no new public surface row is expected, so `docs/SURFACE-MANIFEST.json`
+  should remain unchanged unless implementation adds a surface.
+- Guardrail domains: none detected.
+- Reversibility: template/test edits are straightforward to revert and do not
+  migrate persisted user data.
+
+### Test Strategy
+
+- Existing coverage: generated wave-orchestration high-level contract and
+  reference path checks.
+- New coverage needed:
+  Codex `spawn_agent`; no primary `codex -q --task`; spawn/wait/collect/close;
+  `fork_context: false`; coordinator stop-work while executors run; executor
+  result fields `task_id`, `verdict`, `changed_files`, `test_summary`,
+  `evidence_ref`, `blockers`; `slipway evidence task` as the evidence writer;
+  no subagent self-stamping; no silent inline execution for capable runtimes;
+  single worktree target-overlap preflight; executor handle evidence; wait,
+  missing-result, and stalled-dispatch blockers; post-result changed-file
+  conflict detection; Codex explicit authorization boundary.
+- Verification commands:
+  `go test -count=1 ./internal/tmpl ./internal/toolgen`,
+  `go test -count=1 ./...`, `git diff --check`, and
+  `go run . validate --json`.
+
+### Options
+
+- Option 1: Surface-contract fix only, with strong generated-surface tests.
+  Update the wave-orchestration template/reference to name the runtime adapter
+  contract, strengthen fallback semantics, and define the single worktree
+  dispatch safety backstops. This matches the issue's implementation target and
+  keeps the CLI as lifecycle authority.
+- Option 2: Add typed dispatch-mode fields or runtime capability hints to CLI
+  state. This could make review stricter, but it expands schema and runtime
+  behavior beyond the minimum issue scope.
+- Option 3: Build an internal scheduler/executor in Slipway. This would enforce
+  behavior in code, but it contradicts the issue non-goal and significantly
+  increases blast radius.
+- Selected: Option 1. It directly closes the reported generated-surface gap,
+  leaves typed dispatch metadata and helper commands as follow-up ideas, and
+  gives tests enough specificity to prevent regression back to shell/prose-only
+  Codex dispatch or unsafe same-worktree fan-out.
+
+## Unknowns
+
+- Resolved: Which exact GSD Codex adapter semantics should be borrowed into
+  Slipway? -> Borrow orchestrator/coordinator separation, path-only executor
+  prompts, runtime-specific subagent dispatch, `spawn_agent` mapping, deferred
+  `tool_search` discovery, `fork_context: false`, agent ID collection, wait,
+  structured parsing, close, and coordinator stop-work while executors are
+  active.
+- Resolved: Which GSD behavior must stay out of scope? -> Do not copy GSD
+  project-state files, phase model, commit protocol, fail-soft skip paths, or
+  Claude worktree isolation claims for Codex.
+- Resolved: Is the target now single worktree parallelization or per-executor
+  git worktrees? -> Single worktree parallelization. Borrow GSD's dispatch,
+  handle collection, wait, and recovery ideas, but replace GSD worktree
+  isolation with target-overlap preflight, executor-handle evidence, and
+  post-result changed-file conflict checks in the shared current worktree.
+- Resolved: How should Codex authorization limits be represented? -> If the
+  current Codex runtime requires explicit user authorization for `spawn_agent`
+  and the invocation lacks it, the generated guidance must ask for operator
+  direction and record the boundary instead of forcing spawn or silently
+  completing inline.
+- Resolved: Which generated surfaces are tracked and must be regenerated? ->
+  No project-local generated `.claude`, `.codex`, `.cursor`, `.gemini`, or
+  `.opencode` adapter copies are tracked in this repository. Template sources
+  and tests are tracked. `docs/SURFACE-MANIFEST.json` is regenerated only when a
+  new public surface row is added; this change edits an existing skill surface.
+- Resolved: Which tests should be expanded versus added? -> Expand
+  `TestWaveOrchestrationSkillForcesParallelByDefault` for generated adapter
+  output, and add focused `internal/tmpl` assertions for reference-level Codex
+  adapter semantics and executor result contract.
+- Remaining: None.
+
+## Assumptions
+
+- The issue body is the acceptance contract. Evidence: live GitHub issue #184
+  body retrieved on 2026-06-12.
+- Generated-surface tests should assert product text because the text is the
+  runtime contract. Evidence: existing `internal/toolgen/toolgen_test.go`
+  checks generated skill prose directly.
+- The surface manifest should not change unless a new public surface row is
+  introduced. Evidence: `docs/ai-tools.md:83-93` says the manifest inventories
+  generated adapter, command, skill, JSON, and documentation surfaces.
+
+## Canonical References
+
+- `https://github.com/signalridge/slipway/issues/184`
+- `internal/tmpl/templates/skills/wave-orchestration/SKILL.md.tmpl:69`
+- `internal/tmpl/templates/skills/wave-orchestration/SKILL.md.tmpl:102`
+- `internal/tmpl/templates/skills/wave-orchestration/SKILL.md.tmpl:118`
+- `internal/tmpl/templates/skills/wave-orchestration/references/executor-dispatch-reference.md:34`
+- `internal/tmpl/templates/skills/wave-orchestration/references/executor-dispatch-reference.md:48`
+- `internal/toolgen/toolgen_test.go:1069`
+- `internal/tmpl/thin_host_content_test.go:56`
+- `internal/tmpl/wave_isolation_content_test.go:11`
+- `docs/ai-tools.md:83`
+- `docs/operator-guide.md:139`
+- `/Users/yixianlu/ghq/github.com/open-gsd/gsd-core/gsd-core/workflows/execute-phase.md:12`
+- `/Users/yixianlu/ghq/github.com/open-gsd/gsd-core/gsd-core/workflows/execute-phase.md:24`
+- `/Users/yixianlu/ghq/github.com/open-gsd/gsd-core/gsd-core/workflows/execute-phase.md:492`
+- `/Users/yixianlu/ghq/github.com/open-gsd/gsd-core/gsd-core/workflows/execute-phase.md:558`
+- `/Users/yixianlu/ghq/github.com/open-gsd/gsd-core/gsd-core/workflows/execute-phase.md:687`
+- `/Users/yixianlu/ghq/github.com/open-gsd/gsd-core/bin/install.js:3439`
+- `/Users/yixianlu/ghq/github.com/open-gsd/gsd-core/bin/install.js:3450`
+- `/Users/yixianlu/ghq/github.com/open-gsd/gsd-core/bin/install.js:3460`
+- `/Users/yixianlu/ghq/github.com/open-gsd/gsd-core/tests/bug-279-codex-agent-mapping.test.cjs:12`
+- `/Users/yixianlu/ghq/github.com/open-gsd/gsd-core/tests/bug-3360-codex-execute-phase-worktrees.test.cjs:1`
+- `internal/engine/wave/wave.go:196`
+- `internal/engine/wave/wave_test.go:245`

--- a/artifacts/changes/archived/resolve-github-issue-184-add-gsd-style-automatic-subagent-di/tasks.md
+++ b/artifacts/changes/archived/resolve-github-issue-184-add-gsd-style-automatic-subagent-di/tasks.md
@@ -1,0 +1,45 @@
+# Tasks
+
+## Task List
+
+- [x] `t-01` Add generated-surface contract tests for issue #184
+  - wave: 1
+  - depends_on: []
+  - target_files: [internal/tmpl/thin_host_content_test.go, internal/toolgen/toolgen_test.go]
+  - task_kind: test
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004, REQ-005, REQ-006]
+
+- [x] `t-02` Implement the wave-orchestration executor dispatch contract
+  - wave: 2
+  - depends_on: [t-01]
+  - target_files: [internal/tmpl/templates/skills/wave-orchestration/SKILL.md.tmpl, internal/tmpl/templates/skills/wave-orchestration/references/executor-dispatch-reference.md]
+  - task_kind: code
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004, REQ-005]
+
+- [x] `t-03` Verify generated-surface sync and full issue acceptance
+  - wave: 3
+  - depends_on: [t-02]
+  - target_files: [docs/SURFACE-MANIFEST.json, artifacts/changes/resolve-github-issue-184-add-gsd-style-automatic-subagent-di/verification/wave-orchestration.yaml]
+  - task_kind: test
+  - covers: [REQ-006]
+
+- [x] `t-04` Add single worktree parallelization contract tests
+  - wave: 4
+  - depends_on: [t-03]
+  - target_files: [internal/tmpl/thin_host_content_test.go, internal/toolgen/toolgen_test.go]
+  - task_kind: test
+  - covers: [REQ-007, REQ-008, REQ-009, REQ-010]
+
+- [x] `t-05` Implement single worktree dispatch safety and recovery contract
+  - wave: 5
+  - depends_on: [t-04]
+  - target_files: [internal/tmpl/templates/skills/wave-orchestration/SKILL.md.tmpl, internal/tmpl/templates/skills/wave-orchestration/references/executor-dispatch-reference.md]
+  - task_kind: code
+  - covers: [REQ-007, REQ-008, REQ-009, REQ-010]
+
+- [x] `t-06` Reverify expanded single worktree acceptance
+  - wave: 6
+  - depends_on: [t-05]
+  - target_files: [docs/SURFACE-MANIFEST.json, artifacts/changes/resolve-github-issue-184-add-gsd-style-automatic-subagent-di/verification/wave-orchestration.yaml]
+  - task_kind: test
+  - covers: [REQ-006, REQ-007, REQ-008, REQ-009, REQ-010]

--- a/artifacts/codebase/ARCHITECTURE.md
+++ b/artifacts/codebase/ARCHITECTURE.md
@@ -1,42 +1,58 @@
 # Architecture
 
 Re-authored for change
-`resolve-github-issue-185-prevent-s4-goal-verification-from-s`
-(GitHub issue #185).
+`resolve-github-issue-184-add-gsd-style-automatic-subagent-di`
+(GitHub issue #184).
 
-Question: where should S4 governance-skill digest logic ignore
-evidence-ref-only `change.yaml` mutations without weakening stale detection for
-real authority changes?
+Question: how should Slipway's generated `wave-orchestration` host surface make
+`parallel: true` waves executable through real runtime subagents, especially for
+Codex, without moving lifecycle or evidence authority out of the CLI?
 
-- Entry point:
-  - `cmd/evidence.go:151` through `cmd/evidence.go:218` records passing skill
-    evidence. It checks digest inputs, writes verification YAML, stamps
-    `evidence-digests.yaml`, then records the skill pointer in
-    `change.EvidenceRefs` and saves `change.yaml`.
-- Digest authority:
-  - `internal/engine/progression/evidence_digests.go:36` through
-    `internal/engine/progression/evidence_digests.go:84` centralizes
-    skill-specific input digest construction.
-  - `internal/engine/progression/evidence_digests.go:539` through
-    `internal/engine/progression/evidence_digests.go:564` is the
-    `goal-verification` branch; `final-closeout` reuses it before adding
-    assurance input.
-  - `internal/engine/progression/evidence_digests.go:497` through
-    `internal/engine/progression/evidence_digests.go:536` hashes task changed
-    and target paths reused for S4 verification.
-- Content path source:
-  - `internal/engine/progression/authority.go:361` through
-    `internal/engine/progression/authority.go:382` collects changed and target
-    files from execution-summary tasks and only skips verification-directory
-    paths. The current change `change.yaml` is therefore a valid S4 input.
-- Fix boundary:
-  - Keep command sequencing unchanged.
-  - Special-case only the current `artifacts/changes/<slug>/change.yaml` input
-    while building S4 goal/closeout content hashes.
-  - Strict-decode the authority as `model.Change`, clear `EvidenceRefs`, and use
-    a structured `model.ComputeInputHash` payload.
-- Blast radius:
-  - `internal/engine/progression/evidence_digests.go`
-  - `internal/engine/progression/evidence_digests_test.go`
-  - No public CLI syntax, generated command surface, model schema, or Lattice
-    artifact changes are required.
+## Affected Seams
+
+- `internal/tmpl/templates/skills/wave-orchestration/SKILL.md.tmpl:69` through
+  `internal/tmpl/templates/skills/wave-orchestration/SKILL.md.tmpl:116` is the
+  generated host contract for wave execution. It already says waves dispatch
+  concurrently by default, but it still allows degraded sequential mode as
+  visible-but-nonblocking and names only `changed_files`, `test_summary`, and
+  `evidence_ref` as executor outputs.
+- `internal/tmpl/templates/skills/wave-orchestration/references/executor-dispatch-reference.md:34`
+  through
+  `internal/tmpl/templates/skills/wave-orchestration/references/executor-dispatch-reference.md:61`
+  is the detailed runtime adapter reference. It currently maps Codex to
+  `codex -q --task`, which is the core issue #184 mismatch.
+- `internal/toolgen/toolgen_test.go:1069` through
+  `internal/toolgen/toolgen_test.go:1094` generates a Claude adapter tree and
+  asserts high-level parallel-by-default contract text. This is the established
+  generated-surface regression location.
+- `internal/tmpl/thin_host_content_test.go:56` through
+  `internal/tmpl/thin_host_content_test.go:92` directly renders the
+  `wave-orchestration` template and reads the executor dispatch reference,
+  making it a good focused place for reference-level contract tests.
+
+## Dependency Flow
+
+Template and reference sources under `internal/tmpl/templates/skills/` feed
+`internal/toolgen.Generate`, which renders host-specific adapter trees into
+tool roots during tests and during `slipway init --tools ... --refresh`.
+Codex project-local skills are still generated under `.codex/skills` in
+toolgen tests, while Codex command prompts are global under `$CODEX_HOME/prompts`.
+
+The CLI remains lifecycle authority. Runtime hosts consume generated
+instructions, but task evidence is recorded through `slipway evidence task`;
+the generated surface must not ask executors to write governed verification
+state directly.
+
+## Constraints And Invariants
+
+- `parallel: true` is the host dispatch signal from `slipway next --json`; the
+  surface must not make same-context inline execution look equivalent on
+  runtimes with a real subagent primitive.
+- `parallel: false` and `execution.parallelization: off` must remain clean
+  sequential modes without degraded-mode noise.
+- Executors share the current Slipway worktree unless a runtime explicitly
+  provides stronger isolation. The post-wave integration gate remains the
+  coordinator-owned merged-state check.
+- Codex `spawn_agent` has no direct equivalent for Claude-style
+  `isolation="worktree"`; the generated Codex guidance must not claim that
+  isolation unless a separate explicit protocol exists.

--- a/artifacts/codebase/CONCERNS.md
+++ b/artifacts/codebase/CONCERNS.md
@@ -1,24 +1,29 @@
 # Concerns
 
 Re-authored for change
-`resolve-github-issue-185-prevent-s4-goal-verification-from-s`
-(GitHub issue #185).
+`resolve-github-issue-184-add-gsd-style-automatic-subagent-di`
+(GitHub issue #184).
 
-- Load-bearing invariant: required skill evidence must stale when certified
-  inputs materially change, but must not stale itself because the engine records
-  where that same evidence lives.
-- Self-stale risk: `cmd/evidence.go` stamps the digest before it writes the
-  evidence pointer to `change.yaml`; raw-byte hashing of current `change.yaml`
-  therefore makes a freshly-recorded S4 skill stale immediately.
-- Over-normalization risk: clearing more than `EvidenceRefs` could hide real
-  lifecycle, scope, preset, or artifact-state changes. The fix must clear only
-  `EvidenceRefs`.
-- Path scoping risk: a generic `change.yaml` filename elsewhere in the repo must
-  still use raw content hashing. The special case applies only to
-  `artifacts/changes/<current-slug>/change.yaml`.
-- Corruption risk: strict-decoding the current change authority during hashing
-  means malformed `change.yaml` fails the digest path. That is acceptable because
-  malformed authority should block governed progression.
-- Compatibility risk: old stored digests that used raw `change.yaml` bytes may
-  stale once after this change. Restamping through the normal evidence path is
-  acceptable; no migration or manual evidence editing is required.
+- Contract ambiguity risk: the current reference says a `parallel: true` wave is
+  concurrent by default, but the Codex section still points at `codex -q --task`.
+  That can let hosts degrade to shell-oriented or same-context execution while
+  the product surface implies real fan-out.
+- Governance weakening risk: if degraded sequential remains nonblocking for a
+  capable runtime, a coordinator can pollute its own context and still record a
+  passing wave. The fix should distinguish "runtime lacks a primitive" from
+  "runtime has a primitive but dispatch failed or was skipped".
+- Evidence ownership risk: executors may report refs, but `slipway evidence
+  task` remains the only task evidence ledger writer. Generated prose must not
+  imply subagents can self-stamp `captured_at`, freshness inputs, or governed
+  verification YAML.
+- Isolation overclaim risk: GSD's Claude worktree isolation model cannot be
+  copied into Codex guidance because GSD itself documents that Codex
+  `spawn_agent` has no direct `isolation="worktree"` mapping.
+- Test drift risk: this repository does not track generated `.claude`,
+  `.codex`, `.cursor`, `.gemini`, or `.opencode` adapter copies. Tests must
+  exercise template rendering and toolgen-generated temporary trees instead of
+  relying on committed generated files.
+- Manifest scope risk: `docs/SURFACE-MANIFEST.json` tracks public surface rows.
+  This change edits an existing surface contract and should not require a
+  manifest row update unless a new command, skill, JSON contract, adapter, or
+  documentation surface is added.

--- a/artifacts/codebase/STRUCTURE.md
+++ b/artifacts/codebase/STRUCTURE.md
@@ -1,23 +1,28 @@
 # Structure
 
 Re-authored for change
-`resolve-github-issue-185-prevent-s4-goal-verification-from-s`
-(GitHub issue #185).
+`resolve-github-issue-184-add-gsd-style-automatic-subagent-di`
+(GitHub issue #184).
 
-- `cmd/`
-  - `evidence.go`: public `slipway evidence skill` command. It remains
-    unchanged; it demonstrates why digest stamping happens before
-    `EvidenceRefs` are written.
-- `internal/engine/progression/`
-  - `evidence_digests.go`: owned implementation surface for #185. S4
-    goal/closeout digest helpers live here.
-  - `evidence_digests_test.go`: focused regression location for the self-stale
-    and meaningful-change cases.
-  - `authority.go`: source of the changed/target paths reused by
-    goal-verification and final-closeout.
-- `internal/model/`
-  - `change.go`: `Change.EvidenceRefs` is the engine-owned runtime pointer map
-    stored in `change.yaml`.
-  - `evidence.go`: `ComputeInputHash` provides canonical structured hashing.
-- `artifacts/changes/resolve-github-issue-185-prevent-s4-goal-verification-from-s/`
-  - Governed artifact bundle for #185.
+- `internal/tmpl/templates/skills/wave-orchestration/`
+  - `SKILL.md.tmpl`: primary host skill template for governed S2 execution.
+  - `references/executor-dispatch-reference.md`: runtime-specific executor
+    dispatch reference copied beside generated wave-orchestration skills.
+- `internal/tmpl/`
+  - `thin_host_content_test.go`: focused template/reference content tests.
+  - `wave_isolation_content_test.go`: existing dispatch-contract coverage for
+    test-authoring isolation and TDD sequencing.
+  - `templates_test.go`: broader rendered-template contract tests.
+- `internal/toolgen/`
+  - `toolgen.go`: adapter registry and skill generation authority.
+  - `toolgen_test.go`: generated tree contract tests, including existing
+    wave-orchestration parallel-by-default assertions.
+  - `support_files_test.go` and `testdata/skill_tree_inventory.codex.golden`:
+    generated support-file inventory checks for Codex.
+  - `surface_manifest.go` and `surface_manifest_test.go`: generated public
+    surface inventory; relevant only if a new surface row is introduced.
+- `docs/`
+  - `ai-tools.md`: documents `docs/SURFACE-MANIFEST.json` regeneration when new
+    public surface rows are added.
+  - `operator-guide.md`: documents `slipway init --tools all --refresh` after
+    template or command-contract changes.

--- a/artifacts/codebase/TESTING.md
+++ b/artifacts/codebase/TESTING.md
@@ -1,34 +1,41 @@
 # Testing
 
 Re-authored for change
-`resolve-github-issue-185-prevent-s4-goal-verification-from-s`
-(GitHub issue #185).
+`resolve-github-issue-184-add-gsd-style-automatic-subagent-di`
+(GitHub issue #184).
 
-- Existing coverage:
-  - `internal/engine/progression/evidence_digests_test.go:809` through
-    `internal/engine/progression/evidence_digests_test.go:831` proves a stored
-    `goal-verification` digest stales when a normal target file changes.
-  - Nearby tests cover review digest staleness, deleted S4 target files,
-    execution-summary metadata exclusion, and final-closeout assurance input.
-- Gap:
-  - No prior test represented the issue #185 case where the target file is the
-    current `artifacts/changes/<slug>/change.yaml` and the only subsequent
-    mutation is `EvidenceRefs`.
-- New regression:
-  - `TestGoalAndCloseoutDigestIgnoresEvidenceRefOnlyChangeYAMLMutation` covers
-    both `goal-verification` and `final-closeout`.
-  - It stamps a digest for current `change.yaml`, records only the skill
-    evidence pointer, and expects no stale blocker.
-  - It then mutates `Description` in `change.yaml` and expects
-    `required_skill_stale:<skill>:artifacts/changes/<slug>/change.yaml`.
-- Verification commands:
-  - Failing before fix:
-    `go test -count=1 ./internal/engine/progression -run TestGoalAndCloseoutDigestIgnoresEvidenceRefOnlyChangeYAMLMutation`
-  - Passing after fix:
-    `go test -count=1 ./internal/engine/progression -run TestGoalAndCloseoutDigestIgnoresEvidenceRefOnlyChangeYAMLMutation`
-  - Broader package check:
-    `go test -count=1 ./internal/engine/progression`
-- Planned final checks:
-  - `go test -count=1 ./...`
-  - `git diff --check`
-  - `go run . validate --json`
+## Existing Coverage
+
+- `internal/toolgen/toolgen_test.go:1069` through
+  `internal/toolgen/toolgen_test.go:1094` asserts generated
+  `slipway-wave-orchestration` text includes parallel-by-default dispatch,
+  `parallel: true`, degradation visibility, `parallelization: off`,
+  post-wave integration gate, and structured dispatch references.
+- `internal/tmpl/thin_host_content_test.go:56` through
+  `internal/tmpl/thin_host_content_test.go:92` renders
+  `wave-orchestration/SKILL.md.tmpl` and reads the executor dispatch reference.
+  It already checks that codebase-map content is passed by path rather than
+  inlined into the coordinator context.
+- `internal/tmpl/wave_isolation_content_test.go:11` through
+  `internal/tmpl/wave_isolation_content_test.go:27` checks rendered
+  wave-orchestration dispatch contract text around test-authoring isolation.
+
+## Gaps For Issue #184
+
+- No current test requires Codex guidance to use `spawn_agent`.
+- No current test rejects `codex -q --task` as the primary Codex fan-out path.
+- No current test requires spawn/wait/collect/close semantics, `fork_context:
+  false`, coordinator stop-work wording, or the full executor result field set.
+- Existing degradation assertions require visibility, but do not distinguish a
+  genuinely incapable runtime from a capable runtime that failed to dispatch.
+
+## Verification Plan
+
+- Add focused content tests under `internal/tmpl` for the reference and rendered
+  host contract.
+- Expand `internal/toolgen/toolgen_test.go` so generated adapter output carries
+  the new contract, not just source templates.
+- Run `go test -count=1 ./internal/tmpl ./internal/toolgen` after template and
+  test edits.
+- Run `go test -count=1 ./...`, `git diff --check`, and
+  `go run . validate --json` before claiming done-ready.

--- a/internal/tmpl/templates/skills/wave-orchestration/SKILL.md.tmpl
+++ b/internal/tmpl/templates/skills/wave-orchestration/SKILL.md.tmpl
@@ -71,14 +71,31 @@ Execute waves in sequence. **Within a wave, dispatch every task concurrently by
 default.** Wave planning already guarantees a wave's tasks are dependency-free
 and file-disjoint, and `slipway next --json` marks such a wave `parallel: true`
 in `input_context.wave_plan.waves[]`; do not serialize a `parallel: true` wave
-for convenience. Fall back to sequential only when the host genuinely cannot run
-concurrent executors, and when you do, say so in the wave report and the
+for convenience. A `parallel: true` wave requires real executor subagent fan-out
+where the runtime has a subagent or fresh-session primitive; same-context inline
+execution is not an equivalent dispatch mode for a capable runtime. If a capable
+runtime cannot spawn, wait, collect, parse, and close executor sessions, stop and
+ask for operator direction instead of silently running the whole wave in the
+coordinator context. Fall back to sequential only when the host genuinely lacks
+concurrent executor support, and when you do, say so in the wave report and the
 wave-orchestration verification `references` as
 `dispatch_mode:wave=<wave_index>:degraded_sequential`, with the same fact in
-`notes`, so the degradation stays visible — it does not block completion.
-Notes/prose alone are human-readable context and are not parsed as dispatch
-evidence. A `parallel: false` wave (a single task, or
-`execution.parallelization: off`) runs sequentially with nothing to note.
+`notes`, so the degradation stays visible. Notes/prose alone are
+human-readable context and are not parsed as dispatch evidence. A `parallel:
+false` wave (a single task, or `execution.parallelization: off`) runs
+sequentially with nothing to note.
+
+Single worktree fan-out means executor agents share the current worktree; this
+is not per-executor git worktree isolation. Before spawning a `parallel: true`
+wave, run a target-overlap preflight over the current wave's planned
+`target_files`. If any two tasks overlap by exact path, path alias, parent/child
+scope, case-insensitive match, or glob scope, do not spawn them in parallel.
+Record a blocker such as `dispatch_blocker:wave=<wave_index>:target_overlap`
+and rescope/replan before continuing. After executor results return, run a
+post-result changed-file conflict check across returned `changed_files`; if
+parallel executors touched the same file scope or escaped their declared target
+scope, record a post-result changed-file conflict and do not run the
+integration gate or start the next wave until it is resolved.
 
 For each wave: describe the build goal before spawning, wait
 for all executors, spot-check the first 2 files from each task's
@@ -100,12 +117,18 @@ inside each task executor; leave merged-state build/test/lint checks to this
 gate unless a task owns a genuinely isolated command.
 
 ## Dispatch Contract
-- Dispatch one isolated executor per task concurrently for a `parallel: true` wave; run sequentially only for a `parallel: false` wave or when the host cannot run concurrent executors (note that degradation, as above).
+- Dispatch one fresh-context executor subagent per task concurrently for a `parallel: true` wave; run sequentially only for a `parallel: false` wave or when the host genuinely cannot run concurrent executors (note that degradation, as above).
+- For a capable runtime, failing to spawn real executors for `parallel: true` is a blocker or operator-direction point, not permission for same-context inline execution.
+- Executor agents run in a single worktree unless a runtime explicitly provides stronger isolation; do not claim per-executor worktree isolation.
+- Before spawn, perform the target-overlap preflight against the current wave's `target_files`; block or replan on overlap instead of parallelizing unsafe writes.
+- After results, perform the post-result changed-file conflict check before integration.
+- Record dispatch references for successful fan-out: `dispatch_mode:wave=<wave_index>:parallel_subagents` plus one `executor_agent:wave=<wave_index>:task=<task_id>:<handle>` per spawned task.
+- If an executor handle is lost, no parseable result returns, or waiting stalls, record `executor_handle_lost`, `executor_result_missing`, or `executor_dispatch_stalled` with known handles and last observed state; ask for operator direction and do not inline or mark the task complete without explicit authorization.
 - Pass file paths only; executors read source files in their own context.
 - Inputs: task ID, acceptance criteria, changed-file scope, technique references, locked decisions.
 - For tasks that may need repository-map guidance, pass `input_context.codebase_map_dir` and relevant `input_context.codebase_map_docs` paths instead of inlining map content.
 - Pass `input_context.codebase_map_doc_states` whenever map metadata is present so executors can perform the PR #112 relevance/staleness self-check.
-- Outputs: `changed_files`, `test_summary`, and `evidence_ref`.
+- Outputs: `task_id`, `verdict`, `changed_files`, `test_summary`, `evidence_ref`, `blockers`, and concise `notes`.
 - Write scopes must be disjoint, or the brief must name the merge strategy.
 - For test-bearing work, isolate the `task_kind=test` test-authoring step from
   the `task_kind=code` implementation step: give the test-authoring executor
@@ -128,6 +151,9 @@ Use `--blocker <code[:detail]>` and a non-pass `--verdict` when a task is not
 complete. Slipway computes `freshness_inputs` and `captured_at` unless
 `--captured-at` is explicitly provided. A passing wave-orchestration record
 without task evidence blocks execution-summary generation.
+Executor agents may report evidence refs, but the coordinator records them
+through `slipway evidence task`; executors must not self-stamp governed
+freshness or write verification YAML directly.
 
 **Completeness contract:** record passing evidence for EVERY planned task in the
 wave plan before the change can advance to review. A planned task left without
@@ -160,9 +186,18 @@ notes: |
 ```
 
 References should include the task evidence command outputs or stable refs for
-each recorded task. If any `parallel: true` wave degraded to sequential because
-the host lacked concurrent executors, include one structured reference per
-affected wave:
+each recorded task. For successful `parallel: true` fan-out, include a
+structured dispatch reference and one executor handle reference per planned
+task:
+
+```yaml
+references:
+  - dispatch_mode:wave=<wave_index>:parallel_subagents
+  - executor_agent:wave=<wave_index>:task=<task_id>:<handle>
+```
+
+If any `parallel: true` wave degraded to sequential because the host lacked
+concurrent executors, include one structured reference per affected wave:
 
 ```yaml
 references:
@@ -176,16 +211,21 @@ After confirmation, advance with `slipway run`.
 
 ## DO NOT SKIP
 1. Dependency ordering before execution.
-2. File conflict detection after each wave.
-3. Post-wave integration gate before starting the next wave.
-4. Runtime task evidence via `slipway evidence task`.
-5. Post-execution verification.
+2. The target-overlap preflight before spawning a `parallel: true` wave.
+3. Per-task executor handle references for spawned tasks.
+4. File conflict detection after each wave, including the post-result changed-file conflict check.
+5. Post-wave integration gate before starting the next wave.
+6. Runtime task evidence via `slipway evidence task`.
+7. Post-execution verification.
 
 ## Block If
 - Dependency ordering is incomplete or cyclic.
 - File conflicts remain unresolved after a wave.
 - The post-wave integration gate fails, times out, or is skipped without a
   recorded no-executable-gate rationale.
+- The target-overlap preflight finds unsafe single worktree overlap.
+- A spawned executor loses its handle, returns no parseable result, or stalls
+  without an explicit operator recovery decision.
 - Retry budget is exhausted.
 - A checkpoint resumes without a fresh subagent context.
 - Task evidence was not recorded through the supported CLI.

--- a/internal/tmpl/templates/skills/wave-orchestration/references/executor-dispatch-reference.md
+++ b/internal/tmpl/templates/skills/wave-orchestration/references/executor-dispatch-reference.md
@@ -33,10 +33,27 @@ map content out of the coordinator context.
 
 ## Runtime Boundary
 - A `parallel: true` wave (from `slipway next --json`) is dispatched concurrently by default: one fresh executor per task, spawned together, then wait for the whole wave.
-- Run a wave sequentially only when it is `parallel: false`, or when the host has no concurrent-executor support — in the latter case note the degradation in the wave report and record `dispatch_mode:wave=<wave_index>:degraded_sequential` in the wave-orchestration verification references (it does not block completion). Notes/prose alone are human-readable context and are not parsed as dispatch evidence.
-- Executors share the same worktree. Do not run shared-worktree-wide integration commands such as `go build ./...` concurrently inside each task executor; leave merged-state build/test/lint checks to the post-wave integration gate unless a task owns a genuinely isolated command.
+- A capable runtime must attempt real executor subagent fan-out for `parallel: true`. If spawning, waiting, result collection, parsing, or cleanup fails, the host must not silently execute the wave inline in the coordinator context; stop and ask for operator direction or record a blocking executor-dispatch failure.
+- Run a wave sequentially only when it is `parallel: false`, or when the host has no concurrent-executor support. In the latter case note the degradation in the wave report and record `dispatch_mode:wave=<wave_index>:degraded_sequential` in the wave-orchestration verification references. Notes/prose alone are human-readable context and are not parsed as dispatch evidence. If inline execution would pollute coordinator context and the user has not authorized it, stop rather than pretending parallel dispatch happened.
+- Executors share a single worktree unless the runtime explicitly provides stronger isolation. Do not run shared-worktree-wide integration commands such as `go build ./...` concurrently inside each task executor; leave merged-state build/test/lint checks to the post-wave integration gate unless a task owns a genuinely isolated command.
+- Before spawning a `parallel: true` wave, run a target-overlap preflight over the current wave's `target_files`. If two tasks overlap by exact path, path alias, parent/child scope, case-insensitive match, or glob scope, record `dispatch_blocker:wave=<wave_index>:target_overlap` and replan or serialize only after explicit operator direction.
+- After executor results return, run a post-result changed-file conflict check across returned `changed_files`. If two parallel executors touched the same file scope or changed files outside declared task targets, record a post-result changed-file conflict and stop before the post-wave integration gate.
 - After all executors in a wave finish, run a post-wave integration gate on the merged current worktree before starting the next wave. Use the narrowest meaningful build/test command for code/test waves, the relevant formatter/lint/validation for docs/config/ops-only waves, or record why no executable gate exists.
 - HARD RULE markers describe high-impact behavioral constraints; the engine does not enforce them automatically.
+
+## Dispatch Evidence
+- Successful `parallel: true` fan-out records `dispatch_mode:wave=<wave_index>:parallel_subagents`.
+- Record one stable executor handle reference per spawned task: `executor_agent:wave=<wave_index>:task=<task_id>:<handle>`.
+- Degraded sequential fallback records `dispatch_mode:wave=<wave_index>:degraded_sequential`.
+- A target-overlap preflight failure records `dispatch_blocker:wave=<wave_index>:target_overlap`.
+- Notes explain the decision, but structured references are the reviewable dispatch evidence.
+
+## Wait And Recovery
+- Wait for every spawned executor handle before accepting the wave.
+- If an executor handle is lost, record `executor_handle_lost` with the known handles and last observed state, then ask for operator direction.
+- If an executor returns no parseable result contract, record `executor_result_missing` and do not infer success from narration.
+- If waiting stalls beyond the host's reasonable timeout or progress signal, record `executor_dispatch_stalled`, report active handles and last observed state, and ask whether to keep waiting, retry, or switch to an explicitly authorized recovery path.
+- Do not inline the task, mark task evidence pass, or start the next wave while any spawned executor result is missing.
 
 ## Tool-Specific Dispatch Examples
 
@@ -44,18 +61,27 @@ map content out of the coordinator context.
 - Spawn one `Task` subagent per task.
 - Pass file paths only; never inline file content.
 - Wait for all task executions in a wave before starting the next wave.
+- Use background fan-out only when the runtime supports it safely. If worktree-creating agents are involved and the runtime can race on `.git/config.lock`, spawn calls one at a time while allowing agents to run concurrently after creation.
+- Do not wrap a spawner workflow inside another subagent when that prevents nested executor spawning.
 
 ### Codex
-- Use `codex -q --task "<prompt>"` for isolated task execution.
-- Background wave tasks only when the host tool truly supports parallel execution.
-- Parse `changed_files`, `test_summary`, and `evidence_ref` from task output.
+- Use a `spawn_agent` runtime adapter for executor fan-out. If `spawn_agent` is not currently visible, use deferred tool discovery such as `tool_search` before deciding the runtime lacks the primitive.
+- Spawn one agent per planned task with a bounded executor message and fresh-context behavior such as `fork_context: false` where the available Codex tool supports it.
+- Pass task IDs, acceptance criteria, target file paths, locked decisions, codebase-map paths, and evidence instructions; do not inline source file contents.
+- Spawn each executor, then collect agent IDs, wait for all results, parse each result into the shared executor result contract, and close each agent after result collection when the runtime exposes close semantics.
+- If Codex requires explicit user authorization for `spawn_agent` and the current invocation lacks that authorization, stop and ask for it. Do not force the spawn, and do not claim degraded sequential or same-context completion unless the user explicitly authorizes that recovery path.
+- Codex `spawn_agent` has no direct mapping for Claude-style `isolation="worktree"`. If the surface claims worktree isolation or the task requires unavailable isolation, fail closed or ask for operator direction instead of running workspace-write executors inline.
+- While agents are active, do not read files, edit code, or run tests for their tasks in the coordinator context.
 
 ### Cursor
 - Use a fresh Composer session per task.
-- Execute sequentially when the tool does not support concurrent task sessions.
+- Use a real fresh-session or subagent primitive when present.
+- Execute sequentially only when the tool does not support concurrent task sessions, and record the degraded dispatch mode as described above.
 
 ### Shared Executor Checklist
 - Inputs: task ID, acceptance criteria, changed-file scope, locked decisions, technique references.
 - Inputs for map-aware tasks: `input_context.codebase_map_dir`, relevant `input_context.codebase_map_docs`, and `codebase_map_doc_states`.
-- Outputs: `changed_files`, `test_summary`, `evidence_ref`.
+- Outputs: `task_id`, `verdict`, `changed_files`, `test_summary`, `evidence_ref`, `blockers`, and concise `notes`.
+- Executor result acceptance requires a matching `executor_agent:wave=<wave_index>:task=<task_id>:<handle>` dispatch reference.
 - Enforce TDD for `task_kind=code`, then run post-execution self-check before accepting the task.
+- Executors may report evidence refs, but `slipway evidence task` remains the only supported task evidence ledger writer. Executor agents must not self-stamp `captured_at`, freshness inputs, or governed verification YAML.

--- a/internal/tmpl/thin_host_content_test.go
+++ b/internal/tmpl/thin_host_content_test.go
@@ -91,6 +91,48 @@ func TestThinHostWaveOrchestrationDelegatesCodebaseMapReads(t *testing.T) {
 	assert.Contains(t, flatRef, "relevance/staleness self-check")
 }
 
+func TestWaveOrchestrationDispatchReferenceDefinesRuntimeAdapters(t *testing.T) {
+	t.Parallel()
+
+	ref, err := Content("skills/wave-orchestration/references/executor-dispatch-reference.md")
+	require.NoError(t, err)
+	flatRef := thinHostFlatten(ref)
+
+	assert.Contains(t, flatRef, "spawn_agent")
+	assert.Contains(t, flatRef, "tool_search")
+	assert.Contains(t, flatRef, "fork_context: false")
+	assert.Contains(t, flatRef, "collect agent IDs")
+	assert.Contains(t, flatRef, "wait for all")
+	assert.Contains(t, flatRef, "close each agent")
+	assert.NotContains(t, flatRef, "codex -q --task")
+	assert.Contains(t, flatRef, "dispatch_mode:wave=<wave_index>:degraded_sequential")
+
+	for _, field := range []string{
+		"`task_id`",
+		"`verdict`",
+		"`changed_files`",
+		"`test_summary`",
+		"`evidence_ref`",
+		"`blockers`",
+	} {
+		assert.Contains(t, flatRef, field)
+	}
+
+	assert.Contains(t, flatRef, "capable runtime")
+	assert.Contains(t, flatRef, "must not silently execute")
+	assert.Contains(t, flatRef, "slipway evidence task")
+	assert.Contains(t, flatRef, "must not self-stamp")
+	assert.Contains(t, flatRef, "single worktree")
+	assert.Contains(t, flatRef, "target-overlap preflight")
+	assert.Contains(t, flatRef, "executor_agent:wave=<wave_index>:task=<task_id>:<handle>")
+	assert.Contains(t, flatRef, "executor_dispatch_stalled")
+	assert.Contains(t, flatRef, "executor_result_missing")
+	assert.Contains(t, flatRef, "explicit user authorization")
+	assert.Contains(t, flatRef, "post-result changed-file conflict")
+	assert.Contains(t, flatRef, ".git/config.lock")
+	assert.Contains(t, flatRef, "Do not wrap a spawner workflow inside another subagent")
+}
+
 func TestRemainingHeavyHostsUseDiskHandoffContract(t *testing.T) {
 	t.Parallel()
 

--- a/internal/toolgen/toolgen_test.go
+++ b/internal/toolgen/toolgen_test.go
@@ -1081,6 +1081,8 @@ func TestWaveOrchestrationSkillForcesParallelByDefault(t *testing.T) {
 		"wave-orchestration must reference the per-wave parallel signal from next --json")
 	assert.Contains(t, skill, "degradation",
 		"wave-orchestration must require noting a degraded sequential fallback")
+	assert.Contains(t, skill, "dispatch_mode:wave=<wave_index>:degraded_sequential",
+		"wave-orchestration must require structured degraded dispatch evidence")
 	assert.Contains(t, skill, "parallelization: off",
 		"wave-orchestration must describe the parallelization off-switch")
 	assert.Contains(t, skill, "post-wave integration gate",
@@ -1091,6 +1093,62 @@ func TestWaveOrchestrationSkillForcesParallelByDefault(t *testing.T) {
 		"wave-orchestration must make the structured dispatch reference contract explicit")
 	assert.Contains(t, skill, "do not start the next wave",
 		"wave-orchestration must block subsequent waves when integration fails")
+	assert.Contains(t, skill, "real executor subagent fan-out",
+		"wave-orchestration must require real fan-out for parallel waves")
+	assert.Contains(t, skill, "same-context inline execution",
+		"wave-orchestration must reject silent inline execution for capable runtimes")
+	assert.Contains(t, skill, "task_id",
+		"wave-orchestration must name the stable executor result contract")
+	assert.Contains(t, skill, "single worktree",
+		"wave-orchestration must describe the single-worktree execution boundary")
+	assert.Contains(t, skill, "target-overlap preflight",
+		"wave-orchestration must require a target-overlap preflight before spawning")
+	assert.Contains(t, skill, "post-result changed-file conflict",
+		"wave-orchestration must require post-result conflict detection before integration")
+	assert.Contains(t, skill, "executor_agent:wave=<wave_index>:task=<task_id>:<handle>",
+		"wave-orchestration must require per-task executor handle references")
+}
+
+func TestGeneratedWaveOrchestrationCodexDispatchUsesSpawnAgent(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, Generate(root, []string{"codex"}, true))
+
+	cfg := toolRegistry["codex"]
+	refPath := filepath.Join(
+		root,
+		cfg.SkillsDir,
+		"slipway-wave-orchestration",
+		"references",
+		"executor-dispatch-reference.md",
+	)
+	raw, err := os.ReadFile(refPath)
+	require.NoError(t, err)
+	ref := strings.Join(strings.Fields(string(raw)), " ")
+
+	assert.Contains(t, ref, "spawn_agent",
+		"generated Codex dispatch reference must use spawn_agent")
+	assert.Contains(t, ref, "tool_search",
+		"generated Codex dispatch reference must discover deferred tools")
+	assert.Contains(t, ref, "fork_context: false",
+		"generated Codex dispatch reference must request fresh-context execution")
+	assert.Contains(t, ref, "collect agent IDs",
+		"generated Codex dispatch reference must collect spawned agent handles")
+	assert.Contains(t, ref, "wait for all",
+		"generated Codex dispatch reference must wait for all executors")
+	assert.Contains(t, ref, "close each agent",
+		"generated Codex dispatch reference must close executors when supported")
+	assert.NotContains(t, ref, "codex -q --task",
+		"generated Codex dispatch reference must not include the old shell fan-out path")
+	assert.Contains(t, ref, "explicit user authorization",
+		"generated Codex dispatch reference must stop for authorization when required")
+	assert.Contains(t, ref, "executor_dispatch_stalled",
+		"generated Codex dispatch reference must define stalled-executor recovery")
+	assert.Contains(t, ref, "executor_result_missing",
+		"generated Codex dispatch reference must define missing-result recovery")
+	assert.Contains(t, ref, ".git/config.lock",
+		"generated dispatch reference must preserve safe background fan-out guidance")
+	assert.Contains(t, ref, "Do not wrap a spawner workflow inside another subagent",
+		"generated dispatch reference must preserve nested-spawner guidance")
 }
 
 func TestCodexPromptsUseCommandSpecificPrerequisites(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add GSD-style automatic executor subagent dispatch guidance for `parallel: true` waves.
- Define Codex runtime dispatch through `spawn_agent` semantics instead of `codex -q --task` shell fan-out.
- Add single-worktree safety contracts for target overlap, changed-file conflict checks, executor handles, wait recovery, and explicit authorization boundaries.
- Archive the governed Slipway change bundle for issue #184.

Closes #184.

## Validation

- `go test -count=1 ./internal/tmpl ./internal/toolgen`
- `go run ./internal/toolgen/cmd/gen-surface-manifest --check`
- `git diff --check`
- `go test -count=1 ./...`
- `go test -count=1 -coverprofile=/tmp/slipway-issue184-cover.out ./internal/tmpl ./internal/toolgen`
- `go run . validate --json` reported `G_ship=approved`, `evidence_freshness=fresh`, and no blockers before `slipway done`
- `go run . done --json` completed with `status=done` and `archived=true`