### PR TITLE
feat(wave): compute wave plans from task graph

### DIFF
--- a/artifacts/changes/archived/wave-plans-almost-always-collapse-into-single-task-sequentia/assurance.md
+++ b/artifacts/changes/archived/wave-plans-almost-always-collapse-into-single-task-sequentia/assurance.md
@@ -1,0 +1,105 @@
+# Assurance
+
+## Scope Summary
+Wave assignment moved from hand-declared `wave:` task metadata to
+engine-computed scheduling: `PlanWaves` now derives each task's wave from
+`depends_on` (max of dependency waves + 1; roots share wave 1) with
+deterministic, task-ID-ordered, same-wave-only conflict bumping over
+`target_files` (exact, parent/child, case-insensitive, glob — reusing the
+pre-existing conflict semantics). The review-found deferred-root/dependent
+tie-break edge case is fixed and pinned by regression coverage. The `wave:` key
+is retired fail-closed with a dedicated parser error carrying remediation. The
+declared-wave validation blocker
+(`plan_dimension_execution_missing_wave`) left the validation logic, the
+reason-code registry, and the remediation vocabulary. Planning surfaces
+(`slipway instructions tasks`, plan-audit skill, tasks.md template exemplar,
+docs/workflow.md) now teach the computed-wave contract and the three width
+rules (honest dependencies, precise target files, same-file absorption).
+Delivered across 8 tasks in 3 waves; 31 repository test files migrated off
+legacy wave fixtures.
+
+## Verification Verdict
+PASS. All 8 planned tasks carry passing run-2 task evidence recorded through
+`slipway evidence task` after the self-host waveless migration; the
+wave-orchestration verification records full parallel subagent fan-out with
+no degraded_sequential waves.
+
+## Evidence Index
+- verification/wave-orchestration.yaml — dispatch evidence: 10 executor
+  handles, dispatch_mode parallel_subagents for waves 1-2, run_version 2.
+- verification/integration-gate-notes.md (t-08) — gofmt clean,
+  `go build ./...`, `go vet ./...`, `go test ./... -count=1` all green
+  for the listed packages; dev-binary dogfood: live retirement parse_error
+  quoted from this bundle's then-legacy tasks.md; positive shape via pinned CLI
+  acceptance tests; `gen-surface-manifest --check` up to date; guidance text
+  verified via `instructions tasks` on the dev binary.
+- Runtime task evidence ledger (run 2, all 8 tasks) at
+  .git/slipway/runtime/changes/<slug>/evidence/tasks.
+- Self-host migration proof: re-materialized computed plan from waveless
+  tasks.md reproduced the declared shape exactly — wave 1 =
+  {t-01,t-02,t-03,t-06,t-07} parallel:true, wave 2 = {t-04,t-05}
+  parallel:true, wave 3 = {t-08} parallel:false.
+- verification/plan-audit-notes.md — original 8D audit plus two re-audit
+  addenda (fixture-sweep target expansion; waveless migration).
+
+## Requirement Coverage
+- REQ-001 (computed minimal assignment): wave package tests
+  (roots/fan-in/chain/depth), CLI tests
+  (TestDerivedWavePlanPreviewComputesWavesFromDependencies,
+  TestMaterializeWavePlanComputesWavesFromDependencies), live re-materialized
+  plan shape parity. PASS.
+- REQ-002 (deterministic conflict bumping): TestPlanWavesBumpsExactTargetConflictDeterministically
+  (10× repeat + input-permutation equality),
+  TestPlanWavesBumpsConflictingTargetsForEachConflictKind (8 conflict kinds),
+  cascade and same-wave-only pins, plus
+  TestPlanWavesBumpsLaterTaskIDWhenDeferredRootConflictsWithDependent for the
+  independent-review ordering bug. PASS.
+- REQ-003 (fail-closed retirement): TestParseTaskPlan_RejectsRetiredWaveKey,
+  TestWavePlanRejectsDeclaredWaveMetadata (preview + materialization), live
+  negative dogfood on this bundle. PASS.
+- REQ-004 (validation vocabulary retired):
+  TestValidateTasksChecklistDetailed_WavelessChecklistPassesStructuralValidation,
+  TestDeclaredWaveBlockerVocabularyRetired, snapshot test updated; this
+  bundle's waveless checklist validates as valid. PASS.
+- REQ-005 (hash inputs drop wave): TestTaskPlanHashesAreStableForWavelessPlan;
+  hash entries carry authored contract fields only (all three modes); one-time
+  staleness handled live through the engine-offered reopen flow. PASS.
+- REQ-006 (planning-surface guidance): pinned instructions test
+  (TestInstructionsTasksGuidanceTeachesComputedWaves), plan-audit skill 8D
+  rewrite, dev-binary guidance verification at t-08. PASS.
+- REQ-007 (docs/manifest alignment): docs/workflow.md rewritten;
+  SURFACE-MANIFEST verified registry-derived and fresh via --check; template
+  exemplar aligned (TestArtifactTemplatesParseUnderEngineParsers green). PASS.
+
+## Residual Risks and Exceptions
+- One-time hash-semantics change strands other in-flight bundles' wave plans
+  on first touch by the new binary (intentional, REQ-005, no shim): recovery is
+  the existing public staleness flow, proven live on this very bundle. The
+  main checkout currently has another active change
+  (resolve-issue-163-decisions-gate) that will hit the retirement error and
+  the same recovery on its next touch — expected, documented, fail-closed.
+- The S2 migration UX gap found during review is fixed: the
+  `tasks_checklist_invalid_format` blocker now carries the parser's
+  retirement detail, so operators see the named task, retired `wave:` key,
+  delete-line remediation, and real-`depends_on` guidance directly from
+  validate/status/next blocker paths.
+- The post-review scheduling gap is fixed: a root task deferred by a wave-1
+  conflict can no longer claim a later wave ahead of a lower-ID dependent task
+  that becomes eligible in that wave. Scheduling now scans each wave in sorted
+  task-ID order across currently eligible tasks.
+- Wider computed waves raise concurrent-executor counts; dispatch-side safety
+  (overlap preflight, post-result conflict check, integration gate) is
+  unchanged and owns that risk.
+
+## Rollback Readiness
+Pure code+surface change; no persisted-data migration. A revert restores the
+declared-wave contract; wave-plan.yaml re-materializes from tasks.md on the
+next S1→S2 pass in either direction. Bundles authored waveless would need
+wave declarations restored if rolled back — same one-time staleness flow in
+reverse. No rollback prerequisites beyond a normal revert commit.
+
+## Archive Decision
+Ready to stop at `done_ready` once S4 goal-verification and final-closeout
+records are fresh and `validate --json` shows all governance gates approved.
+Do not run `slipway done` until an explicit finalization request; the active
+bundle should remain inspectable in this worktree at the done-ready boundary.

--- a/artifacts/changes/archived/wave-plans-almost-always-collapse-into-single-task-sequentia/change.yaml
+++ b/artifacts/changes/archived/wave-plans-almost-always-collapse-into-single-task-sequentia/change.yaml
@@ -1,0 +1,63 @@
+version: 1
+slug: wave-plans-almost-always-collapse-into-single-task-sequentia
+description: 'Wave plans almost always collapse into single-task sequential chains, so parallel:true waves rarely exist to dispatch: the planning surfaces (slipway instructions tasks guidance and the plan-audit skill) carry only format requirements and an upper wave-size bound (<=5 tasks), with no wave-width construction rules. Borrow GSD planner-side mechanisms into Slipway planning surfaces: minimal-wave assignment (wave = max(dependency waves)+1; independent file-disjoint tasks share a wave), a sequential-by-default plan warning at plan-audit, shared-files-to-same-task absorption guidance, and precise target_files scoping guidance, so multi-task parallel waves become the planned default where dependencies allow.'
+status: done
+current_state: DONE
+needs_discovery: true
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-06-12T16:26:37.309979Z
+quality_mode: standard
+workflow_preset: standard
+worktree_branch: feat/wave-plans-almost-always-collapse-into-single-task-sequentia
+artifact_schema: expanded
+remediation_sources:
+    - slug: resolve-github-issue-184-add-gsd-style-automatic-subagent-di
+      path: artifacts/changes/archived/resolve-github-issue-184-add-gsd-style-automatic-subagent-di
+      relation: remediates
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: f7fc3ed2daf2fdcc6128c1198993412b840d659279123922d0257c8f293ed6bc
+        updated_at: 2026-06-13T12:49:16.274716738Z
+    decision:
+        id: decision
+        path: decision.md
+        state: frozen
+        content_hash: 4ba30edf9c15bd72aeb2d1ed5ffcb1e92815861a2fa6cf33977244fdd0cb1a4c
+        updated_at: 2026-06-12T16:55:17.617014219Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: 41296388528e4d73926d40a325215d31e7c146dc212fd9c6dd4a4751df50d12f
+        updated_at: 2026-06-12T16:49:27.917901988Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: 1b254b6eb9998b9b32ead9ad4cf21d0b09651e817a139043f785e22f2b84f96c
+        updated_at: 2026-06-12T16:57:33.592135626Z
+    research:
+        id: research
+        path: research.md
+        state: frozen
+        content_hash: 364724658ecb725a7b3edfbcccd7a2a1b0ec67c8828e684fbcf4e844ed41f5ce
+        updated_at: 2026-06-12T16:49:06.694819102Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: 2afde8f44338f4c2e66bc168e616feb232abb4c27bc7c13c4959ccfe4ecdbf73
+        updated_at: 2026-06-12T18:42:03.762313929Z
+evidence_refs:
+    code-quality-review: .worktrees/wave-plans-almost-always-collapse-into-single-task-sequentia/artifacts/changes/wave-plans-almost-always-collapse-into-single-task-sequentia/verification/code-quality-review.yaml
+    final-closeout: .worktrees/wave-plans-almost-always-collapse-into-single-task-sequentia/artifacts/changes/wave-plans-almost-always-collapse-into-single-task-sequentia/verification/final-closeout.yaml
+    goal-verification: .worktrees/wave-plans-almost-always-collapse-into-single-task-sequentia/artifacts/changes/wave-plans-almost-always-collapse-into-single-task-sequentia/verification/goal-verification.yaml
+    intake-clarification: .worktrees/wave-plans-almost-always-collapse-into-single-task-sequentia/artifacts/changes/wave-plans-almost-always-collapse-into-single-task-sequentia/verification/intake-clarification.yaml
+    plan-audit: .worktrees/wave-plans-almost-always-collapse-into-single-task-sequentia/artifacts/changes/wave-plans-almost-always-collapse-into-single-task-sequentia/verification/plan-audit.yaml
+    research-orchestration: .worktrees/wave-plans-almost-always-collapse-into-single-task-sequentia/artifacts/changes/wave-plans-almost-always-collapse-into-single-task-sequentia/verification/research-orchestration.yaml
+    spec-compliance-review: .worktrees/wave-plans-almost-always-collapse-into-single-task-sequentia/artifacts/changes/wave-plans-almost-always-collapse-into-single-task-sequentia/verification/spec-compliance-review.yaml
+    wave-orchestration: .worktrees/wave-plans-almost-always-collapse-into-single-task-sequentia/artifacts/changes/wave-plans-almost-always-collapse-into-single-task-sequentia/verification/wave-orchestration.yaml

--- a/artifacts/changes/archived/wave-plans-almost-always-collapse-into-single-task-sequentia/decision.md
+++ b/artifacts/changes/archived/wave-plans-almost-always-collapse-into-single-task-sequentia/decision.md
@@ -1,0 +1,95 @@
+# Decision
+
+## Alternatives Considered
+- **Option A — compute at the parse boundary**: `ParseTaskPlan` assigns waves
+  immediately after parsing, so every consumer sees computed waves. Rejected:
+  the format layer absorbs scheduling semantics, dependency-cycle detection
+  becomes a "parse error" (wrong category for a graph property), and all nine
+  parse call sites (tasks_contract, validation, scopecontract, status,
+  governance health, wave_sync, state, next_wave_plan) pay graph-computation
+  cost most of them never need.
+- **Option B — compute inside `PlanWaves` (parse stays format-only)**: the
+  parser drops the `wave` key and gains a dedicated retirement error;
+  `PlanWaves(nodes)` derives the assignment; preview and materialization both
+  flow through the one authority. Smallest clean diff (parse.go + wave.go +
+  one validation blocker + surface texts).
+- **Option C — compute only at materialization (S1→S2)**: `PlanWaves` keeps
+  validating declared waves and a new compute path runs only inside
+  `MaterializeWavePlan`. Rejected: the pre-S2 preview in `cmd/next_wave_plan.go`
+  would either duplicate the algorithm or show no waves — two-implementation
+  drift for no benefit.
+- Prose-only guidance, an engine advisory on hand-declared waves, and a hard
+  gate on non-minimal declared waves were considered at intake and rejected by
+  the user in favor of full engine ownership (intent.md, intake rounds 1-2).
+
+## Selected Approach
+Option B, user-confirmed at the research stage. `ParseTaskPlan` stays a pure
+format parser: `wave` leaves `allowedMetadataKeys` and gains a dedicated
+retirement case in `applyStrictMetadata` whose error names the task, the
+retirement, and the remediation (delete the line; declare real `depends_on`).
+`PlanWaves` becomes constructive: it orders tasks topologically with task-ID
+tiebreaks (reusing `compareNodesByTaskID`), assigns
+`wave = max(dependency waves) + 1` (1 for roots), then bumps a task forward
+while its wave contains an already-assigned task whose `target_files` conflict
+under the existing `targetFilesConflict` semantics. Cycle and
+unknown-dependency detection stay in `PlanWaves` as hard errors surfaced
+through the existing wave-plan parse_error/blocker path.
+`validateWaveStaticConflicts` is retained as an internal invariant check on
+the computed output. The `plan_dimension_execution_missing_wave` blocker, its
+reason-code registry entry, and its remediation vocabulary are removed. The
+task-plan hash entries drop the wave field in all three modes. Planning
+surfaces (`cmd/instructions.go` tasks guidance, plan-audit skill template,
+docs/workflow.md) are rewritten to the computed-wave contract with the
+honest-dependency, precise-target-files, and same-file-absorption guidance.
+
+## Interfaces and Data Flow
+- tasks.md (authored: objective, `depends_on`, `target_files`, `task_kind`,
+  `covers`, no `wave`) → `ParseTaskPlan` → nodes → `PlanWaves` (compute +
+  invariant check) → `MaterializeWavePlanAt` → wave-plan.yaml (`wave_index`,
+  `parallel` via unchanged `ApplyEffectiveParallel`) → `slipway next --json`
+  `input_context.wave_plan` → wave-orchestration dispatch. The preview path
+  (`cmd/next_wave_plan.go`) consumes the same `PlanWaves` output pre-S2.
+- Public JSON shapes do not change: `waves[].wave_index`, `waves[].parallel`,
+  and task views keep their fields; only the provenance of `wave_index`
+  changes from declared to computed.
+- Error surfaces: parser retirement error (with remediation) for legacy
+  `wave:` lines; `PlanWaves` hard errors for cycles/unknown deps; no new
+  reason codes introduced; one reason code retired.
+
+## Rollout and Rollback
+- Rollout is a single atomic change: engine + validation vocabulary + surface
+  texts + docs + tests land together so no surface teaches the retired
+  contract.
+- One-time freshness impact: hash functions stop embedding the wave value, so
+  previously stored TasksPlan*Hash values mismatch recomputation once. Active
+  bundles recover through the existing public staleness flow
+  (re-materialization on S1→S2, `slipway repair`, or `pivot --rescope`);
+  archived bundles are not re-parsed and stay frozen.
+- Self-host migration (dogfood): this change's own tasks.md is authored under
+  the old contract (declared waves chosen to match the computed assignment).
+  After implementation lands, the worktree binary becomes lifecycle authority,
+  its parser rejects our own `wave:` lines, and we follow the public
+  remediation: delete the lines and re-walk the reopened stages (#114
+  precedent). Any friction found in that walk is product feedback for this
+  change, not a workaround to normalize.
+- Rollback: pure code+text revert restores the declared-wave contract;
+  wave-plan.yaml re-materializes from tasks.md on the next S1→S2 pass in
+  either direction; no persisted-data migration exists.
+
+## Risk
+- Hash semantics change strands in-flight bundles once (HIGH impact, LOW
+  frequency): mitigated by the documented public recovery paths and proven by
+  this change's own re-walk; explicitly no special-case shim (REQ-005).
+- Legacy `wave:` lines in other active worktrees fail closed at next touch
+  (MEDIUM): the retirement error carries the exact remediation; archived
+  bundles unaffected.
+- Computed waves can be wider than authors previously declared (MEDIUM):
+  execution-side safety is owned by the unchanged dispatch contract
+  (target-overlap preflight, post-result conflict check, integration gate);
+  the >5-task plan-audit soft warning stays as the width pressure valve.
+- Bump-loop correctness (LOW): monotone forward bumps in a fixed processing
+  order terminate (bounded by task count) and are deterministic;
+  property-style tests plus the retained invariant check cover regressions.
+- Surface drift (LOW): template-pinning and toolgen contract tests are updated
+  in-change; README carries no authored-wave tokens (verified during
+  research).

--- a/artifacts/changes/archived/wave-plans-almost-always-collapse-into-single-task-sequentia/intent.md
+++ b/artifacts/changes/archived/wave-plans-almost-always-collapse-into-single-task-sequentia/intent.md
@@ -1,0 +1,152 @@
+# Intent
+
+## Summary
+Wave plans almost always collapse into single-task sequential chains, so parallel:true waves rarely exist to dispatch: the planning surfaces (slipway instructions tasks guidance and the plan-audit skill) carry only format requirements and an upper wave-size bound (<=5 tasks), with no wave-width construction rules. Borrow GSD planner-side mechanisms into Slipway planning surfaces: minimal-wave assignment (wave = max(dependency waves)+1; independent file-disjoint tasks share a wave), a sequential-by-default plan warning at plan-audit, shared-files-to-same-task absorption guidance, and precise target_files scoping guidance, so multi-task parallel waves become the planned default where dependencies allow.
+## Complexity Assessment
+complex
+Rationale: retires the hand-declared `wave:` contract in tasks.md and moves wave
+assignment into the engine (parser, PlanWaves, materialization, plan-audit and
+instructions surfaces, docs, and test fixtures all change together), with a
+self-host migration consideration for in-flight bundles.
+
+## Guardrail Domains
+<!-- none detected -->
+
+## In Scope
+- Engine-computed wave assignment: derive each task's wave from `depends_on`
+  (minimal feasible level, GSD assign_waves style: no deps -> wave 1, else
+  max(dependency waves)+1) and bump later for `target_files` conflicts with
+  earlier-assigned tasks, reusing the existing conflict semantics in
+  `internal/engine/wave/wave.go` (exact, parent/child, case-insensitive, glob).
+  Assignment is deterministic with task-ID-ordered tiebreaks.
+- Retire the hand-declared `wave:` task metadata: the tasks.md parser rejects a
+  `wave:` declaration fail-closed with a public error that names the retirement
+  and the remediation (declare real `depends_on`; the engine now assigns waves).
+- Planning-surface rewrite with new-drift-vector guidance: `slipway
+  instructions tasks` guidance and the plan-audit skill drop the wave authoring
+  requirement and instead teach honest dependencies (`depends_on` is a
+  scheduling input, not narrative order), precise `target_files` (exact files
+  over directories/globs, since broad scopes flatten waves via conflict
+  bumping), and the GSD shared-files-to-same-task absorption rule; the
+  plan-audit dependency-integrity dimension upgrades from reference validity to
+  dependency-necessity judgment.
+- Aligned surfaces and tests as one product: instructions exemplars, plan-audit
+  and (if it references wave authoring) wave-orchestration templates,
+  docs/workflow.md, engine/parser/cmd/toolgen tests and fixtures.
+- Self-host migration: this change's own tasks.md is authored under the old
+  contract and re-authored (wave declarations dropped) once the new engine
+  behavior lands in this worktree, following the #114 mid-flight re-walk
+  precedent.
+
+User decisions at intake:
+- Round 1: wave construction is owned by the engine ("引擎全接管 wave"), not by
+  prose guidance, an advisory, or a hard gate on hand-written wave numbers.
+- Round 2: the `wave:` field is removed outright — fail-closed rejection, no
+  ignore-one-version compatibility window, no manual override. Intentional
+  serialization is expressed only through honest `depends_on` declarations.
+- Round 3: the surface rewrite includes the guidance refresh for the new drift
+  vectors (over-declared depends_on, over-broad target_files), with no new
+  engine fully-sequential advisory signal.
+
+## Out of Scope
+- Dispatch/runtime side: the wave-orchestration executor dispatch contract,
+  dispatch evidence vocabulary (`dispatch_mode:*`, `executor_agent:*`,
+  `degraded_sequential`), and per-host runtime behavior stay unchanged.
+- `execution.parallelization` config semantics and the per-wave `parallel` flag
+  formula (`forcedParallel && len(tasks) > 1`) stay unchanged.
+- No GSD-style per-executor worktree isolation and no plan-level execution
+  granularity; the #184 single-worktree decision stands.
+- No new engine advisory for fully-sequential computed plans (host judgment at
+  plan-audit covers it).
+- The plan-audit soft warning for oversized waves (>5 tasks) keeps its current
+  policy; this change does not re-tune wave-size limits.
+
+## Constraints
+- Computed assignment must be deterministic (stable ordering by task ID) so
+  wave-plan freshness hashes stay reproducible.
+- Existing engine safety invariants stay intact: same-wave tasks remain
+  dependency-free and file-disjoint by construction; cycle detection remains a
+  hard error surfaced through the existing wave-plan parse_error path.
+- The change that retires the wave declaration is itself governed by a tasks.md
+  authored under the current contract; the migration path for in-flight bundles
+  (including this change's own) must be resolved before implementation.
+
+## Acceptance Signals
+- Engine: a tasks.md with three independent file-disjoint tasks plus one task
+  depending on all three materializes (without any wave declarations) as
+  wave-plan.yaml wave 1 x3 `parallel: true` + wave 2 x1 `parallel: false`;
+  a pure `depends_on` chain still yields N single-task sequential waves;
+  target-file overlap (exact/parent-child/case/glob) bumps the later task to a
+  later wave deterministically. Covered by unit tests in the wave package plus
+  a CLI-level materialization test.
+- Contract: a tasks.md carrying a `wave:` declaration fails parsing with the
+  retirement error and actionable remediation text (no silent ignore).
+- Surfaces: `slipway instructions tasks` output and the regenerated plan-audit
+  skill no longer require wave authoring and carry the honest-deps /
+  precise-targets / absorption guidance; toolgen and template contract tests
+  pass.
+- Repository health: gofmt clean, `go build ./...`, `go vet ./...`,
+  `go test ./...` all green in this worktree.
+- Dogfood: this change's own bundle is re-walked under the new contract and its
+  final wave plan contains at least one multi-task `parallel: true` wave if its
+  re-authored tasks permit one honestly.
+
+## Open Questions
+- [x] How exactly does the current tasks.md parser ingest the `wave:` metadata
+  (dedicated field vs generic key), and what is the cleanest fail-closed
+  rejection point with a public error + remediation? → Resolved in research.md:
+  whitelisted key parsed to WaveIndex; retirement = remove from
+  `allowedMetadataKeys` + dedicated retirement error in `applyStrictMetadata`.
+- [x] Full inventory of surfaces that reference wave authoring (instructions
+  guidance/exemplars, plan-audit, wave-orchestration templates, tdd-governance,
+  docs/workflow.md, README contract tokens, test fixtures) to keep the product
+  surface aligned in one pass. → Resolved in research.md (Architecture +
+  Unknowns): engine trio (parse.go/wave.go/validation.go:96) + instructions:87 +
+  plan-audit:90,133 + docs/workflow.md + test fixtures; other "wave" mentions
+  are execution-context phrasing, not authoring contract.
+- [x] Deterministic conflict-bump algorithm details: iteration order, fixpoint
+  behavior when bumping creates new same-wave neighbors, and interaction with
+  the wave-plan freshness hashes. → Resolved in research.md: task-ID-ordered
+  topological assignment, max(dep)+1 with monotone forward bump (terminates,
+  deterministic); all three hash modes currently embed declared wave
+  (parse.go:109-112) so the hash function changes once — one-time staleness
+  handled by existing public recovery flows.
+- [x] In-flight and archived bundle exposure. → Resolved in research.md: nine
+  active-change parse sites hit the retirement error until legacy `wave:` lines
+  are removed; archived bundles are not re-parsed; this change's own bundle is
+  the migration dogfood (#114 precedent).
+
+## Deferred Ideas
+<!-- Identified but postponed ideas -->
+
+## Approved Summary
+Replace hand-declared wave numbers with engine-computed wave assignment: the
+engine derives each task's wave from `depends_on` (minimal feasible level: no
+dependencies -> wave 1, otherwise max(dependency waves)+1) and bumps tasks to
+later waves on `target_files` conflicts using the existing conflict semantics
+(exact, parent/child, case-insensitive, glob), deterministically with
+task-ID-ordered tiebreaks. The `wave:` task metadata is retired outright: the
+tasks.md parser rejects it fail-closed with a public error and remediation
+(declare real `depends_on`; the engine assigns waves), with no compatibility
+window and no manual override — intentional serialization is expressed only
+through honest `depends_on`. The planning surfaces (`slipway instructions
+tasks`, plan-audit, and any other wave-authoring references) are rewritten in
+the same change to teach the new drift vectors: honest dependencies, precise
+`target_files` (exact files over directories/globs), and the
+shared-files-to-same-task absorption rule, upgrading plan-audit's
+dependency-integrity check to a dependency-necessity judgment.
+
+Out of scope: the executor dispatch contract and dispatch evidence vocabulary,
+`execution.parallelization` semantics and the `parallel` flag formula,
+per-executor worktree isolation, a new engine fully-sequential advisory, and
+the >5-task wave-size warning policy.
+
+Primary acceptance signal: a tasks.md with no wave declarations and three
+independent file-disjoint tasks plus one dependent task materializes as
+wave 1 x3 `parallel: true` + wave 2 x1; a tasks.md carrying `wave:` fails
+parsing with the retirement error; full build/vet/test green; this change's own
+bundle is re-walked under the new contract (self-host migration, #114
+precedent).
+
+User confirmed: 2026-06-12T16:42:21Z (intake rounds 1-3 recorded under In
+Scope; summary confirmed via explicit selection "确认").

--- a/artifacts/changes/archived/wave-plans-almost-always-collapse-into-single-task-sequentia/requirements.md
+++ b/artifacts/changes/archived/wave-plans-almost-always-collapse-into-single-task-sequentia/requirements.md
@@ -1,0 +1,132 @@
+# Requirements
+
+### Requirement: Engine-computed minimal wave assignment
+REQ-001: `PlanWaves` MUST compute each task's wave from the dependency graph
+instead of reading a declared wave: a task with no dependencies MUST be
+assigned wave 1, and a task with dependencies MUST be assigned
+`max(wave of each dependency) + 1` before conflict adjustment. The computed
+plan MUST preserve the existing invariants: every wave 1..N is non-empty,
+every dependency resolves to a strictly earlier wave, and `PlanWaves` MUST
+reject dependency cycles and unknown dependency references with a hard error.
+
+#### Scenario: Independent tasks share the first wave
+GIVEN a tasks.md with tasks `t-01`, `t-02`, `t-03` that declare no
+  `depends_on` and pairwise-disjoint `target_files`, and `t-04` declaring
+  `depends_on: [t-01, t-02, t-03]`
+WHEN the wave plan is materialized
+THEN wave 1 contains `t-01`, `t-02`, `t-03` with `parallel: true` and wave 2
+  contains only `t-04` with `parallel: false`
+
+#### Scenario: Dependency chain still serializes
+GIVEN tasks `t-01` ← `t-02` ← `t-03` forming a pure `depends_on` chain
+WHEN the wave plan is materialized
+THEN the plan has exactly three single-task waves in chain order, each
+  `parallel: false`
+
+#### Scenario: Dependency cycle is rejected
+GIVEN tasks whose `depends_on` references form a cycle
+WHEN wave assignment runs
+THEN `PlanWaves` returns a hard error naming the cycle and no wave plan is
+  produced
+
+### Requirement: Deterministic conflict bumping
+REQ-002: When two tasks would share a wave and their `target_files` conflict
+under the existing semantics (exact path, parent/child scope, case-insensitive
+alias, or glob overlap), the engine MUST bump the task-ID-later task to the
+next wave until its wave is conflict-free. Assignment MUST process tasks in
+task-ID-ordered topological order so that repeated materialization of the same
+tasks.md content always produces an identical wave plan.
+
+#### Scenario: Shared file forces a later wave deterministically
+GIVEN independent tasks `t-01` and `t-02` that both list
+  `internal/engine/wave/wave.go` in `target_files`
+WHEN the wave plan is materialized repeatedly
+THEN every materialization assigns `t-01` to wave 1 and `t-02` to wave 2,
+  and no wave contains conflicting targets
+
+#### Scenario: Glob and parent scopes count as conflicts
+GIVEN independent tasks where one targets `internal/engine/wave/` (or a glob
+  such as `internal/engine/wave/*.go`) and another targets
+  `internal/engine/wave/parse.go`
+WHEN the wave plan is materialized
+THEN the two tasks are never assigned to the same wave
+
+### Requirement: Declared wave metadata is retired fail-closed
+REQ-003: The tasks.md parser MUST reject a task carrying a `wave:` metadata
+line with a dedicated retirement error that names the task ID, states that the
+engine now assigns waves from `depends_on` and `target_files`, and instructs
+the author to delete the `wave:` line (declaring real `depends_on` for
+intentional ordering). The parser MUST NOT silently ignore the key, MUST NOT
+accept it as an override, and MUST NOT offer a compatibility window.
+
+#### Scenario: Legacy wave line fails parsing with remediation
+GIVEN a tasks.md whose task `t-02` carries `- wave: 2`
+WHEN the tasks checklist is parsed by any consuming surface
+THEN parsing fails with the retirement error naming `t-02`, the retirement
+  of `wave:`, and the delete-the-line remediation, and no task plan is
+  produced
+
+### Requirement: Declared-wave validation vocabulary is retired
+REQ-004: The plan validation layer MUST NOT require a declared wave on any
+task: the `plan_dimension_execution_missing_wave` blocker MUST be removed from
+the validation logic, the reason-code registry, and the remediation
+vocabulary, and a tasks.md without any wave declarations MUST pass structural
+validation when its other contract obligations are met.
+
+#### Scenario: Waveless checklist passes structural validation
+GIVEN a tasks.md whose tasks declare objectives, `depends_on`,
+  `target_files`, `task_kind`, and `covers` but no `wave:` lines
+WHEN `slipway validate` evaluates the tasks contract at plan-audit
+  enforcement
+THEN no missing-wave blocker is emitted and the checklist is structurally
+  valid
+
+### Requirement: Task-plan freshness hashes drop the wave input
+REQ-005: The task-plan hash functions (structural, scope, semantic) MUST NOT
+include a wave value in their input entries once waves are computed; hash
+inputs MUST be exactly the authored contract fields so that identical authored
+content always yields identical hashes. This is an intentional one-time hash
+semantics change: previously stored hashes MAY mismatch recomputation once,
+and recovery MUST flow through the existing public staleness paths
+(re-materialization, `slipway repair`, or rescope) with no special-case shim.
+
+#### Scenario: Hash stability for unchanged authored content
+GIVEN a waveless tasks.md whose content does not change
+WHEN structural, scope, and semantic hashes are computed repeatedly
+THEN all three hashes are identical across runs and contain no wave-derived
+  input
+
+### Requirement: Planning surfaces teach the computed-wave contract
+REQ-006: The `slipway instructions tasks` guidance and the plan-audit skill
+MUST drop every instruction to author a `wave` value and MUST instead teach
+the new drift vectors: `depends_on` declares real execution-order dependencies
+only (a scheduling input, not narrative order); `target_files` SHALL name
+precise files rather than directories or globs wherever feasible because broad
+scopes flatten waves through conflict bumping; and small steps that must touch
+the same file SHOULD be absorbed into one task rather than split into
+serialized tasks. The plan-audit dependency dimension MUST audit dependency
+necessity (no cycles, no fabricated or narrative-only dependencies), not
+declared-wave ordering.
+
+#### Scenario: Regenerated guidance carries the new contract
+GIVEN the rewritten instructions guidance and plan-audit skill template
+WHEN `slipway instructions tasks` runs and the plan-audit skill is
+  regenerated
+THEN neither surface asks the author for a `wave` value, both state that the
+  engine assigns waves from `depends_on` and `target_files`, and the guidance
+  includes the honest-dependency, precise-target, and same-file-absorption
+  rules
+
+### Requirement: Documentation and surface manifest stay aligned
+REQ-007: User-facing workflow documentation MUST describe wave assignment as
+engine-computed from `depends_on` and `target_files`, and any generated
+surface manifests or template-pinning tests that encode the old authored-wave
+contract MUST be regenerated or updated in the same change so the product
+surface stays consistent.
+
+#### Scenario: Workflow docs match engine behavior
+GIVEN the updated documentation set
+WHEN docs/workflow.md is read against the new engine behavior
+THEN the wave-execution description states that Slipway computes waves from
+  declared dependencies and target files and contains no instruction to author
+  wave numbers

--- a/artifacts/changes/archived/wave-plans-almost-always-collapse-into-single-task-sequentia/research.md
+++ b/artifacts/changes/archived/wave-plans-almost-always-collapse-into-single-task-sequentia/research.md
@@ -1,0 +1,203 @@
+# Research
+
+## Alternatives Considered
+
+### Architecture
+- Affected modules:
+  - `internal/engine/wave/parse.go` — tasks.md checkbox-native parser. `wave`
+    is a whitelisted metadata key (`allowedMetadataKeys`, parse.go:145-154)
+    parsed into `Node.WaveIndex` via `parsePositiveInt` (parse.go:274-279);
+    unknown keys already fail closed in `applyStrictMetadata` (parse.go:243-245).
+    `HasDeclaredWave` (parse.go:48-50) exposes the declaration.
+  - `internal/engine/wave/wave.go` — `PlanWaves` (wave.go:56-110) currently
+    requires a declared wave per task ("missing required wave declaration",
+    wave.go:71-73), validates deps point to earlier waves (wave.go:94-96), and
+    hard-errors on same-wave target conflicts via `validateWaveStaticConflicts`
+    (wave.go:112-134) with exact/parent-child/case-insensitive/glob semantics
+    (wave.go:136-227).
+  - `internal/engine/progression/validation.go:96-99` — emits
+    `plan_dimension_execution_missing_wave:<id>` when a task lacks a declared
+    wave; this blocker retires with the field.
+  - `internal/state/wave_execution.go` — `MaterializeWavePlanAt` →
+    `wave.PlanWaves`; `ApplyEffectiveParallel` sets
+    `Parallel = forcedParallel && len(tasks) > 1` (unchanged).
+  - `cmd/next_wave_plan.go` — pre-S2 preview and S2 authoritative read; the
+    preview already derives `WaveIndex: i + 1` from `PlanWaves` output
+    (next_wave_plan.go:82), so it inherits computed assignment automatically.
+  - Planning surfaces: `cmd/instructions.go:87` (tasks authoring guidance
+    currently mandates `wave`), `internal/tmpl/templates/skills/plan-audit/SKILL.md:90,133`
+    (bundle audit metadata list + 8D Completeness require `wave`), 8D item 3
+    wording ("references valid earlier-wave tasks"), `docs/workflow.md` wave
+    wording.
+- Dependency chains: parser → (`tasks_contract.go`, `validation.go`,
+  `scopecontract/evaluate.go`, `status/view.go`, `governance/health.go`,
+  `wave_sync.go`, `state/wave_execution.go`, `cmd/next_wave_plan.go`) →
+  wave-plan consumers. Verified: every consumer outside the wave package reads
+  the computed plan (`WavePlanWave.WaveIndex`, wave runs), never the declared
+  per-task wave; the only `HasDeclaredWave` consumer is validation.go:96.
+- Blast radius: wave package (parse + plan), one validation blocker, planning
+  surface texts, docs, and test fixtures. No public JSON shape changes:
+  `next --json` wave views are already computed output.
+- Constraints: same-wave tasks remain dependency-free and file-disjoint — now
+  by construction instead of by validation; `parallel` flag formula and
+  `execution.parallelization` semantics unchanged; computed assignment must be
+  deterministic so repeated materialization of the same tasks.md is stable.
+
+### Patterns
+- Existing conventions to reuse:
+  - Conflict semantics: `targetFilesConflict` + `normalizeTargetFileForConflict`
+    (wave.go:136-227) are reused verbatim as the bump predicate.
+  - Deterministic ordering: `compareNodesByTaskID` (wave.go:13) already
+    establishes task-ID ordering as the tiebreak convention.
+  - Fail-closed parser: `applyStrictMetadata`'s unknown-key rejection is the
+    established pattern; the `wave` retirement adds a dedicated case with a
+    remediation-bearing message instead of falling back to the generic
+    unknown-key error.
+  - Blocker vocabulary: `plan_dimension_*` reason codes in validation.go; the
+    retirement removes `plan_dimension_execution_missing_wave` rather than
+    repurposing it.
+- Borrowed mechanism (GSD): `gsd-planner.md:937-961` assign_waves — no deps →
+  wave 1, else max(dependency waves)+1; files_modified overlap bumps the later
+  plan; "shared files → same plan" absorption guidance. Borrow the constructive
+  algorithm and the absorption guidance; do NOT borrow GSD's runtime fail-soft
+  degrade (overlap → serialize wave), which cannot occur here because computed
+  waves are conflict-free by construction.
+- Convention deviation: none — computation lands inside the package that
+  already owns grouping and validation.
+
+### Risks
+- High — freshness-hash function change: all three task-plan hash modes embed
+  `"wave": task.WaveIndex` in their entries (parse.go:109-112) before the mode
+  switch. Removing the field changes hash values for every tasks.md, so
+  TasksPlan*Hash values stored in existing wave-plan.yaml / evidence freshness
+  inputs mismatch recomputation under the new binary even when tasks.md is
+  unchanged. Exposure: active in-flight bundles only; recovery is the existing
+  public staleness flow (re-materialization on S1→S2, `slipway repair`, or
+  `pivot --rescope` for mid-S2 plans). Archived bundles are not re-parsed
+  (cmd/health.go archived scan reads lifecycle events, not tasks.md).
+- Medium — legacy `wave:` lines in active bundles (including this change's own
+  tasks.md) fail parsing at first touch under the new binary. Mitigation: the
+  dedicated retirement error names the remediation (delete the `wave:` lines;
+  declare real `depends_on`); this change re-walks its own bundle as the
+  dogfood proof (#114 mid-flight re-walk precedent).
+- Medium — wider waves change execution texture: computed plans can produce
+  waves wider than authors used to declare; the existing plan-audit >5-task
+  soft warning (unchanged policy) remains the pressure valve.
+- Low — determinism/termination of the bump loop: processing in
+  task-ID-ordered topological order with monotone forward bumps terminates
+  (wave index strictly increases per bump, bounded by task count) and is
+  deterministic; property-style unit tests cover it.
+- Guardrail domains: none (no auth/credentials/financial/schema/irreversible
+  surface).
+- Reversibility: pure code+surface change, no persisted-data migration; a
+  revert restores the declared-wave contract; wave-plan.yaml re-materializes
+  from tasks.md on the next S1→S2 pass either way.
+- Compile-safety note: wider waves increase concurrent executor counts, but
+  the dispatch-side shared-worktree rules (no concurrent repo-wide build/test
+  inside executors; post-wave integration gate) already own that risk and are
+  out of scope here.
+
+### Test Strategy
+- Existing coverage: `internal/engine/wave/parse_test.go` (declared-wave
+  assertions, e.g. parse_test.go:264), `wave_test.go` static-conflict and
+  declared-ordering tests, `cmd/next_wave_plan_test.go` preview tests,
+  `internal/engine/progression` validation tests for
+  `plan_dimension_execution_missing_wave`, toolgen/template contract tests
+  (`internal/tmpl/thin_host_content_test.go`, `internal/toolgen/toolgen_test.go`)
+  pinning surface texts.
+- Infrastructure needs: none new — table-driven unit tests in the wave package
+  suffice; one CLI-level materialization test exercises the acceptance scenario
+  end to end.
+- Verification approach per acceptance criterion:
+  - 3 independent file-disjoint tasks + 1 task depending on all three, no wave
+    declarations → assert wave-plan.yaml = wave 1 ×3 `parallel: true` +
+    wave 2 ×1 `parallel: false` (unit + CLI-level).
+  - Pure `depends_on` chain → N single-task sequential waves.
+  - Target overlap (exact, parent/child, case-only, glob) between otherwise
+    independent tasks → deterministic bump of the task-ID-later task; repeated
+    runs produce identical plans.
+  - Dependency cycle → hard error through the existing wave-plan
+    parse_error/blocker path.
+  - `wave:` line present → parse fails with the retirement error and
+    remediation text (no silent ignore).
+  - Rewritten surfaces: instructions/plan-audit no longer require wave and
+    carry honest-deps / precise-targets / absorption guidance; template and
+    toolgen contract tests updated and green.
+  - Repository health: gofmt clean, `go build ./...`, `go vet ./...`,
+    `go test ./...` green in this worktree.
+
+### Options
+- Option A — compute at the parse boundary (ParseTaskPlan assigns waves):
+  single computation site, but the format layer absorbs scheduling semantics,
+  cycle detection becomes a "parse error" (semantic confusion), and all nine
+  parse call sites pay graph-computation cost they do not need.
+- Option B — compute inside PlanWaves (parse stays format-only): parser drops
+  the `wave` key and gains the dedicated retirement error; `PlanWaves(nodes)`
+  assigns waves in task-ID-ordered topological order
+  (`wave = max(dependency waves)+1`, then bump while conflicting with an
+  already-assigned same-wave task, reusing `targetFilesConflict`); cycle
+  detection stays where dependency validation already lives; preview,
+  materialization, and every consumer stay consistent through the one
+  authority. Smallest clean diff: parse.go + wave.go + one validation blocker.
+- Option C — compute only at materialization (S1→S2): leaves PlanWaves as a
+  validator, so the pre-S2 preview either duplicates the algorithm or shows no
+  waves; two-implementation drift risk for no benefit.
+- Selected: **Option B** (user-confirmed at research stage). Rationale:
+  PlanWaves already owns grouping and validation; computing there keeps one
+  authority for preview and materialization, reuses the existing conflict and
+  ordering conventions, and minimizes the diff.
+
+## Unknowns
+- Resolved: How does the parser ingest `wave:` today? → Dedicated whitelisted
+  key parsed to `WaveIndex` (parse.go:145-154, 274-279); unknown keys already
+  fail closed, so retirement = remove the key + add a dedicated retirement
+  error case in `applyStrictMetadata`.
+- Resolved: Which surfaces reference wave authoring? → Engine:
+  parse.go/wave.go/validation.go:96 (blocker). Texts: cmd/instructions.go:87,
+  plan-audit SKILL.md:90 and :133 (+ 8D item 3 wording), docs/workflow.md
+  wording. Tests/fixtures: parse_test.go, wave tests, next_wave_plan_test.go,
+  validation tests, thin_host_content_test.go, toolgen tests/goldens. Other
+  template mentions of "wave" (tdd-governance, wave-orchestration dispatch,
+  spec-compliance) are execution-context phrasing, not authoring contract.
+- Resolved: Deterministic algorithm details and hash interaction? → Task-ID
+  topological order, max(dep)+1, monotone conflict bump; terminates and is
+  deterministic. All three hash modes currently embed the declared wave
+  (parse.go:109-112); the field leaves the hash inputs, which changes hash
+  values — handled as a one-time staleness event through existing public
+  recovery flows.
+- Resolved: In-flight/archived exposure? → Nine active-change parse sites
+  (inventory above) hit the retirement error until legacy `wave:` lines are
+  removed; archived bundles are not re-parsed. This change's own bundle is the
+  migration dogfood.
+- Remaining for plan-audit: exact retirement-error wording and the
+  reason-code/remediation surface for legacy bundles; final wording of the
+  honest-deps / precise-targets / absorption guidance blocks.
+
+## Assumptions
+- The installed CLI (0.21.0 @ 5972943) is behaviorally identical to this
+  worktree's HEAD for lifecycle operations until the change lands; afterwards
+  the worktree-built binary is the lifecycle authority for this bundle's
+  re-walk. Evidence: `git show --stat dc49d59` (CHANGELOG-only delta).
+- No consumer outside the wave package reads the declared per-task wave.
+  Evidence: `rg HasDeclaredWave` → parse.go, parse_test.go, validation.go:96
+  only; `rg WaveIndex` over scopecontract/status/governance/wave_sync/
+  next_wave_plan shows computed-plan reads only.
+- Same-wave safety invariants stay enforceable as internal invariants after
+  computation (conflict-free by construction). Evidence: bump predicate is the
+  same `targetFilesConflict` used by today's validator.
+
+## Canonical References
+- `internal/engine/wave/parse.go:48-50,109-112,145-154,243-245,274-279`
+- `internal/engine/wave/wave.go:13,56-110,112-134,136-227`
+- `internal/engine/progression/validation.go:96-99`
+- `internal/state/wave_execution.go` (`MaterializeWavePlanAt`,
+  `ApplyEffectiveParallel`, `EffectiveForcedParallel`)
+- `cmd/next_wave_plan.go:82,115`
+- `cmd/instructions.go:87`
+- `internal/tmpl/templates/skills/plan-audit/SKILL.md:90,126-134`
+- `docs/workflow.md:7`
+- `~/ghq/github.com/open-gsd/gsd-core/agents/gsd-planner.md:937-961` (borrowed
+  assign_waves mechanism; fail-soft degrade deliberately not borrowed)
+- `artifacts/changes/archived/resolve-github-issue-184-add-gsd-style-automatic-subagent-di/`
+  (single-worktree parallelization decision; 6×1 sequential wave plan as the
+  observed collapse evidence)

--- a/artifacts/changes/archived/wave-plans-almost-always-collapse-into-single-task-sequentia/tasks.md
+++ b/artifacts/changes/archived/wave-plans-almost-always-collapse-into-single-task-sequentia/tasks.md
@@ -1,0 +1,59 @@
+# Tasks
+
+## Task List
+- [x] `t-01` Author failing wave-package tests for computed assignment and the wave-key retirement
+  - depends_on: []
+  - target_files: [internal/engine/wave/wave_test.go, internal/engine/wave/parse_test.go]
+  - task_kind: test
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-005]
+  - acceptance: New tests cover minimal-level assignment (roots wave 1, max(dep)+1, 3-independent-plus-1-dependent shape), deterministic conflict bumping across exact/parent-child/case-only/glob targets with repeat-run stability, cycle and unknown-dependency hard errors, the dedicated `wave:` retirement error message with task ID and remediation, and three-mode hash stability without wave inputs; tests compile and fail RED against the current engine.
+  - evidence: verdict
+- [x] `t-02` Author failing validation tests retiring the declared-wave blocker vocabulary
+  - depends_on: []
+  - target_files: [internal/engine/progression/validation_test.go, internal/model/reason_code_contract_test.go]
+  - task_kind: test
+  - covers: [REQ-004]
+  - acceptance: Tests assert a waveless tasks checklist passes structural validation at plan-audit enforcement with no missing-wave blocker, and the reason-code contract no longer registers plan_dimension_execution_missing_wave (registry and remediation vocabulary); tests fail RED against the current engine.
+  - evidence: verdict
+- [x] `t-03` Author failing CLI-level tests for waveless preview and materialization
+  - depends_on: []
+  - target_files: [cmd/next_wave_plan_test.go]
+  - task_kind: test
+  - covers: [REQ-001, REQ-003]
+  - acceptance: CLI-level tests cover the acceptance scenario (waveless tasks.md with three independent file-disjoint tasks plus one dependent task previews and materializes as wave 1 x3 parallel:true + wave 2 x1) and the retirement error surfacing through the wave-plan parse_error path for a legacy wave: line; tests fail RED against the current engine.
+  - evidence: verdict
+- [x] `t-06` Rewrite the instructions tasks guidance to the computed-wave contract
+  - depends_on: []
+  - target_files: [cmd/instructions.go, cmd/instructions_test.go]
+  - task_kind: code
+  - covers: [REQ-006]
+  - acceptance: instructionsGuidance("tasks") no longer asks for a wave value, states the engine assigns waves from depends_on and target_files, and carries the honest-dependency (scheduling input, not narrative order), precise-target-files (exact files over directories/globs), and same-file-absorption rules; pinned guidance test updated RED then GREEN.
+  - evidence: verdict
+- [x] `t-07` Rewrite plan-audit template, workflow docs, and surface pins to the computed-wave contract
+  - depends_on: []
+  - target_files: [internal/tmpl/templates/skills/plan-audit/SKILL.md, docs/workflow.md, docs/SURFACE-MANIFEST.json, internal/toolgen/toolgen_test.go, internal/tmpl/thin_host_content_test.go]
+  - task_kind: code
+  - covers: [REQ-006, REQ-007]
+  - acceptance: plan-audit skill drops the wave authoring requirement (metadata list and 8D Completeness), reframes Dependency Integrity as necessity judgment (no cycles, no fabricated or narrative-only dependencies), adds the three width-guidance rules; docs/workflow.md describes engine-computed waves; surface manifest and any template-pinning or toolgen contract tests that encode authored waves are regenerated or updated and green for the touched surfaces.
+  - evidence: verdict
+- [x] `t-04` Implement parser retirement and computed wave assignment in the wave package
+  - depends_on: [t-01, t-03]
+  - target_files: [internal/engine/wave/parse.go, internal/engine/wave/wave.go, internal/tmpl/templates/artifacts/tasks.md, internal/engine/artifact/tasks_contract_test.go, internal/engine/scopecontract/evaluate_test.go, internal/engine/status/view_test.go, internal/state/wave_execution_test.go, internal/state/wave_execution_transaction_test.go, internal/state/execution_summary_test.go, internal/state/health_test.go, internal/state/repair_test.go, internal/engine/progression/wave_sync_test.go, internal/engine/progression/evidence_digests_test.go]
+  - task_kind: code
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-005]
+  - acceptance: wave leaves allowedMetadataKeys with a dedicated retirement error case in applyStrictMetadata; PlanWaves assigns waves constructively (task-ID-ordered topological order, max(dep)+1, monotone conflict bump reusing targetFilesConflict) with cycle/unknown-dep hard errors and validateWaveStaticConflicts retained as an internal invariant check; task-plan hash entries drop the wave field in all three modes; legacy wave-declaring fixtures in the engine-layer test files named in target_files (artifact, scopecontract, status, state, wave_sync, evidence_digests) are migrated to the computed-wave contract; t-01 and t-03 tests turn GREEN with no other test regressions in the touched packages.
+  - evidence: verdict
+- [x] `t-05` Retire the declared-wave validation blocker and its vocabulary
+  - depends_on: [t-02]
+  - target_files: [internal/engine/progression/validation.go, internal/model/reason_code.go, internal/model/recovery.go, internal/engine/progression/validation_test.go, internal/engine/progression/advance_transaction_test.go, internal/engine/progression/stale_evidence_recovery_transaction_test.go, internal/engine/progression/readiness_test.go, internal/engine/progression/advance_test.go, internal/engine/progression/scope_contract_gate_test.go, cmd/health_test.go, cmd/review_test.go, cmd/scope_contract_test.go, cmd/cli_e2e_test.go, cmd/governance_gate_consistency_test.go, cmd/validate_artifact_gate_test.go, cmd/progression_next_test.go, cmd/checkpoint_test.go, cmd/common_test.go, cmd/repair_test.go, cmd/lifecycle_commands_test.go, cmd/abort_test.go, cmd/status_view_build_test.go]
+  - task_kind: code
+  - covers: [REQ-004]
+  - acceptance: HasDeclaredWave consumption and the plan_dimension_execution_missing_wave blocker are removed from validation, the reason-code registry, and the remediation vocabulary; legacy wave-declaring fixtures in the progression and cmd test files named in target_files are migrated to the computed-wave contract; t-02 tests turn GREEN with no other test regressions in the touched packages.
+  - evidence: verdict
+- [x] `t-08` Run the integration gate and dogfood the computed-wave acceptance scenario
+  - depends_on: [t-04, t-05, t-06, t-07]
+  - target_files: [artifacts/changes/wave-plans-almost-always-collapse-into-single-task-sequentia/verification/integration-gate-notes.md]
+  - task_kind: verification
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004, REQ-005, REQ-006, REQ-007]
+  - acceptance: gofmt is clean and go build ./..., go vet ./..., go test ./... pass on the merged worktree; a worktree-built binary dogfoods the acceptance scenario (waveless fixture materializes as wave 1 x3 parallel:true + wave 2 x1, legacy wave: line yields the retirement error); regenerated instructions/plan-audit surfaces carry the new contract; findings recorded in the integration-gate notes file.
+  - evidence: verdict

--- a/cmd/abort_test.go
+++ b/cmd/abort_test.go
@@ -217,13 +217,11 @@ func TestAbortTextUsesRunResumeWhenResumableWaveStateExists(t *testing.T) {
 		bundlePath := filepath.Join(root, "artifacts", "changes", slug)
 		require.NoError(t, os.WriteFile(filepath.Join(bundlePath, "tasks.md"), []byte(`
 - [x] `+"`task-01`"+` preserve completed wave
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/run.go"]
   - task_kind: code
 
 - [ ] `+"`task-02`"+` continue incomplete wave
-  - wave: 2
   - depends_on: ["task-01"]
   - target_files: ["cmd/run.go"]
   - task_kind: code

--- a/cmd/checkpoint_test.go
+++ b/cmd/checkpoint_test.go
@@ -179,13 +179,11 @@ func TestCheckpointRejectsTaskOutsideCurrentWave(t *testing.T) {
 		bundlePath := filepath.Join(root, "artifacts", "changes", slug)
 		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`
 - [ ] `+"`task-01`"+` first wave task
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/checkpoint.go"]
   - task_kind: code
 
 - [ ] `+"`task-02`"+` second wave task
-  - wave: 2
   - depends_on: ["task-01"]
   - target_files: ["cmd/checkpoint.go"]
   - task_kind: code
@@ -219,13 +217,11 @@ func TestCheckpointRejectsWhenWaveRunsAreMissing(t *testing.T) {
 		bundlePath := filepath.Join(root, "artifacts", "changes", slug)
 		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`
 - [x] `+"`task-01`"+` completed first wave
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/checkpoint.go"]
   - task_kind: code
 
 - [ ] `+"`task-02`"+` pending second wave
-  - wave: 2
   - depends_on: ["task-01"]
   - target_files: ["cmd/checkpoint.go"]
   - task_kind: code

--- a/cmd/cli_e2e_test.go
+++ b/cmd/cli_e2e_test.go
@@ -201,13 +201,11 @@ func TestCLIEndToEndRunResumeResponseFlow(t *testing.T) {
 		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
 
 - [ ] `+"`task-01`"+` first wave
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/run.go"]
   - task_kind: code
 
 - [ ] `+"`task-02`"+` checkpointed second wave
-  - wave: 2
   - depends_on: ["task-01"]
   - target_files: ["cmd/run.go"]
   - task_kind: code
@@ -251,13 +249,11 @@ func TestCLIEndToEndAbortThenRunResumeFlow(t *testing.T) {
 		bundlePath := filepath.Join(root, "artifacts", "changes", slug)
 		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`
 - [x] `+"`task-01`"+` completed first wave before abort
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/run.go"]
   - task_kind: code
 
 - [ ] `+"`task-02`"+` continue second wave after abort
-  - wave: 2
   - depends_on: ["task-01"]
   - target_files: ["cmd/run.go"]
   - task_kind: code
@@ -338,7 +334,7 @@ func TestCLIEndToEndValidateIncludesRequirementsContract(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "requirements.md"), []byte(reqContent), 0o644))
 
 		// Write a substantive tasks.md so the tasks_contract surfaces as valid.
-		tasksContent := "# Tasks\n\n## Task List\n\n- [ ] `t-01` Implement token-based authentication for protected routes\n  - wave: 1\n  - target_files: [\"cmd/root.go\"]\n  - covers: [REQ-001]\n"
+		tasksContent := "# Tasks\n\n## Task List\n\n- [ ] `t-01` Implement token-based authentication for protected routes\n  - target_files: [\"cmd/root.go\"]\n  - covers: [REQ-001]\n"
 		require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "tasks.md"), []byte(tasksContent), 0o644))
 
 		stdout, stderr, err := runRootCommandIn(root, []string{"validate", "--json", "--change", slug})
@@ -426,7 +422,7 @@ func TestCLIEndToEndSuccessfulReviewPassAtS7(t *testing.T) {
 		require.NoError(t, os.WriteFile(specPath, []byte("## Requirements\n\n### Requirement: ReviewE2E\n\nREQ-001: The system MUST support review from the CLI.\n\n#### Scenario: Review runs from the CLI\nGIVEN a governed change ready for review\nWHEN the reviewer runs the CLI review command\nTHEN the review result is produced.\n"), 0o644))
 
 		// Write tasks.md covering that requirement.
-		require.NoError(t, os.WriteFile(filepath.Join(bundlePath, "tasks.md"), []byte("# Tasks\n\n- [ ] `t-01` implement review e2e\n  - wave: 1\n  - depends_on: []\n  - target_files: [\"cmd/review.go\"]\n  - task_kind: code\n  - covers: [REQ-001]\n"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(bundlePath, "tasks.md"), []byte("# Tasks\n\n- [ ] `t-01` implement review e2e\n  - depends_on: []\n  - target_files: [\"cmd/review.go\"]\n  - task_kind: code\n  - covers: [REQ-001]\n"), 0o644))
 
 		// Write passing evidence pack and execution summary AFTER all artifacts
 		// so that evidence timestamps post-date artifact modifications.

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -397,7 +397,6 @@ func TestProjectFreshnessIgnoresDerivedTaskCheckboxSync(t *testing.T) {
 	require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
 
 - [ ] `+"`task-01`"+` preserve freshness across derived checkbox sync
-  - wave: 1
   - target_files: ["cmd/next.go"]
   - task_kind: code
 `)))
@@ -437,7 +436,6 @@ func TestProjectFreshnessTracksTasksPlanHash(t *testing.T) {
 	require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
 
 - [ ] `+"`task-01`"+` keep evidence fresh
-  - wave: 1
   - target_files: ["cmd/placeholder.go"]
   - task_kind: code
 `)))
@@ -478,7 +476,6 @@ func TestProjectFreshnessTracksTasksPlanHash(t *testing.T) {
 	require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
 
 - [ ] `+"`task-01`"+` changed evidence plan
-  - wave: 1
   - target_files: ["cmd/placeholder.go"]
   - task_kind: code
 `)))

--- a/cmd/governance_gate_consistency_test.go
+++ b/cmd/governance_gate_consistency_test.go
@@ -75,7 +75,6 @@ Low risk.
 	require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` validate gate consistency
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/status_view_build.go"]
   - task_kind: verification

--- a/cmd/health_test.go
+++ b/cmd/health_test.go
@@ -126,7 +126,6 @@ func TestHealthCommandDoctorOutputsPrioritizedRepairActions(t *testing.T) {
 		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` repairable wave artifact
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/repair.go"]
   - task_kind: code
@@ -207,13 +206,11 @@ func TestHealthCommandDoctorDoesNotSuggestResumeBeforeWaveRepair(t *testing.T) {
 		bundlePath := filepath.Join(root, "artifacts", "changes", slug)
 		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`
 - [x] `+"`task-01`"+` completed first wave
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/health.go"]
   - task_kind: code
 
 - [ ] `+"`task-02`"+` pending checkpointed wave
-  - wave: 2
   - depends_on: ["task-01"]
   - target_files: ["cmd/health.go"]
   - task_kind: code
@@ -332,13 +329,11 @@ func TestHealthCommandDoctorExplainsInterruptedExecution(t *testing.T) {
 		bundlePath := filepath.Join(root, "artifacts", "changes", slug)
 		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`
 - [x] `+"`task-01`"+` completed first wave
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/health.go"]
   - task_kind: code
 
 - [ ] `+"`task-02`"+` pending second wave
-  - wave: 2
   - depends_on: ["task-01"]
   - target_files: ["cmd/health.go"]
   - task_kind: code
@@ -388,7 +383,6 @@ func TestHealthCommandDoctorBlocksWavePlanRepairWhenCurrentTasksDrifted(t *testi
 		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` original execution task
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/run.go"]
   - task_kind: code
@@ -401,7 +395,6 @@ func TestHealthCommandDoctorBlocksWavePlanRepairWhenCurrentTasksDrifted(t *testi
 		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
 
 - [ ] `+"`t-02`"+` replacement task after drift
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/repair.go"]
   - task_kind: code
@@ -492,7 +485,6 @@ func TestHealthCommandDoctorUsesPivotForWavePlanDrift(t *testing.T) {
 		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` preserve original task
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/run.go"]
   - task_kind: code
@@ -503,7 +495,6 @@ func TestHealthCommandDoctorUsesPivotForWavePlanDrift(t *testing.T) {
 		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
 
 - [ ] `+"`t-02`"+` replace task after drift
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/repair.go"]
   - task_kind: code

--- a/cmd/instructions.go
+++ b/cmd/instructions.go
@@ -84,10 +84,17 @@ func instructionsGuidance(name string) string {
 			"until you author it; an empty or structure-only requirements file is rejected by " +
 			"the substance gate and cannot reach done."
 	case "tasks":
-		return "Author each task as a checklist line (- [ ] t-NN <objective>) with wave, " +
-			"depends_on, target_files, task_kind, and covers metadata. Every task names concrete target_files " +
-			"that bound the files or evidence targets it changes or verifies. The engine does not seed a body; an " +
-			"empty or placeholder tasks list is rejected by the substance gate."
+		return "Author each task as a checklist line (- [ ] t-NN <objective>) with depends_on, " +
+			"target_files, task_kind, and covers metadata. Every task names concrete target_files " +
+			"that bound the files or evidence targets it changes or verifies. Do not author a `wave:` " +
+			"line — the engine rejects it and assigns waves from depends_on and target_files, " +
+			"dispatching multi-task waves in parallel. Declare only real execution-order dependencies " +
+			"in depends_on (a scheduling input, not narrative order — fabricated dependencies " +
+			"serialize execution), name precise target_files (exact files over directories or globs — " +
+			"broad scopes are bumped apart on conflict and flatten parallelism), and absorb small " +
+			"steps that must touch the same file into one task instead of splitting them into " +
+			"serialized tasks. The engine does not seed a body; an empty or placeholder tasks list is " +
+			"rejected by the substance gate."
 	case "decision":
 		return "Author a concrete decision with alternatives, selected approach, interfaces and data flow, " +
 			"rollout/rollback, and risk. The engine does not seed this body; a missing or template-only decision " +

--- a/cmd/instructions_test.go
+++ b/cmd/instructions_test.go
@@ -109,6 +109,36 @@ func TestInstructionsTasksGuidanceMatchesTargetFilesGate(t *testing.T) {
 	assert.NotContains(t, view.Guidance, "A `task_kind: code` task")
 }
 
+// TestInstructionsTasksGuidanceTeachesComputedWaves pins the computed-wave
+// contract: wave is no longer authored metadata — the engine assigns waves from
+// depends_on and target_files and rejects a hand-declared `wave:` line — and the
+// guidance teaches the three width rules (real execution-order dependencies
+// only, precise target_files, absorb same-file steps into one task).
+func TestInstructionsTasksGuidanceTeachesComputedWaves(t *testing.T) {
+	t.Parallel()
+	out, err := runInstructions(t, "tasks", "--json")
+	require.NoError(t, err)
+
+	var view instructionsView
+	require.NoError(t, json.Unmarshal([]byte(out), &view))
+
+	// Authored metadata no longer includes wave.
+	assert.Contains(t, view.Guidance, "with depends_on, target_files, task_kind, and covers metadata")
+	assert.NotContains(t, view.Guidance, "with wave",
+		"wave must not be taught as authored task metadata")
+
+	// The engine owns wave assignment and rejects a hand-declared wave line.
+	assert.Contains(t, view.Guidance, "Do not author a `wave:` line")
+	assert.Contains(t, view.Guidance, "engine rejects it and assigns waves from depends_on and target_files")
+	assert.Contains(t, view.Guidance, "parallel")
+
+	// Width rules: real dependencies only, precise target_files, absorb
+	// same-file steps into one task.
+	assert.Contains(t, view.Guidance, "fabricated dependencies serialize execution")
+	assert.Contains(t, view.Guidance, "exact files over directories or globs")
+	assert.Contains(t, view.Guidance, "same file into one task")
+}
+
 func TestInstructionsUnknownArtifactErrors(t *testing.T) {
 	t.Parallel()
 	_, err := runInstructions(t, "not-an-artifact")

--- a/cmd/lifecycle_commands_test.go
+++ b/cmd/lifecycle_commands_test.go
@@ -1984,7 +1984,6 @@ Low risk; failures should surface as explicit readiness blockers.
 	require.NoError(t, writeBundleArtifactFile(bundlePath, change.Slug, "tasks.md", []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` verify ship readiness parity
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/done.go"]
   - task_kind: verification
@@ -2074,7 +2073,6 @@ Low risk fixture.
 	require.NoError(t, writeBundleArtifactFile(bundlePath, change.Slug, "tasks.md", []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` exercise command fixture
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/lifecycle_commands_test.go"]
   - task_kind: verification

--- a/cmd/next_wave_plan_test.go
+++ b/cmd/next_wave_plan_test.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -94,5 +96,171 @@ func TestAuthoritativeWavePlanViewReDerivesParallelFromCurrentConfig(t *testing.
 		require.Empty(t, view.ParseError)
 		require.Len(t, view.Waves, 1)
 		assert.False(t, view.Waves[0].Parallel)
+	})
+}
+
+// wavelessDependencyTasksFixture is the retired-`wave:` contract: no task
+// declares a wave line; three dependency-free tasks with pairwise-disjoint
+// target_files plus one task depending on all three. The engine must compute
+// wave 1 = {t-01, t-02, t-03} (parallel) and wave 2 = {t-04} (not parallel).
+const wavelessDependencyTasksFixture = `# Tasks
+
+- [ ] ` + "`t-01`" + ` cover parser retirement of declared waves
+  - target_files: ["internal/engine/wave/parse.go"]
+  - task_kind: test
+- [ ] ` + "`t-02`" + ` cover dependency-derived wave computation
+  - target_files: ["internal/engine/wave/wave.go"]
+  - task_kind: test
+- [ ] ` + "`t-03`" + ` align the wave-plan view with computed waves
+  - target_files: ["cmd/next_wave_plan.go"]
+  - task_kind: code
+- [ ] ` + "`t-04`" + ` integrate computed wave assignment end to end
+  - depends_on: ["t-01", "t-02", "t-03"]
+  - target_files: ["docs/wave-plan.md"]
+  - task_kind: doc
+`
+
+// declaredWaveTasksFixture carries the retired `wave:` metadata on exactly one
+// task (t-02) so the retirement error must name that task unambiguously.
+const declaredWaveTasksFixture = `# Tasks
+
+- [ ] ` + "`t-01`" + ` waveless task without declared metadata
+  - target_files: ["cmd/next.go"]
+  - task_kind: code
+- [ ] ` + "`t-02`" + ` task still carrying retired declared-wave metadata
+  - wave: 2
+  - depends_on: ["t-01"]
+  - target_files: ["cmd/next_handoff.go"]
+  - task_kind: code
+`
+
+// writeWavePlanTasksFixture writes tasks.md into the governed bundle location
+// for slug and returns the project-relative artifact bundle path used by the
+// derived wave-plan preview.
+func writeWavePlanTasksFixture(t *testing.T, root, slug, content string) string {
+	t.Helper()
+	bundleDir := filepath.Join(root, "artifacts", "changes", slug)
+	require.NoError(t, os.MkdirAll(bundleDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "tasks.md"), []byte(content), 0o644))
+	return filepath.Join("artifacts", "changes", slug)
+}
+
+func waveViewTaskIDs(w waveView) []string {
+	ids := make([]string, 0, len(w.Tasks))
+	for _, task := range w.Tasks {
+		ids = append(ids, task.TaskID)
+	}
+	return ids
+}
+
+func wavePlanModelTaskIDs(w model.WavePlanWave) []string {
+	ids := make([]string, 0, len(w.Tasks))
+	for _, task := range w.Tasks {
+		ids = append(ids, task.TaskID)
+	}
+	return ids
+}
+
+// assertWaveRetirementError pins the retirement contract with resilient
+// substring checks: the error must name the offending task, the retired wave
+// metadata, and the delete-the-line remediation (waves derive from depends_on).
+func assertWaveRetirementError(t *testing.T, message string) {
+	t.Helper()
+	lower := strings.ToLower(message)
+	assert.Contains(t, lower, "t-02", "retirement error must name the task carrying the wave: line")
+	assert.Contains(t, lower, "wave", "retirement error must name the retired wave metadata")
+	assert.Truef(t,
+		strings.Contains(lower, "delete") || strings.Contains(lower, "remove") || strings.Contains(lower, "depends_on"),
+		"retirement error %q must carry the delete-the-line remediation (delete/remove the wave: line; waves derive from depends_on)",
+		message,
+	)
+}
+
+func TestDerivedWavePlanPreviewComputesWavesFromDependencies(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	bundle := writeWavePlanTasksFixture(t, root, "waveless-preview", wavelessDependencyTasksFixture)
+
+	view := derivedWavePlanView(root, bundle)
+	require.NotNil(t, view)
+	require.Emptyf(t, view.ParseError,
+		"waveless tasks.md (no wave: lines) must yield a computed wave plan, got parse error: %s", view.ParseError)
+
+	assert.Equal(t, 4, view.TotalTasks)
+	assert.Equal(t, 2, view.WaveCount)
+	require.Len(t, view.Waves, 2)
+
+	assert.Equal(t, 1, view.Waves[0].WaveIndex)
+	assert.ElementsMatch(t, []string{"t-01", "t-02", "t-03"}, waveViewTaskIDs(view.Waves[0]),
+		"dependency-free tasks all land in computed wave 1")
+	assert.True(t, view.Waves[0].Parallel, "multi-task computed wave is parallel by default")
+
+	assert.Equal(t, 2, view.Waves[1].WaveIndex)
+	assert.Equal(t, []string{"t-04"}, waveViewTaskIDs(view.Waves[1]),
+		"task depending on all wave-1 tasks lands in computed wave 2")
+	assert.False(t, view.Waves[1].Parallel, "single-task wave is not parallel")
+}
+
+func TestMaterializeWavePlanComputesWavesFromDependencies(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	change := model.NewChange("waveless-materialization")
+	change.CurrentState = model.StateS2Execute
+	require.NoError(t, state.SaveChange(root, change))
+	writeWavePlanTasksFixture(t, root, change.Slug, wavelessDependencyTasksFixture)
+
+	plan, err := state.MaterializeWavePlan(root, change)
+	require.NoError(t, err,
+		"materialization must compute waves from depends_on; declared wave: lines are retired")
+
+	assert.Equal(t, 4, plan.TotalTasks)
+	require.Len(t, plan.Waves, 2)
+	assert.Equal(t, 1, plan.Waves[0].WaveIndex)
+	assert.ElementsMatch(t, []string{"t-01", "t-02", "t-03"}, wavePlanModelTaskIDs(plan.Waves[0]))
+	assert.True(t, plan.Waves[0].Parallel, "multi-task computed wave is materialized parallel by default")
+	assert.Equal(t, 2, plan.Waves[1].WaveIndex)
+	assert.Equal(t, []string{"t-04"}, wavePlanModelTaskIDs(plan.Waves[1]))
+	assert.False(t, plan.Waves[1].Parallel, "single-task wave is not parallel")
+
+	view := authoritativeWavePlanView(root, change)
+	require.NotNil(t, view)
+	require.Empty(t, view.ParseError)
+	assert.Equal(t, 2, view.WaveCount)
+	require.Len(t, view.Waves, 2)
+	assert.ElementsMatch(t, []string{"t-01", "t-02", "t-03"}, waveViewTaskIDs(view.Waves[0]))
+	assert.True(t, view.Waves[0].Parallel)
+	assert.Equal(t, []string{"t-04"}, waveViewTaskIDs(view.Waves[1]))
+	assert.False(t, view.Waves[1].Parallel)
+}
+
+func TestWavePlanRejectsDeclaredWaveMetadata(t *testing.T) {
+	t.Parallel()
+
+	t.Run("derived preview surfaces retirement parse error", func(t *testing.T) {
+		t.Parallel()
+
+		root := t.TempDir()
+		bundle := writeWavePlanTasksFixture(t, root, "declared-wave-preview", declaredWaveTasksFixture)
+
+		view := derivedWavePlanView(root, bundle)
+		require.NotNil(t, view)
+		require.NotEmpty(t, view.ParseError, "a tasks.md carrying a wave: line must be rejected")
+		assertWaveRetirementError(t, view.ParseError)
+	})
+
+	t.Run("materialization fails with retirement error", func(t *testing.T) {
+		t.Parallel()
+
+		root := t.TempDir()
+		change := model.NewChange("declared-wave-materialization")
+		change.CurrentState = model.StateS2Execute
+		require.NoError(t, state.SaveChange(root, change))
+		writeWavePlanTasksFixture(t, root, change.Slug, declaredWaveTasksFixture)
+
+		_, err := state.MaterializeWavePlan(root, change)
+		require.Error(t, err, "a tasks.md carrying a wave: line must fail materialization")
+		assertWaveRetirementError(t, err.Error())
 	})
 }

--- a/cmd/progression_next_test.go
+++ b/cmd/progression_next_test.go
@@ -518,7 +518,7 @@ func TestNextDoesNotReturnDoneReadyWithoutGoalVerification(t *testing.T) {
 		require.NoError(t, writeBundleArtifactFile(bundlePath, change.Slug, "intent.md", []byte("# Proposal")))
 		require.NoError(t, writeBundleArtifactFile(bundlePath, change.Slug, "requirements.md", []byte("# Spec")))
 		require.NoError(t, writeBundleArtifactFile(bundlePath, change.Slug, "decision.md", []byte("# Design")))
-		require.NoError(t, writeBundleArtifactFile(bundlePath, change.Slug, "tasks.md", []byte("- [ ] `t-01` verify\n  - wave: 1\n  - target_files: [\"cmd/done.go\"]\n  - task_kind: verification\n")))
+		require.NoError(t, writeBundleArtifactFile(bundlePath, change.Slug, "tasks.md", []byte("- [ ] `t-01` verify\n  - target_files: [\"cmd/done.go\"]\n  - task_kind: verification\n")))
 		writeAssuranceMD(t, root, change.Slug, validAssuranceContent())
 		writePassingExecutionSummary(t, root, slug, 1, "t-01")
 
@@ -592,7 +592,7 @@ func TestNextJSONGoalVerificationHintsDropRetiredFreshEvidence(t *testing.T) {
 		require.NoError(t, writeBundleArtifactFile(bundlePath, change.Slug, "intent.md", []byte("# Intent")))
 		require.NoError(t, writeBundleArtifactFile(bundlePath, change.Slug, "requirements.md", []byte("# Requirements")))
 		require.NoError(t, writeBundleArtifactFile(bundlePath, change.Slug, "decision.md", []byte("# Decision")))
-		require.NoError(t, writeBundleArtifactFile(bundlePath, change.Slug, "tasks.md", []byte("- [ ] `t-01` verify\n  - wave: 1\n  - target_files: [\"cmd/next.go\"]\n  - task_kind: verification\n")))
+		require.NoError(t, writeBundleArtifactFile(bundlePath, change.Slug, "tasks.md", []byte("- [ ] `t-01` verify\n  - target_files: [\"cmd/next.go\"]\n  - task_kind: verification\n")))
 		writeAssuranceMD(t, root, change.Slug, validAssuranceContent())
 		writePassingExecutionSummary(t, root, slug, 1, "t-01")
 		writePassingWaveEvidence(t, root, slug, 1)
@@ -1395,7 +1395,6 @@ THEN the change advances to S2_EXECUTE.
 `)))
 	require.NoError(t, os.WriteFile(filepath.Join(bundlePath, "tasks.md"), []byte(`
 - [ ] `+"`t-01`"+` implement plan audit checks
-  - wave: 1
   - target_files: ["internal/engine/example.go"]
   - task_kind: code
   - covers: [REQ-001]
@@ -1955,7 +1954,6 @@ func TestNextJSONDefaultOmitsFreshnessDiagnosticsWhenDiagnosticsViewHasThem(t *t
 		require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "tasks.md"), []byte(`# Tasks
 
 - [x] `+"`t-01`"+` handoff suppresses freshness diagnostics
-  - wave: 1
   - target_files: ["cmd/next.go"]
   - task_kind: code
 `), 0o644))
@@ -2372,13 +2370,11 @@ func TestRunRequiresExplicitResumeAfterAbortWithWaveBackedState(t *testing.T) {
 		bundlePath := filepath.Join(root, "artifacts", "changes", slug)
 		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`
 - [x] `+"`task-01`"+` preserve completed first wave
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/run.go"]
   - task_kind: code
 
 - [ ] `+"`task-02`"+` continue next wave after abort
-  - wave: 2
   - depends_on: ["task-01"]
   - target_files: ["cmd/run.go"]
   - task_kind: code
@@ -2439,13 +2435,11 @@ func TestRunResumesCheckpointWithValidResponse(t *testing.T) {
 		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
 
 - [ ] `+"`task-01`"+` first wave
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/run.go"]
   - task_kind: code
 
 - [ ] `+"`task-02`"+` checkpointed second wave
-  - wave: 2
   - depends_on: ["task-01"]
   - target_files: ["cmd/run.go"]
   - task_kind: code
@@ -2499,13 +2493,11 @@ func TestRunRejectsResumeResponseWhenWaveArtifactsAreMissing(t *testing.T) {
 		bundlePath := filepath.Join(root, "artifacts", "changes", slug)
 		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`
 - [x] `+"`task-01`"+` completed first wave
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/run.go"]
   - task_kind: code
 
 - [ ] `+"`task-02`"+` pending checkpointed wave
-  - wave: 2
   - depends_on: ["task-01"]
   - target_files: ["cmd/run.go"]
   - task_kind: code
@@ -2592,13 +2584,11 @@ func TestNextRejectsCheckpointContextWhenWaveArtifactsAreMissing(t *testing.T) {
 		bundlePath := filepath.Join(root, "artifacts", "changes", slug)
 		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`
 - [x] `+"`task-01`"+` completed first wave
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/next.go"]
   - task_kind: code
 
 - [ ] `+"`task-02`"+` pending checkpointed wave
-  - wave: 2
   - depends_on: ["task-01"]
   - target_files: ["cmd/next.go"]
   - task_kind: code
@@ -2680,13 +2670,11 @@ func TestRunRejectsResumeWhenWaveRunsAreIncomplete(t *testing.T) {
 		bundlePath := filepath.Join(root, "artifacts", "changes", slug)
 		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`
 - [x] `+"`task-01`"+` completed first wave
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/run.go"]
   - task_kind: code
 
 - [ ] `+"`task-02`"+` pending second wave
-  - wave: 2
   - depends_on: ["task-01"]
   - target_files: ["cmd/run.go"]
   - task_kind: code
@@ -2769,13 +2757,11 @@ func TestRunRejectsInvalidAllowedResponse(t *testing.T) {
 		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
 
 - [ ] `+"`task-01`"+` first wave
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/run.go"]
   - task_kind: code
 
 - [ ] `+"`task-02`"+` decision checkpoint
-  - wave: 2
   - depends_on: ["task-01"]
   - target_files: ["cmd/run.go"]
   - task_kind: code
@@ -2934,7 +2920,6 @@ func TestNextIncludesFreshnessInResumeCheckpoint(t *testing.T) {
 		bundlePath := filepath.Join(root, "artifacts", "changes", change.Slug)
 		require.NoError(t, writeBundleArtifactFile(bundlePath, change.Slug, "tasks.md", []byte(`
 - [x] `+"`task-01`"+` refresh checkpoint freshness
-  - wave: 1
   - target_files: ["cmd/next_context_build.go"]
   - task_kind: code
 `)))
@@ -2982,12 +2967,10 @@ func TestNextDoesNotBuildResumeCheckpointFromChecklistWithoutReadyExecutionSumma
 		bundlePath := filepath.Join(root, "artifacts", "changes", change.Slug)
 		require.NoError(t, writeBundleArtifactFile(bundlePath, change.Slug, "tasks.md", []byte(`
 - [x] `+"`t-01`"+` implement bundle-first resume
-  - wave: 1
   - target_files: ["cmd/next_context_build.go"]
   - task_kind: code
 
 - [ ] `+"`t-02`"+` rerun verification
-  - wave: 2
   - target_files: ["cmd/next_context_build.go"]
   - task_kind: verification
 `)))
@@ -3031,12 +3014,10 @@ func TestNextDoesNotRetainResumeCheckpointWhenOnlyChecklistMarksTasksComplete(t 
 		bundlePath := filepath.Join(root, "artifacts", "changes", change.Slug)
 		require.NoError(t, writeBundleArtifactFile(bundlePath, change.Slug, "tasks.md", []byte(`
 - [x] `+"`t-verify`"+` rerun verification
-  - wave: 1
   - target_files: ["cmd/next_context_build.go"]
   - task_kind: verification
 
 - [ ] `+"`t-next`"+` continue execution
-  - wave: 2
   - target_files: ["cmd/next_context_build.go"]
   - task_kind: code
 `)))
@@ -3072,7 +3053,6 @@ func TestNextPreviewIncludesWavePlanTaskShape(t *testing.T) {
 		bundlePath := filepath.Join(root, "artifacts", "changes", change.Slug)
 		require.NoError(t, writeBundleArtifactFile(bundlePath, change.Slug, "tasks.md", []byte(`
 - [ ] `+"`t-01`"+` execute schema-tightened wave task
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/next.go"]
   - task_kind: code
@@ -3156,12 +3136,10 @@ func TestNextHandoffJSONIncludesWavePlanParallelSignal(t *testing.T) {
 				bundlePath := filepath.Join(root, "artifacts", "changes", change.Slug)
 				require.NoError(t, writeBundleArtifactFile(bundlePath, change.Slug, "tasks.md", []byte(`
 - [ ] `+"`t-01`"+` first handoff wave task
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/next.go"]
   - task_kind: code
 - [ ] `+"`t-02`"+` second handoff wave task
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/run.go"]
   - task_kind: code
@@ -3214,7 +3192,6 @@ func TestNextPreviewUsesAuthoritativeWavePlanDuringExecution(t *testing.T) {
 		bundlePath := filepath.Join(root, "artifacts", "changes", change.Slug)
 		require.NoError(t, writeBundleArtifactFile(bundlePath, change.Slug, "tasks.md", []byte(`
 - [ ] `+"`t-01`"+` authoritative wave task
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/next.go"]
   - task_kind: code
@@ -3224,7 +3201,6 @@ func TestNextPreviewUsesAuthoritativeWavePlanDuringExecution(t *testing.T) {
 
 		require.NoError(t, writeBundleArtifactFile(bundlePath, change.Slug, "tasks.md", []byte(`
 - [ ] `+"`t-01`"+` mutated tasks.md should not replace authoritative wave plan
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/run.go"]
   - task_kind: code
@@ -3300,12 +3276,10 @@ func TestNextPreviewIncludesActiveCheckpointBundle(t *testing.T) {
 		require.NoError(t, writeBundleArtifactFile(bundlePath, change.Slug, "tasks.md", []byte(`# Tasks
 
 - [x] `+"`task-01`"+` preserve preview checkpoint context
-  - wave: 1
   - target_files: ["cmd/next_context_build.go"]
   - task_kind: code
 
 - [ ] `+"`task-09`"+` pending checkpoint task
-  - wave: 2
   - depends_on: ["task-01"]
   - target_files: ["cmd/next_context_build.go"]
   - task_kind: code
@@ -3358,13 +3332,11 @@ func TestNextIncludesActiveCheckpointWithoutRequiringResumeResponse(t *testing.T
 		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
 
 - [ ] `+"`task-01`"+` first wave
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/next_context_build.go"]
   - task_kind: code
 
 - [ ] `+"`task-02`"+` active checkpoint task
-  - wave: 2
   - depends_on: ["task-01"]
   - target_files: ["cmd/next_context_build.go"]
   - task_kind: code
@@ -3448,7 +3420,6 @@ func TestNextResumeCheckpointFreshnessTurnsStaleAfterInputUpdate(t *testing.T) {
 		bundlePath := filepath.Join(root, "artifacts", "changes", change.Slug)
 		require.NoError(t, writeBundleArtifactFile(bundlePath, change.Slug, "tasks.md", []byte(`
 - [x] `+"`task-01`"+` preserve stale freshness on resume
-  - wave: 1
   - target_files: ["cmd/next_context_build.go"]
   - task_kind: code
 `)))
@@ -3870,7 +3841,6 @@ func TestNextS6GovernedMaterializesExecutionSummaryAndRuntimeSummary(t *testing.
 	require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
 
 - [ ] `+"`task-a`"+` materialize run summary
-  - wave: 1
   - target_files: ["cmd/next.go"]
   - task_kind: code
 `)))
@@ -3957,7 +3927,6 @@ func TestReadOnlyS2DiagnosticsUseTaskEvidenceDriftInsteadOfRunSummaryMissing(t *
 	require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
 
 - [ ] `+"`task-a`"+` Initial objective
-  - wave: 1
   - target_files: ["cmd/next.go"]
   - task_kind: code
 `)))
@@ -3978,7 +3947,6 @@ func TestReadOnlyS2DiagnosticsUseTaskEvidenceDriftInsteadOfRunSummaryMissing(t *
 	require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
 
 - [ ] `+"`task-a`"+` Updated objective
-  - wave: 1
   - target_files: ["cmd/status.go"]
   - task_kind: code
 `)))
@@ -4071,7 +4039,6 @@ func prepareStalePlanningRecoveryFixture(t *testing.T, root string, currentState
 	require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` verify recovered planning chain
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/next.go", "cmd/run.go"]
   - task_kind: verification

--- a/cmd/repair_test.go
+++ b/cmd/repair_test.go
@@ -442,7 +442,6 @@ func TestRepairRebuildsUnreadableExecutionSummaryWithoutResidualDrift(t *testing
 		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` rebuild unreadable execution summary
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/repair.go"]
   - task_kind: code
@@ -550,7 +549,6 @@ func TestRepairMaterializesWavePlanRecoversWaveRunsAndClearsStaleCheckpoint(t *t
 		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` recover wave execution state
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/run.go"]
   - task_kind: code
@@ -606,7 +604,6 @@ func TestRepairClearsStaleCheckpointWhenExecutionSummaryUnreadable(t *testing.T)
 		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` clear stale checkpoint despite unreadable summary
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/run.go"]
   - task_kind: code
@@ -662,7 +659,6 @@ func TestRepairRebuildsUnreadableWavePlanAndWaveRuns(t *testing.T) {
 		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` rebuild unreadable wave artifacts
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/repair.go"]
   - task_kind: code
@@ -713,7 +709,6 @@ func TestRepairReportsMalformedTaskEvidenceWithoutFailing(t *testing.T) {
 		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` report malformed task evidence
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/repair.go"]
   - task_kind: code
@@ -766,7 +761,6 @@ func TestRepairDoesNotRewriteHistoricalExecutionStateWhenTasksDrifted(t *testing
 		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` historical executed task
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/run.go"]
   - task_kind: code
@@ -783,7 +777,6 @@ func TestRepairDoesNotRewriteHistoricalExecutionStateWhenTasksDrifted(t *testing
 		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
 
 - [ ] `+"`t-02`"+` replacement task after drift
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/repair.go"]
   - task_kind: code
@@ -856,12 +849,10 @@ func TestRepairRebuildsReadyButStaleExecutionSummaryDrift(t *testing.T) {
 		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` rebuild first stale task
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/repair.go"]
   - task_kind: code
 - [ ] `+"`t-02`"+` rebuild second stale task
-  - wave: 1
   - depends_on: []
   - target_files: ["docs/commands.md"]
   - task_kind: code
@@ -952,12 +943,10 @@ func TestRepairDoesNotRewriteReadyButStaleExecutionSummaryWhenTaskEvidenceInvali
 		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` keep valid stale task
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/repair.go"]
   - task_kind: code
 - [ ] `+"`t-02`"+` leave invalid task evidence unrepaired
-  - wave: 1
   - depends_on: []
   - target_files: ["docs/commands.md"]
   - task_kind: code
@@ -1083,7 +1072,6 @@ REQ-001: Original requirement.
 		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` preserve planning drift
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/repair.go"]
   - task_kind: code
@@ -1115,7 +1103,6 @@ REQ-001: Original requirement.
 		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` preserve changed planning drift
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/repair.go", "cmd/run.go"]
   - task_kind: code

--- a/cmd/review_test.go
+++ b/cmd/review_test.go
@@ -239,7 +239,6 @@ func TestReviewRequiresExecutionSummaryEvenWhenChecklistIsComplete(t *testing.T)
 		require.NoError(t, os.WriteFile(filepath.Join(bundlePath, "tasks.md"), []byte(`# Tasks
 
 - [x] `+"`t-01`"+` checked checklist must not unlock review
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/review.go"]
   - task_kind: verification
@@ -275,7 +274,6 @@ func TestReviewPassFromS7VerifyPreservesGovernedState(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(bundlePath, "tasks.md"), []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` preserve review contract
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/review.go"]
   - task_kind: verification
@@ -334,7 +332,6 @@ func TestReviewRequiresStoredWaveRunsForExecutionSummary(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(bundlePath, "tasks.md"), []byte(`# Tasks
 
 - [x] `+"`t-01`"+` preserve review contract
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/review.go"]
   - task_kind: verification
@@ -426,7 +423,6 @@ func TestReviewFailsClosedOnWaveRunsMissingEvenWhenReadinessIsAlreadyBlocked(t *
 		require.NoError(t, os.WriteFile(filepath.Join(bundlePath, "tasks.md"), []byte(`# Tasks
 
 - [x] `+"`t-01`"+` preserve review contract
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/review.go"]
   - task_kind: verification
@@ -506,14 +502,12 @@ func TestReviewFailsWhenWaveTaskLinkageIsMismatched(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(bundlePath, "tasks.md"), []byte(`# Tasks
 
 - [x] `+"`t-01`"+` preserve first review wave
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/review.go"]
   - task_kind: verification
   - covers: [REQ-001]
 
 - [x] `+"`t-02`"+` preserve second review wave
-  - wave: 2
   - depends_on: ["t-01"]
   - target_files: ["cmd/review.go"]
   - task_kind: verification
@@ -602,7 +596,6 @@ func TestReviewFailsWhenExecutionEvidenceIsStale(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(bundlePath, "tasks.md"), []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` review should fail on stale evidence
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/review.go"]
   - task_kind: verification
@@ -709,7 +702,6 @@ Auth regressions require guardrail review.
 		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` verify review scope
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/review.go"]
   - task_kind: verification
@@ -807,7 +799,6 @@ Missing optional artifacts can silently weaken guardrail review coverage.
 		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` verify optional review scope
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/review.go"]
   - task_kind: verification
@@ -879,7 +870,6 @@ func TestReviewFailsWhenTasksChecklistCoverageDrifts(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(bundlePath, "tasks.md"), []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` implement auth
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/review.go"]
   - task_kind: code

--- a/cmd/scope_contract_test.go
+++ b/cmd/scope_contract_test.go
@@ -217,7 +217,6 @@ func writeScopeContractDriftFixtureInState(t *testing.T, workflowState model.Wor
 	require.NoError(t, os.WriteFile(filepath.Join(bundlePath, "tasks.md"), []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` implement validation surface
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/validate.go"]
   - task_kind: code

--- a/cmd/status_view_build_test.go
+++ b/cmd/status_view_build_test.go
@@ -615,13 +615,11 @@ func TestBuildGovernedStatusViewUsesResumeResponseForActiveCheckpoint(t *testing
 	require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
 
 - [ ] `+"`task-01`"+` first wave
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/status_view_build.go"]
   - task_kind: code
 
 - [ ] `+"`task-02`"+` pending checkpointed wave
-  - wave: 2
   - depends_on: ["task-01"]
   - target_files: ["cmd/status_view_build.go"]
   - task_kind: code
@@ -696,13 +694,11 @@ func TestBuildGovernedStatusViewSuggestsRepairForActiveCheckpointWhenWaveRunsAre
 	bundlePath := filepath.Join(root, "artifacts", "changes", slug)
 	require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`
 - [x] `+"`task-01`"+` completed first wave
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/status_view_build.go"]
   - task_kind: code
 
 - [ ] `+"`task-02`"+` pending checkpointed wave
-  - wave: 2
   - depends_on: ["task-01"]
   - target_files: ["cmd/status_view_build.go"]
   - task_kind: code
@@ -744,13 +740,11 @@ func TestBuildGovernedStatusViewUsesRunResumeForIncompleteWaveExecution(t *testi
 	bundlePath := filepath.Join(root, "artifacts", "changes", slug)
 	require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`
 - [x] `+"`task-01`"+` completed first wave
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/status_view_build.go"]
   - task_kind: code
 
 - [ ] `+"`task-02`"+` pending second wave
-  - wave: 2
   - depends_on: ["task-01"]
   - target_files: ["cmd/status_view_build.go"]
   - task_kind: code
@@ -783,13 +777,11 @@ func TestBuildGovernedStatusViewSurfacesInterruptedExecutionContext(t *testing.T
 	bundlePath := filepath.Join(root, "artifacts", "changes", slug)
 	require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`
 - [x] `+"`task-01`"+` completed first wave
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/status_view_build.go"]
   - task_kind: code
 
 - [ ] `+"`task-02`"+` pending second wave
-  - wave: 2
   - depends_on: ["task-01"]
   - target_files: ["cmd/status_view_build.go"]
   - task_kind: code
@@ -823,13 +815,11 @@ func TestBuildGovernedStatusViewSuggestsRepairWhenWaveRunsAreIncomplete(t *testi
 	bundlePath := filepath.Join(root, "artifacts", "changes", slug)
 	require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`
 - [x] `+"`task-01`"+` completed first wave
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/status_view_build.go"]
   - task_kind: code
 
 - [ ] `+"`task-02`"+` pending second wave
-  - wave: 2
   - depends_on: ["task-01"]
   - target_files: ["cmd/status_view_build.go"]
   - task_kind: code
@@ -878,7 +868,6 @@ func TestBuildGovernedStatusViewSuggestsRepairWhenWaveRunsAreMissingDuringVerify
 	bundlePath := filepath.Join(root, "artifacts", "changes", slug)
 	require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`
 - [x] `+"`task-01`"+` completed only wave
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/status_view_build.go"]
   - task_kind: verification

--- a/cmd/validate_artifact_gate_test.go
+++ b/cmd/validate_artifact_gate_test.go
@@ -217,7 +217,6 @@ THEN G_plan remains blocked with a decision contract blocker.
 	require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` Enforce decision substance in plan readiness
-  - wave: 1
   - depends_on: []
   - target_files: ["internal/engine/progression/readiness.go"]
   - task_kind: code
@@ -592,7 +591,6 @@ func TestValidateBlocksWhenExecutionEvidenceIsStale(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(bundlePath, "tasks.md"), []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` validate stale planning evidence
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/validate.go"]
   - task_kind: verification

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -4,7 +4,7 @@ Slipway routes work through a governed lifecycle:
 
 1. `S0_INTAKE`: capture intent, scope, open questions, and initial evidence.
 2. `S1_PLAN`: produce research, requirements, decision, task, and plan-audit artifacts.
-3. `S2_EXECUTE`: execute dependency-ordered waves from `tasks.md`. A wave's tasks are dependency-free and file-disjoint, so they are dispatched concurrently by default — `slipway next --json` marks such a wave `parallel: true`. Set `execution.parallelization: off` in `.slipway.yaml` to run waves sequentially instead.
+3. `S2_EXECUTE`: execute computed waves. Slipway computes the wave schedule from each task's declared dependencies and target files in `tasks.md`; authors never declare wave numbers. Dependency-free, file-disjoint tasks share a wave and are dispatched concurrently by default — `slipway next --json` marks such a wave `parallel: true`. Set `execution.parallelization: off` in `.slipway.yaml` to run waves sequentially instead.
 4. Review and closeout stages: verify implementation against artifacts, run quality checks, author the `assurance.md` closeout record, and finalize done-ready work.
 
 The active lifecycle state is stored in `artifacts/changes/<slug>/change.yaml`.

--- a/internal/engine/artifact/tasks_contract_test.go
+++ b/internal/engine/artifact/tasks_contract_test.go
@@ -14,21 +14,21 @@ func TestTaskSubstanceBlockers(t *testing.T) {
 
 	assert.NotEmpty(t, TaskSubstanceBlockers(""), "empty tasks must be rejected")
 
-	mechanical := "# Tasks\n## Task List\n- [ ] `t-01` Pending task objective\n  - wave: 1\n  - covers: [REQ-001]\n"
+	mechanical := "# Tasks\n## Task List\n- [ ] `t-01` Pending task objective\n  - covers: [REQ-001]\n"
 	assert.NotEmpty(t, TaskSubstanceBlockers(mechanical), "placeholder objective must be rejected")
 
-	copiedInstructionObjective := "# Tasks\n## Task List\n- [ ] `t-01` <concrete task objective>\n  - wave: 1\n  - target_files: [\"internal/engine/artifact/tasks_contract.go\"]\n  - covers: [REQ-001]\n"
+	copiedInstructionObjective := "# Tasks\n## Task List\n- [ ] `t-01` <concrete task objective>\n  - target_files: [\"internal/engine/artifact/tasks_contract.go\"]\n  - covers: [REQ-001]\n"
 	assert.NotEmpty(t, TaskSubstanceBlockers(copiedInstructionObjective),
 		"copied instructions objective placeholder must be rejected")
 
-	authored := "# Tasks\n## Task List\n- [ ] `t-01` Implement the substance gate in requirements_contract.go\n  - wave: 1\n  - target_files: [\"internal/engine/artifact/requirements_contract.go\"]\n  - covers: [REQ-001]\n"
+	authored := "# Tasks\n## Task List\n- [ ] `t-01` Implement the substance gate in requirements_contract.go\n  - target_files: [\"internal/engine/artifact/requirements_contract.go\"]\n  - covers: [REQ-001]\n"
 	assert.Empty(t, TaskSubstanceBlockers(authored), "authored tasks must pass")
 
 	// Blocker #1 regression (issue #91): the rendered authoring-guidance comment
 	// may itself mention the placeholder sentinel. Because the gate parses the
 	// checklist instead of scanning the whole file, an authored tasks.md that
 	// keeps the comment must still pass.
-	withComment := "# Tasks\n\n## Task List\n\n<!--\nReplace the seeded placeholder objective below; a placeholder tasks list\n(\"Pending task objective\") is rejected by the tasks substance gate.\n-->\n\n- [ ] `t-01` Implement the parser-based tasks substance gate\n  - wave: 1\n  - target_files: [\"internal/engine/artifact/tasks_contract.go\"]\n  - covers: [REQ-001]\n"
+	withComment := "# Tasks\n\n## Task List\n\n<!--\nReplace the seeded placeholder objective below; a placeholder tasks list\n(\"Pending task objective\") is rejected by the tasks substance gate.\n-->\n\n- [ ] `t-01` Implement the parser-based tasks substance gate\n  - target_files: [\"internal/engine/artifact/tasks_contract.go\"]\n  - covers: [REQ-001]\n"
 	assert.Empty(t, TaskSubstanceBlockers(withComment), "authored tasks retaining the guidance comment must pass")
 
 	// Blocker #2 regression (issue #91): non-empty prose with no checklist task is
@@ -44,26 +44,26 @@ func TestTaskSubstanceBlockers(t *testing.T) {
 	// issue #119: target_files are a kind-agnostic execution/scope boundary.
 	// This code task is just the smallest fixture for the missing-target case.
 	// The objective is concrete, so the target_files blocker is the only one.
-	codeNoTargets := "# Tasks\n## Task List\n- [ ] `t-01` Implement the parser-based code gate in tasks_contract.go\n  - wave: 1\n  - task_kind: code\n  - covers: [REQ-001]\n"
+	codeNoTargets := "# Tasks\n## Task List\n- [ ] `t-01` Implement the parser-based code gate in tasks_contract.go\n  - task_kind: code\n  - covers: [REQ-001]\n"
 	codeNoTargetsBlockers := TaskSubstanceBlockers(codeNoTargets)
 	require.Len(t, codeNoTargetsBlockers, 1, "a code task with no target_files yields exactly the target_files blocker")
 	assert.Contains(t, codeNoTargetsBlockers[0], "target_files",
 		"the blocker must name the missing target_files")
 
 	// The same code task passes once it names the files it will change.
-	codeWithTargets := "# Tasks\n## Task List\n- [ ] `t-01` Implement the parser-based code gate in tasks_contract.go\n  - wave: 1\n  - target_files: [\"internal/engine/artifact/tasks_contract.go\"]\n  - task_kind: code\n  - covers: [REQ-001]\n"
+	codeWithTargets := "# Tasks\n## Task List\n- [ ] `t-01` Implement the parser-based code gate in tasks_contract.go\n  - target_files: [\"internal/engine/artifact/tasks_contract.go\"]\n  - task_kind: code\n  - covers: [REQ-001]\n"
 	assert.Empty(t, TaskSubstanceBlockers(codeWithTargets), "a code task naming target_files must pass")
 
 	// target_files are the execution/scope boundary for every task kind, not
 	// just code tasks. A verification task with no target_files would otherwise
 	// make the contract view say "valid" while plan readiness blocks it.
-	verificationNoTargets := "# Tasks\n## Task List\n- [ ] `t-01` Verify the code gate rejects an empty target_files list\n  - wave: 1\n  - task_kind: verification\n  - covers: [REQ-001]\n"
+	verificationNoTargets := "# Tasks\n## Task List\n- [ ] `t-01` Verify the code gate rejects an empty target_files list\n  - task_kind: verification\n  - covers: [REQ-001]\n"
 	verificationNoTargetsBlockers := TaskSubstanceBlockers(verificationNoTargets)
 	require.Len(t, verificationNoTargetsBlockers, 1, "a non-code task with no target_files yields exactly the target_files blocker")
 	assert.Contains(t, verificationNoTargetsBlockers[0], "target_files",
 		"the blocker must name the missing target_files")
 
-	placeholderTargets := "# Tasks\n## Task List\n- [ ] `t-01` Implement the parser-based code gate in tasks_contract.go\n  - wave: 1\n  - target_files: [<path/to/file.go>]\n  - task_kind: code\n  - covers: [REQ-001]\n"
+	placeholderTargets := "# Tasks\n## Task List\n- [ ] `t-01` Implement the parser-based code gate in tasks_contract.go\n  - target_files: [<path/to/file.go>]\n  - task_kind: code\n  - covers: [REQ-001]\n"
 	placeholderTargetBlockers := TaskSubstanceBlockers(placeholderTargets)
 	require.Len(t, placeholderTargetBlockers, 1, "a placeholder target_files entry yields exactly the target_files blocker")
 	assert.Contains(t, placeholderTargetBlockers[0], "placeholder target_files",
@@ -100,7 +100,7 @@ func TestEvaluateTasksContract(t *testing.T) {
 
 	t.Run("invalid placeholder", func(t *testing.T) {
 		t.Parallel()
-		bundleDir := write(t, "# Tasks\n## Task List\n- [ ] `t-01` Pending task objective\n  - wave: 1\n  - covers: [REQ-001]\n")
+		bundleDir := write(t, "# Tasks\n## Task List\n- [ ] `t-01` Pending task objective\n  - covers: [REQ-001]\n")
 		res, err := EvaluateTasksContract(bundleDir)
 		require.NoError(t, err)
 		assert.Equal(t, TasksContractStatusInvalid, res.Status)
@@ -109,7 +109,7 @@ func TestEvaluateTasksContract(t *testing.T) {
 
 	t.Run("valid authored", func(t *testing.T) {
 		t.Parallel()
-		bundleDir := write(t, "# Tasks\n## Task List\n- [ ] `t-01` Implement the tasks substance validator and wire it into validate\n  - wave: 1\n  - target_files: [\"internal/engine/artifact/tasks_contract.go\"]\n  - covers: [REQ-001]\n")
+		bundleDir := write(t, "# Tasks\n## Task List\n- [ ] `t-01` Implement the tasks substance validator and wire it into validate\n  - target_files: [\"internal/engine/artifact/tasks_contract.go\"]\n  - covers: [REQ-001]\n")
 		res, err := EvaluateTasksContract(bundleDir)
 		require.NoError(t, err)
 		assert.Equal(t, TasksContractStatusValid, res.Status)
@@ -117,7 +117,7 @@ func TestEvaluateTasksContract(t *testing.T) {
 
 	t.Run("valid authored keeping guidance comment", func(t *testing.T) {
 		t.Parallel()
-		bundleDir := write(t, "# Tasks\n\n## Task List\n\n<!--\nReplace the seeded placeholder objective below; a placeholder tasks list\n(\"Pending task objective\") is rejected by the tasks substance gate.\n-->\n\n- [ ] `t-01` Implement the tasks substance validator and wire it into validate\n  - wave: 1\n  - target_files: [\"internal/engine/artifact/tasks_contract.go\"]\n  - covers: [REQ-001]\n")
+		bundleDir := write(t, "# Tasks\n\n## Task List\n\n<!--\nReplace the seeded placeholder objective below; a placeholder tasks list\n(\"Pending task objective\") is rejected by the tasks substance gate.\n-->\n\n- [ ] `t-01` Implement the tasks substance validator and wire it into validate\n  - target_files: [\"internal/engine/artifact/tasks_contract.go\"]\n  - covers: [REQ-001]\n")
 		res, err := EvaluateTasksContract(bundleDir)
 		require.NoError(t, err)
 		assert.Equal(t, TasksContractStatusValid, res.Status)
@@ -145,7 +145,7 @@ func TestEvaluateTasksContract(t *testing.T) {
 
 	t.Run("invalid code task missing target_files", func(t *testing.T) {
 		t.Parallel()
-		bundleDir := write(t, "# Tasks\n## Task List\n- [ ] `t-01` Implement the parser-based code gate in tasks_contract.go\n  - wave: 1\n  - task_kind: code\n  - covers: [REQ-001]\n")
+		bundleDir := write(t, "# Tasks\n## Task List\n- [ ] `t-01` Implement the parser-based code gate in tasks_contract.go\n  - task_kind: code\n  - covers: [REQ-001]\n")
 		res, err := EvaluateTasksContract(bundleDir)
 		require.NoError(t, err)
 		assert.Equal(t, TasksContractStatusInvalid, res.Status)
@@ -154,7 +154,7 @@ func TestEvaluateTasksContract(t *testing.T) {
 
 	t.Run("invalid verification task missing target_files", func(t *testing.T) {
 		t.Parallel()
-		bundleDir := write(t, "# Tasks\n## Task List\n- [ ] `t-01` Verify target_files contract parity\n  - wave: 1\n  - task_kind: verification\n  - covers: [REQ-001]\n")
+		bundleDir := write(t, "# Tasks\n## Task List\n- [ ] `t-01` Verify target_files contract parity\n  - task_kind: verification\n  - covers: [REQ-001]\n")
 		res, err := EvaluateTasksContract(bundleDir)
 		require.NoError(t, err)
 		assert.Equal(t, TasksContractStatusInvalid, res.Status)
@@ -163,7 +163,7 @@ func TestEvaluateTasksContract(t *testing.T) {
 
 	t.Run("invalid placeholder target_files", func(t *testing.T) {
 		t.Parallel()
-		bundleDir := write(t, "# Tasks\n## Task List\n- [ ] `t-01` Implement target_files placeholder rejection\n  - wave: 1\n  - target_files: [<path/to/file.go>]\n  - task_kind: code\n  - covers: [REQ-001]\n")
+		bundleDir := write(t, "# Tasks\n## Task List\n- [ ] `t-01` Implement target_files placeholder rejection\n  - target_files: [<path/to/file.go>]\n  - task_kind: code\n  - covers: [REQ-001]\n")
 		res, err := EvaluateTasksContract(bundleDir)
 		require.NoError(t, err)
 		assert.Equal(t, TasksContractStatusInvalid, res.Status)

--- a/internal/engine/progression/advance_test.go
+++ b/internal/engine/progression/advance_test.go
@@ -958,7 +958,6 @@ Low; an unchanged authority simply skips the persist.
 
 - [ ] `+"`task-a`"+` preserve change authority
   - target_files: ["cmd/next.go"]
-  - wave: 1
   - task_kind: code
 `), 0o644); err != nil {
 		t.Fatalf("write tasks.md: %v", err)
@@ -1087,18 +1086,15 @@ Low; incomplete or stale evidence still blocks the advance.
 	writeTasksAndMaterializeWavePlan(t, root, change, `# Tasks
 
 - [ ] `+"`t-01`"+` add regression test
-  - wave: 1
   - target_files: ["internal/engine/progression/advance_test.go"]
   - task_kind: test
 
 - [ ] `+"`t-02`"+` implement change
-  - wave: 2
   - depends_on: [t-01]
   - target_files: ["internal/engine/progression/advance_governed.go"]
   - task_kind: code
 
 - [ ] `+"`t-03`"+` verify behavior
-  - wave: 3
   - depends_on: [t-02]
   - target_files: ["internal/engine/progression"]
   - task_kind: verification
@@ -1255,7 +1251,6 @@ Low; failed or missing evidence still returns the existing metadata blocker.
 	if err := os.WriteFile(filepath.Join(bundleDir, "tasks.md"), []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` exercise worktree preflight ordering
-  - wave: 1
   - depends_on: []
   - target_files: ["a.go", "b.go", "c.go", "d.go", "e.go", "f.go", "g.go", "h.go", "i.go", "j.go", "k.go"]
   - task_kind: code

--- a/internal/engine/progression/advance_transaction_test.go
+++ b/internal/engine/progression/advance_transaction_test.go
@@ -192,7 +192,6 @@ Rollback failure must be visible.
 ## Task List
 
 - [ ] `+"`t-01`"+` implement transaction
-  - wave: 1
   - target_files: ["internal/fsutil/transaction.go"]
   - task_kind: code
   - covers: [REQ-001]

--- a/internal/engine/progression/evidence_digests_test.go
+++ b/internal/engine/progression/evidence_digests_test.go
@@ -1360,7 +1360,6 @@ REQ-001: S4 ship gate approval reopens stale review digests. Traces to INT-001.
 `), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "tasks.md"), []byte(`# Tasks
 - [x] `+"`t-01`"+` update digest input
-  - wave: 1
   - depends_on: []
   - target_files: ["tracked.go"]
   - task_kind: code
@@ -1497,7 +1496,6 @@ func uncheckedDigestTasks() string {
 	return `# Tasks
 
 - [ ] ` + "`t-01`" + ` prove digest freshness
-  - wave: 1
   - target_files: ["internal/engine/progression/evidence_digests_test.go"]
   - task_kind: test
   - acceptance: digest contract is covered
@@ -1508,7 +1506,6 @@ func checkedDigestTasks() string {
 	return `# Tasks
 
 - [x] ` + "`t-01`" + ` prove digest freshness
-  - wave: 1
   - target_files: ["internal/engine/progression/evidence_digests_test.go"]
   - task_kind: test
   - acceptance: digest contract is covered
@@ -1519,7 +1516,6 @@ func scopeOnlyDigestTasks() string {
 	return `# Tasks
 
 - [ ] ` + "`t-01`" + ` prove digest freshness
-  - wave: 1
   - target_files: ["internal/engine/progression/stale_evidence_recovery.go"]
   - task_kind: test
   - acceptance: digest contract is covered
@@ -1530,7 +1526,6 @@ func realChangedDigestTasks() string {
 	return `# Tasks
 
 - [x] ` + "`t-01`" + ` prove changed digest freshness
-  - wave: 1
   - target_files: ["internal/engine/progression/evidence_digests_test.go"]
   - task_kind: test
   - acceptance: digest contract is covered

--- a/internal/engine/progression/readiness_test.go
+++ b/internal/engine/progression/readiness_test.go
@@ -70,7 +70,6 @@ func evaluateSensitiveMigrationReadiness(t *testing.T, evidenceRef string, migra
 	writeTasksAndMaterializeWavePlan(t, root, change, `# Tasks
 
 - [ ] `+"`t-01`"+` apply schema migration
-  - wave: 1
   - target_files: ["`+migration+`"]
   - task_kind: code
 `)

--- a/internal/engine/progression/scope_contract_gate_test.go
+++ b/internal/engine/progression/scope_contract_gate_test.go
@@ -42,7 +42,6 @@ func seedScopeContractChange(t *testing.T, state2 model.WorkflowState) (string, 
 	writeTasksAndMaterializeWavePlan(t, root, change, "# Tasks\n\n"+
 		"- [x] `task-a` Implement task A\n"+
 		"  - target_files: [\"cmd/next.go\"]\n"+
-		"  - wave: 1\n"+
 		"  - task_kind: code\n")
 	return root, change
 }
@@ -220,7 +219,6 @@ func seedSensitiveEvidenceExecution(
 
 - [x] `+"`t-01`"+` apply schema migration
   - target_files: ["`+migration+`"]
-  - wave: 1
   - task_kind: code
 `)
 

--- a/internal/engine/progression/stale_evidence_recovery_transaction_test.go
+++ b/internal/engine/progression/stale_evidence_recovery_transaction_test.go
@@ -41,7 +41,6 @@ func TestStaleEvidenceRecoveryRestoresEvidenceWhenAuthorityWriteFails(t *testing
 ## Task List
 
 - [ ] `+"`t-01`"+` changed task plan
-  - wave: 1
   - target_files: ["internal/fsutil/transaction.go"]
   - task_kind: code
   - covers: [REQ-001]

--- a/internal/engine/progression/validation.go
+++ b/internal/engine/progression/validation.go
@@ -52,7 +52,7 @@ func ValidateTasksChecklistDetailed(root string, change model.Change) TaskCheckl
 	}
 	plan, err := wave.ParseTaskPlan(string(raw))
 	if err != nil {
-		result.Blockers = []string{"tasks_checklist_invalid_format"}
+		result.Blockers = []string{"tasks_checklist_invalid_format:" + err.Error()}
 		return result
 	}
 	if len(plan.Tasks) == 0 {
@@ -67,8 +67,8 @@ func ValidateTasksChecklistDetailed(root string, change model.Change) TaskCheckl
 	seen := map[string]struct{}{}
 	idSet := map[string]struct{}{}
 	dependencies := map[string][]string{}
+	dependencyGraphValid := true
 	coverageAsWarning := false
-	allTasksDeclareWave := true
 	if presetPolicy, presetErr := governance.ResolvePresetPolicy(root, change); presetErr == nil {
 		coverageAsWarning = presetPolicy.EffectivePreset == model.WorkflowPresetLight
 	}
@@ -92,10 +92,6 @@ func ValidateTasksChecklistDetailed(root string, change model.Change) TaskCheckl
 		// onward, mirroring target_files, so pre-audit drafts stay lenient.
 		if objective == "" || (enforceTargetFiles && artifact.LooksLikeTemplatePlaceholder(objective)) {
 			result.Blockers = append(result.Blockers, fmt.Sprintf("plan_dimension_completeness_missing_objective:%s", id))
-		}
-		if !task.HasDeclaredWave() {
-			result.Blockers = append(result.Blockers, fmt.Sprintf("plan_dimension_execution_missing_wave:%s", id))
-			allTasksDeclareWave = false
 		}
 		if enforceTargetFiles {
 			if len(task.TargetFiles) == 0 {
@@ -141,18 +137,21 @@ func ValidateTasksChecklistDetailed(root string, change model.Change) TaskCheckl
 		for _, dep := range deps {
 			if dep == id {
 				result.Blockers = append(result.Blockers, fmt.Sprintf("plan_dimension_dependency_self_reference:%s", id))
+				dependencyGraphValid = false
 				continue
 			}
 			if _, exists := idSet[dep]; !exists {
 				result.Blockers = append(result.Blockers, fmt.Sprintf("plan_dimension_dependency_unknown:%s->%s", id, dep))
+				dependencyGraphValid = false
 			}
 		}
 	}
 
 	if HasDependencyCycle(dependencies) {
 		result.Blockers = append(result.Blockers, "plan_dimension_dependency_cycle_detected")
+		dependencyGraphValid = false
 	}
-	if allTasksDeclareWave {
+	if dependencyGraphValid {
 		if _, err := wave.PlanWaves(plan.Nodes()); err != nil {
 			result.Blockers = append(result.Blockers, "plan_dimension_execution_invalid_wave_plan:"+err.Error())
 		}

--- a/internal/engine/progression/validation_test.go
+++ b/internal/engine/progression/validation_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -36,7 +37,6 @@ func TestValidateTasksChecklist_Valid(t *testing.T) {
 	content := `# Tasks
 
 - [ ] ` + "`t-01`" + ` do something
-  - wave: 1
   - target_files: [main.go]
   - task_kind: code
 `
@@ -87,7 +87,6 @@ func TestValidateTasksChecklist_RejectsInstructionPlaceholderTargetFilesAtPlanAu
 	content := `# Tasks
 
 - [ ] ` + "`t-01`" + ` implement target placeholder rejection
-  - wave: 1
   - target_files: [<path/to/file.go>]
   - task_kind: code
 `
@@ -120,7 +119,6 @@ func TestValidateTasksChecklist_RejectsPlaceholderObjectiveAtPlanAudit(t *testin
 	content := `# Tasks
 
 - [ ] ` + "`t-01`" + ` Pending task objective
-  - wave: 1
   - target_files: [main.go]
   - task_kind: verification
 `
@@ -153,7 +151,6 @@ func assertChecklistCoverageBlocker(t *testing.T, slug, coverRef, specContent, w
 	content := fmt.Sprintf(`# Tasks
 
 - [ ] %s implement auth flow
-  - wave: 1
   - target_files: [main.go]
   - task_kind: code
   - covers: [%s]
@@ -261,7 +258,6 @@ func TestValidateTasksChecklistDetailed_DowngradesOptionalFieldsAndCoverageToWar
 	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "tasks.md"), []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` implement auth flow
-  - wave: 1
   - depends_on: []
   - target_files: [main.go]
 `), 0o644))
@@ -311,7 +307,6 @@ func writeSubstanceGateBundle(t *testing.T, root, slug, requirements string) {
 	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "tasks.md"), []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` implement auth flow
-  - wave: 1
   - depends_on: []
   - target_files: [main.go]
   - task_kind: code
@@ -395,6 +390,162 @@ REQ-001: The system handles authentication for requests.
 		require.False(t, contains(result.Warnings, "plan_dimension_coverage_requirements_invalid_warning"),
 			"requirements validity must not be downgraded to a warning, got warnings=%v", result.Warnings)
 	})
+}
+
+// The hand-declared `wave:` task metadata is retired: the engine computes
+// execution waves from depends_on + target_files. A checklist whose tasks
+// declare objective, depends_on, target_files, task_kind, and covers — but no
+// `wave:` lines — is therefore structurally complete, and validation must not
+// emit the retired plan_dimension_execution_missing_wave blocker for it, even
+// at plan-audit where enforcement is strictest.
+func TestValidateTasksChecklistDetailed_WavelessChecklistPassesStructuralValidation(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	slug := "waveless-valid"
+	bundleDir := filepath.Join(root, "artifacts", "changes", slug)
+	require.NoError(t, os.MkdirAll(bundleDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "tasks.md"), []byte(`# Tasks
+
+- [ ] `+"`t-01`"+` implement auth flow
+  - depends_on: []
+  - target_files: [main.go]
+  - task_kind: code
+  - covers: [REQ-001]
+
+- [ ] `+"`t-02`"+` test auth flow
+  - depends_on: [t-01]
+  - target_files: [main_test.go]
+  - task_kind: test
+  - covers: [REQ-001]
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "requirements.md"), []byte(`## Requirements
+
+### Requirement: Auth
+REQ-001: The system MUST authenticate requests.
+
+#### Scenario: Rejects anonymous request
+GIVEN a request without credentials
+WHEN it reaches a protected route
+THEN the system returns 401.
+`), 0o644))
+
+	change := model.Change{
+		Slug:           slug,
+		WorkflowPreset: model.WorkflowPresetStandard,
+		CurrentState:   model.StateS1Plan,
+		PlanSubStep:    model.PlanSubStepAudit,
+	}
+
+	result := ValidateTasksChecklistDetailed(root, change)
+	for _, blocker := range result.Blockers {
+		assert.NotContains(t, blocker, "plan_dimension_execution_missing_wave",
+			"the declared-wave blocker vocabulary is retired; waveless tasks must not be blocked for a missing wave")
+	}
+	require.Empty(t, result.Blockers,
+		"a checklist declaring objective, depends_on, target_files, task_kind, and covers but no wave: lines must pass structural validation")
+}
+
+func TestValidateTasksChecklistDetailed_InvalidFormatCarriesParserDetail(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	slug := "legacy-wave-detail"
+	bundleDir := filepath.Join(root, "artifacts", "changes", slug)
+	require.NoError(t, os.MkdirAll(bundleDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "tasks.md"), []byte(`# Tasks
+
+- [ ] `+"`t-01`"+` implement auth flow
+  - depends_on: []
+  - target_files: [main.go]
+  - task_kind: code
+
+- [ ] `+"`t-02`"+` test auth flow
+  - wave: 2
+  - depends_on: [t-01]
+  - target_files: [main_test.go]
+  - task_kind: test
+`), 0o644))
+
+	result := ValidateTasksChecklistDetailed(root, model.Change{Slug: slug})
+	require.Len(t, result.Blockers, 1)
+
+	blocker := result.Blockers[0]
+	assert.True(t, strings.HasPrefix(blocker, "tasks_checklist_invalid_format:"),
+		"invalid format blocker must carry the parser detail")
+	assert.Contains(t, blocker, "t-02")
+	assert.Contains(t, blocker, "retired metadata key")
+	assert.Contains(t, blocker, "delete the wave line")
+	assert.Contains(t, blocker, "depends_on")
+}
+
+func TestValidateTasksChecklistDetailed_DependencyPrecheckSuppressesDuplicateWavePlanBlocker(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		tasks       string
+		wantBlocker string
+	}{
+		{
+			name: "unknown dependency",
+			tasks: `# Tasks
+
+- [ ] ` + "`t-01`" + ` implement auth flow
+  - depends_on: [t-99]
+  - target_files: [main.go]
+  - task_kind: code
+`,
+			wantBlocker: "plan_dimension_dependency_unknown:t-01->t-99",
+		},
+		{
+			name: "self dependency",
+			tasks: `# Tasks
+
+- [ ] ` + "`t-01`" + ` implement auth flow
+  - depends_on: [t-01]
+  - target_files: [main.go]
+  - task_kind: code
+`,
+			wantBlocker: "plan_dimension_dependency_self_reference:t-01",
+		},
+		{
+			name: "dependency cycle",
+			tasks: `# Tasks
+
+- [ ] ` + "`t-01`" + ` implement auth flow
+  - depends_on: [t-02]
+  - target_files: [main.go]
+  - task_kind: code
+
+- [ ] ` + "`t-02`" + ` test auth flow
+  - depends_on: [t-01]
+  - target_files: [main_test.go]
+  - task_kind: test
+`,
+			wantBlocker: "plan_dimension_dependency_cycle_detected",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := t.TempDir()
+			slug := strings.ReplaceAll(tt.name, " ", "-")
+			bundleDir := filepath.Join(root, "artifacts", "changes", slug)
+			require.NoError(t, os.MkdirAll(bundleDir, 0o755))
+			require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "tasks.md"), []byte(tt.tasks), 0o644))
+
+			result := ValidateTasksChecklistDetailed(root, model.Change{Slug: slug})
+			assert.Contains(t, result.Blockers, tt.wantBlocker)
+			for _, blocker := range result.Blockers {
+				assert.Falsef(t, strings.HasPrefix(blocker, "plan_dimension_execution_invalid_wave_plan:"),
+					"dependency precheck failures should not be duplicated as wave-plan blockers: %v", result.Blockers)
+			}
+		})
+	}
 }
 
 func TestValidateTasksChecklistDetailed_ScaffoldedGuardrailRequirementsStayCovered(t *testing.T) {

--- a/internal/engine/progression/wave_sync_test.go
+++ b/internal/engine/progression/wave_sync_test.go
@@ -418,7 +418,6 @@ func TestSyncGovernedWaveExecution_PersistsExecutionSummaryAndRuntimeSummary(t *
 
 - [x] `+"`task-a`"+` Implement task A
   - target_files: ["cmd/next.go"]
-  - wave: 1
   - task_kind: code
 `)
 
@@ -488,12 +487,10 @@ func TestSyncGovernedWaveExecutionRecordsDegradedDispatchMode(t *testing.T) {
 
 - [x] `+"`task-a`"+` Implement task A
   - target_files: ["cmd/next.go"]
-  - wave: 1
   - task_kind: code
 
 - [x] `+"`task-b`"+` Implement task B
   - target_files: ["cmd/run.go"]
-  - wave: 1
   - task_kind: code
 `)
 
@@ -591,12 +588,10 @@ func TestSyncGovernedWaveExecutionUsesEffectiveParallelForDispatchMode(t *testin
 
 - [x] `+"`task-a`"+` Implement task A
   - target_files: ["cmd/next.go"]
-  - wave: 1
   - task_kind: code
 
 - [x] `+"`task-b`"+` Implement task B
   - target_files: ["cmd/run.go"]
-  - wave: 1
   - task_kind: code
 `), 0o644))
 			writeVerificationForTest(t, root, tt.slug, SkillWaveOrchestration, model.VerificationRecord{
@@ -676,17 +671,14 @@ func TestSyncGovernedWaveExecution_PersistsIncompleteExecutionBlockerInSummary(t
 
 - [ ] `+"`task-a`"+` A
   - target_files: ["cmd/next.go"]
-  - wave: 1
   - task_kind: code
 
 - [ ] `+"`task-b`"+` B
   - target_files: ["cmd/run.go"]
-  - wave: 1
   - task_kind: code
 
 - [ ] `+"`task-c`"+` C
   - target_files: ["cmd/status.go"]
-  - wave: 1
   - task_kind: code
 `)
 
@@ -766,7 +758,6 @@ func TestSyncGovernedWaveExecutionRejectsWaveEvidenceOlderThanTaskEvidence(t *te
 
 - [ ] `+"`task-a`"+` Implement task A
   - target_files: ["cmd/next.go"]
-  - wave: 1
   - task_kind: code
 `)
 
@@ -820,7 +811,6 @@ func TestSyncGovernedWaveExecutionSurfacesParseIssuesAlongsideStaleEvidence(t *t
 
 - [ ] `+"`task-a`"+` Implement task A
   - target_files: ["cmd/next.go"]
-  - wave: 1
   - task_kind: code
 `)
 
@@ -885,7 +875,6 @@ func TestSyncGovernedWaveExecution_DoesNotRewriteMatchingExecutionSummary(t *tes
 
 - [x] `+"`task-a`"+` Implement task A
   - target_files: ["cmd/next.go"]
-  - wave: 1
   - task_kind: code
 `)
 	plan, err := state.LoadWavePlanForChange(root, change)
@@ -948,7 +937,6 @@ func TestSyncGovernedWaveExecution_DoesNotRewriteMatchingExecutionSummaryWithMon
 
 - [ ] `+"`task-a`"+` Implement task A
   - target_files: ["cmd/next.go"]
-  - wave: 1
   - task_kind: code
 `)
 	plan, err := state.LoadWavePlanForChange(root, change)
@@ -1011,7 +999,6 @@ func TestCurrentTasksPlanStructuralHashIgnoresTargetFiles(t *testing.T) {
 
 - [ ] ` + "`task-a`" + ` Implement A
   - target_files: ["cmd/next.go"]
-  - wave: 1
   - task_kind: code
 `
 	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "tasks.md"), []byte(tasks), 0o644))
@@ -1057,12 +1044,10 @@ func TestSyncGovernedWaveExecution_ChecksOffPassingTasksInTasksChecklist(t *test
 
 - [ ] ` + "`task-a`" + ` Implement task A
   - target_files: ["cmd/next.go"]
-  - wave: 1
   - task_kind: code
 
 - [ ] ` + "`task-b`" + ` Implement task B
   - target_files: ["cmd/status.go"]
-  - wave: 2
   - task_kind: doc
 `
 	tasksPath := writeTasksAndMaterializeWavePlan(t, root, change, content)
@@ -1144,12 +1129,10 @@ func TestSyncGovernedWaveExecution_SharedSessionProducesBlocker(t *testing.T) {
 
 - [ ] `+"`task-a`"+` Implement task A
   - target_files: ["cmd/next.go"]
-  - wave: 1
   - task_kind: code
 
 - [ ] `+"`task-b`"+` Implement task B
   - target_files: ["cmd/status.go"]
-  - wave: 2
   - task_kind: code
 `)
 	tasksAt := record.Timestamp.Add(-time.Minute)
@@ -1223,7 +1206,6 @@ func TestSyncGovernedWaveExecutionBlocksWhenTasksPlanChangedSinceEvidence(t *tes
 
 - [ ] ` + "`task-a`" + ` Initial objective
   - target_files: ["cmd/next.go"]
-  - wave: 1
   - task_kind: code
 `
 	tasksPath := writeTasksAndMaterializeWavePlan(t, root, change, initialTasks)
@@ -1265,7 +1247,6 @@ func TestSyncGovernedWaveExecutionBlocksWhenTasksPlanChangedSinceEvidence(t *tes
 
 - [ ] ` + "`task-a`" + ` Updated objective
   - target_files: ["cmd/status.go"]
-  - wave: 1
   - task_kind: code
 `
 	require.NoError(t, os.WriteFile(tasksPath, []byte(updatedTasks), 0o644))
@@ -1322,7 +1303,6 @@ func TestSyncGovernedWaveExecutionRematerializesScopeOnlyTaskPlanChanges(t *test
 
 - [ ] ` + "`task-a`" + ` Implement task A
   - target_files: ["cmd/next.go"]
-  - wave: 1
   - task_kind: code
 `
 	tasksPath := writeTasksAndMaterializeWavePlan(t, root, change, initialTasks)
@@ -1353,7 +1333,6 @@ func TestSyncGovernedWaveExecutionRematerializesScopeOnlyTaskPlanChanges(t *test
 
 - [ ] ` + "`task-a`" + ` Implement task A
   - target_files: ["cmd/status.go"]
-  - wave: 1
   - task_kind: code
 `
 	require.NoError(t, os.WriteFile(tasksPath, []byte(scopeOnlyTasks), 0o644))
@@ -1416,7 +1395,6 @@ func TestSyncGovernedWaveExecutionClearsPlanDriftAfterFreshEvidence(t *testing.T
 
 - [ ] ` + "`task-a`" + ` Initial objective
   - target_files: ["cmd/next.go"]
-  - wave: 1
   - task_kind: code
 `
 	tasksPath := writeTasksAndMaterializeWavePlan(t, root, change, initialTasks)
@@ -1458,7 +1436,6 @@ func TestSyncGovernedWaveExecutionClearsPlanDriftAfterFreshEvidence(t *testing.T
 
 - [ ] ` + "`task-a`" + ` Updated objective
   - target_files: ["cmd/status.go"]
-  - wave: 1
   - task_kind: code
 `
 	require.NoError(t, os.WriteFile(tasksPath, []byte(updatedTasks), 0o644))
@@ -1503,7 +1480,6 @@ func TestSyncGovernedWaveExecutionClearsPlanDriftAfterFreshEvidence(t *testing.T
 
 - [x] ` + "`task-a`" + ` Updated objective
   - target_files: ["cmd/status.go"]
-  - wave: 1
   - task_kind: code
 `
 	currentTasksRaw, err := os.ReadFile(tasksPath)
@@ -1545,7 +1521,6 @@ func TestSyncGovernedWaveExecutionBlocksFirstSummaryWhenTasksChangedAfterEvidenc
 
 - [ ] ` + "`task-a`" + ` Initial objective
   - target_files: ["cmd/next.go"]
-  - wave: 1
   - task_kind: code
 `
 	tasksPath := writeTasksAndMaterializeWavePlan(t, root, change, initialTasks)
@@ -1570,7 +1545,6 @@ func TestSyncGovernedWaveExecutionBlocksFirstSummaryWhenTasksChangedAfterEvidenc
 
 - [ ] ` + "`task-a`" + ` Updated objective
   - target_files: ["cmd/status.go"]
-  - wave: 1
   - task_kind: code
 `
 	require.NoError(t, os.WriteFile(tasksPath, []byte(updatedTasks), 0o644))

--- a/internal/engine/scopecontract/evaluate_test.go
+++ b/internal/engine/scopecontract/evaluate_test.go
@@ -150,7 +150,6 @@ func TestEvaluateBundleReadsTasksMarkdown(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "tasks.md"), []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` implement validation
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/validate.go"]
   - task_kind: code

--- a/internal/engine/status/view_test.go
+++ b/internal/engine/status/view_test.go
@@ -36,11 +36,9 @@ func TestBuildProjectionUsesBundleProgressOutsideExecutionStates(t *testing.T) {
 
 - [x] `+"`task-a`"+` completed
   - target_files: ["cmd/status.go"]
-  - wave: 1
   - task_kind: code
 - [ ] `+"`task-b`"+` pending
   - target_files: ["cmd/status.go"]
-  - wave: 2
   - task_kind: verification
 `), 0o644))
 
@@ -70,7 +68,6 @@ func TestBuildProjectionKeepsExecutionSummaryProgressInExecutionStates(t *testin
 
 - [x] `+"`task-checklist-only`"+` should not replace execution summary
   - target_files: ["cmd/status.go"]
-  - wave: 1
   - task_kind: code
 `), 0o644))
 
@@ -110,13 +107,11 @@ func TestBuildProjectionDoesNotSynthesizeWaveProgressWhenWaveRunsAreMissing(t *t
 - [x] `+"`task-a`"+` completed first wave
   - depends_on: []
   - target_files: ["cmd/status.go"]
-  - wave: 1
   - task_kind: code
 
 - [ ] `+"`task-b`"+` pending second wave
   - depends_on: ["task-a"]
   - target_files: ["cmd/status.go"]
-  - wave: 2
   - task_kind: code
 `), 0o644))
 	_, err = state.MaterializeWavePlan(root, change)
@@ -158,13 +153,11 @@ func TestBuildProjectionDoesNotLabelCompletedExecutionAsResumableWave(t *testing
 - [x] `+"`task-a`"+` completed first wave
   - depends_on: []
   - target_files: ["cmd/status.go"]
-  - wave: 1
   - task_kind: code
 
 - [x] `+"`task-b`"+` completed second wave
   - depends_on: ["task-a"]
   - target_files: ["cmd/status.go"]
-  - wave: 2
   - task_kind: code
 `), 0o644))
 	plan, err := state.MaterializeWavePlan(root, change)

--- a/internal/engine/wave/parse.go
+++ b/internal/engine/wave/parse.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/signalridge/slipway/internal/model"
@@ -43,10 +42,6 @@ func (p TaskPlan) Nodes() []Node {
 
 func (t TaskNode) HasDeclaredTaskKind() bool {
 	return t.taskKindDeclared
-}
-
-func (t TaskNode) HasDeclaredWave() bool {
-	return t.WaveIndex > 0
 }
 
 // ParseTaskPlan parses the steady-state checkbox-native tasks.md contract.
@@ -108,7 +103,6 @@ func taskPlanHash(content string, mode taskPlanHashMode) (string, error) {
 	for _, task := range plan.Tasks {
 		entry := map[string]any{
 			"task_id": task.TaskID,
-			"wave":    task.WaveIndex,
 		}
 		switch mode {
 		case taskPlanHashStructural:
@@ -143,7 +137,6 @@ func taskPlanHash(content string, mode taskPlanHashMode) (string, error) {
 // allowedMetadataKeys is the union of required + optional keys accepted by
 // the checkbox-native contract.
 var allowedMetadataKeys = map[string]struct{}{
-	"wave":            {},
 	"depends_on":      {},
 	"target_files":    {},
 	"task_kind":       {},
@@ -226,7 +219,6 @@ func parseCheckboxTaskPlan(content string) (TaskPlan, error) {
 type taskNodeBuilder struct {
 	taskID         string
 	objective      string
-	waveIndex      int
 	dependsOn      []string
 	targetFiles    []string
 	taskKind       string
@@ -238,9 +230,13 @@ type taskNodeBuilder struct {
 	seenKeys       map[string]struct{}
 }
 
-// applyStrictMetadata enforces the checkbox-native contract: rejects unknown
-// keys and fails on duplicate metadata keys.
+// applyStrictMetadata enforces the checkbox-native contract: rejects the
+// retired wave key with dedicated remediation, rejects unknown keys, and
+// fails on duplicate metadata keys.
 func (b *taskNodeBuilder) applyStrictMetadata(key, value string) error {
+	if key == "wave" {
+		return fmt.Errorf("task %q declares retired metadata key %q; the engine now assigns waves from depends_on and target_files — delete the wave line and declare real depends_on for intentional ordering", b.taskID, key)
+	}
 	if _, allowed := allowedMetadataKeys[key]; !allowed {
 		return fmt.Errorf("task %q uses unknown metadata key %q", b.taskID, key)
 	}
@@ -271,12 +267,6 @@ func (b *taskNodeBuilder) applyMetadata(key, value string) error {
 		b.objective = cleanValue(value)
 	case "checkpoint_type":
 		b.checkpointType = cleanValue(value)
-	case "wave":
-		waveIndex, err := parsePositiveInt(value)
-		if err != nil {
-			return fmt.Errorf("task %q has invalid wave %q: %w", b.taskID, cleanValue(value), err)
-		}
-		b.waveIndex = waveIndex
 	}
 	return nil
 }
@@ -310,7 +300,6 @@ func (b *taskNodeBuilder) build() (TaskNode, error) {
 		Node: Node{
 			TaskID:         b.taskID,
 			Objective:      b.objective,
-			WaveIndex:      b.waveIndex,
 			DependsOn:      append([]string(nil), b.dependsOn...),
 			TargetFiles:    normalizeTargetFiles(b.targetFiles),
 			TaskKind:       kind,
@@ -461,15 +450,4 @@ func parseStringList(s string) []string {
 		}
 	}
 	return result
-}
-
-func parsePositiveInt(s string) (int, error) {
-	value, err := strconv.Atoi(cleanValue(s))
-	if err != nil {
-		return 0, err
-	}
-	if value < 1 {
-		return 0, fmt.Errorf("must be >= 1")
-	}
-	return value, nil
 }

--- a/internal/engine/wave/parse_test.go
+++ b/internal/engine/wave/parse_test.go
@@ -1,6 +1,7 @@
 package wave
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/signalridge/slipway/internal/model"
@@ -14,19 +15,16 @@ func TestParseTaskPlan_CheckboxNativeCapturesCompletionState(t *testing.T) {
 ## Task List
 
 - [x] ` + "`t-01`" + ` Setup database schema
-  - wave: 1
   - depends_on: []
   - target_files: ["internal/db/schema.go", "internal/db/migrate.go"]
   - task_kind: code
 
 - [ ] ` + "`t-02`" + ` Implement API handlers
-  - wave: 2
   - depends_on: ["t-01"]
   - target_files: ["internal/api/handler.go"]
   - task_kind: code
 
 - [ ] ` + "`t-03`" + ` Write documentation
-  - wave: 3
   - depends_on: ["t-01", "t-02"]
   - target_files: ["docs/api.md"]
   - task_kind: doc
@@ -60,7 +58,6 @@ func TestParseTaskPlan_CommaSeparatedDeps(t *testing.T) {
 	md := `# Tasks
 
 - [ ] ` + "`t-01`" + ` First
-  - wave: 1
   - depends_on: t-02, t-03
   - target_files: src/main.go
   - task_kind: code
@@ -98,7 +95,6 @@ func TestParseTaskPlan_CheckpointType(t *testing.T) {
 	md := `# Tasks
 
 - [ ] ` + "`t-01`" + ` Manual task
-  - wave: 1
   - task_kind: other
   - checkpoint_type: human_verify
 `
@@ -114,7 +110,6 @@ func TestParseTaskPlan_AcceptsEvidenceAndAcceptanceMetadata(t *testing.T) {
 	md := `# Tasks
 
 - [ ] ` + "`t-01`" + ` Parser-compatible audit task
-  - wave: 1
   - target_files: ["internal/engine/wave/parse.go"]
   - task_kind: code
   - evidence: verdict
@@ -132,7 +127,6 @@ func TestTaskPlanSemanticHashIncludesEvidenceAndAcceptance(t *testing.T) {
 	base := `# Tasks
 
 - [ ] ` + "`t-01`" + ` Parser-compatible audit task
-  - wave: 1
   - target_files: ["internal/engine/wave/parse.go"]
   - task_kind: code
   - evidence: verdict
@@ -141,7 +135,6 @@ func TestTaskPlanSemanticHashIncludesEvidenceAndAcceptance(t *testing.T) {
 	changed := `# Tasks
 
 - [ ] ` + "`t-01`" + ` Parser-compatible audit task
-  - wave: 1
   - target_files: ["internal/engine/wave/parse.go"]
   - task_kind: code
   - evidence: artifact
@@ -159,12 +152,10 @@ func TestParseTaskPlan_RejectsDuplicateTaskID(t *testing.T) {
 	md := `# Tasks
 
 - [ ] ` + "`t-01`" + ` First task
-  - wave: 1
   - task_kind: code
   - target_files: ["a.go"]
 
 - [ ] ` + "`t-01`" + ` Duplicate task
-  - wave: 2
   - task_kind: code
   - target_files: ["b.go"]
 `
@@ -179,7 +170,6 @@ func TestParseTaskPlan_RejectsDuplicateMetadataKey(t *testing.T) {
 	md := `# Tasks
 
 - [ ] ` + "`t-01`" + ` Task with dup key
-  - wave: 1
   - task_kind: code
   - target_files: ["a.go"]
   - task_kind: test
@@ -195,7 +185,6 @@ func TestParseTaskPlan_RejectsUnknownMetadataKey(t *testing.T) {
 	md := `# Tasks
 
 - [ ] ` + "`t-01`" + ` Task with unknown key
-  - wave: 1
   - task_kind: code
   - target_files: ["a.go"]
   - some_random_key: value
@@ -207,22 +196,60 @@ func TestParseTaskPlan_RejectsUnknownMetadataKey(t *testing.T) {
 	assert.Contains(t, err.Error(), "some_random_key")
 }
 
+// TestParseTaskPlan_RejectsRetiredWaveKey pins the wave-key retirement
+// contract: ParseTaskPlan stays a pure format parser, and a task carrying a
+// `- wave:` metadata line fails parsing with a dedicated retirement error.
+//
+// Asserted error-message contract (the implementation must satisfy ALL):
+//  1. contains the offending task ID (here "t-02"),
+//  2. contains the word "wave" (case-insensitive),
+//  3. contains at least ONE of "delete", "remove", or "depends_on"
+//     (case-insensitive) — i.e. the remediation: delete the wave: line and
+//     declare real depends_on for intentional ordering, because the engine
+//     now assigns waves from depends_on and target_files.
+func TestParseTaskPlan_RejectsRetiredWaveKey(t *testing.T) {
+	md := `# Tasks
+
+- [ ] ` + "`t-01`" + ` Healthy task without wave metadata
+  - depends_on: []
+  - target_files: ["a.go"]
+  - task_kind: code
+
+- [ ] ` + "`t-02`" + ` Task still carrying retired wave metadata
+  - wave: 2
+  - depends_on: ["t-01"]
+  - target_files: ["b.go"]
+  - task_kind: code
+`
+
+	_, err := ParseTaskPlan(md)
+	require.Error(t, err, "wave: metadata is retired and must fail parsing")
+
+	msg := err.Error()
+	lowered := strings.ToLower(msg)
+	assert.Contains(t, msg, "t-02", "retirement error must name the offending task ID")
+	assert.Contains(t, lowered, "wave", "retirement error must name the retired wave key")
+	hasRemediation := strings.Contains(lowered, "delete") ||
+		strings.Contains(lowered, "remove") ||
+		strings.Contains(lowered, "depends_on")
+	assert.True(t, hasRemediation,
+		"retirement error must carry remediation containing one of %q, %q, %q; got: %q",
+		"delete", "remove", "depends_on", msg)
+}
+
 func TestParseTaskPlan_IntegrationWithPlanWaves(t *testing.T) {
 	md := `# Tasks
 
 - [ ] ` + "`t-01`" + ` Foundation
-  - wave: 1
   - target_files: ["a.go"]
   - task_kind: code
 
 - [ ] ` + "`t-02`" + ` Depends on t-01
-  - wave: 2
   - depends_on: ["t-01"]
   - target_files: ["b.go"]
   - task_kind: code
 
 - [ ] ` + "`t-03`" + ` Independent
-  - wave: 1
   - target_files: ["c.go"]
   - task_kind: code
 `
@@ -234,32 +261,8 @@ func TestParseTaskPlan_IntegrationWithPlanWaves(t *testing.T) {
 
 	waves, err := PlanWaves(nodes)
 	require.NoError(t, err)
-	require.Len(t, waves, 2)
-
-	wave1IDs := make([]string, len(waves[0].Nodes))
-	for i, n := range waves[0].Nodes {
-		wave1IDs[i] = n.TaskID
-	}
-	assert.Contains(t, wave1IDs, "t-01")
-	assert.Contains(t, wave1IDs, "t-03")
-
-	assert.Len(t, waves[1].Nodes, 1)
-	assert.Equal(t, "t-02", waves[1].Nodes[0].TaskID)
-}
-
-func TestParseTaskPlan_CapturesDeclaredWave(t *testing.T) {
-	md := `# Tasks
-
-- [ ] ` + "`t-01`" + ` Foundation
-  - wave: 3
-  - depends_on: []
-  - target_files: ["a.go"]
-  - task_kind: code
-`
-
-	plan, err := ParseTaskPlan(md)
-	require.NoError(t, err)
-	require.Len(t, plan.Tasks, 1)
-	assert.Equal(t, 3, plan.Tasks[0].WaveIndex)
-	assert.True(t, plan.Tasks[0].HasDeclaredWave())
+	assert.Equal(t, [][]string{
+		{"t-01", "t-03"},
+		{"t-02"},
+	}, waveTaskIDGroups(waves))
 }

--- a/internal/engine/wave/wave.go
+++ b/internal/engine/wave/wave.go
@@ -15,7 +15,6 @@ func compareNodesByTaskID(a, b Node) int { return cmp.Compare(a.TaskID, b.TaskID
 type Node struct {
 	TaskID         string         `json:"task_id"`
 	Objective      string         `json:"objective,omitempty"`
-	WaveIndex      int            `json:"wave,omitempty"`
 	DependsOn      []string       `json:"depends_on,omitempty"`
 	TargetFiles    []string       `json:"target_files,omitempty"`
 	TaskKind       model.TaskKind `json:"task_kind,omitempty"`
@@ -53,14 +52,22 @@ type ExecutionResult struct {
 	Aborted       bool                     `json:"aborted,omitempty"`
 }
 
+// PlanWaves computes the wave assignment for the given tasks from their
+// declared depends_on edges and their target_files. Nothing is declared by
+// the author: wave(task) = 1 for roots, otherwise max(wave of each
+// dependency) + 1 before conflict adjustment. Waves are then filled in task-ID
+// order from tasks whose dependencies are already in earlier waves, deferring
+// any task that conflicts with an already accepted task in the current wave.
+// Conflicts are a same-wave-only concern because waves run sequentially. Depth
+// is minimal for pure dependency constraints; conflict bumping is deterministic
+// greedy placement, not a depth-optimal schedule (that is graph-coloring-hard).
+// The plan is deterministic across input orderings.
 func PlanWaves(nodes []Node) ([]Wave, error) {
 	if len(nodes) == 0 {
 		return nil, nil
 	}
 
 	nodeByID := map[string]Node{}
-	declaredWaves := map[int][]Node{}
-	maxWaveIndex := 0
 	for _, node := range nodes {
 		if err := model.ValidateTaskID(node.TaskID); err != nil {
 			return nil, err
@@ -68,45 +75,145 @@ func PlanWaves(nodes []Node) ([]Wave, error) {
 		if _, exists := nodeByID[node.TaskID]; exists {
 			return nil, fmt.Errorf("duplicate task_id %q", node.TaskID)
 		}
-		if node.WaveIndex < 1 {
-			return nil, fmt.Errorf("task %q missing required wave declaration", node.TaskID)
-		}
 		nodeByID[node.TaskID] = node
-		declaredWaves[node.WaveIndex] = append(declaredWaves[node.WaveIndex], node)
-		if node.WaveIndex > maxWaveIndex {
-			maxWaveIndex = node.WaveIndex
-		}
-	}
-
-	for waveIndex := 1; waveIndex <= maxWaveIndex; waveIndex++ {
-		layer, exists := declaredWaves[waveIndex]
-		if !exists || len(layer) == 0 {
-			return nil, fmt.Errorf("wave %d missing from declared wave plan", waveIndex)
-		}
 	}
 
 	for _, node := range nodes {
 		for _, dep := range node.DependsOn {
-			dependency, exists := nodeByID[dep]
-			if !exists {
+			if _, exists := nodeByID[dep]; !exists {
 				return nil, fmt.Errorf("task %q depends on unknown task %q", node.TaskID, dep)
-			}
-			if dependency.WaveIndex >= node.WaveIndex {
-				return nil, fmt.Errorf("task %q depends on %q in same or later wave", node.TaskID, dep)
 			}
 		}
 	}
 
-	waves := make([]Wave, 0, maxWaveIndex)
-	for waveIndex := 1; waveIndex <= maxWaveIndex; waveIndex++ {
-		layer := append([]Node(nil), declaredWaves[waveIndex]...)
-		slices.SortFunc(layer, compareNodesByTaskID)
+	ordered, err := topologicalTaskOrder(nodeByID)
+	if err != nil {
+		return nil, err
+	}
+
+	taskIDs := append([]string(nil), ordered...)
+	slices.Sort(taskIDs)
+	assignedWave := map[string]int{}
+	remaining := map[string]struct{}{}
+	for _, taskID := range taskIDs {
+		remaining[taskID] = struct{}{}
+	}
+
+	waves := []Wave{}
+	for waveIndex := 1; len(remaining) > 0; waveIndex++ {
+		layer := []Node{}
+		for _, taskID := range taskIDs {
+			if _, pending := remaining[taskID]; !pending {
+				continue
+			}
+			node := nodeByID[taskID]
+			if !dependenciesAssignedBeforeWave(node, assignedWave, waveIndex) {
+				continue
+			}
+			if nodeConflictsWithWave(layer, node) {
+				continue
+			}
+			layer = append(layer, node)
+			assignedWave[taskID] = waveIndex
+			delete(remaining, taskID)
+		}
+
+		if len(layer) == 0 {
+			return nil, fmt.Errorf("no schedulable tasks for wave %d", waveIndex)
+		}
+		// Internal invariant: conflict-driven placement above must have
+		// produced conflict-free waves; fail closed if it ever does not.
 		if err := validateWaveStaticConflicts(waveIndex, layer); err != nil {
 			return nil, err
 		}
 		waves = append(waves, Wave{Nodes: layer})
 	}
 	return waves, nil
+}
+
+func dependenciesAssignedBeforeWave(node Node, assignedWave map[string]int, waveIndex int) bool {
+	for _, dep := range node.DependsOn {
+		depWave, ok := assignedWave[dep]
+		if !ok || depWave >= waveIndex {
+			return false
+		}
+	}
+	return true
+}
+
+// topologicalTaskOrder returns every task ID in dependency order with
+// task-ID-ordered tiebreaks (Kahn's algorithm popping the smallest ready
+// ID), so wave assignment is deterministic regardless of input order.
+// Duplicate depends_on entries are tolerated; an unresolvable remainder is a
+// dependency cycle and fails the plan.
+func topologicalTaskOrder(nodeByID map[string]Node) ([]string, error) {
+	taskIDs := make([]string, 0, len(nodeByID))
+	for taskID := range nodeByID {
+		taskIDs = append(taskIDs, taskID)
+	}
+	slices.Sort(taskIDs)
+
+	pendingDeps := map[string]int{}
+	dependents := map[string][]string{}
+	for _, taskID := range taskIDs {
+		seenDeps := map[string]struct{}{}
+		for _, dep := range nodeByID[taskID].DependsOn {
+			if _, dup := seenDeps[dep]; dup {
+				continue
+			}
+			seenDeps[dep] = struct{}{}
+			pendingDeps[taskID]++
+			dependents[dep] = append(dependents[dep], taskID)
+		}
+	}
+
+	ready := make([]string, 0, len(taskIDs))
+	for _, taskID := range taskIDs {
+		if pendingDeps[taskID] == 0 {
+			ready = append(ready, taskID)
+		}
+	}
+
+	ordered := make([]string, 0, len(taskIDs))
+	for len(ready) > 0 {
+		taskID := ready[0]
+		ready = ready[1:]
+		ordered = append(ordered, taskID)
+		for _, dependent := range dependents[taskID] {
+			pendingDeps[dependent]--
+			if pendingDeps[dependent] == 0 {
+				insertAt, _ := slices.BinarySearch(ready, dependent)
+				ready = slices.Insert(ready, insertAt, dependent)
+			}
+		}
+	}
+
+	if len(ordered) != len(taskIDs) {
+		stuck := make([]string, 0, len(taskIDs)-len(ordered))
+		for _, taskID := range taskIDs {
+			if pendingDeps[taskID] > 0 {
+				stuck = append(stuck, taskID)
+			}
+		}
+		return nil, fmt.Errorf("depends_on cycle detected among tasks %s; remove a circular depends_on reference so every task can be ordered", strings.Join(stuck, ", "))
+	}
+	return ordered, nil
+}
+
+// nodeConflictsWithWave reports whether the candidate's target files overlap
+// any target file already owned by another task assigned to the wave.
+func nodeConflictsWithWave(occupants []Node, candidate Node) bool {
+	for _, candidateFile := range candidate.TargetFiles {
+		candidateTarget := normalizeTargetFileForConflict(candidateFile)
+		for _, occupant := range occupants {
+			for _, occupantFile := range occupant.TargetFiles {
+				if targetFilesConflict(normalizeTargetFileForConflict(occupantFile), candidateTarget) {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 func validateWaveStaticConflicts(waveIndex int, nodes []Node) error {

--- a/internal/engine/wave/wave.go
+++ b/internal/engine/wave/wave.go
@@ -1,7 +1,6 @@
 package wave
 
 import (
-	"cmp"
 	"fmt"
 	"path"
 	"slices"
@@ -9,8 +8,6 @@ import (
 
 	"github.com/signalridge/slipway/internal/model"
 )
-
-func compareNodesByTaskID(a, b Node) int { return cmp.Compare(a.TaskID, b.TaskID) }
 
 type Node struct {
 	TaskID         string         `json:"task_id"`

--- a/internal/engine/wave/wave_test.go
+++ b/internal/engine/wave/wave_test.go
@@ -2,6 +2,8 @@ package wave
 
 import (
 	"encoding/json"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/signalridge/slipway/internal/model"
@@ -9,94 +11,163 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPlanWavesBuildsDeclaredWavePlan(t *testing.T) {
-	t.Parallel()
-	nodes := []Node{
-		{TaskID: "b", WaveIndex: 1, DependsOn: nil, TargetFiles: []string{"y.go"}, TaskKind: model.TaskKindCode},
-		{TaskID: "a", WaveIndex: 1, DependsOn: nil, TargetFiles: []string{"x.go"}, TaskKind: model.TaskKindCode},
-		{TaskID: "c", WaveIndex: 2, DependsOn: []string{"a"}, TargetFiles: []string{"z.go"}, TaskKind: model.TaskKindCode},
+// waveTaskIDGroups maps a computed plan to per-wave task-ID groups. Wave
+// numbering is positional: groups[i] holds the task IDs assigned to wave i+1.
+// IDs inside each group are sorted so assertions pin wave membership, not
+// intra-wave ordering.
+func waveTaskIDGroups(waves []Wave) [][]string {
+	groups := make([][]string, 0, len(waves))
+	for _, w := range waves {
+		ids := make([]string, 0, len(w.Nodes))
+		for _, node := range w.Nodes {
+			ids = append(ids, node.TaskID)
+		}
+		slices.Sort(ids)
+		groups = append(groups, ids)
 	}
+	return groups
+}
+
+func TestPlanWavesAssignsRootsAndFanInDependent(t *testing.T) {
+	t.Parallel()
+
+	// Canonical shape: three independent, file-disjoint tasks plus one task
+	// depending on all three. The engine computes waves from depends_on and
+	// target_files; nothing is declared. Expected: exactly two waves, wave 1
+	// holds exactly the three roots, wave 2 holds the dependent task.
+	// Input order is deliberately shuffled: assignment uses task-ID tiebreaks.
+	nodes := []Node{
+		{TaskID: "t-02", TargetFiles: []string{"b.go"}, TaskKind: model.TaskKindCode},
+		{TaskID: "t-04", DependsOn: []string{"t-01", "t-02", "t-03"}, TargetFiles: []string{"d.go"}, TaskKind: model.TaskKindCode},
+		{TaskID: "t-01", TargetFiles: []string{"a.go"}, TaskKind: model.TaskKindCode},
+		{TaskID: "t-03", TargetFiles: []string{"c.go"}, TaskKind: model.TaskKindCode},
+	}
+
 	waves, err := PlanWaves(nodes)
 	require.NoError(t, err)
-	require.Len(t, waves, 2)
-	assert.Equal(t, []Node{nodes[1], nodes[0]}, waves[0].Nodes)
-	assert.Equal(t, []Node{nodes[2]}, waves[1].Nodes)
+	assert.Equal(t, [][]string{
+		{"t-01", "t-02", "t-03"},
+		{"t-04"},
+	}, waveTaskIDGroups(waves))
 }
 
-func TestPlanWavesRejectsStaticConflictsInsideDeclaredWave(t *testing.T) {
+func TestPlanWavesComputesChainAsSingleTaskWaves(t *testing.T) {
 	t.Parallel()
-	_, err := PlanWaves([]Node{
-		{TaskID: "a", WaveIndex: 1, TargetFiles: []string{"a.go"}, TaskKind: model.TaskKindCode},
-		{TaskID: "b", WaveIndex: 1, TargetFiles: []string{"a.go"}, TaskKind: model.TaskKindCode},
+
+	// Pure depends_on chain t-a <- t-b <- t-c must yield three single-task
+	// waves in chain order.
+	nodes := []Node{
+		{TaskID: "t-c", DependsOn: []string{"t-b"}, TargetFiles: []string{"c.go"}, TaskKind: model.TaskKindCode},
+		{TaskID: "t-a", TargetFiles: []string{"a.go"}, TaskKind: model.TaskKindCode},
+		{TaskID: "t-b", DependsOn: []string{"t-a"}, TargetFiles: []string{"b.go"}, TaskKind: model.TaskKindCode},
+	}
+
+	waves, err := PlanWaves(nodes)
+	require.NoError(t, err)
+	assert.Equal(t, [][]string{{"t-a"}, {"t-b"}, {"t-c"}}, waveTaskIDGroups(waves))
+}
+
+func TestPlanWavesAssignsDependentAfterDeepestDependency(t *testing.T) {
+	t.Parallel()
+
+	// wave(task) = max(wave of dependencies) + 1: t-03 depends on both the
+	// wave-1 root and the wave-2 task, so it must land in wave 3 (not 2).
+	nodes := []Node{
+		{TaskID: "t-01", TargetFiles: []string{"a.go"}, TaskKind: model.TaskKindCode},
+		{TaskID: "t-02", DependsOn: []string{"t-01"}, TargetFiles: []string{"b.go"}, TaskKind: model.TaskKindCode},
+		{TaskID: "t-03", DependsOn: []string{"t-01", "t-02"}, TargetFiles: []string{"c.go"}, TaskKind: model.TaskKindCode},
+	}
+
+	waves, err := PlanWaves(nodes)
+	require.NoError(t, err)
+	assert.Equal(t, [][]string{{"t-01"}, {"t-02"}, {"t-03"}}, waveTaskIDGroups(waves))
+}
+
+func TestPlanWavesKeepsFileDisjointSiblingsInOneWave(t *testing.T) {
+	t.Parallel()
+
+	// Disjoint sibling files in the same directory are not a target conflict;
+	// independent tasks must not be over-serialized.
+	nodes := []Node{
+		{TaskID: "t-01", TargetFiles: []string{"internal/db/schema.go"}, TaskKind: model.TaskKindCode},
+		{TaskID: "t-02", TargetFiles: []string{"internal/db/migrate.go"}, TaskKind: model.TaskKindCode},
+	}
+
+	waves, err := PlanWaves(nodes)
+	require.NoError(t, err)
+	assert.Equal(t, [][]string{{"t-01", "t-02"}}, waveTaskIDGroups(waves))
+}
+
+func TestPlanWavesBumpsExactTargetConflictDeterministically(t *testing.T) {
+	t.Parallel()
+
+	// Two independent tasks sharing the same target file cannot share a wave:
+	// the task with the later task ID is bumped to a later wave. The result
+	// must be identical across repeated computations and input orderings.
+	makeNodes := func() []Node {
+		return []Node{
+			{TaskID: "t-01", TargetFiles: []string{"shared.go"}, TaskKind: model.TaskKindCode},
+			{TaskID: "t-02", TargetFiles: []string{"shared.go"}, TaskKind: model.TaskKindCode},
+		}
+	}
+
+	first, err := PlanWaves(makeNodes())
+	require.NoError(t, err)
+	assert.Equal(t, [][]string{{"t-01"}, {"t-02"}}, waveTaskIDGroups(first))
+
+	for i := 0; i < 10; i++ {
+		again, err := PlanWaves(makeNodes())
+		require.NoError(t, err)
+		assert.Equal(t, first, again, "repeated computation %d must produce an identical plan", i)
+	}
+
+	nodes := makeNodes()
+	reversed := []Node{nodes[1], nodes[0]}
+	flipped, err := PlanWaves(reversed)
+	require.NoError(t, err)
+	assert.Equal(t, first, flipped, "input order must not change the computed plan")
+}
+
+func TestPlanWavesBumpsTaskIDLaterConflictWhenReadinessOrderDiffers(t *testing.T) {
+	t.Parallel()
+
+	// t-02 becomes topologically ready before t-01 because t-00 is processed
+	// before t-99, but both tasks have the same dependency level and target the
+	// same file. Conflict resolution is defined by task ID inside the computed
+	// level, so t-01 stays in wave 2 and the later ID t-02 is bumped.
+	waves, err := PlanWaves([]Node{
+		{TaskID: "t-00", TargetFiles: []string{"dep-a.go"}, TaskKind: model.TaskKindCode},
+		{TaskID: "t-99", TargetFiles: []string{"dep-b.go"}, TaskKind: model.TaskKindCode},
+		{TaskID: "t-01", DependsOn: []string{"t-99"}, TargetFiles: []string{"shared.go"}, TaskKind: model.TaskKindCode},
+		{TaskID: "t-02", DependsOn: []string{"t-00"}, TargetFiles: []string{"shared.go"}, TaskKind: model.TaskKindCode},
 	})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "static target conflict")
+	require.NoError(t, err)
+	assert.Equal(t, [][]string{
+		{"t-00", "t-99"},
+		{"t-01"},
+		{"t-02"},
+	}, waveTaskIDGroups(waves))
 }
 
-func TestPlanWavesRejectsStaticConflictsWithPathAliases(t *testing.T) {
+func TestPlanWavesBumpsConflictingTargetsForEachConflictKind(t *testing.T) {
 	t.Parallel()
 
-	_, err := PlanWaves([]Node{
-		{TaskID: "a", WaveIndex: 1, TargetFiles: []string{"a.go"}, TaskKind: model.TaskKindCode},
-		{TaskID: "b", WaveIndex: 1, TargetFiles: []string{"./a.go"}, TaskKind: model.TaskKindCode},
-	})
-
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "static target conflict")
-	assert.Contains(t, err.Error(), "a.go")
-}
-
-func TestPlanWavesRejectsStaticConflictsWithBackslashPathAliases(t *testing.T) {
-	t.Parallel()
-
-	_, err := PlanWaves([]Node{
-		{TaskID: "a", WaveIndex: 1, TargetFiles: []string{`internal\engine\wave.go`}, TaskKind: model.TaskKindCode},
-		{TaskID: "b", WaveIndex: 1, TargetFiles: []string{"internal/engine/wave.go"}, TaskKind: model.TaskKindCode},
-	})
-
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "static target conflict")
-	assert.Contains(t, err.Error(), "internal/engine/wave.go")
-}
-
-func TestPlanWavesRejectsStaticConflictsWithCaseAliases(t *testing.T) {
-	t.Parallel()
-
-	_, err := PlanWaves([]Node{
-		{TaskID: "a", WaveIndex: 1, TargetFiles: []string{"Foo.go"}, TaskKind: model.TaskKindCode},
-		{TaskID: "b", WaveIndex: 1, TargetFiles: []string{"foo.go"}, TaskKind: model.TaskKindCode},
-	})
-
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "static target conflict")
-	assert.Contains(t, err.Error(), "foo.go")
-}
-
-func TestPlanWavesRejectsStaticConflictsWithParentChildTargets(t *testing.T) {
-	t.Parallel()
-
-	_, err := PlanWaves([]Node{
-		{TaskID: "a", WaveIndex: 1, TargetFiles: []string{"internal/engine/progression"}, TaskKind: model.TaskKindCode},
-		{TaskID: "b", WaveIndex: 1, TargetFiles: []string{"internal/engine/progression/advance.go"}, TaskKind: model.TaskKindCode},
-	})
-
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "static target conflict")
-	assert.Contains(t, err.Error(), "internal/engine/progression")
-	assert.Contains(t, err.Error(), "internal/engine/progression/advance.go")
-}
-
-func TestPlanWavesRejectsStaticConflictsWithGlobTargets(t *testing.T) {
-	t.Parallel()
-
+	// Every targetFilesConflict kind forces the later task ID into a later
+	// wave instead of failing the plan: exact path, normalization aliases,
+	// case-only alias, parent/child containment, and glob overlap.
 	tests := []struct {
 		name  string
-		left  string
-		right string
+		left  string // target of t-01
+		right string // target of t-02
 	}{
-		{name: "star overlaps concrete file", left: "cmd/*.go", right: "cmd/next.go"},
+		{name: "exact path", left: "internal/db/schema.go", right: "internal/db/schema.go"},
+		{name: "dot slash alias", left: "a.go", right: "./a.go"},
+		{name: "backslash alias", left: `internal\engine\wave.go`, right: "internal/engine/wave.go"},
+		{name: "case only alias", left: "Foo.go", right: "foo.go"},
+		{name: "parent directory contains child file", left: "internal/engine/progression", right: "internal/engine/progression/advance.go"},
+		{name: "glob overlaps concrete file", left: "internal/engine/wave/*.go", right: "internal/engine/wave/parse.go"},
 		{name: "double star overlaps nested file", left: "docs/**", right: "docs/guides/workflow.md"},
-		{name: "concrete file overlaps star", left: "internal/engine/wave/wave.go", right: "internal/engine/wave/*.go"},
+		{name: "concrete file overlaps glob", left: "cmd/next.go", right: "cmd/*.go"},
 	}
 
 	for _, tt := range tests {
@@ -104,54 +175,194 @@ func TestPlanWavesRejectsStaticConflictsWithGlobTargets(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := PlanWaves([]Node{
-				{TaskID: "a", WaveIndex: 1, TargetFiles: []string{tt.left}, TaskKind: model.TaskKindCode},
-				{TaskID: "b", WaveIndex: 1, TargetFiles: []string{tt.right}, TaskKind: model.TaskKindCode},
+			waves, err := PlanWaves([]Node{
+				{TaskID: "t-01", TargetFiles: []string{tt.left}, TaskKind: model.TaskKindCode},
+				{TaskID: "t-02", TargetFiles: []string{tt.right}, TaskKind: model.TaskKindCode},
 			})
-
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), "static target conflict")
+			require.NoError(t, err)
+			assert.Equal(t, [][]string{{"t-01"}, {"t-02"}}, waveTaskIDGroups(waves),
+				"conflicting targets must bump the later task ID to a later wave")
 		})
 	}
+}
+
+func TestPlanWavesCascadesBumpsAcrossSharedTarget(t *testing.T) {
+	t.Parallel()
+
+	// Three independent tasks over one shared file serialize into three
+	// waves in task-ID order: a bumped task re-checks its destination wave
+	// for conflicts and keeps moving forward.
+	nodes := []Node{
+		{TaskID: "t-03", TargetFiles: []string{"shared.go"}, TaskKind: model.TaskKindCode},
+		{TaskID: "t-01", TargetFiles: []string{"shared.go"}, TaskKind: model.TaskKindCode},
+		{TaskID: "t-02", TargetFiles: []string{"shared.go"}, TaskKind: model.TaskKindCode},
+	}
+
+	waves, err := PlanWaves(nodes)
+	require.NoError(t, err)
+	assert.Equal(t, [][]string{{"t-01"}, {"t-02"}, {"t-03"}}, waveTaskIDGroups(waves))
+}
+
+func TestPlanWavesBumpsLaterTaskIDWhenDeferredRootConflictsWithDependent(t *testing.T) {
+	t.Parallel()
+
+	// t-03 is a root, but it cannot stay in wave 1 because it conflicts with
+	// t-01. When it becomes eligible for wave 2, t-02 is also eligible through
+	// its dependency on t-01. Conflict resolution must still keep the lower task
+	// ID in the earlier wave and defer the later ID.
+	waves, err := PlanWaves([]Node{
+		{TaskID: "t-01", TargetFiles: []string{"shared.go"}, TaskKind: model.TaskKindCode},
+		{TaskID: "t-02", DependsOn: []string{"t-01"}, TargetFiles: []string{"shared.go"}, TaskKind: model.TaskKindCode},
+		{TaskID: "t-03", TargetFiles: []string{"shared.go"}, TaskKind: model.TaskKindCode},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, [][]string{{"t-01"}, {"t-02"}, {"t-03"}}, waveTaskIDGroups(waves))
+}
+
+func TestPlanWavesAllowsSharedTargetAcrossDifferentWaves(t *testing.T) {
+	t.Parallel()
+
+	// Conflict bumping is a same-wave concern only: waves run sequentially,
+	// so a root task may share a target with a task that depends_on pushed
+	// into a later wave. t-03 (b.go) stays in wave 1 even though t-02 also
+	// targets b.go from wave 2.
+	nodes := []Node{
+		{TaskID: "t-01", TargetFiles: []string{"a.go"}, TaskKind: model.TaskKindCode},
+		{TaskID: "t-02", DependsOn: []string{"t-01"}, TargetFiles: []string{"b.go"}, TaskKind: model.TaskKindCode},
+		{TaskID: "t-03", TargetFiles: []string{"b.go"}, TaskKind: model.TaskKindCode},
+	}
+
+	waves, err := PlanWaves(nodes)
+	require.NoError(t, err)
+	assert.Equal(t, [][]string{{"t-01", "t-03"}, {"t-02"}}, waveTaskIDGroups(waves))
 }
 
 func TestPlanWavesAllowsTaskIDThatLooksLikeLegacyRunSuffix(t *testing.T) {
 	t.Parallel()
 
-	plan, err := PlanWaves([]Node{
-		{TaskID: "task-a__legacy", WaveIndex: 1, TargetFiles: []string{"a.go"}, TaskKind: model.TaskKindCode},
+	waves, err := PlanWaves([]Node{
+		{TaskID: "task-a__legacy", TargetFiles: []string{"a.go"}, TaskKind: model.TaskKindCode},
 	})
 	require.NoError(t, err)
-	require.Len(t, plan, 1)
+	assert.Equal(t, [][]string{{"task-a__legacy"}}, waveTaskIDGroups(waves))
 }
 
-func TestPlanWavesRejectsMissingWaveDeclarations(t *testing.T) {
+func TestPlanWavesRejectsDependencyCycles(t *testing.T) {
 	t.Parallel()
-	_, err := PlanWaves([]Node{
-		{TaskID: "a", TaskKind: model.TaskKindCode},
-	})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "missing required wave declaration")
+
+	// Contract: a depends_on cycle is a hard error and produces no plan. The
+	// error must identify the failure as a cycle (case-insensitive substring
+	// "cycle").
+	tests := []struct {
+		name  string
+		nodes []Node
+	}{
+		{
+			name: "two task cycle",
+			nodes: []Node{
+				{TaskID: "t-01", DependsOn: []string{"t-02"}, TargetFiles: []string{"a.go"}, TaskKind: model.TaskKindCode},
+				{TaskID: "t-02", DependsOn: []string{"t-01"}, TargetFiles: []string{"b.go"}, TaskKind: model.TaskKindCode},
+			},
+		},
+		{
+			name: "self cycle",
+			nodes: []Node{
+				{TaskID: "t-01", DependsOn: []string{"t-01"}, TargetFiles: []string{"a.go"}, TaskKind: model.TaskKindCode},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			waves, err := PlanWaves(tt.nodes)
+			require.Error(t, err)
+			assert.Nil(t, waves, "cycle must produce no plan")
+			assert.Contains(t, strings.ToLower(err.Error()), "cycle")
+		})
+	}
 }
 
-func TestPlanWavesRejectsSameWaveDependencies(t *testing.T) {
+func TestPlanWavesRejectsUnknownDependencyReference(t *testing.T) {
 	t.Parallel()
-	_, err := PlanWaves([]Node{
-		{TaskID: "a", WaveIndex: 1, TargetFiles: []string{"a.go"}, TaskKind: model.TaskKindCode},
-		{TaskID: "b", WaveIndex: 1, DependsOn: []string{"a"}, TargetFiles: []string{"b.go"}, TaskKind: model.TaskKindCode},
+
+	// Contract: an unresolved depends_on reference is a hard error and
+	// produces no plan. The error must call the dependency unknown
+	// (case-insensitive substring "unknown") and name the missing task ID.
+	waves, err := PlanWaves([]Node{
+		{TaskID: "t-01", DependsOn: []string{"t-missing"}, TargetFiles: []string{"a.go"}, TaskKind: model.TaskKindCode},
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "same or later wave")
+	assert.Nil(t, waves, "unknown dependency must produce no plan")
+	assert.Contains(t, strings.ToLower(err.Error()), "unknown")
+	assert.Contains(t, err.Error(), "t-missing")
 }
 
-func TestPlanWavesRejectsWaveGaps(t *testing.T) {
+func TestTaskPlanHashesAreStableForWavelessPlan(t *testing.T) {
 	t.Parallel()
-	_, err := PlanWaves([]Node{
-		{TaskID: "a", WaveIndex: 1, TargetFiles: []string{"a.go"}, TaskKind: model.TaskKindCode},
-		{TaskID: "b", WaveIndex: 3, TargetFiles: []string{"b.go"}, TaskKind: model.TaskKindCode},
-	})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "wave 2 missing")
+
+	base := `# Tasks
+
+Intro prose that is not task metadata.
+
+- [ ] ` + "`t-01`" + ` Build the parser
+  - depends_on: []
+  - target_files: ["internal/engine/wave/parse.go"]
+  - task_kind: code
+
+- [ ] ` + "`t-02`" + ` Cover the parser
+  - depends_on: ["t-01"]
+  - target_files: ["internal/engine/wave/parse_test.go"]
+  - task_kind: test
+`
+
+	// Identical tasks; whitespace-only reformatting of unrelated prose.
+	reformatted := `# Tasks
+
+
+Intro prose that is not task metadata.
+
+
+- [ ] ` + "`t-01`" + ` Build the parser
+  - depends_on: []
+  - target_files: ["internal/engine/wave/parse.go"]
+  - task_kind: code
+
+- [ ] ` + "`t-02`" + ` Cover the parser
+  - depends_on: ["t-01"]
+  - target_files: ["internal/engine/wave/parse_test.go"]
+  - task_kind: test
+`
+
+	hashFns := map[string]func(string) (string, error){
+		"structural": TaskPlanStructuralHash,
+		"scope":      TaskPlanScopeHash,
+		"semantic":   TaskPlanSemanticHash,
+	}
+
+	for name, hashFn := range hashFns {
+		name, hashFn := name, hashFn
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			first, err := hashFn(base)
+			require.NoError(t, err)
+			assert.NotEmpty(t, first)
+
+			for i := 0; i < 3; i++ {
+				again, err := hashFn(base)
+				require.NoError(t, err)
+				assert.Equal(t, first, again, "repeated calls must hash identically")
+			}
+
+			reformattedHash, err := hashFn(reformatted)
+			require.NoError(t, err)
+			assert.Equal(t, first, reformattedHash,
+				"whitespace-only reformatting of unrelated prose must not change the hash")
+		})
+	}
 }
 
 func TestTaskPlanSemanticHashIgnoresCheckboxState(t *testing.T) {

--- a/internal/model/reason_code.go
+++ b/internal/model/reason_code.go
@@ -362,10 +362,6 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 		Severity: ReasonSeverityError,
 		Message:  "A task is missing a concrete objective",
 	},
-	"plan_dimension_execution_missing_wave": {
-		Severity: ReasonSeverityError,
-		Message:  "A task is missing an execution wave",
-	},
 	"plan_dimension_key_links_missing_target_files": {
 		Severity: ReasonSeverityError,
 		Message:  "A task is missing target files",

--- a/internal/model/reason_code_contract_test.go
+++ b/internal/model/reason_code_contract_test.go
@@ -130,7 +130,6 @@ func canonicalReasonCodeSnapshot() []string {
 		"plan_dimension_dependency_self_reference",
 		"plan_dimension_dependency_unknown",
 		"plan_dimension_execution_invalid_wave_plan",
-		"plan_dimension_execution_missing_wave",
 		"plan_dimension_key_links_missing_target_files",
 		"plan_dimension_scope_invalid_target",
 		"plan_dimension_scope_out_of_bounds_target",
@@ -229,6 +228,30 @@ func canonicalReasonSeveritySnapshot(codes []string) map[string]ReasonSeverity {
 		severities[code] = severity
 	}
 	return severities
+}
+
+// The hand-declared `wave:` task metadata is retired — the engine computes
+// execution waves from depends_on + target_files — so validation no longer
+// demands a declared wave and the blocker vocabulary for it must be fully
+// removed: no canonical reason definition, no remediation vocabulary entry,
+// and no public recognition as a canonical code. The retired code is kept as
+// a string literal on purpose: any Go identifier for it is deleted together
+// with the vocabulary, and this contract must keep compiling after that.
+func TestDeclaredWaveBlockerVocabularyRetired(t *testing.T) {
+	t.Parallel()
+
+	const retired = "plan_dimension_execution_missing_wave"
+
+	_, inRegistry := canonicalReasonDefinitions[retired]
+	assert.Falsef(t, inRegistry,
+		"the canonical reason registry must not define the retired declared-wave blocker %q", retired)
+
+	_, inRemediations := blockerRemediations[retired]
+	assert.Falsef(t, inRemediations,
+		"the remediation vocabulary must not define the retired declared-wave blocker %q", retired)
+
+	assert.Falsef(t, IsCanonicalReasonCode(retired),
+		"%q must no longer be recognized as a canonical reason code", retired)
 }
 
 func TestNewReasonCodeMakesUnknownCodeExplicit(t *testing.T) {

--- a/internal/model/recovery.go
+++ b/internal/model/recovery.go
@@ -319,11 +319,6 @@ var blockerRemediations = map[string]blockerRemediation{
 		CommandTemplate: "slipway validate",
 		Class:           RecoveryClassFixScope,
 	},
-	"plan_dimension_execution_missing_wave": {
-		Remediation:     "Fix tasks.md so every task declares an execution wave.",
-		CommandTemplate: "slipway validate",
-		Class:           RecoveryClassFixScope,
-	},
 	"plan_dimension_key_links_missing_target_files": {
 		Remediation:     "Fix tasks.md so every task declares target_files.",
 		CommandTemplate: "slipway validate",

--- a/internal/state/execution_summary_test.go
+++ b/internal/state/execution_summary_test.go
@@ -419,7 +419,6 @@ func TestExecutionSummaryFreshnessTreatsTasksPlanHashMismatchAsStale(t *testing.
 	tasksPath := filepath.Join(bundleDir, "tasks.md")
 	require.NoError(t, os.WriteFile(tasksPath, []byte(`
 - [x] `+"`t-01`"+` complete implementation
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/a.go"]
   - task_kind: code
@@ -476,7 +475,6 @@ func TestExecutionSummaryFreshnessDiagnosticsIncludesPlanningEvidenceChain(t *te
 	tasksPath := filepath.Join(bundleDir, "tasks.md")
 	require.NoError(t, os.WriteFile(tasksPath, []byte(`
 - [x] `+"`task-a`"+` update diagnostics chain
-  - wave: 1
   - target_files: ["cmd/next.go"]
   - task_kind: code
 `), 0o644))

--- a/internal/state/health_test.go
+++ b/internal/state/health_test.go
@@ -155,7 +155,6 @@ func TestCollectHealthReportReportsMissingWavePlan(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "tasks.md"), []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` recover wave plan
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/run.go"]
   - task_kind: code
@@ -205,7 +204,6 @@ func TestCollectHealthReportReportsMalformedTaskEvidenceWithoutFailing(t *testin
 	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "tasks.md"), []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` report malformed task evidence
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/health.go"]
   - task_kind: code
@@ -261,7 +259,6 @@ func TestCollectHealthReportBlocksWavePlanRepairWhenCurrentTasksDrifted(t *testi
 	require.NoError(t, os.WriteFile(tasksPath, []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` historical task
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/run.go"]
   - task_kind: code
@@ -286,7 +283,6 @@ func TestCollectHealthReportBlocksWavePlanRepairWhenCurrentTasksDrifted(t *testi
 	require.NoError(t, os.WriteFile(tasksPath, []byte(`# Tasks
 
 - [ ] `+"`t-02`"+` replacement task after drift
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/repair.go"]
   - task_kind: code
@@ -327,7 +323,6 @@ func TestCollectHealthReportReportsWavePlanDriftWithPivotHint(t *testing.T) {
 	require.NoError(t, os.WriteFile(tasksPath, []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` preserve original task
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/run.go"]
   - task_kind: code
@@ -338,7 +333,6 @@ func TestCollectHealthReportReportsWavePlanDriftWithPivotHint(t *testing.T) {
 	require.NoError(t, os.WriteFile(tasksPath, []byte(`# Tasks
 
 - [ ] `+"`t-02`"+` replace task after drift
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/repair.go"]
   - task_kind: code
@@ -378,7 +372,6 @@ func TestCollectHealthReportBlocksUnreadableWavePlanRepairWhenCurrentTasksDrifte
 	require.NoError(t, os.WriteFile(tasksPath, []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` historical task
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/run.go"]
   - task_kind: code
@@ -405,7 +398,6 @@ func TestCollectHealthReportBlocksUnreadableWavePlanRepairWhenCurrentTasksDrifte
 	require.NoError(t, os.WriteFile(tasksPath, []byte(`# Tasks
 
 - [ ] `+"`t-02`"+` replacement task after drift
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/repair.go"]
   - task_kind: code
@@ -446,7 +438,6 @@ func TestCollectHealthReportReportsMissingWaveRuns(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "tasks.md"), []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` recover wave evidence
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/run.go"]
   - task_kind: code
@@ -500,13 +491,11 @@ func TestCollectHealthReportReportsIncompleteWaveRuns(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "tasks.md"), []byte(`# Tasks
 
 - [x] `+"`t-01`"+` completed first wave
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/run.go"]
   - task_kind: code
 
 - [ ] `+"`t-02`"+` pending second wave
-  - wave: 2
   - depends_on: ["t-01"]
   - target_files: ["cmd/review.go"]
   - task_kind: code
@@ -573,13 +562,11 @@ func TestCollectHealthReportReportsWaveTaskLinkageMismatch(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "tasks.md"), []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` build first wave
-  - wave: 1
   - depends_on: []
   - target_files: ["cmd/run.go"]
   - task_kind: code
 
 - [ ] `+"`t-02`"+` build second wave
-  - wave: 2
   - depends_on: ["t-01"]
   - target_files: ["cmd/review.go"]
   - task_kind: code

--- a/internal/state/repair_test.go
+++ b/internal/state/repair_test.go
@@ -100,7 +100,7 @@ func seedWavePlanRepairChange(t *testing.T, slug, tasksMD string) (string, model
 
 func TestWavePlanRepairDriftRebuildsOnStructuralDriftWhenSummaryNotReady(t *testing.T) {
 	t.Parallel()
-	tasksA := "# Tasks\n\n- [ ] `t-01` original\n  - wave: 1\n  - target_files: [\"a.go\"]\n  - task_kind: code\n"
+	tasksA := "# Tasks\n\n- [ ] `t-01` original\n  - target_files: [\"a.go\"]\n  - task_kind: code\n"
 	root, change, plan := seedWavePlanRepairChange(t, "wave-repair-structural", tasksA)
 
 	// No drift before editing tasks.md.
@@ -113,7 +113,7 @@ func TestWavePlanRepairDriftRebuildsOnStructuralDriftWhenSummaryNotReady(t *test
 	// the readable-but-stale plan (#97 / REQ-006).
 	bundleDir := filepath.Join(root, "artifacts", "changes", change.Slug)
 	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "tasks.md"),
-		[]byte("# Tasks\n\n- [ ] `t-01` original\n  - wave: 1\n  - target_files: [\"a.go\"]\n  - task_kind: test\n"), 0o644))
+		[]byte("# Tasks\n\n- [ ] `t-01` original\n  - target_files: [\"a.go\"]\n  - task_kind: test\n"), 0o644))
 	changed, blocked, err = wavePlanRepairDrift(root, change, plan, nil)
 	require.NoError(t, err)
 	assert.True(t, changed, "structural drift with no ready summary must rebuild the wave-plan")
@@ -122,7 +122,7 @@ func TestWavePlanRepairDriftRebuildsOnStructuralDriftWhenSummaryNotReady(t *test
 
 func TestWavePlanRepairDriftRebuildsLegacyPlanMissingScopeHash(t *testing.T) {
 	t.Parallel()
-	tasksA := "# Tasks\n\n- [ ] `t-01` original\n  - wave: 1\n  - target_files: [\"a.go\"]\n  - task_kind: code\n"
+	tasksA := "# Tasks\n\n- [ ] `t-01` original\n  - target_files: [\"a.go\"]\n  - task_kind: code\n"
 	root, change, plan := seedWavePlanRepairChange(t, "wave-repair-legacy-scope", tasksA)
 
 	// Simulate a plan materialized before the scope-hash field existed: structure
@@ -132,7 +132,7 @@ func TestWavePlanRepairDriftRebuildsLegacyPlanMissingScopeHash(t *testing.T) {
 	// A target_files-only edit keeps the structure identical but changes scope.
 	bundleDir := filepath.Join(root, "artifacts", "changes", change.Slug)
 	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "tasks.md"),
-		[]byte("# Tasks\n\n- [ ] `t-01` original\n  - wave: 1\n  - target_files: [\"b.go\"]\n  - task_kind: code\n"), 0o644))
+		[]byte("# Tasks\n\n- [ ] `t-01` original\n  - target_files: [\"b.go\"]\n  - task_kind: code\n"), 0o644))
 
 	changed, blocked, err := wavePlanRepairDrift(root, change, plan, nil)
 	require.NoError(t, err)

--- a/internal/state/wave_execution_test.go
+++ b/internal/state/wave_execution_test.go
@@ -97,7 +97,6 @@ func TestMaterializeWavePlanGeneratedAtUsesMaterializationTime(t *testing.T) {
 	require.NoError(t, os.WriteFile(tasksPath, []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` prove generated_at boundary
-  - wave: 1
   - target_files: ["internal/state/wave_execution.go"]
   - task_kind: test
   - acceptance: generated_at is materialization time
@@ -115,9 +114,9 @@ func TestMaterializeWavePlanGeneratedAtUsesMaterializationTime(t *testing.T) {
 
 const (
 	twoIndependentTasksMD = "# Tasks\n\n" +
-		"- [ ] `t-01` first\n  - wave: 1\n  - target_files: [\"a.go\"]\n  - task_kind: code\n" +
-		"- [ ] `t-02` second\n  - wave: 1\n  - target_files: [\"b.go\"]\n  - task_kind: code\n"
-	oneTaskMD = "# Tasks\n\n- [ ] `t-01` solo\n  - wave: 1\n  - target_files: [\"a.go\"]\n  - task_kind: code\n"
+		"- [ ] `t-01` first\n  - target_files: [\"a.go\"]\n  - task_kind: code\n" +
+		"- [ ] `t-02` second\n  - target_files: [\"b.go\"]\n  - task_kind: code\n"
+	oneTaskMD = "# Tasks\n\n- [ ] `t-01` solo\n  - target_files: [\"a.go\"]\n  - task_kind: code\n"
 )
 
 var waveMaterializeTime = time.Date(2026, 6, 9, 0, 0, 0, 0, time.UTC)
@@ -177,7 +176,7 @@ func TestMaterializeWavePlanNormalizesBackslashTargetFiles(t *testing.T) {
 	root := createRuntimeLayout(t)
 	change := saveActiveChangeForTest(t, root, "wave-normalize-backslash-target")
 	writeBundleTasksForTest(t, root, change, "# Tasks\n\n"+
-		"- [ ] `t-01` first\n  - wave: 1\n  - target_files: [\"cmd\\\\run.go\"]\n  - task_kind: code\n")
+		"- [ ] `t-01` first\n  - target_files: [\"cmd\\\\run.go\"]\n  - task_kind: code\n")
 
 	plan, err := MaterializeWavePlanAt(root, change, waveMaterializeTime)
 	require.NoError(t, err)

--- a/internal/state/wave_execution_transaction_test.go
+++ b/internal/state/wave_execution_transaction_test.go
@@ -27,7 +27,6 @@ func TestMaterializeWavePlanTransactionOpDefersWriteUntilApplied(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "tasks.md"), []byte(`# Tasks
 
 - [ ] `+"`t-01`"+` implement transaction
-  - wave: 1
   - target_files: ["internal/fsutil/transaction.go"]
   - task_kind: code
 `), 0o644))

--- a/internal/tmpl/templates/artifacts/tasks.md
+++ b/internal/tmpl/templates/artifacts/tasks.md
@@ -10,7 +10,6 @@ output path, and the upstream dependencies to read by path.
 Format — replace every <...> with concrete, change-specific content:
 
   - [ ] `t-01` <concrete task objective>
-    - wave: 1
     - depends_on: []
     - target_files: [<path/to/file.go>]
     - task_kind: code
@@ -18,6 +17,8 @@ Format — replace every <...> with concrete, change-specific content:
 
 Every task MUST name concrete `target_files` that bound the files or evidence
 targets it changes or verifies.
+Do not declare a `wave:` line: the engine assigns waves from `depends_on` and
+`target_files`, and a hand-declared wave is rejected.
 This file is unwritten until you author it: an empty or placeholder task list is
 rejected by the tasks substance gate and cannot reach done.
 -->

--- a/internal/tmpl/templates/skills/plan-audit/SKILL.md
+++ b/internal/tmpl/templates/skills/plan-audit/SKILL.md
@@ -87,9 +87,19 @@ path; honor its `context`/`rules` but never copy them into the file:
   selected approach and evidence recorded in `research.md`; author the formal
   decision here after the requirements are real.
 - `slipway instructions tasks` — each task carries a concrete objective plus
-  `wave`, `depends_on`, `target_files`, `task_kind`, and `covers`. Every task
-  names concrete `target_files` that bound the files or evidence targets it
-  changes or verifies.
+  `depends_on`, `target_files`, `task_kind`, and `covers`. The engine assigns
+  waves from `depends_on` and `target_files`; do not author a `wave:` line — a
+  hand-declared wave is rejected fail-closed. Every task names concrete
+  `target_files` that bound the files or evidence targets it changes or
+  verifies.
+
+Author task width for the computed schedule. Keep `depends_on` honest: it is a
+scheduling input, not narrative order, and a dependency that is not a real
+execution-order constraint needlessly serializes the waves. Keep `target_files`
+precise: name exact files rather than directories or globs, because overlapping
+or broad targets bump tasks into later waves and flatten the schedule. Absorb
+small same-file steps into one task instead of splitting work that can never
+run concurrently.
 
 A mechanical or vacuous plan artifact cannot reach done. Re-run `slipway validate`
 until the substance gate passes, then audit.
@@ -130,8 +140,8 @@ more than 5 tasks; oversized waves are warnings, not blockers.
 Explicitly check all eight dimensions and record blocker/warning IDs by
 dimension:
 1. **Coverage (Nyquist Check)**: every `REQ-*` SHOULD be covered by at least one task. Standard/strict uncovered requirements block; light uncovered requirements warn.
-2. **Completeness**: each task has objective, `wave`, dependencies, and expected outputs.
-3. **Dependency Integrity**: `depends_on` references valid earlier-wave tasks and has no cycles.
+2. **Completeness**: each task has objective, dependencies, and expected outputs.
+3. **Dependency Integrity**: every `depends_on` reference resolves and has no cycles, and every dependency is a real execution-order dependency — reject fabricated or narrative-only dependencies that needlessly serialize the computed waves.
 4. **Key Links**: each task names concrete `target_files` for the files or evidence targets it changes or verifies.
 5. **Scope Control**: task targets stay inside declared scope.
 6. **Context Compliance**: task metadata supports context-safe execution (`task_kind` where present).


### PR DESCRIPTION
## Summary

- Compute task waves in the engine from `depends_on` and `target_files`, with deterministic same-wave conflict bumping.
- Retire authored `wave:` metadata fail-closed across parsing, validation vocabulary, hashes, command/state fixtures, and public guidance.
- Update planning surfaces and workflow docs to teach honest dependencies, precise target files, and same-file absorption.
- Add regression coverage for the review-found deferred-root/dependent task-ID ordering edge case, then finalize the governed change archive.

## Verification

- `go test ./... -count=1`
- `go build ./...`
- `go vet ./...`
- `git diff --check`
- `go run . validate --json` before finalization: fresh evidence, `G_plan/G_scope/G_ship` approved
- `go run . done --json`: archived the governed change, `status=done`, `archive_commit_required=true` satisfied by this commit
