### PR TITLE
fix(ci): normalize archive path assertion

### DIFF
--- a/cmd/cli_e2e_test.go
+++ b/cmd/cli_e2e_test.go
@@ -489,7 +489,7 @@ func TestCLIEndToEndSuccessfulDoneArchive(t *testing.T) {
 		assert.Equal(t, true, statusPayload["archived"])
 		assert.Equal(t, "done", statusPayload["lifecycle_status"])
 		assert.Equal(t, string(model.StateDone), statusPayload["current_state"])
-		assert.Contains(t, statusPayload["source_state_file"], filepath.Join("artifacts", "changes", "archived", slug, "change.yaml"))
+		assert.Contains(t, statusPayload["source_state_file"], filepath.ToSlash(filepath.Join("artifacts", "changes", "archived", slug, "change.yaml")))
 		assert.NotContains(t, statusOut.String(), "change_state_load_failed")
 	})
 }


### PR DESCRIPTION
## Summary
- fixes the failing `main` CI Windows test by normalizing the expected archived status path
- keeps the product behavior unchanged: status continues to expose slash-normalized repo-relative paths

## Root Cause
`main` CI failed only in `Test (windows-latest)` for `TestCLIEndToEndSuccessfulDoneArchive`. The test asserted a Windows-native `filepath.Join(...)` path, while the status output intentionally reports slash-normalized paths such as `artifacts/changes/archived/done-e2e-positive-path/change.yaml`.

Classification: test-fault.

## Verification
- `go test -count=1 ./cmd -run TestCLIEndToEndSuccessfulDoneArchive`
- `go test -count=1 ./cmd`
- `go test -count=1 ./...`
- `git diff --check`
- `git diff --cached --check`
