### PR TITLE
fix(lifecycle): soften prose scaffold digest churn

### DIFF
--- a/artifacts/changes/archived/resolve-github-issue-155-knuth-invariant-overwrite-only-own/assurance.md
+++ b/artifacts/changes/archived/resolve-github-issue-155-knuth-invariant-overwrite-only-own/assurance.md
@@ -1,0 +1,57 @@
+# Assurance
+
+## Scope Summary
+
+Delivered issue #155 scope: prose artifact input digests now use a material
+view instead of raw bytes. The change is limited to
+`internal/engine/progression/evidence_digests.go` and
+`internal/engine/progression/evidence_digests_test.go`.
+
+## Verification Verdict
+
+Pass. Focused digest tests and the full Go test suite passed after the
+implementation. `go run . validate --json` reports fresh evidence, approved
+`G_scope` and `G_plan`, and `scope_contract.status=pass`.
+
+## Evidence Index
+
+- RED test command:
+  `go test -count=1 ./internal/engine/progression -run 'TestPlanAuditInputDigestIgnoresScaffoldOnlyProseEdits|TestProseFileInputHashTreatsKnownDefaultsAsNonMaterial|TestEvaluateRequiredSkillsUsesContentDigestNotMTime|TestResearchOrchestrationInputDigestIncludesResearchArtifact'`
+  failed before implementation.
+- Focused verification:
+  `go test -count=1 ./internal/engine/progression` passed.
+- Full verification:
+  `go test -count=1 ./...` passed.
+- Runtime task evidence exists for `t-01`, `t-02`, and `t-03` with
+  `run_summary_version=1`.
+- Current validation proof: `go run . validate --json` reports fresh evidence
+  and scope-contract pass.
+
+## Requirement Coverage
+
+- REQ-001 is covered by
+  `TestPlanAuditInputDigestIgnoresScaffoldOnlyProseEdits` and
+  `TestProseFileInputHashTreatsKnownDefaultsAsNonMaterial`.
+- REQ-002 is covered by the authored-prose branch in
+  `TestProseFileInputHashTreatsKnownDefaultsAsNonMaterial`, plus the existing
+  `TestEvaluateRequiredSkillsUsesContentDigestNotMTime` and
+  `TestResearchOrchestrationInputDigestIncludesResearchArtifact` stale evidence
+  tests.
+
+## Residual Risks and Exceptions
+
+No accepted exceptions. The main residual risk is future over-broad known
+defaults; the current implementation keeps the known-default table narrow and
+defaults unknown non-empty prose to material.
+
+## Rollback Readiness
+
+Rollback is a normal git revert of the two changed source/test files. No data
+migration, dependency update, external API change, or generated surface update
+is involved.
+
+## Archive Decision
+
+Not archived yet. The requested endpoint is done-ready, so `slipway done` must
+not be run in this workflow unless the user later asks for finalization. Before
+any future `done`, capture fresh active `validate --json` readiness proof.

--- a/artifacts/changes/archived/resolve-github-issue-155-knuth-invariant-overwrite-only-own/change.yaml
+++ b/artifacts/changes/archived/resolve-github-issue-155-knuth-invariant-overwrite-only-own/change.yaml
@@ -1,0 +1,59 @@
+version: 1
+slug: resolve-github-issue-155-knuth-invariant-overwrite-only-own
+description: 'Resolve GitHub issue #155: Knuth-invariant overwrite-only-own-defaults for prose artifact edit materiality and auto-reopen softening, referencing local gsd-core'
+status: done
+current_state: DONE
+needs_discovery: true
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-06-12T16:18:37.222233Z
+quality_mode: standard
+workflow_preset: standard
+worktree_branch: feat/resolve-github-issue-155-knuth-invariant-overwrite-only-own
+artifact_schema: expanded
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: 569beae6cc2dd71772a7212824fe4c5c61f486b1e6b7c72118e45ac533cb20b9
+        updated_at: 2026-06-12T16:34:59.001707755Z
+    decision:
+        id: decision
+        path: decision.md
+        state: frozen
+        content_hash: 6aa81914c9e9b80706b28113d872d893299f008b98dcac22421a13c39af5b5db
+        updated_at: 2026-06-12T16:26:40.406766864Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: 9dc4eeee3e2ab4099a54df8d37036f1bb63f6b56b541bb99cc19b8461a2c5cfc
+        updated_at: 2026-06-12T16:24:43.330210408Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: ab98c9f2ebdddd12890f49794bfbcb20481aec4e40e0a2bf0f86393005e1588e
+        updated_at: 2026-06-12T16:26:40.406587532Z
+    research:
+        id: research
+        path: research.md
+        state: frozen
+        content_hash: 58c9729b1b3beb21106b98453079931b6e9ed3bd6940d25aeb2b2048f1612258
+        updated_at: 2026-06-12T16:24:34.791003Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: 869bcd9123b3b3f502fdb6b21302e294d3c68ea688bace6d9296e202dce6c1aa
+        updated_at: 2026-06-12T16:34:06.925420777Z
+evidence_refs:
+    code-quality-review: .worktrees/resolve-github-issue-155-knuth-invariant-overwrite-only-own/artifacts/changes/resolve-github-issue-155-knuth-invariant-overwrite-only-own/verification/code-quality-review.yaml
+    final-closeout: .worktrees/resolve-github-issue-155-knuth-invariant-overwrite-only-own/artifacts/changes/resolve-github-issue-155-knuth-invariant-overwrite-only-own/verification/final-closeout.yaml
+    goal-verification: .worktrees/resolve-github-issue-155-knuth-invariant-overwrite-only-own/artifacts/changes/resolve-github-issue-155-knuth-invariant-overwrite-only-own/verification/goal-verification.yaml
+    intake-clarification: .worktrees/resolve-github-issue-155-knuth-invariant-overwrite-only-own/artifacts/changes/resolve-github-issue-155-knuth-invariant-overwrite-only-own/verification/intake-clarification.yaml
+    plan-audit: .worktrees/resolve-github-issue-155-knuth-invariant-overwrite-only-own/artifacts/changes/resolve-github-issue-155-knuth-invariant-overwrite-only-own/verification/plan-audit.yaml
+    research-orchestration: .worktrees/resolve-github-issue-155-knuth-invariant-overwrite-only-own/artifacts/changes/resolve-github-issue-155-knuth-invariant-overwrite-only-own/verification/research-orchestration.yaml
+    spec-compliance-review: .worktrees/resolve-github-issue-155-knuth-invariant-overwrite-only-own/artifacts/changes/resolve-github-issue-155-knuth-invariant-overwrite-only-own/verification/spec-compliance-review.yaml
+    wave-orchestration: .worktrees/resolve-github-issue-155-knuth-invariant-overwrite-only-own/artifacts/changes/resolve-github-issue-155-knuth-invariant-overwrite-only-own/verification/wave-orchestration.yaml

--- a/artifacts/changes/archived/resolve-github-issue-155-knuth-invariant-overwrite-only-own/decision.md
+++ b/artifacts/changes/archived/resolve-github-issue-155-knuth-invariant-overwrite-only-own/decision.md
@@ -1,0 +1,58 @@
+# Decision
+
+## Alternatives Considered
+
+- Strip only HTML comments before hashing prose artifacts. This is safe but too
+  narrow: scaffold-only headings and known default bodies can still churn a
+  digest even though they are engine-owned structure.
+- Add a prose artifact material-view digest. This strips comments, ignores empty
+  scaffold sections, recognizes only narrow known defaults, and includes all
+  unknown non-empty prose. This matches the GSD invariant without adding a GSD
+  dependency.
+- Build a full artifact AST and overwrite framework. This is broader than issue
+  #155 needs and would change authoring semantics outside digest freshness.
+
+Status: accepted.
+
+## Selected Approach
+
+Implement the prose artifact material-view digest in
+`internal/engine/progression/evidence_digests.go` and keep stale recovery
+unchanged. The digest layer is the right boundary because stale recovery already
+operates on named digest drift; changing the recovery layer would only hide a
+bad input classification.
+
+The selected approach is Option 2 from `research.md`: suppress only
+engine-owned scaffold/default noise, and treat unknown non-empty prose as
+material.
+
+## Interfaces and Data Flow
+
+No public CLI or JSON interface changes. Internal data flow changes from:
+
+`prose file bytes -> model.ComputeInputHash({"content": raw})`
+
+to:
+
+`prose file bytes -> material prose view -> model.ComputeInputHash(...)`.
+
+`tasks.md` remains on `wave.TaskPlanStructuralHash`; `assurance.md` remains
+excluded from plan-audit digest inputs.
+
+## Rollout and Rollback
+
+Rollout is covered by focused unit tests in
+`internal/engine/progression/evidence_digests_test.go`, followed by
+`go test -count=1 ./internal/engine/progression` and `go test -count=1 ./...`.
+
+Rollback is a normal git revert of the helper and test additions. Existing
+verification records remain governed by recomputed current digests on the next
+validation run.
+
+## Risk
+
+Primary risk is a false negative that accepts stale evidence after a real prose
+edit. The implementation mitigates this by including unknown non-empty prose in
+the material view and recognizing only narrow defaults. Secondary risk is
+over-normalizing whitespace; the implementation should avoid broad prose
+rewrites beyond comments, empty scaffold sections, and known defaults.

--- a/artifacts/changes/archived/resolve-github-issue-155-knuth-invariant-overwrite-only-own/intent.md
+++ b/artifacts/changes/archived/resolve-github-issue-155-knuth-invariant-overwrite-only-own/intent.md
@@ -1,0 +1,77 @@
+# Intent
+
+## Summary
+Resolve GitHub issue #155: Knuth-invariant overwrite-only-own-defaults for prose artifact edit materiality and auto-reopen softening, referencing local gsd-core
+## Complexity Assessment
+complex
+Rationale: this changes lifecycle freshness and auto-reopen behavior for
+governed prose artifacts. It must preserve fail-closed evidence behavior while
+distinguishing scaffold/default edits from human-authored material edits.
+
+## Guardrail Domains
+<!-- none detected -->
+
+## In Scope
+- Resolve GitHub issue #155 for prose-artifact edit materiality, specifically
+  intent.md, requirements.md, research.md, and decision.md digest/reopen
+  behavior.
+- Add a first-class, testable "engine-owned default/scaffold vs
+  human-authored material content" decision for prose artifacts.
+- Use local `/Users/yixianlu/ghq/github.com/open-gsd/gsd-core` as a behavioral
+  reference for the overwrite-only-own-defaults invariant, especially
+  `KNOWN_TEMPLATE_DEFAULTS` and `stateReplaceFieldIfTemplate`.
+- Preserve target_files structural hashing behavior that issue #155 already
+  says is fixed/stale.
+- Add focused tests proving default/scaffold-only structural edits avoid broad
+  downstream reopen while material prose edits still reopen.
+
+## Out of Scope
+- Do not copy GSD implementation details or TypeScript structure directly.
+- Do not weaken evidence-freshness, verification, or fail-closed reopen paths.
+- Do not rework unrelated lifecycle stages, codebase-map scaffold detection, or
+  target_files hashing beyond what the issue explicitly requires.
+- Do not finalize with `slipway done`; the requested endpoint is done-ready.
+
+## Constraints
+- Work only in the Slipway-provisioned worktree for this change.
+- Keep the implementation repo-native and minimal; GSD is a reference, not a
+  dependency or source transplant.
+- Default to material/reopen when artifact edit materiality is uncertain.
+- Follow Slipway lifecycle gates and record evidence through the CLI, not by
+  hand-editing verification state.
+
+## Acceptance Signals
+- `go test` coverage exercises scaffold/default prose edits, human-authored
+  material prose edits, and the fail-closed unknown case.
+- `go run . validate --json` reports the governed change can advance through
+  the required gates.
+- `go run . status --json` reaches done-ready and remains bound to
+  `.worktrees/resolve-github-issue-155-knuth-invariant-overwrite-only-own`.
+- The implementation demonstrably references the GSD behavior without adding a
+  runtime dependency on GSD.
+
+## Open Questions
+<!-- Track real unknowns as a checklist. An unchecked `- [ ]` item is unresolved
+     and routes intake to S0_INTAKE/research; mark `- [x]` once resolved. Leave the
+     section empty (or write `None`) when there are none. Prose here is
+     documentation, not a blocker — a genuine open question must be a `- [ ]`. -->
+- [x] Which current Slipway digest/reopen functions own prose artifact
+      materiality for intent.md, requirements.md, research.md, and decision.md?
+- [x] What exact scaffold/default values are engine-owned today for each prose
+      artifact, and where should that table live?
+- [x] Which tests currently cover auto-reopen on artifact edits, and what
+      focused tests should be added for issue #155?
+- [x] Does GSD's state-document default overwrite model imply any recovery or
+      fail-closed edge case that Slipway lacks?
+
+## Deferred Ideas
+- Generalizing the known-default table to every governed artifact type.
+- Adding a user-facing command to explain why a prose edit was classified as
+  material or non-material.
+
+## Approved Summary
+User directive confirms this scope: use the Slipway governed flow to solve all
+of GitHub issue #155, reference local gsd-core during implementation, make the
+best available choice on blockers, and stop at done-ready. This change is
+limited to prose-artifact materiality and auto-reopen softening; it must not
+weaken evidence freshness or copy GSD code directly.

--- a/artifacts/changes/archived/resolve-github-issue-155-knuth-invariant-overwrite-only-own/requirements.md
+++ b/artifacts/changes/archived/resolve-github-issue-155-knuth-invariant-overwrite-only-own/requirements.md
@@ -1,0 +1,35 @@
+# Requirements
+
+## Requirements
+
+### Requirement: Prose scaffold edits are non-material
+REQ-001: The system MUST compute planning and research skill input digests from
+the material view of governed prose artifacts, so engine-owned comments,
+empty scaffold sections, and narrow known default prose do not stale evidence.
+
+#### Scenario: scaffold-only prose edit keeps planning evidence fresh
+GIVEN `plan-audit` evidence was stamped for a governed change with authored
+planning artifacts
+WHEN an artifact edit changes only HTML guidance comments, empty scaffold
+sections, or a recognized engine-owned default in `intent.md`,
+`requirements.md`, `research.md`, or `decision.md`
+THEN the named prose artifact input digest remains unchanged.
+
+### Requirement: Human prose remains fail-closed material
+REQ-002: The system MUST include any unknown non-empty or human-authored prose
+artifact content in skill input digests, preserving stale evidence recovery for
+material edits.
+
+#### Scenario: authored prose edit stales planning evidence
+GIVEN `plan-audit` evidence was stamped for a governed change with authored
+planning artifacts
+WHEN a user changes human-authored prose in `requirements.md`, `research.md`, or
+`decision.md`
+THEN `EvaluateRequiredSkillsForChange` reports the corresponding
+`required_skill_stale:<skill>:<artifact>` blocker.
+
+#### Scenario: research artifact material edit stales research evidence
+GIVEN `research-orchestration` evidence was stamped for a discovery-required
+change
+WHEN a user changes human-authored prose in `research.md`
+THEN the research skill input digest changes for `research.md`.

--- a/artifacts/changes/archived/resolve-github-issue-155-knuth-invariant-overwrite-only-own/research.md
+++ b/artifacts/changes/archived/resolve-github-issue-155-knuth-invariant-overwrite-only-own/research.md
@@ -1,0 +1,116 @@
+# Research
+
+## Alternatives Considered
+
+### Architecture
+- Affected modules: `internal/engine/progression/evidence_digests.go` owns
+  skill input digest construction. The relevant branch starts at
+  `certifiedSkillInputDigest` and routes `plan-audit`,
+  `intake-clarification`, and `research-orchestration` to governed artifact
+  inputs.
+- Dependency chains:
+  `evidence_digests.go` -> `model.ComputeInputHash` for canonical digesting;
+  `evidence_digests.go` -> `wave.TaskPlanStructuralHash` for `tasks.md`;
+  `evidence_digests.go` -> `state.LoadOptionalEvidenceDigestsForChange` for
+  stored/current comparison; stale blockers feed `stale_evidence_recovery.go`.
+- Blast radius: planning skill evidence freshness for `intent.md`,
+  `requirements.md`, `research.md`, and `decision.md`; research evidence
+  freshness for `intent.md` and `research.md`; intake evidence freshness for
+  `intent.md`.
+- Constraints: evidence freshness remains fail-closed. The classifier may
+  suppress engine-owned scaffold/comment churn only when material content is
+  absent or recognized as a narrow known default.
+
+### Patterns
+- Existing conventions: `tasks.md` already uses structural hashing through
+  `wave.TaskPlanStructuralHash`, while prose artifacts call
+  `computeProseFileInputHash`.
+- Reusable abstractions: artifact templates are accessible through
+  `artifact.TemplateContent`, and artifact substance gates already strip HTML
+  comments and reject scaffold-only content.
+- Convention deviations: the current prose digest is raw-content based; issue
+  #155 requires a material-view digest for prose while keeping tasks on their
+  existing structural hash path.
+- GSD reference: local gsd-core uses `KNOWN_TEMPLATE_DEFAULTS` and
+  `stateReplaceFieldIfTemplate` to replace fields only when the current value is
+  absent, blank, or a recognized handler-written default.
+
+### Risks
+- Technical risks: high false-negative risk if authored prose is omitted from
+  the digest; medium false-positive risk if comments/scaffold-only sections keep
+  triggering reopens; low performance risk because artifacts are small markdown
+  files.
+- Guardrail domains: none of the sensitive guardrail domains are directly
+  touched, but lifecycle evidence freshness is load-bearing.
+- Reversibility: safe to roll back by reverting the prose digest material-view
+  helper and tests. Existing evidence records will be recomputed on future
+  checks.
+
+### Test Strategy
+- Existing coverage: `evidence_digests_test.go` already covers plan-audit
+  digest inputs, CRLF normalization, tasks structural hashing, stale blockers,
+  and research artifact digest drift.
+- Infrastructure needs: no new fixtures beyond writing artifact markdown bodies
+  in existing temp-bundle helpers.
+- Verification approach: add tests that comment/scaffold-only prose edits keep
+  the digest stable, human-authored prose edits stale the relevant named input,
+  and unknown non-empty prose is included in the digest.
+
+### Options
+- Option 1: Strip only HTML comments before hashing prose artifacts.
+  Tradeoff: small and safe, but it does not express the known-default invariant
+  from issue #155 and still churns on scaffold-only heading/body defaults.
+- Option 2: Add a prose artifact material-view digest that strips comments,
+  treats empty/comment-only scaffold sections as non-material, recognizes only
+  narrow engine-owned defaults, and includes all unknown non-empty prose.
+  Tradeoff: slightly more code, but it matches the GSD invariant without
+  weakening fail-closed material edits.
+- Option 3: Build a full per-artifact AST and field-overwrite framework.
+  Tradeoff: broad and likely over-engineered for the issue; it risks changing
+  authoring and validation semantics unrelated to digest freshness.
+- Selected: Option 2. It is the smallest repo-native analogue of GSD's
+  overwrite-only-own-defaults behavior and gives tests a precise materiality
+  boundary.
+
+## Unknowns
+- Resolved: Which current Slipway digest/reopen functions own prose artifact
+  materiality? -> `computeProseFileInputHash` in
+  `internal/engine/progression/evidence_digests.go` is the central seam; stale
+  recovery consumes its blockers through `stale_evidence_recovery.go`.
+- Resolved: What exact scaffold/default values are engine-owned today? ->
+  HTML authoring comments and empty scaffold sections are engine-owned; the
+  `intent.md` fallback summary "Describe the change objective." is a narrow
+  known default. Other non-empty prose should default to material unless a
+  future test adds a narrow known default.
+- Resolved: Which tests cover auto-reopen on artifact edits? ->
+  `evidence_digests_test.go` covers named digest drift and should be extended
+  there before touching broader lifecycle tests.
+- Resolved: Does GSD imply a recovery edge case Slipway lacks? -> GSD's key
+  invariant is not recovery-specific; it is the classification boundary: absent,
+  blank, or known defaults are handler-owned, everything else is preserved and
+  therefore material.
+- Remaining: None.
+
+## Assumptions
+- The materiality classifier should operate at digest-input time, not by
+  mutating artifact files. Evidence: current stale recovery is driven by named
+  digest input changes.
+- A comment-only scaffold refresh is non-material. Evidence: artifact substance
+  gates strip HTML comments before deciding whether sections have authored
+  content.
+- Unknown non-empty prose is material. Evidence: issue #155 explicitly requires
+  defaulting to reopen on doubt.
+
+## Canonical References
+- `internal/engine/progression/evidence_digests.go:36`
+- `internal/engine/progression/evidence_digests.go:388`
+- `internal/engine/progression/evidence_digests.go:426`
+- `internal/engine/progression/stale_evidence_recovery.go:59`
+- `internal/engine/artifact/manager.go:152`
+- `internal/engine/artifact/manager.go:329`
+- `internal/engine/artifact/manager.go:559`
+- `internal/engine/artifact/requirements.go:35`
+- `internal/engine/progression/evidence_digests_test.go:18`
+- `/Users/yixianlu/ghq/github.com/open-gsd/gsd-core/src/state-document.cts:154`
+- `/Users/yixianlu/ghq/github.com/open-gsd/gsd-core/src/state-document.cts:209`
+- `/Users/yixianlu/ghq/github.com/open-gsd/gsd-core/src/state-document.cts:257`

--- a/artifacts/changes/archived/resolve-github-issue-155-knuth-invariant-overwrite-only-own/tasks.md
+++ b/artifacts/changes/archived/resolve-github-issue-155-knuth-invariant-overwrite-only-own/tasks.md
@@ -1,0 +1,24 @@
+# Tasks
+
+## Task List
+
+- [x] `t-01` Add failing digest materiality tests for prose artifacts.
+  - wave: 1
+  - depends_on: []
+  - target_files: ["internal/engine/progression/evidence_digests_test.go"]
+  - task_kind: test
+  - covers: [REQ-001, REQ-002]
+
+- [x] `t-02` Implement prose artifact material-view hashing for skill input digests.
+  - wave: 2
+  - depends_on: [t-01]
+  - target_files: ["internal/engine/progression/evidence_digests.go"]
+  - task_kind: code
+  - covers: [REQ-001, REQ-002]
+
+- [x] `t-03` Verify focused and full Go test suites plus Slipway validation.
+  - wave: 3
+  - depends_on: [t-02]
+  - target_files: ["internal/engine/progression/evidence_digests.go", "internal/engine/progression/evidence_digests_test.go"]
+  - task_kind: verification
+  - covers: [REQ-001, REQ-002]

--- a/artifacts/codebase/ARCHITECTURE.md
+++ b/artifacts/codebase/ARCHITECTURE.md
@@ -1,51 +1,54 @@
 # Architecture
 
 Re-authored for change
-`resolve-github-issues-195-and-196-make-status-expose-done-re`
-(GitHub issues #195 and #196).
+`resolve-github-issue-155-knuth-invariant-overwrite-only-own`
+(GitHub issue #155).
 
-Question: how should `slipway status` expose terminal readiness and archived
-records without weakening active lifecycle authority?
+Question: which Slipway freshness/digest seams should classify prose artifact
+edits as engine-default/scaffold versus human material while preserving
+fail-closed reopen behavior?
 
 ## Affected Seams
 
-- `cmd/status.go:202` through `cmd/status.go:219` is the explicit
-  `status --change <slug>` route. It currently calls `loadChangeBySlug`, whose
-  active-only loader returns an error before archived records can be surfaced.
-- `cmd/common.go:347` through `cmd/common.go:367` already contains the archived
-  fallback pattern for active-only commands. `resolveExplicitChange` maps an
-  archived slug to `archived_change_not_validatable` with archive metadata,
-  proving that archived lookup is already a supported read concern.
-- `cmd/status_view_build.go:21` through `cmd/status_view_build.go:155` builds
-  the governed status projection. It evaluates governance readiness and gate
-  state, but does not convert an approved S4 ship gate into a top-level
-  done-ready signal for status.
-- `cmd/next.go:516` through `cmd/next.go:535` contains the existing read-only
-  done-ready projection used by `next`: S4 plus approved ship authority becomes
-  `advanced.action=done_ready` with `run_slipway_done_to_finalize`.
-- `internal/state/lifecycle.go:23` through `internal/state/lifecycle.go:32`
-  loads archived changes from `artifacts/changes/archived/<slug>/change.yaml`.
-  `internal/state/store.go:223` through `internal/state/store.go:228`
-  searches archived records across workspace roots.
+- `internal/engine/progression/evidence_digests.go:36` through
+  `internal/engine/progression/evidence_digests.go:79` is the skill input
+  digest switch. `intake-clarification` consumes `intent.md`,
+  `research-orchestration` consumes `intent.md` plus `research.md`, and
+  `plan-audit` consumes the planning artifacts.
+- `internal/engine/progression/evidence_digests.go:388` through
+  `internal/engine/progression/evidence_digests.go:423` is the plan-audit
+  artifact input collector. It hashes `intent.md`, `requirements.md`,
+  `research.md`, and `decision.md`, while `tasks.md` already uses
+  `wave.TaskPlanStructuralHash`.
+- `internal/engine/progression/evidence_digests.go:426` through
+  `internal/engine/progression/evidence_digests.go:448` is the prose file
+  digest seam. `computeProseFileInputHash` currently hashes raw content, so
+  authoring comments and scaffold-only sections can churn evidence digests.
+- `internal/engine/progression/stale_evidence_recovery.go:59` through
+  `internal/engine/progression/stale_evidence_recovery.go:93` turns digest
+  drift into the earliest stale evidence recovery target. A digest false
+  positive here reopens earlier lifecycle stages.
+- `internal/engine/artifact/manager.go:152` through
+  `internal/engine/artifact/manager.go:167` exposes artifact templates, and
+  `internal/engine/artifact/manager.go:329` through
+  `internal/engine/artifact/manager.go:349` documents which artifacts are
+  skill-authored rather than always engine-scaffolded.
 
 ## Dependency Flow
 
-`status --change` resolves a slug, loads active state, builds a status view,
-then renders JSON/text. Archived records are not active lifecycle authorities,
-but they are valid query targets because `state.LoadArchivedChange` already
-loads them for read surfaces.
-
-Done-ready status is a projection, not a persisted lifecycle state. The change
-must keep `change.status=active` until `slipway done` archives the record, while
-making the readiness visible through status view fields and narrative.
+Governed artifacts live in `artifacts/changes/<slug>/`. Skill verification is
+accepted through `slipway evidence skill`, which stamps current input digests.
+Later readiness checks recompute those digests and compare named inputs; changed
+inputs become `required_skill_stale:<skill>:<artifact>` blockers that can reopen
+the change to the earliest affected stage.
 
 ## Constraints And Invariants
 
-- Active `change.yaml` remains the only authority for active lifecycle
-  mutation.
-- Archived records are terminal query records and must not be routed through
-  active lifecycle mutation or repair guidance.
-- Done-ready must not be reported as `done` before `slipway done` runs.
-- The status surface should reuse existing reason code
-  `run_slipway_done_to_finalize` instead of inventing a second finalization
-  blocker taxonomy.
+- Evidence freshness remains fail-closed. Unknown or material content must keep
+  changing the digest and reopening stale evidence.
+- `tasks.md` structural hashing is intentionally separate and already excludes
+  checkbox-only and `target_files`-only churn for plan-audit.
+- Prose artifact materiality should be derived from repo-owned scaffold/template
+  knowledge, not from mutable file timestamps.
+- GSD is a behavioral reference only. Slipway must not gain a runtime dependency
+  on the local GSD checkout.

--- a/artifacts/codebase/CONCERNS.md
+++ b/artifacts/codebase/CONCERNS.md
@@ -1,17 +1,22 @@
 # Concerns
 
 Re-authored for change
-`resolve-github-issues-195-and-196-make-status-expose-done-re`
-(GitHub issues #195 and #196).
+`resolve-github-issue-155-knuth-invariant-overwrite-only-own`
+(GitHub issue #155).
 
-- Lifecycle ambiguity risk: status must make done-ready obvious without saying
-  the change is already done. `change.status` stays active until finalization.
-- False-corruption risk: an archived change with no active bundle must not be
-  reported as `change_state_load_failed` or remediated with generic repair.
-- Real-corruption risk: if neither active nor archived authority can be loaded,
-  existing delete/repair diagnostics should still surface.
-- Compatibility risk: adding optional JSON fields is lower risk than changing
-  existing `lifecycle_status` semantics from `active` to `done_ready`.
-- Text/JSON drift risk: if only JSON is changed, operators using text status
-  still see the ambiguous handoff. Text rendering should show the same
-  done-ready/archived facts.
+- False-negative freshness risk: if the classifier treats human prose as
+  scaffold/default, stale plan or research evidence may be accepted. The
+  implementation must include unknown non-empty prose in the digest.
+- False-positive reopen risk: if authoring comments or empty scaffold-only
+  sections stay in the digest, engine-owned scaffold refreshes can reopen
+  downstream stages without a material change.
+- Contract drift risk: template-derived defaults and hand-maintained phrase
+  lists can diverge. Prefer deriving scaffold defaults from embedded templates
+  where possible, and keep any literal known defaults narrow and tested.
+- Artifact-stage risk: `intent.md` is engine-scaffolded at creation, while
+  `requirements.md`, `research.md`, `decision.md`, `tasks.md`, and
+  `assurance.md` are skill-authored/deferred. A one-size-fits-all overwrite
+  rule would be too broad.
+- Recovery risk: stale recovery removes verification records from the target
+  stage onward. Digest materiality changes must be covered before relying on
+  `stale_evidence_recovery.go` to reopen correctly.

--- a/artifacts/codebase/STRUCTURE.md
+++ b/artifacts/codebase/STRUCTURE.md
@@ -1,28 +1,28 @@
 # Structure
 
 Re-authored for change
-`resolve-github-issues-195-and-196-make-status-expose-done-re`
-(GitHub issues #195 and #196).
+`resolve-github-issue-155-knuth-invariant-overwrite-only-own`
+(GitHub issue #155).
 
-- `cmd/status.go`
-  - Defines `statusView`.
-  - Resolves explicit `--change` requests.
-  - Routes active status to `showStatusForChange`.
-  - Contains delete-recovery status diagnostics for broken active state.
-- `cmd/status_view_build.go`
-  - Builds governed status projections from readiness, execution context,
-    timeline, blockers, and recovery.
-  - Owns the status narrative.
-- `cmd/status_render.go`
-  - Renders status JSON through `statusJSONView` and text through
-    `renderStatusText`.
-  - Owns the first user-visible "what next" hint for text output.
-- `cmd/common.go`
-  - Provides shared active-change loaders and archived fallback behavior used by
-    validate-like active commands.
-- `cmd/status_view_build_test.go`
-  - Focused unit tests for status view projection.
-- `cmd/cli_e2e_test.go`
-  - Command-level e2e tests around `done` and JSON command behavior.
-- `internal/state/lifecycle.go` and `internal/state/store.go`
-  - Archive load and archive path discovery helpers.
+- `internal/engine/progression/`
+  - `evidence_digests.go`: skill input digest construction, named stale input
+    blockers, and the prose artifact digest seam for this change.
+  - `evidence_digests_test.go`: existing digest policy tests and the target for
+    new prose materiality regression coverage.
+  - `stale_evidence_recovery.go`: consumes stale digest blockers to reopen the
+    earliest affected lifecycle authority; not expected to change for issue
+    #155.
+- `internal/engine/artifact/`
+  - `manager.go`: artifact schemas, embedded template access, scaffold/deferred
+    artifact behavior, and existing template-derived scaffold detection pattern.
+  - `requirements.go`: narrow requirements placeholder detection, useful as a
+    warning against broad substring-based materiality suppression.
+  - `schemas.yaml`: expanded artifact graph for `intent.md`,
+    `requirements.md`, `decision.md`, `tasks.md`, `assurance.md`, and
+    discovery-only `research.md`.
+- `internal/tmpl/templates/artifacts/`
+  - `intent.md`, `requirements.md`, `research.md`, and `decision.md`: embedded
+    artifact templates whose comments and scaffold-only sections define
+    engine-owned prose defaults.
+- Local reference outside this repo:
+  `/Users/yixianlu/ghq/github.com/open-gsd/gsd-core/src/state-document.cts`.

--- a/artifacts/codebase/TESTING.md
+++ b/artifacts/codebase/TESTING.md
@@ -1,34 +1,46 @@
 # Testing
 
 Re-authored for change
-`resolve-github-issues-195-and-196-make-status-expose-done-re`
-(GitHub issues #195 and #196).
+`resolve-github-issue-155-knuth-invariant-overwrite-only-own`
+(GitHub issue #155).
 
 ## Existing Coverage
 
-- `cmd/progression_next_test.go:1727` through
-  `cmd/progression_next_test.go:1774` proves `next` already projects
-  done-ready for S4 with approved ship readiness.
-- `cmd/cli_e2e_test.go:448` through `cmd/cli_e2e_test.go:480` proves `done`
-  archives a ready change and `state.LoadArchivedChange` can load it afterward.
-- `cmd/status_view_build_test.go` contains focused status-view tests and is the
-  lowest-cost home for done-ready projection assertions.
-- `internal/state/lifecycle_test.go` covers archived load path behavior, so this
-  change should not need new state-layer archive tests unless archive discovery
-  changes.
+- `internal/engine/progression/evidence_digests_test.go:18` through
+  `internal/engine/progression/evidence_digests_test.go:57` already pins the
+  plan-audit digest policy: assurance is excluded, CRLF-only prose rewrites do
+  not stale, checkbox-only task edits do not stale, `target_files`-only task
+  edits do not stale, and objective changes do stale.
+- `internal/engine/progression/evidence_digests_test.go:136` through
+  `internal/engine/progression/evidence_digests_test.go:167` proves stale
+  evidence is content-digest based rather than mtime based.
+- `internal/engine/progression/evidence_digests_test.go:779` through
+  `internal/engine/progression/evidence_digests_test.go:807` proves
+  `research-orchestration` stales when `research.md` material content changes.
+- `internal/engine/artifact/requirements.go:35` through
+  `internal/engine/artifact/requirements.go:103` contains narrow requirements
+  placeholder detection, useful as a fail-closed warning against overbroad
+  scaffold classification.
+- `internal/engine/artifact/manager.go:559` through
+  `internal/engine/artifact/manager.go:640` derives assurance scaffold
+  detection from the embedded template, establishing a local pattern for
+  template-derived scaffold checks.
 
-## Gaps For Issues #195 And #196
+## Gaps For Issue #155
 
-- No status-view test asserts a top-level done-ready signal after S4 ship
-  readiness passes.
-- No command test asserts `status --json --change <slug>` after `done` returns
-  an archived/done status view instead of `change_state_load_failed`.
+- No test proves comment-only or scaffold-only prose artifact edits are
+  non-material for input digests.
+- No test proves human-authored prose edits still stale `plan-audit` and
+  `research-orchestration`.
+- No test covers the fail-closed unknown case: unknown non-empty prose must be
+  included in the material view rather than silently ignored.
 
 ## Verification Plan
 
-- Add a focused status-view test that builds an S4 ship-ready change and asserts
-  done-ready fields, finalization blocker, and narrative.
-- Add a command-level test that finalizes a ready change, runs
-  `status --json --change <slug>`, and asserts archived status metadata.
-- Run focused tests for `./cmd`.
-- Run `go test ./...`, `git diff --check`, and `go run . validate --json`.
+- Add focused unit tests in `internal/engine/progression/evidence_digests_test.go`.
+- Cover `intent.md`, `requirements.md`, `research.md`, and `decision.md` through
+  the plan-audit digest path.
+- Include a `research-orchestration` case so the research artifact digest still
+  reacts to authored research content.
+- Run `go test -count=1 ./internal/engine/progression` after implementation,
+  then broaden to `go test -count=1 ./...` before done-ready.

--- a/internal/engine/progression/evidence_digests.go
+++ b/internal/engine/progression/evidence_digests.go
@@ -443,8 +443,99 @@ func computeProseFileInputHash(path string) (string, error) {
 		return "", err
 	}
 	return model.ComputeInputHash(map[string]any{
-		"content": string(raw),
+		"artifact":          filepath.Base(path),
+		"material_sections": proseArtifactMaterialSections(filepath.Base(path), string(raw)),
 	})
+}
+
+func proseArtifactMaterialSections(name, content string) []map[string]string {
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+	content = stringutil.StripHTMLComments(content)
+
+	type proseSection struct {
+		heading string
+		lines   []string
+	}
+
+	sections := []proseSection{{}}
+	for _, line := range strings.Split(content, "\n") {
+		if heading, ok := proseArtifactSectionHeading(line); ok {
+			sections = append(sections, proseSection{heading: heading})
+			continue
+		}
+		last := len(sections) - 1
+		sections[last].lines = append(sections[last].lines, line)
+	}
+
+	material := make([]map[string]string, 0, len(sections))
+	for _, section := range sections {
+		body := normalizeProseArtifactSectionBody(section.lines)
+		if body == "" || proseArtifactKnownDefault(name, section.heading, body) {
+			continue
+		}
+		entry := map[string]string{"body": body}
+		if section.heading != "" {
+			entry["heading"] = section.heading
+		}
+		material = append(material, entry)
+	}
+	return material
+}
+
+func proseArtifactSectionHeading(line string) (string, bool) {
+	trimmed := strings.TrimSpace(line)
+	if !strings.HasPrefix(trimmed, "## ") {
+		return "", false
+	}
+	heading := strings.TrimSpace(strings.TrimPrefix(trimmed, "## "))
+	return heading, heading != ""
+}
+
+func normalizeProseArtifactSectionBody(lines []string) string {
+	normalized := make([]string, 0, len(lines))
+	for _, line := range lines {
+		normalized = append(normalized, strings.TrimRight(line, " \t"))
+	}
+	for len(normalized) > 0 && strings.TrimSpace(normalized[0]) == "" {
+		normalized = normalized[1:]
+	}
+	for len(normalized) > 0 && strings.TrimSpace(normalized[len(normalized)-1]) == "" {
+		normalized = normalized[:len(normalized)-1]
+	}
+	if len(normalized) == 1 && strings.HasPrefix(strings.TrimSpace(normalized[0]), "# ") {
+		return ""
+	}
+	return strings.Join(normalized, "\n")
+}
+
+func proseArtifactKnownDefault(name, heading, body string) bool {
+	defaultsByHeading := proseArtifactKnownDefaults[strings.TrimSpace(name)]
+	if len(defaultsByHeading) == 0 {
+		return false
+	}
+	defaults := defaultsByHeading[strings.ToLower(strings.TrimSpace(heading))]
+	if len(defaults) == 0 {
+		return false
+	}
+	normalizedBody := normalizeKnownProseDefault(body)
+	for _, known := range defaults {
+		if normalizedBody == normalizeKnownProseDefault(known) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeKnownProseDefault(value string) string {
+	return strings.ToLower(strings.Join(strings.Fields(strings.TrimSpace(value)), " "))
+}
+
+var proseArtifactKnownDefaults = map[string]map[string][]string{
+	"intent.md": {
+		"summary": {
+			"Describe the change objective.",
+		},
+	},
 }
 
 func addExecutionAndContentInputs(

--- a/internal/engine/progression/evidence_digests_test.go
+++ b/internal/engine/progression/evidence_digests_test.go
@@ -56,6 +56,93 @@ func TestPlanAuditInputDigestExcludesAssuranceAndIncludesStructuralTasks(t *test
 	assert.Equal(t, realChange.Inputs, changedAssurance.Inputs, "assurance.md changes must not affect the plan-audit digest")
 }
 
+func TestPlanAuditInputDigestIgnoresScaffoldOnlyProseEdits(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		artifact string
+		content  string
+	}{
+		{
+			name:     "intent scaffold-only section",
+			artifact: "intent.md",
+			content:  "# Intent\nship digest freshness\n\n## Deferred Ideas\n<!-- Identified but postponed ideas -->\n",
+		},
+		{
+			name:     "requirements scaffold-only section",
+			artifact: "requirements.md",
+			content:  "# Requirements\nREQ-001 digest freshness\n\n## Requirements\n<!-- Author each requirement here. -->\n",
+		},
+		{
+			name:     "research scaffold-only section",
+			artifact: "research.md",
+			content:  "# Research\ncurrent facts\n\n## Assumptions\n<!-- Assumptions with the evidence that supports them. -->\n",
+		},
+		{
+			name:     "decision scaffold-only section",
+			artifact: "decision.md",
+			content:  "# Decision\nuse digest inputs\n\n## Risk\n<!-- Concrete risks found by inspecting the affected code and contracts. -->\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := t.TempDir()
+			change := model.NewChange("plan-audit-prose-scaffold-" + strings.ReplaceAll(tt.name, " ", "-"))
+			require.NoError(t, state.SaveChange(root, change))
+			bundleDir := writeDigestPlanningBundle(t, root, change, uncheckedDigestTasks())
+
+			before, err := certifiedSkillInputDigest(root, change, SkillPlanAudit, nil)
+			require.NoError(t, err)
+
+			require.NoError(t, os.WriteFile(filepath.Join(bundleDir, tt.artifact), []byte(tt.content), 0o644))
+			after, err := certifiedSkillInputDigest(root, change, SkillPlanAudit, nil)
+			require.NoError(t, err)
+
+			assert.Equal(t, before.Inputs[tt.artifact], after.Inputs[tt.artifact],
+				"scaffold-only edits must not stale %s", tt.artifact)
+		})
+	}
+}
+
+func TestProseFileInputHashTreatsKnownDefaultsAsNonMaterial(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	intentPath := filepath.Join(root, "intent.md")
+
+	require.NoError(t, os.WriteFile(intentPath, []byte(`# Intent
+
+## Summary
+Describe the change objective.
+`), 0o644))
+	defaultHash, err := computeProseFileInputHash(intentPath)
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(intentPath, []byte(`# Intent
+
+## Summary
+<!-- Summary is still un-authored scaffold. -->
+`), 0o644))
+	commentOnlyHash, err := computeProseFileInputHash(intentPath)
+	require.NoError(t, err)
+	assert.Equal(t, defaultHash, commentOnlyHash,
+		"the engine-owned intent summary default must hash like an empty scaffold section")
+
+	require.NoError(t, os.WriteFile(intentPath, []byte(`# Intent
+
+## Summary
+Ship prose digest materiality.
+`), 0o644))
+	authoredHash, err := computeProseFileInputHash(intentPath)
+	require.NoError(t, err)
+	assert.NotEqual(t, defaultHash, authoredHash,
+		"unknown non-empty authored prose must remain material")
+}
+
 func TestGovernedSkillInputDigestsCoverStageAuthorities(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- resolve #155 by hashing governed prose artifacts through a material view instead of raw file bytes
- ignore engine-owned HTML guidance comments, empty scaffold sections, and narrow known defaults while keeping unknown non-empty prose material
- archive the governed change bundle for `resolve-github-issue-155-knuth-invariant-overwrite-only-own`

## Why

Issue #155 was about preserving the Knuth-style invariant that the engine only overwrites or suppresses what it owns. Raw prose hashing made comment-only or scaffold-only artifact refreshes stale evidence even when no human-authored plan material changed.

## Validation

- `go run . validate --json`
- `git diff --check`
- `go test -count=1 ./internal/engine/progression`
- `go test -count=1 ./cmd`
- `go test -count=1 ./...`

Closes #155
