### PR TITLE
fix(cli): resolve Lattice workflow feedback

### DIFF
--- a/artifacts/changes/archived/resolve-lattice-workflow-feedback-issues-183-189-192/assurance.md
+++ b/artifacts/changes/archived/resolve-lattice-workflow-feedback-issues-183-189-192/assurance.md
@@ -1,0 +1,89 @@
+# Assurance
+
+## Scope Summary
+
+This change resolves the three open Lattice-related Slipway feedback issues in
+the Slipway CLI:
+
+- #183: `slipway evidence skill --notes-file` now resolves workspace-relative
+  notes files against the active change's authoritative workspace, including a
+  bound worktree.
+- #192: post-S2 attempts to refresh task evidence or `wave-orchestration`
+  evidence now keep the same fail-closed wrong-state errors while naming the
+  S3/S4 replacement evidence surfaces.
+- #189: skill handoff hard stops now state that the operator must run the named
+  governance skill and record evidence, while `--resume-response` explicitly
+  remains valid only for active checkpoints.
+
+No lifecycle state, model schema, persisted field, bypass path, or force-close
+path was added.
+
+## Verification Verdict
+
+Verification is passing for the implemented scope. The current governed evidence
+chain includes passing wave execution, spec-compliance review, and
+code-quality review for run version 1. Fresh command verification in the current
+worktree passed:
+
+- `go test -count=1 ./...`
+- `go vet ./...`
+- `git diff --check`
+
+## Evidence Index
+
+- Runtime task evidence:
+  `.git/slipway/runtime/changes/resolve-lattice-workflow-feedback-issues-183-189-192/evidence/tasks/`
+- Wave orchestration evidence:
+  `verification/wave-orchestration.yaml`
+- Spec compliance review evidence:
+  `verification/spec-compliance-review.yaml`
+- Code quality review evidence:
+  `verification/code-quality-review.yaml`
+- Review notes:
+  `verification/spec-compliance-review-notes.md`
+  `verification/code-quality-review-notes.md`
+- Lifecycle validation:
+  `slipway validate --json` reported `scope_contract.status=pass` after review
+  evidence was recorded, with only this assurance artifact missing at that time.
+
+## Requirement Coverage
+
+- REQ-001 is covered by `cmd/evidence.go` and
+  `TestEvidenceSkillNotesFileUsesBoundWorktreeWorkspace`, which proves
+  bound-worktree `artifacts/...` notes files are read from the bound workspace.
+- REQ-002 is covered by `cmd/evidence.go`,
+  `TestEvidenceTaskWrongStateInS3RoutesToReviewAndVerificationEvidence`,
+  `TestEvidenceTaskWrongStateInS4RoutesToGoalVerificationAndFinalCloseout`,
+  `TestEvidenceSkillWrongStateForWaveOrchestrationInS3RoutesToReviewAndVerificationEvidence`,
+  and `TestEvidenceSkillWrongStateForReviewEvidenceInS4RoutesToVerificationEvidence`.
+- REQ-003 is covered by `cmd/next.go`, `cmd/next_context_build.go`,
+  `TestConfirmationRequirementDistinguishesHardStopFromCommandBoundary`,
+  `TestNextHandoffViewUsesStructuredConfirmationRequirement`,
+  `TestRunRejectsResumeResponseWithoutCheckpoint`, and
+  `TestRunAutoAdvanceIntoReviewSurfacesSkillHandoff`.
+
+## Residual Risks and Exceptions
+
+No known residual code blockers remain. The change intentionally does not add a
+new post-review execution evidence command; it documents the current accepted
+replacement path through review and verification evidence while preserving the
+existing fail-closed lifecycle boundary.
+
+The wave plan had to be amended to include `cmd/lifecycle_commands_test.go`
+after scope-contract drift detected that legitimate test assertion update. The
+wave evidence was then refreshed against the amended plan.
+
+## Rollback Readiness
+
+Rollback is a normal git revert of this branch's code, test, and governed
+artifact changes. No migration, schema update, generated state change, or
+external system contract was introduced. Reverting restores the previous CLI
+wording and notes-file behavior.
+
+## Archive Decision
+
+The change is ready to proceed through S4 verification and final closeout. Active
+`validate --json` freshness/readiness proof must be captured again after this
+assurance file is authored and before `slipway done` is ever run. Once the ship
+gate reaches done-ready, the archive can record this governed bundle as the
+completed delivery evidence for issues #183, #189, and #192.

--- a/artifacts/changes/archived/resolve-lattice-workflow-feedback-issues-183-189-192/change.yaml
+++ b/artifacts/changes/archived/resolve-lattice-workflow-feedback-issues-183-189-192/change.yaml
@@ -1,0 +1,59 @@
+version: 1
+slug: resolve-lattice-workflow-feedback-issues-183-189-192
+description: resolve Lattice workflow feedback issues 183 189 192
+status: done
+current_state: DONE
+needs_discovery: true
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-06-12T07:01:04.229019Z
+quality_mode: standard
+workflow_preset: standard
+worktree_branch: feat/resolve-lattice-workflow-feedback-issues-183-189-192
+artifact_schema: expanded
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: e402f6992a570aaf937054415de020a5a5e9fac52ee4918e815c4082d022b77c
+        updated_at: 2026-06-12T12:27:48.382025943Z
+    decision:
+        id: decision
+        path: decision.md
+        state: frozen
+        content_hash: 32bda7d82933a3d8ecb26e1d1315cef48624f1a6f10c35239d6f3fb43aea20dc
+        updated_at: 2026-06-12T07:08:46.842856359Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: af1f5a24c78fb9c643cdb54785d3f1c8cb27b2ee49208c170713e90dfbe2ade9
+        updated_at: 2026-06-12T07:05:08.063411747Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: a286061c690dcef2b136cd42c30413c8c1a1a3ffa5f3af72884c0c5db865770f
+        updated_at: 2026-06-12T07:08:46.842635983Z
+    research:
+        id: research
+        path: research.md
+        state: frozen
+        content_hash: 2204f5daefd065d60c0a914b759568a2a41cefff82ba96d21246cba4c3ccfccf
+        updated_at: 2026-06-12T07:07:25.826753331Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: cbcc9ac0c7b517b5a6589068040adf661c4529dd93ba4b54c5cd4512114fa814
+        updated_at: 2026-06-12T07:22:51.055220502Z
+evidence_refs:
+    code-quality-review: .worktrees/resolve-lattice-workflow-feedback-issues-183-189-192/artifacts/changes/resolve-lattice-workflow-feedback-issues-183-189-192/verification/code-quality-review.yaml
+    final-closeout: .worktrees/resolve-lattice-workflow-feedback-issues-183-189-192/artifacts/changes/resolve-lattice-workflow-feedback-issues-183-189-192/verification/final-closeout.yaml
+    goal-verification: .worktrees/resolve-lattice-workflow-feedback-issues-183-189-192/artifacts/changes/resolve-lattice-workflow-feedback-issues-183-189-192/verification/goal-verification.yaml
+    intake-clarification: .worktrees/resolve-lattice-workflow-feedback-issues-183-189-192/artifacts/changes/resolve-lattice-workflow-feedback-issues-183-189-192/verification/intake-clarification.yaml
+    plan-audit: .worktrees/resolve-lattice-workflow-feedback-issues-183-189-192/artifacts/changes/resolve-lattice-workflow-feedback-issues-183-189-192/verification/plan-audit.yaml
+    research-orchestration: .worktrees/resolve-lattice-workflow-feedback-issues-183-189-192/artifacts/changes/resolve-lattice-workflow-feedback-issues-183-189-192/verification/research-orchestration.yaml
+    spec-compliance-review: .worktrees/resolve-lattice-workflow-feedback-issues-183-189-192/artifacts/changes/resolve-lattice-workflow-feedback-issues-183-189-192/verification/spec-compliance-review.yaml
+    wave-orchestration: .worktrees/resolve-lattice-workflow-feedback-issues-183-189-192/artifacts/changes/resolve-lattice-workflow-feedback-issues-183-189-192/verification/wave-orchestration.yaml

--- a/artifacts/changes/archived/resolve-lattice-workflow-feedback-issues-183-189-192/decision.md
+++ b/artifacts/changes/archived/resolve-lattice-workflow-feedback-issues-183-189-192/decision.md
@@ -1,0 +1,77 @@
+# Decision
+
+## Alternatives Considered
+
+### Option A: Narrow CLI-surface repair
+Resolve the active change workspace for `--notes-file`, improve wrong-state
+remediation for post-S2 evidence attempts, and clarify checkpoint-vs-skill
+handoff text. This keeps all existing lifecycle states and error codes.
+
+Tradeoff: it does not create a new post-review evidence command, but it removes
+the misleading guidance that caused the Lattice workflow friction.
+
+### Option B: Add a post-review execution evidence refresh command
+Create a new command or evidence category that can explicitly refresh execution
+evidence after review-driven repairs.
+
+Tradeoff: this may be useful later, but it expands lifecycle semantics and
+requires a broader evidence model. It is larger than the current issue reports.
+
+### Option C: Treat delegated autonomy as fresh intake confirmation
+Allow the original user objective to satisfy later skill-handoff confirmation.
+
+Tradeoff: this weakens the current hard-stop confirmation boundary and risks a
+bypass path for governance skills.
+
+## Selected Approach
+
+Select Option A. It directly fixes issues #183, #189, and #192 while preserving
+fail-closed lifecycle behavior:
+
+- #183 is fixed by resolving notes-file paths against the active change's
+  authoritative workspace.
+- #192 is fixed by making wrong-state evidence errors point to the accepted
+  S3/S4 evidence path for review-driven repairs.
+- #189 is fixed by making the JSON/action surface and `--resume-response`
+  remediation explicit that missing skill evidence is not checkpoint resume.
+
+## Interfaces and Data Flow
+
+Changed command-layer data flow:
+
+- `makeEvidenceSkillCmd` loads the active change before notes-file resolution.
+- `resolveEvidenceSkillNotes` receives the active change and resolves
+  `--notes-file` against `state.WorkspaceRootForChange(root, change)`.
+- `validateEvidenceSkillStage` keeps existing validation and error codes but
+  uses a post-S2 remediation helper when the requested evidence belongs to an
+  earlier lifecycle state.
+- `confirmation_requirement.next_action` remains prose but becomes more precise
+  for `skill_handoff:*` reasons.
+- `no_active_checkpoint` keeps its error code and category but gets clearer
+  remediation.
+
+No model schema, persisted state shape, or lifecycle transition changes are
+planned.
+
+## Rollout and Rollback
+
+Rollout:
+
+- Land command-layer code and focused regression tests together.
+- Verify with `go test ./cmd`, `go test ./...`, `git diff --check`, and current
+  Slipway validation/next evidence.
+
+Rollback:
+
+- Revert the code and test changes in this branch.
+- No data migration rollback is required because only command behavior and tests
+  change.
+
+## Risk
+
+- Automation compatibility risk is limited because existing error codes and JSON
+  field names remain stable.
+- Path authority risk is mitigated by using the existing bound-workspace
+  resolver and preserving path validation.
+- Governance weakening risk is avoided by keeping `resume_response_supported`
+  false for skill handoffs and by not creating bypass/force-close behavior.

--- a/artifacts/changes/archived/resolve-lattice-workflow-feedback-issues-183-189-192/intent.md
+++ b/artifacts/changes/archived/resolve-lattice-workflow-feedback-issues-183-189-192/intent.md
@@ -1,0 +1,77 @@
+# Intent
+
+## Summary
+Resolve the three current open Lattice-reported Slipway workflow feedback issues:
+#183, #189, and #192.
+
+## Complexity Assessment
+complex
+
+Rationale: the change touches public CLI JSON/error/remediation surfaces and
+governed evidence path semantics across bound worktrees, S0 handoff, and
+post-S2 verification workflows. The intended implementation remains narrow and
+test-led.
+
+## Guardrail Domains
+External API contracts: additive/behavioral CLI JSON and error-remediation
+surface changes.
+
+## In Scope
+- `cmd/evidence.go`: make `slipway evidence skill --notes-file artifacts/...`
+  resolve workspace-relative notes against the active change's authoritative
+  workspace/bound worktree, not always the root checkout.
+- `cmd/evidence.go`: make post-S2 wrong-state evidence errors for task evidence
+  and `wave-orchestration` evidence point to the correct S3/S4 verification
+  surfaces instead of implying S2 evidence can or should be refreshed.
+- `cmd/next.go` and `cmd/next_context_build.go`: make skill-handoff hard stops
+  and `--resume-response` without an active checkpoint state clearly that
+  `--resume-response` is only for active checkpoints and is not a bridge for
+  missing governance skill evidence.
+- Focused regression tests covering #183, #189, and #192 user-visible behavior.
+
+## Out of Scope
+- Do not modify the Lattice repository.
+- Do not weaken fresh confirmation requirements for `intake-clarification` or
+  any other governance skill handoff.
+- Do not add a new lifecycle state, evidence type, bypass flag, or force-close
+  path.
+- Do not redesign the broader checkpoint/resume mechanism beyond the precise
+  remediation and action-surface clarity needed for these issues.
+
+## Constraints
+- Preserve existing JSON field names and error codes unless the change is
+  additive or strictly improves remediation prose.
+- Keep the fix fail-closed: post-review repairs must be captured through S3/S4
+  review and verification evidence, not by mutating stale S2 task evidence.
+- Keep path handling workspace-relative and reject absolute paths or traversal.
+
+## Acceptance Signals
+- A regression test proves `--notes-file artifacts/...` reads from the bound
+  worktree/authoritative workspace for a worktree-bound change.
+- Regression tests prove S3/S4 wrong-state errors mention the correct
+  replacement verification surfaces (`spec-compliance-review`,
+  `code-quality-review`, `goal-verification`, `final-closeout`) for post-S2
+  repairs.
+- Regression tests prove `confirmation_requirement` / `--resume-response`
+  surfaces distinguish skill handoff from checkpoint resume.
+- Focused package tests for the touched command behavior pass.
+- Repository-level Go tests pass before claiming done-ready.
+
+## Open Questions
+None
+
+## Deferred Ideas
+- A first-class post-review evidence refresh command can be reconsidered later,
+  but this change only fixes the current CLI guidance and accepted replacement
+  evidence path.
+- Delegated-autonomy policy for S0 intake can be reconsidered later, but this
+  change does not alter hard-stop confirmation semantics.
+
+## Approved Summary
+User confirmed continuation on 2026-06-12 after reviewing the proposed scope.
+This change fixes Slipway CLI/evidence workflow surfaces reported from Lattice
+issues #183, #189, and #192. It is limited to bound-worktree notes-file path
+authority, post-review evidence remediation clarity, and checkpoint-vs-skill
+handoff guidance. It explicitly excludes Lattice code changes, bypass paths, and
+weakening fresh confirmation requirements. Primary acceptance is focused
+regression coverage plus passing Go tests.

--- a/artifacts/changes/archived/resolve-lattice-workflow-feedback-issues-183-189-192/requirements.md
+++ b/artifacts/changes/archived/resolve-lattice-workflow-feedback-issues-183-189-192/requirements.md
@@ -1,0 +1,59 @@
+# Requirements
+
+## Requirements
+
+### Requirement: Bound-worktree notes-file authority
+REQ-001: The system MUST resolve `slipway evidence skill --notes-file` paths
+against the active change's authoritative workspace so worktree-bound governed
+changes can use `artifacts/...` paths from their bound worktree.
+
+#### Scenario: notes file under bound worktree
+GIVEN an active governed change is bound to a dedicated worktree
+WHEN `slipway evidence skill --change <slug> --notes-file artifacts/changes/<slug>/verification/<notes>.md` is run
+THEN the notes file is read from the bound worktree's `artifacts/...` path
+AND the recorded verification notes match the bound-worktree file contents.
+
+#### Scenario: invalid notes path remains rejected
+GIVEN a user passes an absolute path or parent traversal path as `--notes-file`
+WHEN evidence skill validation runs
+THEN the command rejects the path before reading from disk.
+
+### Requirement: Post-review evidence replacement guidance
+REQ-002: The system MUST explain the correct S3/S4 replacement evidence surfaces
+when task evidence or `wave-orchestration` evidence is requested after S2 has
+already advanced.
+
+#### Scenario: S3 task evidence wrong state
+GIVEN a governed change is in `S3_REVIEW`
+WHEN `slipway evidence task` is invoked
+THEN the error keeps `evidence_task_wrong_state`
+AND the remediation names S3 review evidence surfaces rather than only saying
+task evidence is S2-only.
+
+#### Scenario: S3 wave evidence wrong state
+GIVEN a governed change is in `S3_REVIEW`
+WHEN `slipway evidence skill --skill wave-orchestration` is invoked
+THEN the error keeps `evidence_skill_wrong_state`
+AND the remediation names review-driven repair evidence through
+`spec-compliance-review`, `code-quality-review`, `goal-verification`, and
+`final-closeout`.
+
+### Requirement: Checkpoint resume and skill handoff clarity
+REQ-003: The system MUST distinguish skill-handoff hard stops from active
+checkpoint resume boundaries in both `confirmation_requirement` and
+`--resume-response` error remediation.
+
+#### Scenario: skill handoff is not checkpoint resume
+GIVEN `slipway next --json` returns a governance skill handoff
+WHEN `confirmation_requirement` is rendered
+THEN `next_action_kind` remains `skill_handoff`
+AND `resume_response_supported` remains false
+AND `next_action` states that the operator must run/complete the named
+governance skill and record evidence, not pass `--resume-response`.
+
+#### Scenario: resume response without checkpoint is actionable
+GIVEN no active checkpoint exists
+WHEN `slipway run --resume-response <text>` is invoked
+THEN the error keeps `no_active_checkpoint`
+AND the remediation states that `--resume-response` is only valid for active
+checkpoints and not for missing governance skill evidence.

--- a/artifacts/changes/archived/resolve-lattice-workflow-feedback-issues-183-189-192/research.md
+++ b/artifacts/changes/archived/resolve-lattice-workflow-feedback-issues-183-189-192/research.md
@@ -1,0 +1,145 @@
+# Research
+
+## Alternatives Considered
+
+### Architecture
+- Affected modules:
+  - `cmd/evidence.go:138` reads `--notes-file` before recording skill evidence;
+    `cmd/evidence.go:785` through `cmd/evidence.go:819` currently resolves the
+    notes file against the project root.
+  - `cmd/evidence.go:323` through `cmd/evidence.go:333` owns task-evidence
+    wrong-state remediation.
+  - `cmd/evidence.go:743` through `cmd/evidence.go:765` owns skill-evidence
+    lifecycle-state validation and remediation.
+  - `cmd/next.go:664` through `cmd/next.go:760` owns
+    `confirmation_requirement` hard-stop action text and action kind.
+  - `cmd/next_context_build.go:333` through `cmd/next_context_build.go:340`
+    owns the `no_active_checkpoint` error when `--resume-response` is supplied
+    without a real checkpoint.
+- Dependency chains:
+  - `makeEvidenceSkillCmd` -> `resolveActiveChangeRef` -> `loadActiveChange` ->
+    `resolveEvidenceSkillNotes` -> `state.SaveVerification`.
+  - `makeEvidenceTaskCmd` -> `loadActiveChange` -> S2 state check -> CLI error.
+  - `buildNextView` -> `deriveConfirmationRequirement` -> JSON
+    `confirmation_requirement`.
+- Blast radius: command-layer behavior and tests in `cmd`; no model schema or
+  lifecycle state transition change is required.
+- Constraints:
+  - `--notes-file` must remain workspace-relative and retain
+    `validateEvidencePath` protections.
+  - Post-review repairs must remain fail-closed through S3/S4 verification
+    evidence, not S2 evidence mutation.
+  - `resume_response_supported` must stay true only for active checkpoints.
+
+### Patterns
+- Existing conventions:
+  - Worktree-bound change authority is resolved through
+    `state.WorkspaceRootForChange` and `state.ResolveChangePaths`, not by
+    guessing from root checkout paths.
+  - User-facing command errors use stable `error_code` values with improved
+    remediation text and `details` metadata.
+  - Confirmation surface tests already assert `confirmation_requirement` fields
+    in `cmd/progression_next_test.go`.
+- Reusable abstractions:
+  - `state.WorkspaceRootForChange` should be reused for the notes-file base.
+  - `progression.S4VerificationRecoveryRemediation()` already centralizes S4
+    "rerun goal-verification, then rerun final-closeout" wording.
+- Convention deviations: none required. The fix can be additive and local.
+
+### Risks
+- Technical risks:
+  - Medium: changing notes-file base can affect root-checkout invocations that
+    use `--change` for a worktree-bound change. Mitigation: use the active
+    change's authoritative workspace, which is the same path authority already
+    exposed by `next/status`.
+  - Low: remediation text updates can affect brittle tests that assert exact
+    prose. Mitigation: keep error codes stable and update focused assertions.
+  - Low: making skill-handoff guidance more explicit could lengthen JSON
+    strings. Mitigation: keep field names and action kind stable.
+- Guardrail domains: external API contracts, because CLI JSON and errors are
+  automation surfaces.
+- Reversibility: the change is reversible by reverting command-layer helper and
+  test edits; no persisted data migration is involved.
+
+### Test Strategy
+- Existing coverage:
+  - `cmd/evidence_skill_test.go:18` through `cmd/evidence_skill_test.go:84`
+    covers `--notes-file` on a root-bound change.
+  - `cmd/evidence_test.go:25` through `cmd/evidence_test.go:50` covers S4 task
+    evidence wrong-state remediation.
+  - `cmd/evidence_skill_test.go:291` through `cmd/evidence_skill_test.go:313`
+    covers generic wrong-state skill evidence.
+  - `cmd/progression_next_test.go:1702` through
+    `cmd/progression_next_test.go:1722` covers `--resume-response` without a
+    checkpoint.
+  - `cmd/progression_next_test.go:2069` through
+    `cmd/progression_next_test.go:2167` covers structured
+    `confirmation_requirement`.
+- Infrastructure needs: command tests using existing helpers
+  `initGitRepoForWorktreeTests`, `runGit`, `state.PersistScopeWorktreeMetadata`,
+  and `state.RelocateGovernedBundle`.
+- Verification approach:
+  - Add #183 regression proving relative notes read from the bound worktree.
+  - Add #192 regression for S3 task wrong-state and S3 `wave-orchestration`
+    wrong-state remediation.
+  - Add #189 assertions for skill-handoff action text and
+    `no_active_checkpoint` remediation.
+  - Run focused `go test ./cmd`, then broader `go test ./...`.
+
+### Options
+- Option A: narrow CLI-surface repair.
+  - Use authoritative workspace resolution for notes-file.
+  - Improve remediation/action text without adding new lifecycle machinery.
+  - Tradeoff: does not add a first-class post-review evidence refresh command,
+    but solves the current confusing and misleading surfaces.
+- Option B: add a new post-review evidence refresh command.
+  - Tradeoff: could model review-driven repairs more directly, but it expands
+    lifecycle semantics and is beyond the reported immediate gaps.
+- Option C: accept delegated autonomy as a replacement for fresh intake
+  confirmation.
+  - Tradeoff: could reduce pauses, but weakens a hard-stop confirmation control
+    and contradicts the fail-closed scope boundary.
+- Selected: Option A. It fixes all three current Lattice-reported symptoms while
+  preserving existing lifecycle gates and avoiding bypass semantics.
+
+## Unknowns
+- Resolved: Is the current codebase map relevant? -> No. The populated map is
+  explicitly re-authored for issue #184 in `artifacts/codebase/ARCHITECTURE.md:3`
+  through `artifacts/codebase/ARCHITECTURE.md:5` and
+  `artifacts/codebase/TESTING.md:3` through `artifacts/codebase/TESTING.md:5`,
+  so this research re-derived the current seams from source.
+- Resolved: Does #183 reproduce in this worktree? -> Yes. The intake evidence
+  command using `--notes-file artifacts/...` failed by opening the root checkout
+  path, matching the issue report; the `.worktrees/<slug>/artifacts/...`
+  workaround succeeded.
+- Remaining: None.
+
+## Assumptions
+- The three Lattice issues are safe to resolve together because they touch the
+  same command-layer governance surfaces and no implementation requires a schema
+  migration or new lifecycle state. Evidence: affected files are concentrated in
+  `cmd/evidence.go`, `cmd/next.go`, and `cmd/next_context_build.go`.
+- Existing error codes should remain stable for automation. Evidence: current
+  tests assert codes like `evidence_skill_wrong_state`,
+  `evidence_task_wrong_state`, and `no_active_checkpoint`.
+- Post-review repairs should be represented by S3/S4 skill evidence, not by
+  refreshing S2 task evidence after S2. Evidence:
+  `internal/engine/progression/authority.go:214` already routes S4 recovery to
+  goal-verification and final-closeout.
+
+## Canonical References
+- `cmd/evidence.go:138`
+- `cmd/evidence.go:323`
+- `cmd/evidence.go:743`
+- `cmd/evidence.go:785`
+- `cmd/next.go:664`
+- `cmd/next.go:718`
+- `cmd/next_context_build.go:333`
+- `internal/engine/progression/authority.go:214`
+- `cmd/evidence_skill_test.go:18`
+- `cmd/evidence_skill_test.go:291`
+- `cmd/evidence_test.go:25`
+- `cmd/progression_next_test.go:1702`
+- `cmd/progression_next_test.go:2069`
+- `artifacts/codebase/ARCHITECTURE.md:3`
+- `artifacts/codebase/TESTING.md:3`

--- a/artifacts/changes/archived/resolve-lattice-workflow-feedback-issues-183-189-192/tasks.md
+++ b/artifacts/changes/archived/resolve-lattice-workflow-feedback-issues-183-189-192/tasks.md
@@ -1,0 +1,42 @@
+# Tasks
+
+## Task List
+
+- [x] `t-01` Add failing regression tests for bound-worktree `--notes-file`
+  resolution and post-S2 evidence wrong-state guidance.
+  - wave: 1
+  - depends_on: []
+  - target_files: ["cmd/evidence_skill_test.go", "cmd/evidence_test.go"]
+  - task_kind: test
+  - covers: [REQ-001, REQ-002]
+
+- [x] `t-02` Add failing regression tests for skill-handoff versus checkpoint
+  resume clarity.
+  - wave: 1
+  - depends_on: []
+  - target_files: ["cmd/progression_next_test.go", "cmd/lifecycle_commands_test.go"]
+  - task_kind: test
+  - covers: [REQ-003]
+
+- [x] `t-03` Implement authoritative workspace notes-file resolution and
+  post-S2 evidence remediation helpers.
+  - wave: 2
+  - depends_on: ["t-01"]
+  - target_files: ["cmd/evidence.go"]
+  - task_kind: code
+  - covers: [REQ-001, REQ-002]
+
+- [x] `t-04` Implement clearer skill-handoff action and no-checkpoint
+  remediation text.
+  - wave: 2
+  - depends_on: ["t-02"]
+  - target_files: ["cmd/next.go", "cmd/next_context_build.go"]
+  - task_kind: code
+  - covers: [REQ-003]
+
+- [x] `t-05` Run focused command tests and repository-level verification.
+  - wave: 3
+  - depends_on: ["t-03", "t-04"]
+  - target_files: ["cmd/evidence.go", "cmd/next.go", "cmd/next_context_build.go", "cmd/evidence_skill_test.go", "cmd/evidence_test.go", "cmd/progression_next_test.go", "cmd/lifecycle_commands_test.go"]
+  - task_kind: verification
+  - covers: [REQ-001, REQ-002, REQ-003]

--- a/cmd/evidence.go
+++ b/cmd/evidence.go
@@ -135,7 +135,7 @@ func makeEvidenceSkillCmd() *cobra.Command {
 					)
 				}
 
-				notesText, err := resolveEvidenceSkillNotes(root, notes, notesFile)
+				notesText, err := resolveEvidenceSkillNotes(root, change, notes, notesFile)
 				if err != nil {
 					return err
 				}
@@ -321,10 +321,7 @@ func makeEvidenceTaskCmd() *cobra.Command {
 					return err
 				}
 				if change.CurrentState != model.StateS2Execute {
-					remediation := "Record task evidence only during wave execution."
-					if change.CurrentState == model.StateS4Verify {
-						remediation = progression.S4VerificationRecoveryRemediation()
-					}
+					remediation := evidenceTaskWrongStateRemediation(change.CurrentState)
 					return newInvalidUsageError(
 						"evidence_task_wrong_state",
 						fmt.Sprintf("task evidence requires S2_EXECUTE state, current: %s", change.CurrentState),
@@ -753,7 +750,7 @@ func validateEvidenceSkillStage(change model.Change, def skill.Definition) error
 		return newInvalidUsageError(
 			"evidence_skill_wrong_state",
 			fmt.Sprintf("%s evidence requires %s state, current: %s", def.Name, def.State, change.CurrentState),
-			fmt.Sprintf("Run the lifecycle to %s before recording %s evidence.", def.State, def.Name),
+			evidenceSkillWrongStateRemediation(change.CurrentState, def),
 			map[string]any{
 				"skill":          def.Name,
 				"expected":       def.State,
@@ -782,7 +779,53 @@ func validateEvidenceSkillStage(change model.Change, def skill.Definition) error
 	return nil
 }
 
-func resolveEvidenceSkillNotes(root, notes, notesFile string) (string, error) {
+func evidenceTaskWrongStateRemediation(current model.WorkflowState) string {
+	switch current {
+	case model.StateS3Review:
+		return postReviewReplacementEvidenceRemediation("task evidence")
+	case model.StateS4Verify:
+		return s4ReplacementEvidenceRemediation("task evidence")
+	default:
+		return "Record task evidence only during wave execution."
+	}
+}
+
+func evidenceSkillWrongStateRemediation(current model.WorkflowState, def skill.Definition) string {
+	switch current {
+	case model.StateS3Review:
+		if def.State == model.StateS2Execute {
+			return postReviewReplacementEvidenceRemediation(def.Name + " evidence")
+		}
+	case model.StateS4Verify:
+		if def.State == model.StateS2Execute || def.State == model.StateS3Review {
+			return s4ReplacementEvidenceRemediation(def.Name + " evidence")
+		}
+	}
+	return fmt.Sprintf("Run the lifecycle to %s before recording %s evidence.", def.State, def.Name)
+}
+
+func postReviewReplacementEvidenceRemediation(surface string) string {
+	return fmt.Sprintf(
+		"%s is S2-only after wave execution. For review-driven repairs or tests, record fresh proof in %s and %s evidence, then rerun %s and %s.",
+		surface,
+		progression.SkillSpecComplianceReview,
+		progression.SkillCodeQualityReview,
+		progression.SkillGoalVerification,
+		progression.SkillFinalCloseout,
+	)
+}
+
+func s4ReplacementEvidenceRemediation(surface string) string {
+	return fmt.Sprintf(
+		"%s cannot be refreshed from S4_VERIFY. Record fresh proof in %s and %s evidence; %s.",
+		surface,
+		progression.SkillGoalVerification,
+		progression.SkillFinalCloseout,
+		progression.S4VerificationRecoveryRemediation(),
+	)
+}
+
+func resolveEvidenceSkillNotes(root string, change model.Change, notes, notesFile string) (string, error) {
 	notes = strings.TrimSpace(notes)
 	notesFile = strings.TrimSpace(notesFile)
 	if notes != "" && notesFile != "" {
@@ -804,15 +847,29 @@ func resolveEvidenceSkillNotes(root, notes, notesFile string) (string, error) {
 			nil,
 		)
 	}
-	path := filepath.Join(root, filepath.FromSlash(model.NormalizePublicPath(notesFile)))
+	workspaceRoot, err := state.WorkspaceRootForChange(root, change)
+	if err != nil {
+		return "", newStateIntegrityError(
+			"evidence_skill_notes_workspace_resolve_failed",
+			fmt.Sprintf("failed to resolve notes workspace for %q: %v", change.Slug, err),
+			"Repair the governed change worktree binding and retry.",
+			change.Slug,
+			map[string]any{"path": notesFile},
+		)
+	}
+	path := filepath.Join(workspaceRoot, filepath.FromSlash(model.NormalizePublicPath(notesFile)))
 	raw, err := os.ReadFile(path) // #nosec G304 -- path is validated as workspace-relative before reading.
 	if err != nil {
 		return "", newStateIntegrityError(
 			"evidence_skill_notes_file_read_failed",
 			fmt.Sprintf("failed to read notes file %q: %v", notesFile, err),
 			"Write the delegated review or verification notes to the referenced workspace-relative path and retry.",
-			"",
-			map[string]any{"path": notesFile},
+			change.Slug,
+			map[string]any{
+				"path":           notesFile,
+				"resolved_path":  state.DisplayPath(root, path),
+				"workspace_root": state.DisplayPath(root, workspaceRoot),
+			},
 		)
 	}
 	return strings.TrimSpace(string(raw)), nil

--- a/cmd/evidence_skill_test.go
+++ b/cmd/evidence_skill_test.go
@@ -83,6 +83,61 @@ func TestEvidenceSkillRecordsPlanAuditVerification(t *testing.T) {
 	})
 }
 
+func TestEvidenceSkillNotesFileUsesBoundWorktreeWorkspace(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		require.NoError(t, os.WriteFile(filepath.Join(root, "README.md"), []byte("test\n"), 0o644))
+		runGit(t, root, "add", ".")
+		runGit(t, root, "commit", "-m", "init")
+		initTestWorkspace(t, root)
+
+		slug := createGovernedRequest(t, root, "L2", "evidence skill bound notes file")
+		change := setEvidenceSkillChangeState(t, root, slug, model.StateS1Plan, model.PlanSubStepAudit)
+
+		worktreeRoot := filepath.Join(t.TempDir(), slug)
+		branch := "feat/" + slug
+		runGit(t, root, "worktree", "add", worktreeRoot, "-b", branch, "HEAD")
+
+		bound := change
+		require.NoError(t, state.PersistScopeWorktreeMetadata(&bound, worktreeRoot, branch))
+		require.NoError(t, state.RelocateGovernedBundle(root, change, bound))
+		require.NoError(t, state.SaveChange(root, bound))
+
+		notesRel := filepath.ToSlash(filepath.Join("artifacts", "changes", slug, "verification", "plan-audit-notes.md"))
+		notesPath := filepath.Join(worktreeRoot, filepath.FromSlash(notesRel))
+		require.NoError(t, os.MkdirAll(filepath.Dir(notesPath), 0o755))
+		require.NoError(t, os.WriteFile(notesPath, []byte("Bound worktree plan audit passed.\n"), 0o644))
+
+		cmd := commandForRoot(t, root, makeEvidenceCmd())
+		cmd.SetArgs([]string{
+			"skill",
+			"--json",
+			"--change", slug,
+			"--skill", progression.SkillPlanAudit,
+			"--verdict", model.VerificationVerdictPass,
+			"--reference", "plan-audit:pass",
+			"--notes-file", notesRel,
+		})
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		require.NoError(t, cmd.Execute())
+
+		var view evidenceSkillView
+		require.NoError(t, json.Unmarshal(out.Bytes(), &view))
+		expectedPath := state.DisplayPath(
+			root,
+			filepath.Join(worktreeRoot, "artifacts", "changes", slug, "verification", "plan-audit.yaml"),
+		)
+		assert.Equal(t, expectedPath, view.Path)
+
+		rec, err := state.LoadVerification(root, slug, progression.SkillPlanAudit)
+		require.NoError(t, err)
+		assert.Equal(t, "Bound worktree plan audit passed.", rec.Notes)
+	})
+}
+
 func TestEvidenceSkillFailOverwritesPlanAuditAndPrunesDigest(t *testing.T) {
 	t.Parallel()
 
@@ -310,6 +365,56 @@ func TestEvidenceSkillRejectsWrongState(t *testing.T) {
 		assert.Equal(t, progression.SkillSpecComplianceReview, cliErr.Details["skill"])
 		assert.Equal(t, string(model.StateS3Review), cliErr.Details["required_state"])
 		assert.Equal(t, string(model.StateS1Plan), cliErr.Details["current_state"])
+	})
+}
+
+func TestEvidenceSkillWrongStateForWaveOrchestrationInS3RoutesToReviewAndVerificationEvidence(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		slug := createGovernedRequest(t, root, "L2", "evidence skill wave wrong state in review")
+		setEvidenceSkillChangeState(t, root, slug, model.StateS3Review, model.PlanSubStepNone)
+
+		cmd := commandForRoot(t, root, makeEvidenceCmd())
+		cmd.SetArgs([]string{
+			"skill",
+			"--change", slug,
+			"--skill", progression.SkillWaveOrchestration,
+			"--verdict", model.VerificationVerdictPass,
+		})
+		cliErr := asCLIError(cmd.Execute())
+		require.NotNil(t, cliErr)
+		assert.Equal(t, "evidence_skill_wrong_state", cliErr.ErrorCode)
+		assert.Contains(t, cliErr.Remediation, progression.SkillSpecComplianceReview)
+		assert.Contains(t, cliErr.Remediation, progression.SkillCodeQualityReview)
+		assert.Contains(t, cliErr.Remediation, progression.SkillGoalVerification)
+		assert.Contains(t, cliErr.Remediation, progression.SkillFinalCloseout)
+	})
+}
+
+func TestEvidenceSkillWrongStateForReviewEvidenceInS4RoutesToVerificationEvidence(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		slug := createGovernedRequest(t, root, "L2", "evidence skill review wrong state in verify")
+		setEvidenceSkillChangeState(t, root, slug, model.StateS4Verify, model.PlanSubStepNone)
+
+		cmd := commandForRoot(t, root, makeEvidenceCmd())
+		cmd.SetArgs([]string{
+			"skill",
+			"--change", slug,
+			"--skill", progression.SkillSpecComplianceReview,
+			"--verdict", model.VerificationVerdictPass,
+		})
+		cliErr := asCLIError(cmd.Execute())
+		require.NotNil(t, cliErr)
+		assert.Equal(t, "evidence_skill_wrong_state", cliErr.ErrorCode)
+		assert.Contains(t, cliErr.Remediation, progression.SkillGoalVerification)
+		assert.Contains(t, cliErr.Remediation, progression.SkillFinalCloseout)
 	})
 }
 

--- a/cmd/evidence_test.go
+++ b/cmd/evidence_test.go
@@ -48,3 +48,32 @@ func TestEvidenceTaskWrongStateInS4RoutesToGoalVerificationAndFinalCloseout(t *t
 		assert.Contains(t, cliErr.Remediation, "final-closeout")
 	})
 }
+
+func TestEvidenceTaskWrongStateInS3RoutesToReviewAndVerificationEvidence(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		_, change := createEvidenceTaskFixture(t, root)
+		change.CurrentState = model.StateS3Review
+		require.NoError(t, state.SaveChange(root, change))
+
+		cmd := commandForRoot(t, root, makeEvidenceCmd())
+		cmd.SetArgs([]string{
+			"task",
+			"--task-id", "t-01",
+			"--run-summary-version", "1",
+			"--task-kind", "verification",
+			"--verdict", "pass",
+			"--evidence-ref", "test:wrong-state",
+		})
+		cliErr := asCLIError(cmd.Execute())
+		require.NotNil(t, cliErr)
+		assert.Equal(t, "evidence_task_wrong_state", cliErr.ErrorCode)
+		assert.Contains(t, cliErr.Remediation, "spec-compliance-review")
+		assert.Contains(t, cliErr.Remediation, "code-quality-review")
+		assert.Contains(t, cliErr.Remediation, "goal-verification")
+		assert.Contains(t, cliErr.Remediation, "final-closeout")
+	})
+}

--- a/cmd/lifecycle_commands_test.go
+++ b/cmd/lifecycle_commands_test.go
@@ -1349,7 +1349,7 @@ func TestRunStalePlanningRecoveryRequiresFreshReviewAfterExecutionRefresh(t *tes
 	assert.NotContains(t, reasons, "run_slipway_run_to_advance:"+string(model.StateS3Review))
 	assert.Equal(t, "skill_handoff:"+progression.SkillSpecComplianceReview, syncView.ConfirmationRequirement.Reason)
 	assert.False(t, syncView.ConfirmationRequirement.ResumeResponseSupported)
-	assert.Equal(t, "complete governance skill handoff: "+progression.SkillSpecComplianceReview, syncView.ConfirmationRequirement.NextAction)
+	assert.Equal(t, "run governance skill "+progression.SkillSpecComplianceReview+" and record evidence; --resume-response is only for active checkpoints", syncView.ConfirmationRequirement.NextAction)
 }
 
 func TestRunStalePlanningRecoveryRefreshesEvidenceInOrder(t *testing.T) {

--- a/cmd/next.go
+++ b/cmd/next.go
@@ -720,7 +720,7 @@ func hardStopNextAction(reason string, resumeResponseSupported bool) string {
 		return "resume pending checkpoint with slipway run --resume-response"
 	}
 	if skillName, ok := strings.CutPrefix(reason, "skill_handoff:"); ok && strings.TrimSpace(skillName) != "" {
-		return "complete governance skill handoff: " + strings.TrimSpace(skillName)
+		return "run governance skill " + strings.TrimSpace(skillName) + " and record evidence; --resume-response is only for active checkpoints"
 	}
 	switch reason {
 	case "preset_confirmation_required":

--- a/cmd/next_context_build.go
+++ b/cmd/next_context_build.go
@@ -334,7 +334,7 @@ func buildResumeCheckpoint(root string, change *model.Change, execCtx executionC
 		return newPreconditionError(
 			"no_active_checkpoint",
 			"--resume-response provided but no active checkpoint exists",
-			"Remove --resume-response when no checkpoint is pending.",
+			"Remove --resume-response; it is only valid for active checkpoint resume. For missing governance skill evidence, follow `slipway next --json` and record the required skill evidence instead.",
 			"",
 			nil,
 		)

--- a/cmd/progression_next_test.go
+++ b/cmd/progression_next_test.go
@@ -1720,6 +1720,8 @@ func TestRunRejectsResumeResponseWithoutCheckpoint(t *testing.T) {
 		assert.Equal(t, "no_active_checkpoint", cliErr.ErrorCode)
 		assert.Equal(t, categoryPrecondition, cliErr.Category)
 		assert.Equal(t, exitCodePrecondition, cliErr.ExitCode)
+		assert.Contains(t, cliErr.Remediation, "active checkpoint")
+		assert.Contains(t, cliErr.Remediation, "skill evidence")
 	})
 }
 
@@ -2078,7 +2080,7 @@ func TestConfirmationRequirementDistinguishesHardStopFromCommandBoundary(t *test
 	assert.False(t, handoff.PriorAuthorizationSufficient)
 	assert.Equal(t, "skill_handoff:code-quality-review", handoff.Reason)
 	assert.False(t, handoff.ResumeResponseSupported)
-	assert.Equal(t, "complete governance skill handoff: code-quality-review", handoff.NextAction)
+	assert.Equal(t, "run governance skill code-quality-review and record evidence; --resume-response is only for active checkpoints", handoff.NextAction)
 	assert.Equal(t, "skill_handoff", handoff.NextActionKind)
 	assert.Empty(t, handoff.NextCommand)
 
@@ -2162,7 +2164,7 @@ func TestNextHandoffViewUsesStructuredConfirmationRequirement(t *testing.T) {
 	confirmation := payload["confirmation_requirement"].(map[string]any)
 	require.Equal(t, "hard_stop", confirmation["boundary"])
 	assert.Equal(t, false, confirmation["resume_response_supported"])
-	assert.Equal(t, "complete governance skill handoff: code-quality-review", confirmation["next_action"])
+	assert.Equal(t, "run governance skill code-quality-review and record evidence; --resume-response is only for active checkpoints", confirmation["next_action"])
 	assert.Equal(t, "skill_handoff", confirmation["next_action_kind"])
 }
 


### PR DESCRIPTION
## Summary

- Resolve bound-worktree `slipway evidence skill --notes-file artifacts/...` paths against the active change workspace.
- Clarify post-S2 task and wave evidence wrong-state remediation so review-driven repairs point to S3/S4 verification evidence.
- Distinguish governance skill handoff from checkpoint resume in `confirmation_requirement` and `--resume-response` remediation.

Closes #183.
Closes #189.
Closes #192.

## Validation

- `go run . status --json`
- `go run . validate --json`
- `go run . next --json --diagnostics`
- `git diff --check`
- `git diff --cached --check`
- focused `go test ./cmd -run 'TestEvidenceSkillNotesFileUsesBoundWorktreeWorkspace|TestEvidenceTaskWrongStateInS3RoutesToReviewAndVerificationEvidence|TestEvidenceTaskWrongStateInS4RoutesToGoalVerificationAndFinalCloseout|TestEvidenceSkillWrongStateForWaveOrchestrationInS3RoutesToReviewAndVerificationEvidence|TestEvidenceSkillWrongStateForReviewEvidenceInS4RoutesToVerificationEvidence|TestRunRejectsResumeResponseWithoutActiveCheckpoint|TestConfirmationRequirementDistinguishesHardStopFromCommandBoundary|TestNextJSONIncludesConfirmationRequirement' -count=1`
- `go test ./...`
- `go run . done --json`