### PR TITLE
fix(status): expose done-ready and archived status

### DIFF
--- a/artifacts/changes/archived/resolve-github-issues-195-and-196-make-status-expose-done-re/assurance.md
+++ b/artifacts/changes/archived/resolve-github-issues-195-and-196-make-status-expose-done-re/assurance.md
@@ -1,0 +1,88 @@
+# Assurance
+
+## Scope Summary
+
+This change resolves GitHub issues #195 and #196 for the `slipway status`
+surface:
+
+- Active governed changes that are ready for finalization now expose a
+  machine-readable `done_ready: true` projection while preserving the persisted
+  lifecycle status as `active`.
+- Explicit status lookup for a finalized archived change now returns a
+  read-only archived status view instead of reporting a missing active bundle as
+  `change_state_load_failed`.
+
+The implementation is scoped to the status command/view/rendering path and
+focused regression tests listed in `tasks.md`.
+
+## Verification Verdict
+
+Current execution evidence for task `t-01` is passing with fresh task evidence.
+Regression coverage was added before implementation and then made green:
+
+- RED: `go test ./cmd -run 'TestBuildGovernedStatusViewExposesDoneReadyReadiness|TestCLIEndToEndSuccessfulDoneArchive' -count=1`
+  failed before the implementation because `done_ready` was absent and archived
+  lookup returned a missing active change error.
+- GREEN: the same focused command passed after implementation.
+- GREEN: `go test ./cmd -count=1` passed.
+- GREEN: `go test -count=1 ./...` passed.
+- GREEN: `git diff --check` passed.
+- GREEN: `go test -count=1 -coverpkg=./cmd,./internal/state
+  -coverprofile=/tmp/slipway-195-196-cross-cover.out ./cmd ./internal/state`
+  passed, with changed behavior covered by focused status and archive tests.
+
+The latest active validation reached `S4_VERIFY` with fresh evidence and a
+passing scope contract. Spec-compliance review, code-quality review, and
+goal-verification are all recorded as passing for run summary version `1`.
+Final ship-readiness still depends on final-closeout recording the required
+standard-preset assurance attestation before `slipway done` archives the change.
+
+## Evidence Index
+
+- Task evidence: `verification/execution-summary.yaml` records `t-01` as
+  passing with changed files matching planned target files.
+- Scope contract: `go run . status --json` and `go run . validate --json`
+  report `scope_contract.status=pass`.
+- Review evidence:
+  - `verification/spec-compliance-review.yaml` records `layer:R0=pass`,
+    `scope_contract:pass`, and `negative_path:pass`.
+  - `verification/code-quality-review.yaml` records `layer:IR1=pass`.
+- Goal evidence: `verification/goal-verification.yaml` records fresh command
+  proof, scope-contract proof, and change-surface coverage proof.
+- Implementation: `cmd/status.go`, `cmd/status_view_build.go`, and
+  `cmd/status_render.go`.
+- Regression tests: `cmd/status_view_build_test.go` and `cmd/cli_e2e_test.go`.
+
+## Requirement Coverage
+
+- REQ-001 is covered by the done-ready projection in status view construction,
+  JSON/text rendering, the `run_slipway_done_to_finalize` reason, and
+  `TestBuildGovernedStatusViewExposesDoneReadyReadiness`.
+- REQ-002 is covered by archived fallback status lookup, archived status view
+  rendering, and the archived lookup assertions in
+  `TestCLIEndToEndSuccessfulDoneArchive`.
+
+## Residual Risks and Exceptions
+
+No residual implementation exceptions are accepted at this point. The primary
+risk is accidental drift between text and JSON status surfaces; both are updated
+from the same `statusView` projection fields and covered by focused tests.
+
+The archived fallback intentionally preserves active state priority: active
+`state.LoadChange` succeeds first when an active change exists, and archived
+lookup is used only after active loading fails.
+
+## Rollback Readiness
+
+Rollback is a normal git revert of the status command/view/rendering changes and
+their focused regression tests. No dependency, schema migration, external API,
+or irreversible data operation is part of this change.
+
+## Archive Decision
+
+Ready for final closeout. Active `validate --json` freshness and scope evidence
+has been captured at `S4_VERIFY`; required review evidence and goal-verification
+evidence are passing. After final-closeout records
+`closeout:assurance_complete=pass` and the ship gate reports done-ready,
+`slipway done` should archive the governed bundle under
+`artifacts/changes/archived/resolve-github-issues-195-and-196-make-status-expose-done-re/`.

--- a/artifacts/changes/archived/resolve-github-issues-195-and-196-make-status-expose-done-re/change.yaml
+++ b/artifacts/changes/archived/resolve-github-issues-195-and-196-make-status-expose-done-re/change.yaml
@@ -1,0 +1,59 @@
+version: 1
+slug: resolve-github-issues-195-and-196-make-status-expose-done-re
+description: 'Resolve GitHub issues #195 and #196: make status expose done-ready readiness and archived-change status without false missing active bundle repair guidance.'
+status: done
+current_state: DONE
+needs_discovery: true
+complexity_level: simple
+base_ref: HEAD
+created_at: 2026-06-13T15:33:50.285159Z
+quality_mode: standard
+workflow_preset: standard
+worktree_branch: feat/resolve-github-issues-195-and-196-make-status-expose-done-re
+artifact_schema: expanded
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: d5d9966575298531f8ef2c5e3df5ff727f676d76c29b91824984c170b68b3062
+        updated_at: 2026-06-13T16:40:37.800088395Z
+    decision:
+        id: decision
+        path: decision.md
+        state: frozen
+        content_hash: e204bc9931fc71123788dcb9b4b7eddf7daa7045332e1c969c473b79f6cd8c91
+        updated_at: 2026-06-13T15:42:21.838102505Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: 61481d9beff4b8d439cfa45bfb2a04d35d311ada1ab2a8842dba33c96ae46e97
+        updated_at: 2026-06-13T15:35:46.735136921Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: 6e15ccdd56355444bf8f6a2937bda9f28eb274be82b0143fcb245b6cf3821363
+        updated_at: 2026-06-13T15:42:21.837625089Z
+    research:
+        id: research
+        path: research.md
+        state: frozen
+        content_hash: 9ce9b6b891c94aa534a41a1773d66f7becc6a1552c09ecd31db5f65450b1b477
+        updated_at: 2026-06-13T15:41:06.636344254Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: a90264a3e925610a4df2d72a194c44d3ca493229bf9ed75d7f5add74544a7a02
+        updated_at: 2026-06-13T16:19:41.863706913Z
+evidence_refs:
+    code-quality-review: .worktrees/resolve-github-issues-195-and-196-make-status-expose-done-re/artifacts/changes/resolve-github-issues-195-and-196-make-status-expose-done-re/verification/code-quality-review.yaml
+    final-closeout: .worktrees/resolve-github-issues-195-and-196-make-status-expose-done-re/artifacts/changes/resolve-github-issues-195-and-196-make-status-expose-done-re/verification/final-closeout.yaml
+    goal-verification: .worktrees/resolve-github-issues-195-and-196-make-status-expose-done-re/artifacts/changes/resolve-github-issues-195-and-196-make-status-expose-done-re/verification/goal-verification.yaml
+    intake-clarification: .worktrees/resolve-github-issues-195-and-196-make-status-expose-done-re/artifacts/changes/resolve-github-issues-195-and-196-make-status-expose-done-re/verification/intake-clarification.yaml
+    plan-audit: .worktrees/resolve-github-issues-195-and-196-make-status-expose-done-re/artifacts/changes/resolve-github-issues-195-and-196-make-status-expose-done-re/verification/plan-audit.yaml
+    research-orchestration: .worktrees/resolve-github-issues-195-and-196-make-status-expose-done-re/artifacts/changes/resolve-github-issues-195-and-196-make-status-expose-done-re/verification/research-orchestration.yaml
+    spec-compliance-review: .worktrees/resolve-github-issues-195-and-196-make-status-expose-done-re/artifacts/changes/resolve-github-issues-195-and-196-make-status-expose-done-re/verification/spec-compliance-review.yaml
+    wave-orchestration: .worktrees/resolve-github-issues-195-and-196-make-status-expose-done-re/artifacts/changes/resolve-github-issues-195-and-196-make-status-expose-done-re/verification/wave-orchestration.yaml

--- a/artifacts/changes/archived/resolve-github-issues-195-and-196-make-status-expose-done-re/decision.md
+++ b/artifacts/changes/archived/resolve-github-issues-195-and-196-make-status-expose-done-re/decision.md
@@ -1,0 +1,61 @@
+# Decision
+
+## Alternatives Considered
+
+### Option A: Reuse `lifecycle_status` for done-ready
+Set `lifecycle_status` to `done_ready` when S4 ship readiness is approved.
+This would make the handoff visible, but it would overload a field that already
+maps to persisted `model.Change.Status`. Consumers could mistake readiness for a
+finalized terminal state.
+
+### Option B: Add projection fields and narrative
+Keep `lifecycle_status` as the persisted change status and add optional
+projection fields for `done_ready` and `archived`. Update the status narrative
+and text hint to make the same facts human-visible. This is additive, keeps the
+state machine semantics intact, and gives agents a machine-readable contract.
+
+### Option C: Narrative-only repair
+Only rewrite the narrative for S4 ship-ready and archived views. This avoids
+schema additions but leaves agents and scripts without a clear top-level status
+signal.
+
+## Selected Approach
+
+Select Option B. `status` will keep persisted lifecycle status intact, add
+machine-readable projection fields for done-ready and archived states, and align
+the text narrative with those fields. Explicit archived status reads will use
+`state.LoadArchivedChange` only after active load fails, preserving active state
+priority.
+
+## Interfaces and Data Flow
+
+- `statusView` gains optional `done_ready`, `archived`, and `archive_path`
+  fields.
+- Governed status construction sets `done_ready` when the current state is
+  `S4_VERIFY` and `G_ship` is approved, then appends
+  `run_slipway_done_to_finalize` and canonical recovery.
+- `status --change <slug>` first attempts active `state.LoadChange`; if active
+  load fails and `state.LoadArchivedChange` succeeds, it renders a read-only
+  archived status view.
+- Text rendering uses the same `done_ready` and `archived` fields for narrative
+  and primary action hints.
+
+## Rollout and Rollback
+
+Rollout is a normal CLI release of additive status behavior. Rollback is a git
+revert of the changes to `cmd/status.go`, `cmd/status_view_build.go`,
+`cmd/status_render.go`, and focused tests. Verification commands:
+
+- `go test ./cmd`
+- `go test ./...`
+- `git diff --check`
+- `go run . validate --json`
+
+## Risk
+
+- Done-ready must not become a persisted terminal state. The implementation
+  keeps `lifecycle_status=active` and adds `done_ready=true`.
+- Archived fallback must not hide a valid active change. The implementation
+  tries active load first and falls back only on active-load failure.
+- Text and JSON status could drift. The implementation updates both the JSON
+  view and the text hint/narrative path.

--- a/artifacts/changes/archived/resolve-github-issues-195-and-196-make-status-expose-done-re/intent.md
+++ b/artifacts/changes/archived/resolve-github-issues-195-and-196-make-status-expose-done-re/intent.md
@@ -1,0 +1,50 @@
+# Intent
+
+## Summary
+Resolve GitHub issues #195 and #196: make status expose done-ready readiness and archived-change status without false missing active bundle repair guidance.
+
+## Complexity Assessment
+simple
+Rationale: both issues target the same CLI status boundary. The likely change is
+localized to status projection and archived-bundle lookup/error classification,
+with focused command-output tests.
+
+## In Scope
+- `status --json` top-level output after a `done.ready` lifecycle event, so
+  operators can see that all gates passed and `slipway done` is the remaining
+  action without inspecting the timeline.
+- `status --json --change <slug>` behavior when the active bundle is missing
+  because the change was finalized into `artifacts/changes/archived/<slug>`.
+- Regression tests for the done-ready and archived-change status surfaces.
+
+## Out of Scope
+- Changing `slipway done` archival mechanics.
+- Reopening or repairing historical Lattice bundles.
+- Broad lifecycle-state model redesign outside the status-facing projection.
+
+## Constraints
+- The current worktree's Slipway behavior is authority.
+- Archived changes must not be presented as active corruption when an archived
+  bundle exists.
+- Done-ready must remain a readiness/finalization signal, not a false completed
+  state before `slipway done` runs.
+
+## Acceptance Signals
+- Focused tests cover status output for `done.ready` after S4 verification.
+- Focused tests cover `status --change <slug>` when only the archived bundle
+  exists.
+- `go test ./...` passes.
+- `go run . validate --json` reports the governed change ready to advance or
+  identifies only expected lifecycle evidence steps before final closeout.
+
+## Open Questions
+None.
+
+## Approved Summary
+Approved by the user's request to resolve open issues #195 and #196. The change
+will make `status --json` expose done-ready readiness after all gates pass, and
+will make archived changes report as archived/done or explicitly out of active
+status scope instead of `change_state_load_failed` for a missing active bundle.
+Scope excludes changing archival mechanics, historical bundle repair, and broad
+lifecycle model redesign. Primary acceptance is focused status regression tests
+plus the repository test suite.

--- a/artifacts/changes/archived/resolve-github-issues-195-and-196-make-status-expose-done-re/requirements.md
+++ b/artifacts/changes/archived/resolve-github-issues-195-and-196-make-status-expose-done-re/requirements.md
@@ -1,0 +1,29 @@
+# Requirements
+
+## Requirements
+
+### Requirement: Done-ready status projection
+REQ-001: The system MUST expose a top-level done-ready readiness signal in
+`slipway status --json` when an active governed change is in `S4_VERIFY` and
+the ship gate is approved, without changing the persisted lifecycle status to
+done before finalization.
+
+#### Scenario: Status shows done-ready handoff
+GIVEN an active governed change in `S4_VERIFY` with approved ship readiness
+WHEN an operator runs `slipway status --json --change <slug>`
+THEN the JSON output includes `done_ready: true`
+AND the output includes the `run_slipway_done_to_finalize` reason
+AND the narrative tells the operator to run `slipway done` to finalize.
+
+### Requirement: Archived change status lookup
+REQ-002: The system MUST make `slipway status --json --change <slug>` report an
+archived terminal record when the active bundle is absent or missing authority
+but `artifacts/changes/archived/<slug>/change.yaml` exists.
+
+#### Scenario: Status reports archived terminal record
+GIVEN a governed change that has been successfully finalized and archived
+WHEN an operator runs `slipway status --json --change <slug>`
+THEN the command exits successfully
+AND the JSON output includes `archived: true`
+AND the lifecycle status reflects the archived record status
+AND the output does not report `change_state_load_failed`.

--- a/artifacts/changes/archived/resolve-github-issues-195-and-196-make-status-expose-done-re/research.md
+++ b/artifacts/changes/archived/resolve-github-issues-195-and-196-make-status-expose-done-re/research.md
@@ -1,0 +1,127 @@
+# Research
+
+## Alternatives Considered
+
+### Architecture
+- Affected modules:
+  - `cmd/status.go`: explicit `status --change` route and `statusView` JSON
+    shape.
+  - `cmd/status_view_build.go`: governed status readiness projection and
+    narrative.
+  - `cmd/status_render.go`: text rendering and "What's Next" hint.
+  - `cmd/common.go`: shared active-change loading and existing archived fallback
+    precedent.
+  - `internal/state/lifecycle.go` and `internal/state/store.go`: archived
+    change loading and archive path discovery.
+- Dependency chains:
+  - `status --change` -> `loadChangeBySlug` -> `state.LoadChange` -> status
+    view rendering.
+  - governed status view -> `progression.EvaluateGovernanceReadiness` ->
+    status blockers/recovery/narrative.
+  - archived read path -> `state.LoadArchivedChange` ->
+    `artifacts/changes/archived/<slug>/change.yaml`.
+- Blast radius: low to medium. The public `status` surface changes, but the
+  lifecycle mutation path, archive mechanics, and state persistence remain
+  unchanged.
+- Constraints:
+  - Active lifecycle state must remain `active` until `slipway done` archives
+    the change.
+  - Archived records are terminal read targets, not active lifecycle targets.
+  - Existing repair/delete diagnostics must remain available when no archived
+    authority exists.
+
+### Patterns
+- Existing conventions:
+  - `cmd/next.go` projects done-ready as a read-only query result rather than
+    persisting a new state.
+  - `cmd/common.go` already falls back to archived records for active-only
+    command resolution and returns archive metadata instead of raw load failure.
+  - `cmd/status_view_build.go` centralizes status narrative and blocker
+    projection.
+- Reusable abstractions:
+  - `appendReasonCodes` for deduplicating `run_slipway_done_to_finalize`.
+  - `model.BuildRecovery` for canonical finalization recovery.
+  - `state.LoadArchivedChange` and `state.ArchivedChangeFilePathForRead` for
+    terminal record reads.
+- Convention deviations:
+  - Additive `statusView` fields are required because `lifecycle_status` already
+    means persisted change status.
+
+### Risks
+- Technical risks:
+  - Medium: reporting done-ready as `done` would incorrectly imply the archive
+    already happened.
+  - Medium: an archive fallback could hide real active-bundle corruption if
+    applied before checking a valid active change.
+  - Low: additive JSON fields may require text rendering updates to avoid
+    operator drift.
+- Guardrail domains: none of the sensitive domains apply. This is local CLI
+  state projection.
+- Reversibility: high. The change is confined to status view construction,
+  explicit status routing, and tests.
+
+### Test Strategy
+- Existing coverage:
+  - `cmd/progression_next_test.go` verifies done-ready read-only projection for
+    `next`.
+  - `cmd/cli_e2e_test.go` verifies `done` archives a ready change.
+  - `cmd/status_view_build_test.go` covers status view projection.
+- Infrastructure needs:
+  - Reuse existing command fixtures: `createGovernedRequest`,
+    `markChangeReadyForDone`, `writePassingFinalCloseoutEvidence`, and
+    `state.ArchiveChange`.
+- Verification approach:
+  - Add a focused status-view test asserting `done_ready`, finalization blocker,
+    and narrative for an S4 ship-ready change.
+  - Add a command-level archived-status test asserting
+    `status --json --change <slug>` returns archived/done metadata after
+    finalization.
+  - Run focused `go test ./cmd`, then full `go test ./...` and Slipway
+    validation.
+
+### Options
+- Option A: Change `lifecycle_status` from `active` to `done_ready` when S4 ship
+  readiness is approved. Tradeoff: very visible, but it overloads a persisted
+  status field and risks consumers treating the change as terminal before
+  `slipway done`.
+- Option B: Add explicit top-level status projection fields such as
+  `done_ready` and `archived`, keep persisted `lifecycle_status`, and update the
+  narrative/text hint. Tradeoff: additive and compatible, but consumers must
+  read the new fields for the richer state.
+- Option C: Keep JSON shape unchanged and only rewrite narrative. Tradeoff:
+  lowest schema impact, but weaker machine-readable contract and less useful
+  for agents.
+- Selected: Option B. It preserves lifecycle semantics while adding the
+  machine-readable and human-readable signals requested by #195 and #196.
+
+## Unknowns
+- Resolved: whether archived fallback already exists elsewhere -> yes,
+  `resolveExplicitChange` uses `state.LoadArchivedChange` to avoid active-state
+  false positives.
+- Resolved: whether done-ready can be projected without new persistence -> yes,
+  `next` already does this through S4 ship authority evaluation.
+- Remaining: None.
+
+## Assumptions
+- `run_slipway_done_to_finalize` remains the canonical done-ready reason code.
+  Evidence: existing `next` projection and recovery taxonomy use it.
+- `lifecycle_status` should continue to reflect `model.Change.Status`.
+  Evidence: `statusView` currently maps it directly from `change.Status`, and
+  `done` is only set by archive finalization.
+- Archived status should be read-only and not expose active next actions.
+  Evidence: archived changes are loaded from `artifacts/changes/archived` and
+  active commands treat them as outside active validation scope.
+
+## Canonical References
+- `cmd/status.go:15`
+- `cmd/status.go:202`
+- `cmd/status.go:381`
+- `cmd/status_view_build.go:21`
+- `cmd/status_view_build.go:318`
+- `cmd/status_render.go:39`
+- `cmd/common.go:347`
+- `cmd/next.go:516`
+- `internal/state/lifecycle.go:23`
+- `internal/state/store.go:223`
+- `cmd/progression_next_test.go:1727`
+- `cmd/cli_e2e_test.go:448`

--- a/artifacts/changes/archived/resolve-github-issues-195-and-196-make-status-expose-done-re/tasks.md
+++ b/artifacts/changes/archived/resolve-github-issues-195-and-196-make-status-expose-done-re/tasks.md
@@ -1,0 +1,9 @@
+# Tasks
+
+## Task List
+
+- [x] `t-01` Implement done-ready and archived status projections with focused regression tests
+  - depends_on: []
+  - target_files: ["cmd/status.go", "cmd/status_view_build.go", "cmd/status_render.go", "cmd/status_view_build_test.go", "cmd/cli_e2e_test.go", "internal/state/store.go"]
+  - task_kind: code
+  - covers: [REQ-001, REQ-002]

--- a/artifacts/codebase/ARCHITECTURE.md
+++ b/artifacts/codebase/ARCHITECTURE.md
@@ -1,58 +1,51 @@
 # Architecture
 
 Re-authored for change
-`resolve-github-issue-184-add-gsd-style-automatic-subagent-di`
-(GitHub issue #184).
+`resolve-github-issues-195-and-196-make-status-expose-done-re`
+(GitHub issues #195 and #196).
 
-Question: how should Slipway's generated `wave-orchestration` host surface make
-`parallel: true` waves executable through real runtime subagents, especially for
-Codex, without moving lifecycle or evidence authority out of the CLI?
+Question: how should `slipway status` expose terminal readiness and archived
+records without weakening active lifecycle authority?
 
 ## Affected Seams
 
-- `internal/tmpl/templates/skills/wave-orchestration/SKILL.md.tmpl:69` through
-  `internal/tmpl/templates/skills/wave-orchestration/SKILL.md.tmpl:116` is the
-  generated host contract for wave execution. It already says waves dispatch
-  concurrently by default, but it still allows degraded sequential mode as
-  visible-but-nonblocking and names only `changed_files`, `test_summary`, and
-  `evidence_ref` as executor outputs.
-- `internal/tmpl/templates/skills/wave-orchestration/references/executor-dispatch-reference.md:34`
-  through
-  `internal/tmpl/templates/skills/wave-orchestration/references/executor-dispatch-reference.md:61`
-  is the detailed runtime adapter reference. It currently maps Codex to
-  `codex -q --task`, which is the core issue #184 mismatch.
-- `internal/toolgen/toolgen_test.go:1069` through
-  `internal/toolgen/toolgen_test.go:1094` generates a Claude adapter tree and
-  asserts high-level parallel-by-default contract text. This is the established
-  generated-surface regression location.
-- `internal/tmpl/thin_host_content_test.go:56` through
-  `internal/tmpl/thin_host_content_test.go:92` directly renders the
-  `wave-orchestration` template and reads the executor dispatch reference,
-  making it a good focused place for reference-level contract tests.
+- `cmd/status.go:202` through `cmd/status.go:219` is the explicit
+  `status --change <slug>` route. It currently calls `loadChangeBySlug`, whose
+  active-only loader returns an error before archived records can be surfaced.
+- `cmd/common.go:347` through `cmd/common.go:367` already contains the archived
+  fallback pattern for active-only commands. `resolveExplicitChange` maps an
+  archived slug to `archived_change_not_validatable` with archive metadata,
+  proving that archived lookup is already a supported read concern.
+- `cmd/status_view_build.go:21` through `cmd/status_view_build.go:155` builds
+  the governed status projection. It evaluates governance readiness and gate
+  state, but does not convert an approved S4 ship gate into a top-level
+  done-ready signal for status.
+- `cmd/next.go:516` through `cmd/next.go:535` contains the existing read-only
+  done-ready projection used by `next`: S4 plus approved ship authority becomes
+  `advanced.action=done_ready` with `run_slipway_done_to_finalize`.
+- `internal/state/lifecycle.go:23` through `internal/state/lifecycle.go:32`
+  loads archived changes from `artifacts/changes/archived/<slug>/change.yaml`.
+  `internal/state/store.go:223` through `internal/state/store.go:228`
+  searches archived records across workspace roots.
 
 ## Dependency Flow
 
-Template and reference sources under `internal/tmpl/templates/skills/` feed
-`internal/toolgen.Generate`, which renders host-specific adapter trees into
-tool roots during tests and during `slipway init --tools ... --refresh`.
-Codex project-local skills are still generated under `.codex/skills` in
-toolgen tests, while Codex command prompts are global under `$CODEX_HOME/prompts`.
+`status --change` resolves a slug, loads active state, builds a status view,
+then renders JSON/text. Archived records are not active lifecycle authorities,
+but they are valid query targets because `state.LoadArchivedChange` already
+loads them for read surfaces.
 
-The CLI remains lifecycle authority. Runtime hosts consume generated
-instructions, but task evidence is recorded through `slipway evidence task`;
-the generated surface must not ask executors to write governed verification
-state directly.
+Done-ready status is a projection, not a persisted lifecycle state. The change
+must keep `change.status=active` until `slipway done` archives the record, while
+making the readiness visible through status view fields and narrative.
 
 ## Constraints And Invariants
 
-- `parallel: true` is the host dispatch signal from `slipway next --json`; the
-  surface must not make same-context inline execution look equivalent on
-  runtimes with a real subagent primitive.
-- `parallel: false` and `execution.parallelization: off` must remain clean
-  sequential modes without degraded-mode noise.
-- Executors share the current Slipway worktree unless a runtime explicitly
-  provides stronger isolation. The post-wave integration gate remains the
-  coordinator-owned merged-state check.
-- Codex `spawn_agent` has no direct equivalent for Claude-style
-  `isolation="worktree"`; the generated Codex guidance must not claim that
-  isolation unless a separate explicit protocol exists.
+- Active `change.yaml` remains the only authority for active lifecycle
+  mutation.
+- Archived records are terminal query records and must not be routed through
+  active lifecycle mutation or repair guidance.
+- Done-ready must not be reported as `done` before `slipway done` runs.
+- The status surface should reuse existing reason code
+  `run_slipway_done_to_finalize` instead of inventing a second finalization
+  blocker taxonomy.

--- a/artifacts/codebase/CONCERNS.md
+++ b/artifacts/codebase/CONCERNS.md
@@ -1,29 +1,17 @@
 # Concerns
 
 Re-authored for change
-`resolve-github-issue-184-add-gsd-style-automatic-subagent-di`
-(GitHub issue #184).
+`resolve-github-issues-195-and-196-make-status-expose-done-re`
+(GitHub issues #195 and #196).
 
-- Contract ambiguity risk: the current reference says a `parallel: true` wave is
-  concurrent by default, but the Codex section still points at `codex -q --task`.
-  That can let hosts degrade to shell-oriented or same-context execution while
-  the product surface implies real fan-out.
-- Governance weakening risk: if degraded sequential remains nonblocking for a
-  capable runtime, a coordinator can pollute its own context and still record a
-  passing wave. The fix should distinguish "runtime lacks a primitive" from
-  "runtime has a primitive but dispatch failed or was skipped".
-- Evidence ownership risk: executors may report refs, but `slipway evidence
-  task` remains the only task evidence ledger writer. Generated prose must not
-  imply subagents can self-stamp `captured_at`, freshness inputs, or governed
-  verification YAML.
-- Isolation overclaim risk: GSD's Claude worktree isolation model cannot be
-  copied into Codex guidance because GSD itself documents that Codex
-  `spawn_agent` has no direct `isolation="worktree"` mapping.
-- Test drift risk: this repository does not track generated `.claude`,
-  `.codex`, `.cursor`, `.gemini`, or `.opencode` adapter copies. Tests must
-  exercise template rendering and toolgen-generated temporary trees instead of
-  relying on committed generated files.
-- Manifest scope risk: `docs/SURFACE-MANIFEST.json` tracks public surface rows.
-  This change edits an existing surface contract and should not require a
-  manifest row update unless a new command, skill, JSON contract, adapter, or
-  documentation surface is added.
+- Lifecycle ambiguity risk: status must make done-ready obvious without saying
+  the change is already done. `change.status` stays active until finalization.
+- False-corruption risk: an archived change with no active bundle must not be
+  reported as `change_state_load_failed` or remediated with generic repair.
+- Real-corruption risk: if neither active nor archived authority can be loaded,
+  existing delete/repair diagnostics should still surface.
+- Compatibility risk: adding optional JSON fields is lower risk than changing
+  existing `lifecycle_status` semantics from `active` to `done_ready`.
+- Text/JSON drift risk: if only JSON is changed, operators using text status
+  still see the ambiguous handoff. Text rendering should show the same
+  done-ready/archived facts.

--- a/artifacts/codebase/CONVENTIONS.md
+++ b/artifacts/codebase/CONVENTIONS.md
@@ -1,18 +1,13 @@
 # Conventions
 
 Re-authored for change
-`resolve-github-issue-185-prevent-s4-goal-verification-from-s`
-(GitHub issue #185).
+`resolve-github-issues-195-and-196-make-status-expose-done-re`
+(GitHub issues #195 and #196).
 
-- Keep public CLI command behavior stable unless the issue requires a surface
-  change. #185 can be fixed in digest input semantics without changing flags or
-  command ordering.
-- Required skill freshness must fail closed for real input changes and report
-  canonical `required_skill_stale:<skill>:<input>` details.
-- Verification YAML, `evidence-digests.yaml`, timestamps, run versions, and
-  evidence refs remain engine-owned. Tests may use helpers, but normal workflow
-  should not hand-edit these files.
-- Use focused package tests for digest behavior before broadening to full
-  repository tests.
-- Special-case logic should be path-scoped and skill-scoped; avoid broad
-  exclusions that make unrelated content invisible to freshness checks.
+- Keep active lifecycle state authoritative; status can project readiness, but
+  must not persist done-ready as a new terminal state.
+- Prefer optional additive JSON fields for new status facts when existing fields
+  have established meanings.
+- Reuse canonical reason codes and recovery summaries where possible.
+- Preserve existing delete/repair recovery for genuinely broken active state.
+- Use command/view tests in `cmd/` before broad repository verification.

--- a/artifacts/codebase/INTEGRATIONS.md
+++ b/artifacts/codebase/INTEGRATIONS.md
@@ -1,19 +1,17 @@
 # Integrations
 
 Re-authored for change
-`resolve-github-issue-185-prevent-s4-goal-verification-from-s`
-(GitHub issue #185).
+`resolve-github-issues-195-and-196-make-status-expose-done-re`
+(GitHub issues #195 and #196).
 
 - External integrations:
-  - None. The change is local CLI/governance engine behavior.
+  - None. The change is local CLI/governance state projection behavior.
 - Public CLI surfaces involved:
-  - `slipway evidence skill` records governance verification evidence.
-  - `slipway run`, `slipway next`, `slipway status`, and `slipway validate`
-    consume required-skill freshness and surface `required_skill_stale`
-    blockers.
+  - `slipway status --json`
+  - `slipway status --json --change <slug>`
+  - text `slipway status`
 - Internal integration points:
-  - `cmd/evidence.go` records verification and evidence refs.
-  - `internal/engine/progression/evidence_digests.go` stamps and evaluates
-    skill digest freshness.
-  - `internal/state` persists `change.yaml`, verification YAML, execution
-    summaries, and evidence digest records.
+  - `cmd/status.go` for route and view shape.
+  - `cmd/status_view_build.go` for governed readiness projection.
+  - `cmd/status_render.go` for text hints.
+  - `internal/state.LoadArchivedChange` for terminal records.

--- a/artifacts/codebase/STACK.md
+++ b/artifacts/codebase/STACK.md
@@ -1,17 +1,14 @@
 # Stack
 
 Re-authored for change
-`resolve-github-issue-185-prevent-s4-goal-verification-from-s`
-(GitHub issue #185).
+`resolve-github-issues-195-and-196-make-status-expose-done-re`
+(GitHub issues #195 and #196).
 
 - Language: Go.
 - CLI framework: Cobra command tree under `cmd/`.
-- Persistence: YAML governed bundle authority under
-  `artifacts/changes/<slug>/change.yaml`, verification YAML under
-  `artifacts/changes/<slug>/verification/`, and runtime task evidence under
-  `.git/slipway/runtime/changes/<slug>/`.
-- Serialization: `gopkg.in/yaml.v3` for strict authority decoding and
-  `encoding/json` via `model.ComputeInputHash` for canonical digest payloads.
+- Persistence: active governed bundle authority under
+  `artifacts/changes/<slug>/change.yaml`; archived terminal authority under
+  `artifacts/changes/archived/<slug>/change.yaml`.
+- Serialization: `encoding/json` for command output and `gopkg.in/yaml.v3` for
+  change/verification files.
 - Tests: Go `testing` plus `testify`.
-- Expected checks: focused progression tests, full Go test suite, `git diff
-  --check`, and Slipway `validate --json`.

--- a/artifacts/codebase/STRUCTURE.md
+++ b/artifacts/codebase/STRUCTURE.md
@@ -1,28 +1,28 @@
 # Structure
 
 Re-authored for change
-`resolve-github-issue-184-add-gsd-style-automatic-subagent-di`
-(GitHub issue #184).
+`resolve-github-issues-195-and-196-make-status-expose-done-re`
+(GitHub issues #195 and #196).
 
-- `internal/tmpl/templates/skills/wave-orchestration/`
-  - `SKILL.md.tmpl`: primary host skill template for governed S2 execution.
-  - `references/executor-dispatch-reference.md`: runtime-specific executor
-    dispatch reference copied beside generated wave-orchestration skills.
-- `internal/tmpl/`
-  - `thin_host_content_test.go`: focused template/reference content tests.
-  - `wave_isolation_content_test.go`: existing dispatch-contract coverage for
-    test-authoring isolation and TDD sequencing.
-  - `templates_test.go`: broader rendered-template contract tests.
-- `internal/toolgen/`
-  - `toolgen.go`: adapter registry and skill generation authority.
-  - `toolgen_test.go`: generated tree contract tests, including existing
-    wave-orchestration parallel-by-default assertions.
-  - `support_files_test.go` and `testdata/skill_tree_inventory.codex.golden`:
-    generated support-file inventory checks for Codex.
-  - `surface_manifest.go` and `surface_manifest_test.go`: generated public
-    surface inventory; relevant only if a new surface row is introduced.
-- `docs/`
-  - `ai-tools.md`: documents `docs/SURFACE-MANIFEST.json` regeneration when new
-    public surface rows are added.
-  - `operator-guide.md`: documents `slipway init --tools all --refresh` after
-    template or command-contract changes.
+- `cmd/status.go`
+  - Defines `statusView`.
+  - Resolves explicit `--change` requests.
+  - Routes active status to `showStatusForChange`.
+  - Contains delete-recovery status diagnostics for broken active state.
+- `cmd/status_view_build.go`
+  - Builds governed status projections from readiness, execution context,
+    timeline, blockers, and recovery.
+  - Owns the status narrative.
+- `cmd/status_render.go`
+  - Renders status JSON through `statusJSONView` and text through
+    `renderStatusText`.
+  - Owns the first user-visible "what next" hint for text output.
+- `cmd/common.go`
+  - Provides shared active-change loaders and archived fallback behavior used by
+    validate-like active commands.
+- `cmd/status_view_build_test.go`
+  - Focused unit tests for status view projection.
+- `cmd/cli_e2e_test.go`
+  - Command-level e2e tests around `done` and JSON command behavior.
+- `internal/state/lifecycle.go` and `internal/state/store.go`
+  - Archive load and archive path discovery helpers.

--- a/artifacts/codebase/TESTING.md
+++ b/artifacts/codebase/TESTING.md
@@ -1,41 +1,34 @@
 # Testing
 
 Re-authored for change
-`resolve-github-issue-184-add-gsd-style-automatic-subagent-di`
-(GitHub issue #184).
+`resolve-github-issues-195-and-196-make-status-expose-done-re`
+(GitHub issues #195 and #196).
 
 ## Existing Coverage
 
-- `internal/toolgen/toolgen_test.go:1069` through
-  `internal/toolgen/toolgen_test.go:1094` asserts generated
-  `slipway-wave-orchestration` text includes parallel-by-default dispatch,
-  `parallel: true`, degradation visibility, `parallelization: off`,
-  post-wave integration gate, and structured dispatch references.
-- `internal/tmpl/thin_host_content_test.go:56` through
-  `internal/tmpl/thin_host_content_test.go:92` renders
-  `wave-orchestration/SKILL.md.tmpl` and reads the executor dispatch reference.
-  It already checks that codebase-map content is passed by path rather than
-  inlined into the coordinator context.
-- `internal/tmpl/wave_isolation_content_test.go:11` through
-  `internal/tmpl/wave_isolation_content_test.go:27` checks rendered
-  wave-orchestration dispatch contract text around test-authoring isolation.
+- `cmd/progression_next_test.go:1727` through
+  `cmd/progression_next_test.go:1774` proves `next` already projects
+  done-ready for S4 with approved ship readiness.
+- `cmd/cli_e2e_test.go:448` through `cmd/cli_e2e_test.go:480` proves `done`
+  archives a ready change and `state.LoadArchivedChange` can load it afterward.
+- `cmd/status_view_build_test.go` contains focused status-view tests and is the
+  lowest-cost home for done-ready projection assertions.
+- `internal/state/lifecycle_test.go` covers archived load path behavior, so this
+  change should not need new state-layer archive tests unless archive discovery
+  changes.
 
-## Gaps For Issue #184
+## Gaps For Issues #195 And #196
 
-- No current test requires Codex guidance to use `spawn_agent`.
-- No current test rejects `codex -q --task` as the primary Codex fan-out path.
-- No current test requires spawn/wait/collect/close semantics, `fork_context:
-  false`, coordinator stop-work wording, or the full executor result field set.
-- Existing degradation assertions require visibility, but do not distinguish a
-  genuinely incapable runtime from a capable runtime that failed to dispatch.
+- No status-view test asserts a top-level done-ready signal after S4 ship
+  readiness passes.
+- No command test asserts `status --json --change <slug>` after `done` returns
+  an archived/done status view instead of `change_state_load_failed`.
 
 ## Verification Plan
 
-- Add focused content tests under `internal/tmpl` for the reference and rendered
-  host contract.
-- Expand `internal/toolgen/toolgen_test.go` so generated adapter output carries
-  the new contract, not just source templates.
-- Run `go test -count=1 ./internal/tmpl ./internal/toolgen` after template and
-  test edits.
-- Run `go test -count=1 ./...`, `git diff --check`, and
-  `go run . validate --json` before claiming done-ready.
+- Add a focused status-view test that builds an S4 ship-ready change and asserts
+  done-ready fields, finalization blocker, and narrative.
+- Add a command-level test that finalizes a ready change, runs
+  `status --json --change <slug>`, and asserts archived status metadata.
+- Run focused tests for `./cmd`.
+- Run `go test ./...`, `git diff --check`, and `go run . validate --json`.

--- a/cmd/cli_e2e_test.go
+++ b/cmd/cli_e2e_test.go
@@ -477,6 +477,20 @@ func TestCLIEndToEndSuccessfulDoneArchive(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, model.ChangeStatusDone, archived.Status)
 		assert.Equal(t, model.StateDone, archived.CurrentState)
+
+		statusOut := bytes.NewBuffer(nil)
+		statusCmd := commandForRoot(t, root, makeStatusCmd())
+		statusCmd.SetOut(statusOut)
+		statusCmd.SetErr(statusOut)
+		statusCmd.SetArgs([]string{"--json", "--change", slug})
+		require.NoError(t, statusCmd.Execute())
+
+		statusPayload := decodeJSONMap(t, statusOut.String())
+		assert.Equal(t, true, statusPayload["archived"])
+		assert.Equal(t, "done", statusPayload["lifecycle_status"])
+		assert.Equal(t, string(model.StateDone), statusPayload["current_state"])
+		assert.Contains(t, statusPayload["source_state_file"], filepath.Join("artifacts", "changes", "archived", slug, "change.yaml"))
+		assert.NotContains(t, statusOut.String(), "change_state_load_failed")
 	})
 }
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -29,6 +31,9 @@ type statusView struct {
 	NeedsDiscovery            bool                                 `json:"needs_discovery,omitempty"`
 	Phase                     model.UserPhase                      `json:"phase,omitempty"`
 	LifecycleStatus           string                               `json:"lifecycle_status,omitempty"`
+	DoneReady                 bool                                 `json:"done_ready,omitempty"`
+	Archived                  bool                                 `json:"archived,omitempty"`
+	ArchivePath               string                               `json:"archive_path,omitempty"`
 	CurrentState              model.WorkflowState                  `json:"current_state,omitempty"`
 	IntakeSubStep             model.IntakeSubStep                  `json:"intake_substep,omitempty"`
 	PlanSubStep               model.PlanSubStep                    `json:"plan_substep,omitempty"`
@@ -209,12 +214,15 @@ func makeStatusCmd() *cobra.Command {
 						return err
 					}
 				}
-				change, err := loadChangeBySlug(root, changeSlug)
+				change, archived, err := loadStatusChangeBySlug(root, changeSlug)
 				if err != nil {
 					if diag := deleteRecoveryStatusViewForSlug(root, changeSlug); diag != nil {
 						return printStatusView(cmd, root, *diag, outputFormat, hydrate)
 					}
 					return err
+				}
+				if archived {
+					return showArchivedStatusForChange(cmd, root, change, outputFormat, effectiveView, hydrateKeys, hydrate)
 				}
 				return showStatusForChange(cmd, root, change, outputFormat, effectiveView, hydrateKeys, hydrate)
 			}
@@ -393,6 +401,65 @@ func showStatusForChange(cmd *cobra.Command, root string, change model.Change, o
 		view.HydrateReferences = hydrateKeys
 		return printStatusView(cmd, root, view, outputFormat, hydrate)
 	})
+}
+
+func showArchivedStatusForChange(cmd *cobra.Command, root string, change model.Change, outputFormat string, requestedView string, hydrateKeys []string, hydrate bool) error {
+	view := buildArchivedStatusView(root, change)
+	view.Mode = requestedView
+	view.HydrateReferences = hydrateKeys
+	return printStatusView(cmd, root, view, outputFormat, hydrate)
+}
+
+func buildArchivedStatusView(root string, change model.Change) statusView {
+	archivePath := filepath.ToSlash(filepath.Join("artifacts", "changes", "archived", change.Slug, "change.yaml"))
+	if path, err := state.ArchivedChangeFilePathForRead(root, change.Slug); err == nil {
+		archivePath = state.DisplayPath(root, path)
+	}
+	view := statusView{
+		ExecutionMode:     "archived",
+		Slug:              change.Slug,
+		Phase:             model.PhaseFor(change.CurrentState),
+		LifecycleStatus:   string(change.Status),
+		Archived:          true,
+		ArchivePath:       archivePath,
+		CurrentState:      change.CurrentState,
+		EvidenceFreshness: "unknown",
+		SourceStateFile:   archivePath,
+	}
+	view.Narrative = buildStatusNarrative(view)
+	return view
+}
+
+func loadStatusChangeBySlug(root, slug string) (model.Change, bool, error) {
+	change, err := state.LoadChange(root, slug)
+	if err == nil {
+		return change, false, nil
+	}
+	if shouldFallbackToArchivedStatus(err) {
+		if archived, archiveErr := state.LoadArchivedChange(root, slug); archiveErr == nil {
+			return archived, true, nil
+		}
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		if recoveryErr := deleteRecoveryError(root, slug); recoveryErr != nil {
+			return model.Change{}, false, recoveryErr
+		}
+		return model.Change{}, false, newPreconditionError(
+			"change_not_found",
+			fmt.Sprintf("no change found for slug %q", slug),
+			"Check the slug with `slipway status`.",
+			slug,
+			nil,
+		)
+	}
+	if recoveryErr := deleteRecoveryError(root, slug); recoveryErr != nil {
+		return model.Change{}, false, recoveryErr
+	}
+	return model.Change{}, false, newChangeStateLoadFailedError(slug, err)
+}
+
+func shouldFallbackToArchivedStatus(activeLoadErr error) bool {
+	return errors.Is(activeLoadErr, os.ErrNotExist) || state.IsMissingBundleAuthority(activeLoadErr)
 }
 
 func resolveStatusFormat(format string, jsonFlag bool) (string, error) {

--- a/cmd/status_render.go
+++ b/cmd/status_render.go
@@ -62,6 +62,12 @@ func renderStatusText(view statusView) string {
 	label := view.Slug
 	writeLine("# %s\n\n", label)
 	writeLine("Phase: %s | Mode: %s | Status: %s\n", view.Phase, view.ExecutionMode, view.LifecycleStatus)
+	if view.DoneReady {
+		writeLine("Readiness: done-ready\n")
+	}
+	if view.Archived && view.ArchivePath != "" {
+		writeLine("Archive: %s\n", view.ArchivePath)
+	}
 	if strings.TrimSpace(view.Mode) != "" {
 		writeLine("Focus: %s\n", view.Mode)
 	}
@@ -285,6 +291,12 @@ var actionHints = map[model.WorkflowState]string{
 }
 
 func primaryActionHint(view statusView) string {
+	if view.Archived {
+		return "archived change; no active lifecycle action"
+	}
+	if view.DoneReady {
+		return "slipway done  (finalize and archive done-ready change)"
+	}
 	if view.PresetConfirmationPending {
 		return "slipway preset <light|standard|strict>  (confirm governance preset before continuing)"
 	}

--- a/cmd/status_view_build.go
+++ b/cmd/status_view_build.go
@@ -130,6 +130,7 @@ func buildGovernedStatusViewWithExecutionContext(root string, change model.Chang
 		view.ArtifactAmendments = append([]artifact.AmendmentEvent(nil), readiness.ArtifactProjection.Amendments...)
 	}
 	view.Blockers = model.NormalizeReasonCodes(append(view.Blockers, waveBlockers...))
+	applyDoneReadyProjection(change, readiness.GateEvaluations, &view)
 	if staleTarget, ok, err := progression.StaleEvidenceRecoveryAvailable(root, change, view.Blockers); err != nil {
 		return statusView{}, err
 	} else if ok {
@@ -326,6 +327,13 @@ func buildStatusNarrative(view statusView) string {
 		interruptSuffix = " The last governed execution was interrupted at " + view.InterruptedExecutionAt + "."
 	}
 	switch {
+	case view.Archived:
+		if view.ArchivePath != "" {
+			return "Archived change is " + view.LifecycleStatus + ". Active lifecycle actions are complete; inspect archived evidence at " + view.ArchivePath + "."
+		}
+		return "Archived change is " + view.LifecycleStatus + ". Active lifecycle actions are complete."
+	case view.DoneReady:
+		return "Done-ready in " + stateLabel + ". All governance gates passed; run `slipway done` to finalize."
 	case len(view.Blockers) > 0:
 		return "Blocked in " + stateLabel + "." + recoverySuffix + interruptSuffix + " Resolve the current blockers before running the next lifecycle action."
 	case len(view.SelectedPriorContext) > 0:
@@ -333,6 +341,26 @@ func buildStatusNarrative(view statusView) string {
 	default:
 		return "Active in " + stateLabel + "." + recoverySuffix + interruptSuffix + " Continue with the next lifecycle action."
 	}
+}
+
+func applyDoneReadyProjection(change model.Change, evaluations map[gate.GateID]gate.GateEvaluation, view *statusView) {
+	if view == nil || change.CurrentState != model.StateS4Verify {
+		return
+	}
+	for _, blocker := range view.Blockers {
+		if blocker.Severity == model.ReasonSeverityError {
+			return
+		}
+	}
+	evaluation, ok := evaluations[gate.GateShip]
+	if !ok || evaluation.Status != model.GateStatusApproved {
+		return
+	}
+	view.DoneReady = true
+	view.Blockers = appendReasonCodes(
+		view.Blockers,
+		[]model.ReasonCode{model.NewReasonCode("run_slipway_done_to_finalize", "")},
+	)
 }
 
 func buildMultiChangeSummaryView(changes []model.Change) multiChangeSummaryView {

--- a/cmd/status_view_build_test.go
+++ b/cmd/status_view_build_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -123,6 +124,97 @@ func TestBuildGovernedStatusViewPreAuditOmitsShipGateDebt(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotContains(t, view.GateStatus, "G_ship")
 	assert.NotContains(t, model.ReasonSpecs(view.Blockers), "plan_dimension_key_links_missing_target_files")
+}
+
+func TestBuildGovernedStatusViewExposesDoneReadyReadiness(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	ensureTestGitRepo(t, root)
+	initTestWorkspace(t, root)
+
+	slug := createGovernedRequest(t, root, "L2", "done-ready status projection")
+	change, err := state.LoadChange(root, slug)
+	require.NoError(t, err)
+	markChangeReadyForDone(t, root, &change)
+	writeSkillVerification(t, root, slug, progression.SkillPlanAudit, model.VerificationRecord{
+		Verdict:    model.VerificationVerdictPass,
+		Blockers:   []model.ReasonCode{},
+		Timestamp:  time.Now().UTC(),
+		RunVersion: 0,
+		References: []string{"plan-audit:pass"},
+	})
+	refreshPassingSkillDigestsForTest(t, root, slug, progression.SkillPlanAudit)
+
+	view, err := buildStatusViewFromChange(root, change)
+	require.NoError(t, err)
+
+	raw, err := json.Marshal(buildStatusJSONResponse(view))
+	require.NoError(t, err)
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(raw, &payload))
+
+	assert.Equal(t, true, payload["done_ready"])
+	assert.Equal(t, "active", payload["lifecycle_status"])
+	assert.Contains(t, model.ReasonSpecs(view.Blockers), "run_slipway_done_to_finalize")
+	assert.Contains(t, view.Narrative, "Done-ready")
+	assert.Contains(t, view.Narrative, "slipway done")
+	assert.Contains(t, renderStatusText(view), "slipway done")
+}
+
+func TestLoadStatusChangeBySlugFallsBackToArchivedForMissingActiveAuthority(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	ensureTestGitRepo(t, root)
+	initTestWorkspace(t, root)
+
+	slug := "archived-missing-active-authority"
+	change := model.NewChange(slug)
+	change.Status = model.ChangeStatusDone
+	change.CurrentState = model.StateDone
+	change.PlanSubStep = model.PlanSubStepNone
+	require.NoError(t, state.SaveChange(root, change))
+	_, err := state.ArchiveChange(root, change, model.ChangeStatusDone)
+	require.NoError(t, err)
+
+	activePath := state.BundleChangeFilePath(root, slug)
+	require.NoError(t, os.MkdirAll(filepath.Dir(activePath), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(filepath.Dir(activePath), "notes.md"), []byte("orphaned active bundle\n"), 0o644))
+
+	loaded, archived, err := loadStatusChangeBySlug(root, slug)
+	require.NoError(t, err)
+	assert.True(t, archived)
+	assert.Equal(t, slug, loaded.Slug)
+	assert.Equal(t, model.ChangeStatusDone, loaded.Status)
+}
+
+func TestLoadStatusChangeBySlugDoesNotMaskMalformedActiveAuthorityWithArchive(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	ensureTestGitRepo(t, root)
+	initTestWorkspace(t, root)
+
+	slug := "archived-malformed-active-authority"
+	change := model.NewChange(slug)
+	change.Status = model.ChangeStatusDone
+	change.CurrentState = model.StateDone
+	change.PlanSubStep = model.PlanSubStepNone
+	require.NoError(t, state.SaveChange(root, change))
+	_, err := state.ArchiveChange(root, change, model.ChangeStatusDone)
+	require.NoError(t, err)
+
+	activePath := state.BundleChangeFilePath(root, slug)
+	require.NoError(t, os.MkdirAll(filepath.Dir(activePath), 0o755))
+	require.NoError(t, os.WriteFile(activePath, []byte("slug: [\n"), 0o644))
+
+	_, archived, err := loadStatusChangeBySlug(root, slug)
+	require.Error(t, err)
+	assert.False(t, archived)
+	cliErr := asCLIError(err)
+	require.NotNil(t, cliErr)
+	assert.Equal(t, "change_state_load_failed", cliErr.ErrorCode)
 }
 
 func TestBuildGovernedStatusViewIncludesStaleExecutionEvidenceBlocker(t *testing.T) {

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -23,6 +23,12 @@ var (
 	errAmbiguousWorktreeBinding = errors.New("ambiguous worktree binding")
 )
 
+// IsMissingBundleAuthority reports whether err means a bundle directory exists
+// but its change.yaml authority file is absent.
+func IsMissingBundleAuthority(err error) bool {
+	return errors.Is(err, errMissingBundleAuthority)
+}
+
 type BoundChangeRef struct {
 	Slug         string
 	WorktreePath string


### PR DESCRIPTION
## Summary
- expose done-ready status without requiring agents to infer the finalization command
- allow explicit status lookup for archived changes and show DONE/done lifecycle output
- archive the governed evidence bundle for resolve-github-issues-195-and-196-make-status-expose-done-re

Closes #195
Closes #196

## Verification
- go test -count=1 ./...
- go test -count=1 -coverpkg=./cmd,./internal/state -coverprofile=/tmp/slipway-195-196-cross-cover.out ./cmd ./internal/state
- git diff --check
- git diff --cached --check
- go run . status --json --change resolve-github-issues-195-and-196-make-status-expose-done-re

## Notes
- Slipway archived status reports current_state=DONE, lifecycle_status=done, archived=true for the explicit change slug.
- Default status selection may still pick another active governed change when no --change is provided; this PR only relies on explicit archived lookup for the archived verification path.