### PR TITLE
fix(governance): explain domain review evidence mapping

### DIFF
--- a/artifacts/changes/archived/explain-domain-review-mapping/assurance.md
+++ b/artifacts/changes/archived/explain-domain-review-mapping/assurance.md
@@ -1,0 +1,46 @@
+# Assurance
+
+## Scope Summary
+
+Delivered issue #203 by adding structured `satisfied_by` attribution to governance required actions and exposing that attribution through status, validate, and next JSON surfaces. The behavior preserves the existing policy that current passing `spec-compliance-review` evidence satisfies the `domain-review` control.
+
+## Verification Verdict
+
+Current implementation verification is passing for the governed change.
+
+- `go test -count=1 ./...`: pass; transcript stored at `verification/go-test-all.txt`.
+- `go run github.com/securego/gosec/v2/cmd/gosec@v2.27.1 -fmt=sarif -out=artifacts/changes/explain-domain-review-mapping/verification/sast/gosec.sarif ./...`: pass; SARIF contains one gosec run and zero results.
+- `go run . validate --json`: active S4 validation is fresh; `scope_contract.status=pass`.
+
+Governed execution evidence reached `run_summary_version=1`, with both planned tasks passing.
+
+## Evidence Index
+
+- `verification/execution-summary.yaml`: completed `t-01` and `t-02`, overall verdict pass.
+- `verification/wave-orchestration.yaml`: run_version=1, pass.
+- `verification/plan-audit.yaml`: pass.
+- `internal/engine/governance/runtime_actions_test.go`: engine attribution and fail-closed stale evidence coverage.
+- `cmd/governance_gate_consistency_test.go`: status, validate, and next surface consistency coverage.
+- `cmd/status_json_test.go`: encoded status JSON summary coverage for attributed satisfied actions.
+- `verification/goal-verification.yaml`: pass, run_version=1, with `high_risk_check:external_api_contracts.safety_baseline=pass`.
+- `verification/go-test-all.txt`: fresh full-suite transcript for `go test -count=1 ./...`.
+- `verification/sast/gosec.sarif`: fresh SAST artifact with zero results.
+- `verification/status-current.json`, `verification/validate-current.json`, `verification/next-current.json`: current CLI-surface proof snapshots.
+
+## Requirement Coverage
+
+- REQ-001: Covered by `TestResolveRuntimeRequiredActionsExplainsDomainReviewSatisfiedBySpecCompliance`.
+- REQ-002: Covered by `TestSatisfiedDomainReviewAttributionStaysConsistentAcrossStatusValidateAndNext` and `TestStatusJSONResponseIncludesAttributedSatisfiedActions`.
+- REQ-003: Covered by the stale evidence assertion in `TestResolveRuntimeRequiredActionsUsesEvidenceReadinessAndRollbackDocs`.
+
+## Residual Risks and Exceptions
+
+No accepted functional exceptions. The new JSON fields are additive. Consumers that reject unknown JSON fields may need their own compatibility review outside this change, but no existing field was removed or changed.
+
+## Rollback Readiness
+
+Rollback is straightforward: revert the additive `satisfied_by` model/view fields, runtime attribution construction, status summary addition, validate surface addition, and associated tests. No persisted data migration is required.
+
+## Archive Decision
+
+Ready to proceed to `done_ready` after final-closeout records this assurance attestation and active `validate --json` confirms `G_ship` approval. Do not run `slipway done` in this turn unless explicitly requested; the user requested stopping at done-ready.

--- a/artifacts/changes/archived/explain-domain-review-mapping/change.yaml
+++ b/artifacts/changes/archived/explain-domain-review-mapping/change.yaml
@@ -1,0 +1,61 @@
+version: 1
+slug: explain-domain-review-mapping
+description: explain domain review mapping
+status: done
+current_state: DONE
+needs_discovery: true
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-06-14T01:22:54.954125Z
+guardrail_domain: external_api_contracts
+quality_mode: standard
+workflow_profile: code
+workflow_preset: standard
+worktree_branch: feat/explain-domain-review-mapping
+artifact_schema: expanded
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: 9eb60aeee99ba00317522f4762bd15c94ef773dee0ff3a181af29c08552d53dd
+        updated_at: 2026-06-14T01:55:25.905831724Z
+    decision:
+        id: decision
+        path: decision.md
+        state: frozen
+        content_hash: 7c25e2546ceec9a7ae33e63aafeac4e8cc2b414abe3c496db2d5c36a2a44eaa9
+        updated_at: 2026-06-14T01:29:37.105330083Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: 46c87cb3caf4c3bc2f0f8b8ac95d1740e9936ab769751bd55f84ae922566ff99
+        updated_at: 2026-06-14T01:25:30.021376434Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: 2054ec8158d1a1205285201b7838d101dfd5b03fec5213a0a19e7f1e9e7ca662
+        updated_at: 2026-06-14T01:29:37.105001834Z
+    research:
+        id: research
+        path: research.md
+        state: frozen
+        content_hash: 4a051deca415932d14056d3a388e635fa84adb0ceae073a645e4d8955392bd3e
+        updated_at: 2026-06-14T01:28:41.021379744Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: a5849820cc6adfe96b4dcddbb4228cc3471fc29eb3309e45cca346d66dc17127
+        updated_at: 2026-06-14T01:45:14.766633511Z
+evidence_refs:
+    code-quality-review: .worktrees/explain-domain-review-mapping/artifacts/changes/explain-domain-review-mapping/verification/code-quality-review.yaml
+    final-closeout: .worktrees/explain-domain-review-mapping/artifacts/changes/explain-domain-review-mapping/verification/final-closeout.yaml
+    goal-verification: .worktrees/explain-domain-review-mapping/artifacts/changes/explain-domain-review-mapping/verification/goal-verification.yaml
+    intake-clarification: .worktrees/explain-domain-review-mapping/artifacts/changes/explain-domain-review-mapping/verification/intake-clarification.yaml
+    plan-audit: .worktrees/explain-domain-review-mapping/artifacts/changes/explain-domain-review-mapping/verification/plan-audit.yaml
+    research-orchestration: .worktrees/explain-domain-review-mapping/artifacts/changes/explain-domain-review-mapping/verification/research-orchestration.yaml
+    spec-compliance-review: .worktrees/explain-domain-review-mapping/artifacts/changes/explain-domain-review-mapping/verification/spec-compliance-review.yaml
+    wave-orchestration: .worktrees/explain-domain-review-mapping/artifacts/changes/explain-domain-review-mapping/verification/wave-orchestration.yaml

--- a/artifacts/changes/archived/explain-domain-review-mapping/decision.md
+++ b/artifacts/changes/archived/explain-domain-review-mapping/decision.md
@@ -1,0 +1,60 @@
+# Decision
+
+## Alternatives Considered
+
+### Option A: Structured Satisfied-By Attribution
+
+Add an optional attribution field to `governance.RequiredAction`, populate it from the runtime evidence that satisfied the action, and map it through `governanceActionView`.
+
+Tradeoffs:
+
+- Pros: machine-readable, shared by status/validate/next, and keeps the policy decision in the engine layer.
+- Cons: expands the required-action JSON shape and needs regression coverage for stale-evidence behavior.
+
+### Option B: Description-Only Explanation
+
+Append text such as "satisfied by spec-compliance-review" to the action description when `domain-review` is satisfied.
+
+Tradeoffs:
+
+- Pros: smaller code change.
+- Cons: forces JSON consumers to parse prose, mixes remediation text with proof, and does not create a stable contract.
+
+### Option C: Separate Domain Review Evidence
+
+Require `domain-review.yaml` in addition to `spec-compliance-review.yaml`.
+
+Tradeoffs:
+
+- Pros: creates an obvious standalone evidence file.
+- Cons: changes current policy semantics and adds workflow friction beyond issue #203, which asks for explanation if the existing mapping is intended.
+
+## Selected Approach
+
+Use Option A. `spec-compliance-review` remains the evidence source for `domain-review`, but the satisfied action will carry structured attribution that names the satisfying skill and reason. This fixes the black-box traceability gap without requiring a new evidence file.
+
+## Interfaces and Data Flow
+
+- Add an optional `SatisfiedBy` field to `internal/engine/governance.RequiredAction`.
+- Add an attribution input to `RequiredActionsInput` for review controls.
+- Extend runtime verification satisfaction to return attribution only when the evidence is passing, current, and otherwise acceptable.
+- Map the engine attribution through `cmd/governance_surface.go` into `governanceActionView`.
+- Expose the resulting field in command JSON as an additive field.
+
+## Rollout and Rollback
+
+Rollout:
+
+- Implement the additive field and focused tests.
+- Verify with `go test -count=1 ./internal/engine/governance ./cmd`.
+- Continue governed review and closeout before final completion.
+
+Rollback:
+
+- Revert the additive fields, mapping, and tests. Existing `description` and `satisfied` fields remain unchanged, so rollback does not require data migration.
+
+## Risk
+
+- JSON compatibility risk is controlled by only adding optional fields.
+- Review readiness risk is controlled by deriving attribution from the same readiness checks that already set `Satisfied`.
+- Surface consistency risk is controlled by using the shared command surface mapper rather than patching individual commands.

--- a/artifacts/changes/archived/explain-domain-review-mapping/intent.md
+++ b/artifacts/changes/archived/explain-domain-review-mapping/intent.md
@@ -1,0 +1,40 @@
+# Intent
+
+## Summary
+Resolve GitHub issue #203 by making Slipway's user-facing governance surfaces explain when the `domain-review` control is satisfied by `spec-compliance-review` evidence.
+## Complexity Assessment
+complex
+Rationale: this changes machine-readable CLI surfaces for a guardrail-triggered workflow. The code blast radius is expected to be small, but the JSON contract and governance traceability behavior require regression coverage.
+
+## Guardrail Domains
+external_api_contracts
+
+## In Scope
+- Inspect how `domain-review` required actions are satisfied from recorded skill evidence.
+- Update `validate --json` and/or `next --json --diagnostics` user-facing output so a satisfied `domain-review` action explicitly names the satisfying evidence or skill when `spec-compliance-review` is the evidence source.
+- Preserve the intended policy behavior if `spec-compliance-review` is the correct domain-aware review evidence.
+- Add focused regression coverage for the issue #203 scenario.
+
+## Out of Scope
+- Do not require a separate `domain-review.yaml` evidence file unless current code proves that the existing policy behavior is incorrect.
+- Do not redesign the governance policy model or guardrail-domain selection.
+- Do not change unrelated lifecycle stages, prompts, or generated skill semantics.
+
+## Constraints
+- Treat current CLI output and current worktree behavior as authority.
+- Keep JSON additions backward-compatible for existing consumers where practical.
+- Do not hand-edit engine-owned verification freshness state.
+
+## Acceptance Signals
+- A reproduction-shaped test shows that after only `spec-compliance-review` evidence is recorded, `domain-review` can be reported satisfied and the JSON/diagnostic surface includes an explicit satisfied-by mapping.
+- Relevant Go tests pass for the touched packages.
+- Governed evidence reaches the required ready state for this change.
+
+## Open Questions
+None
+
+## Deferred Ideas
+- A later change could add a broader governance-control-to-evidence explanation table in docs or help text if more implicit mappings exist.
+
+## Approved Summary
+User confirmed continuation after the guardrail scope prompt on 2026-06-14. The approved scope is to fix issue #203 by making the `domain-review` satisfaction path explicit in Slipway CLI JSON/diagnostic output when `spec-compliance-review` evidence is the satisfying record. The change will preserve current policy semantics unless implementation evidence shows the mapping is a bug, and it will exclude broader governance-policy redesign.

--- a/artifacts/changes/archived/explain-domain-review-mapping/requirements.md
+++ b/artifacts/changes/archived/explain-domain-review-mapping/requirements.md
@@ -1,0 +1,38 @@
+# Requirements
+
+## Requirements
+
+### Requirement: Domain Review Attribution
+
+REQ-001: The system MUST expose structured attribution when the `domain-review` governance action is satisfied by another skill evidence record.
+
+#### Scenario: Spec compliance satisfies domain review
+
+GIVEN a guarded change whose active controls include blocking `domain-review`
+AND the latest execution summary is present
+AND only current passing `spec-compliance-review` evidence exists for domain review
+WHEN Slipway resolves runtime required actions
+THEN the `domain-review` action is satisfied
+AND the action identifies `spec-compliance-review` as the satisfying evidence source.
+
+### Requirement: CLI Surface Consistency
+
+REQ-002: The system MUST preserve required-action attribution in the shared command JSON surfaces used by `status`, `validate`, and `next --json --diagnostics`.
+
+#### Scenario: Read-only command surfaces explain satisfied domain review
+
+GIVEN a guarded change whose `domain-review` action is satisfied by current `spec-compliance-review` evidence
+WHEN the status, validate, and next JSON views are built
+THEN each view includes the same structured satisfied-by mapping on the `domain-review` required action.
+
+### Requirement: Fail-Closed Review Readiness
+
+REQ-003: The system MUST NOT report satisfied-by attribution for stale, failing, missing, or execution-summary-unbound `spec-compliance-review` evidence.
+
+#### Scenario: Stale spec compliance remains unsatisfied
+
+GIVEN a guarded change with a latest execution summary version
+AND `spec-compliance-review` evidence recorded against an older run version
+WHEN Slipway resolves runtime required actions
+THEN the `domain-review` action remains unsatisfied
+AND its blocker diagnostics continue to explain the readiness failure.

--- a/artifacts/changes/archived/explain-domain-review-mapping/research.md
+++ b/artifacts/changes/archived/explain-domain-review-mapping/research.md
@@ -1,0 +1,62 @@
+# Research
+
+## Alternatives Considered
+
+### Architecture
+
+- Affected modules: `internal/engine/governance/actions.go`, `internal/engine/governance/runtime_actions.go`, `cmd/governance_surface.go`, `cmd/status.go`, plus engine and command regressions.
+- Dependency chains: runtime verification records are loaded in `runtime_actions.go`, converted into `governance.RequiredAction`, passed through `progression.GovernanceReadiness`, then rendered by `cmd/governance_surface.go`.
+- Blast radius: low to medium. The change is additive JSON metadata on governance required actions, but those actions are part of user-facing CLI contracts.
+- Constraints: `domain-review` must remain fail-closed on missing, failing, stale, or execution-summary-unbound `spec-compliance-review` evidence.
+
+### Patterns
+
+- Existing conventions: `RequiredAction` is the engine-owned action model, and `governanceActionView` is the command-owned JSON view.
+- Reusable abstractions: `runtimeVerificationState.skillSatisfied` is the existing source of evidence readiness; extending the result shape there avoids duplicating readiness logic in command code.
+- Convention deviations: no separate `domain-review` verification skill exists today, so the explicit mapping must say that the control is satisfied by the `spec-compliance-review` skill rather than inventing a new evidence file.
+
+### Risks
+
+- Technical risks: medium compatibility risk if JSON shape is changed non-additively; low runtime risk if fields are additive.
+- Guardrail domains: `external_api_contracts`, because `required_actions` is a machine-readable CLI surface.
+- Reversibility: high. The fix can be reverted by removing additive fields and tests without data migration.
+
+### Test Strategy
+
+- Existing coverage: stale/missing review evidence blockers are covered, but positive satisfied-by traceability is not covered.
+- Infrastructure needs: no new fixtures are required; existing helpers can create governed changes, execution summaries, and skill verification records.
+- Verification approach: assert engine action metadata and command view JSON metadata for a change where only `spec-compliance-review` evidence satisfies `domain-review`.
+
+### Options
+
+- Option A: Add an explicit evidence attribution field to `governance.RequiredAction`, populate it in runtime action resolution, and map it through the command view. Tradeoff: slightly expands the engine model, but preserves source-of-truth attribution across all CLI surfaces.
+- Option B: Append a textual phrase to `Description` when `domain-review` is satisfied. Tradeoff: minimal structure change, but weak for JSON consumers and easy to confuse with remediation text.
+- Option C: Require a separate `domain-review` evidence record. Tradeoff: makes the black-box trail obvious, but changes current policy semantics and adds workflow friction beyond the issue's expected behavior.
+- Selected: Option A. It directly fixes traceability without changing policy semantics, and it gives scripts a structured field rather than requiring description parsing.
+
+## Unknowns
+
+- Resolved: Is `spec-compliance-review` intended to satisfy `domain-review`? Yes. Runtime action resolution computes `domainReviewDone` from `skillSpecComplianceReview`, while stale or unready records fail closed.
+- Resolved: Where is the explanation lost? It is lost before rendering because `RequiredActionsInput` carries only booleans and `governanceActionView` exposes no satisfied-by field.
+- Remaining: None.
+
+## Assumptions
+
+- Adding an optional JSON field is backward-compatible for current consumers. Evidence: existing action fields remain unchanged in `cmd/status.go`.
+- A satisfied-by record should appear only for satisfied actions. Evidence: stale evidence currently changes `Satisfied` to false and appends diagnostics to `Description`.
+- The issue is a traceability/UX defect, not a policy defect. Evidence: issue #203 states the reporter is not asserting the mapping itself is invalid, only that the surface does not explain it.
+
+## Canonical References
+
+- `internal/engine/governance/actions.go:7-14`
+- `internal/engine/governance/actions.go:45-48`
+- `internal/engine/governance/actions.go:73-85`
+- `internal/engine/governance/runtime_actions.go:15-20`
+- `internal/engine/governance/runtime_actions.go:39-44`
+- `internal/engine/governance/runtime_actions.go:64-75`
+- `internal/engine/governance/runtime_actions.go:195-209`
+- `cmd/governance_surface.go:42-56`
+- `cmd/status.go:94-99`
+- `internal/engine/governance/runtime_actions_test.go:128-138`
+- `cmd/governance_gate_consistency_test.go:127-167`
+- `cmd/governance_gate_consistency_test.go:392-409`

--- a/artifacts/changes/archived/explain-domain-review-mapping/tasks.md
+++ b/artifacts/changes/archived/explain-domain-review-mapping/tasks.md
@@ -1,0 +1,15 @@
+# Tasks
+
+## Task List
+
+- [x] `t-01` Add engine-level required-action satisfied-by attribution
+  - depends_on: []
+  - target_files: ["internal/engine/governance/actions.go", "internal/engine/governance/runtime_actions.go", "internal/engine/governance/runtime_actions_test.go"]
+  - task_kind: code
+  - covers: [REQ-001, REQ-003]
+
+- [x] `t-02` Propagate attribution through command JSON surfaces
+  - depends_on: ["t-01"]
+  - target_files: ["cmd/status.go", "cmd/status_json.go", "cmd/status_json_test.go", "cmd/validate.go", "cmd/governance_surface.go", "cmd/governance_gate_consistency_test.go"]
+  - task_kind: code
+  - covers: [REQ-002]

--- a/artifacts/codebase/ARCHITECTURE.md
+++ b/artifacts/codebase/ARCHITECTURE.md
@@ -1,54 +1,27 @@
 # Architecture
 
-Re-authored for change
-`resolve-github-issue-155-knuth-invariant-overwrite-only-own`
-(GitHub issue #155).
+Re-authored for change `explain-domain-review-mapping` (GitHub issue #203).
 
-Question: which Slipway freshness/digest seams should classify prose artifact
-edits as engine-default/scaffold versus human material while preserving
-fail-closed reopen behavior?
+Question: where should Slipway preserve and expose the evidence source that satisfies a governance control?
 
 ## Affected Seams
 
-- `internal/engine/progression/evidence_digests.go:36` through
-  `internal/engine/progression/evidence_digests.go:79` is the skill input
-  digest switch. `intake-clarification` consumes `intent.md`,
-  `research-orchestration` consumes `intent.md` plus `research.md`, and
-  `plan-audit` consumes the planning artifacts.
-- `internal/engine/progression/evidence_digests.go:388` through
-  `internal/engine/progression/evidence_digests.go:423` is the plan-audit
-  artifact input collector. It hashes `intent.md`, `requirements.md`,
-  `research.md`, and `decision.md`, while `tasks.md` already uses
-  `wave.TaskPlanStructuralHash`.
-- `internal/engine/progression/evidence_digests.go:426` through
-  `internal/engine/progression/evidence_digests.go:448` is the prose file
-  digest seam. `computeProseFileInputHash` currently hashes raw content, so
-  authoring comments and scaffold-only sections can churn evidence digests.
-- `internal/engine/progression/stale_evidence_recovery.go:59` through
-  `internal/engine/progression/stale_evidence_recovery.go:93` turns digest
-  drift into the earliest stale evidence recovery target. A digest false
-  positive here reopens earlier lifecycle stages.
-- `internal/engine/artifact/manager.go:152` through
-  `internal/engine/artifact/manager.go:167` exposes artifact templates, and
-  `internal/engine/artifact/manager.go:329` through
-  `internal/engine/artifact/manager.go:349` documents which artifacts are
-  skill-authored rather than always engine-scaffolded.
+- `internal/engine/governance/actions.go:7-14` defines `RequiredAction`. It currently stores `control_id`, `mode`, `scope`, `description`, and `satisfied`, but no reason or evidence source for a satisfied action.
+- `internal/engine/governance/actions.go:45-48` maps `domain-review` to `DomainReviewDone`. The policy decision is already abstracted as input to this layer.
+- `internal/engine/governance/actions.go:73-85` defines `RequiredActionsInput`. It currently accepts boolean satisfaction inputs, not the source evidence that produced them.
+- `internal/engine/governance/runtime_actions.go:15-20` defines runtime skill constants. `skillSpecComplianceReview` is the evidence skill used for domain review satisfaction.
+- `internal/engine/governance/runtime_actions.go:39-44` computes review-side satisfaction. `domainReviewDone` comes from `skillSatisfied(skillSpecComplianceReview, ...)`, while independent review comes from `skillCodeQualityReview`.
+- `internal/engine/governance/runtime_actions.go:64-75` passes only booleans into `ResolveRequiredActions`, losing the evidence-source mapping before CLI views are built.
+- `cmd/governance_surface.go:42-56` converts `governance.RequiredAction` into CLI `governanceActionView`; it cannot expose information not present on the engine action.
+- `cmd/status.go:94-99` defines the JSON shape used by status, validate, and next governance surfaces for each required action.
 
 ## Dependency Flow
 
-Governed artifacts live in `artifacts/changes/<slug>/`. Skill verification is
-accepted through `slipway evidence skill`, which stamps current input digests.
-Later readiness checks recompute those digests and compare named inputs; changed
-inputs become `required_skill_stale:<skill>:<artifact>` blockers that can reopen
-the change to the earliest affected stage.
+`EvaluateGovernanceReadiness` computes runtime required actions, command builders map those actions through `cmd/governance_surface.go`, and `status`, `validate`, and `next --json --diagnostics` emit the resulting `required_actions` array. The issue #203 gap is not in control derivation; it is in runtime evidence attribution being reduced to a boolean before the JSON surface is rendered.
 
 ## Constraints And Invariants
 
-- Evidence freshness remains fail-closed. Unknown or material content must keep
-  changing the digest and reopening stale evidence.
-- `tasks.md` structural hashing is intentionally separate and already excludes
-  checkbox-only and `target_files`-only churn for plan-audit.
-- Prose artifact materiality should be derived from repo-owned scaffold/template
-  knowledge, not from mutable file timestamps.
-- GSD is a behavioral reference only. Slipway must not gain a runtime dependency
-  on the local GSD checkout.
+- Preserve current policy semantics: `spec-compliance-review` is allowed to satisfy `domain-review` when the verification is passing and current for the latest execution summary.
+- Keep stale or missing execution-summary behavior fail-closed; stale `spec-compliance-review` must not satisfy `domain-review`.
+- Add JSON fields in an additive way so existing consumers of `control_id`, `mode`, `description`, and `satisfied` keep working.
+- Keep action blockers based on unsatisfied blocking actions only; satisfied action explanations should not create new blockers.

--- a/artifacts/codebase/CONCERNS.md
+++ b/artifacts/codebase/CONCERNS.md
@@ -1,22 +1,9 @@
 # Concerns
 
-Re-authored for change
-`resolve-github-issue-155-knuth-invariant-overwrite-only-own`
-(GitHub issue #155).
+Re-authored for change `explain-domain-review-mapping` (GitHub issue #203).
 
-- False-negative freshness risk: if the classifier treats human prose as
-  scaffold/default, stale plan or research evidence may be accepted. The
-  implementation must include unknown non-empty prose in the digest.
-- False-positive reopen risk: if authoring comments or empty scaffold-only
-  sections stay in the digest, engine-owned scaffold refreshes can reopen
-  downstream stages without a material change.
-- Contract drift risk: template-derived defaults and hand-maintained phrase
-  lists can diverge. Prefer deriving scaffold defaults from embedded templates
-  where possible, and keep any literal known defaults narrow and tested.
-- Artifact-stage risk: `intent.md` is engine-scaffolded at creation, while
-  `requirements.md`, `research.md`, `decision.md`, `tasks.md`, and
-  `assurance.md` are skill-authored/deferred. A one-size-fits-all overwrite
-  rule would be too broad.
-- Recovery risk: stale recovery removes verification records from the target
-  stage onward. Digest materiality changes must be covered before relying on
-  `stale_evidence_recovery.go` to reopen correctly.
+- Traceability risk: preserving only `Satisfied bool` makes a control appear to satisfy itself when another review skill is the actual evidence source.
+- Compatibility risk: changing existing JSON fields would break consumers; prefer additive fields such as `satisfied_by`.
+- False-positive explanation risk: an explanation must only appear when the action is actually satisfied by current passing evidence. Stale or missing run-summary cases must remain unsatisfied and continue to show diagnostics.
+- Scope risk: requiring a new `domain-review.yaml` would change policy semantics and expand the issue beyond user-facing traceability unless code proves the current mapping is wrong.
+- Surface consistency risk: status, validate, and next share `cmd/governance_surface.go`; fixing only one command would leave the black-box behavior inconsistent.

--- a/artifacts/codebase/STRUCTURE.md
+++ b/artifacts/codebase/STRUCTURE.md
@@ -1,28 +1,17 @@
 # Structure
 
-Re-authored for change
-`resolve-github-issue-155-knuth-invariant-overwrite-only-own`
-(GitHub issue #155).
+Re-authored for change `explain-domain-review-mapping` (GitHub issue #203).
 
-- `internal/engine/progression/`
-  - `evidence_digests.go`: skill input digest construction, named stale input
-    blockers, and the prose artifact digest seam for this change.
-  - `evidence_digests_test.go`: existing digest policy tests and the target for
-    new prose materiality regression coverage.
-  - `stale_evidence_recovery.go`: consumes stale digest blockers to reopen the
-    earliest affected lifecycle authority; not expected to change for issue
-    #155.
-- `internal/engine/artifact/`
-  - `manager.go`: artifact schemas, embedded template access, scaffold/deferred
-    artifact behavior, and existing template-derived scaffold detection pattern.
-  - `requirements.go`: narrow requirements placeholder detection, useful as a
-    warning against broad substring-based materiality suppression.
-  - `schemas.yaml`: expanded artifact graph for `intent.md`,
-    `requirements.md`, `decision.md`, `tasks.md`, `assurance.md`, and
-    discovery-only `research.md`.
-- `internal/tmpl/templates/artifacts/`
-  - `intent.md`, `requirements.md`, `research.md`, and `decision.md`: embedded
-    artifact templates whose comments and scaffold-only sections define
-    engine-owned prose defaults.
-- Local reference outside this repo:
-  `/Users/yixianlu/ghq/github.com/open-gsd/gsd-core/src/state-document.cts`.
+- `internal/engine/governance/`
+  - `actions.go`: required-action domain model and action satisfaction input contract.
+  - `runtime_actions.go`: runtime evidence loading, skill readiness checks, and required-action satisfaction assembly.
+  - `runtime_actions_test.go`: engine-level regressions for review control satisfaction and fail-closed readiness.
+- `cmd/`
+  - `status.go`: shared JSON view structs for status/validate/next governance action output.
+  - `validate.go`: validate JSON view assembly, now expected to expose required-action attribution.
+  - `governance_surface.go`: shared mapper from `progression.GovernanceReadiness` to command governance views.
+  - `governance_gate_consistency_test.go`: command-level regressions that compare status, validate, and next behavior.
+- Governed artifact bundle:
+  - `artifacts/changes/explain-domain-review-mapping/requirements.md`: REQ-001 through REQ-003.
+  - `artifacts/changes/explain-domain-review-mapping/decision.md`: selected structured attribution approach.
+  - `artifacts/changes/explain-domain-review-mapping/tasks.md`: two dependent execution tasks.

--- a/artifacts/codebase/TESTING.md
+++ b/artifacts/codebase/TESTING.md
@@ -1,46 +1,22 @@
 # Testing
 
-Re-authored for change
-`resolve-github-issue-155-knuth-invariant-overwrite-only-own`
-(GitHub issue #155).
+Re-authored for change `explain-domain-review-mapping` (GitHub issue #203).
 
 ## Existing Coverage
 
-- `internal/engine/progression/evidence_digests_test.go:18` through
-  `internal/engine/progression/evidence_digests_test.go:57` already pins the
-  plan-audit digest policy: assurance is excluded, CRLF-only prose rewrites do
-  not stale, checkbox-only task edits do not stale, `target_files`-only task
-  edits do not stale, and objective changes do stale.
-- `internal/engine/progression/evidence_digests_test.go:136` through
-  `internal/engine/progression/evidence_digests_test.go:167` proves stale
-  evidence is content-digest based rather than mtime based.
-- `internal/engine/progression/evidence_digests_test.go:779` through
-  `internal/engine/progression/evidence_digests_test.go:807` proves
-  `research-orchestration` stales when `research.md` material content changes.
-- `internal/engine/artifact/requirements.go:35` through
-  `internal/engine/artifact/requirements.go:103` contains narrow requirements
-  placeholder detection, useful as a fail-closed warning against overbroad
-  scaffold classification.
-- `internal/engine/artifact/manager.go:559` through
-  `internal/engine/artifact/manager.go:640` derives assurance scaffold
-  detection from the embedded template, establishing a local pattern for
-  template-derived scaffold checks.
+- `internal/engine/governance/runtime_actions_test.go:128-138` verifies that stale `spec-compliance-review` does not satisfy `domain-review`, and that current `code-quality-review` can satisfy `independent-review`.
+- `cmd/governance_gate_consistency_test.go:127-167` verifies that missing execution-summary blockers are consistent across status, validate, and next when review evidence is present but not ready.
+- `cmd/governance_gate_consistency_test.go:392-409` verifies that next surfaces `domain-review` blockers when a guardrail domain is active and no satisfying evidence exists.
+- `cmd/governance_surface.go:42-56` is a narrow mapping seam suitable for a focused unit-style assertion through existing command-view helpers.
 
-## Gaps For Issue #155
+## Gaps For Issue #203
 
-- No test proves comment-only or scaffold-only prose artifact edits are
-  non-material for input digests.
-- No test proves human-authored prose edits still stale `plan-audit` and
-  `research-orchestration`.
-- No test covers the fail-closed unknown case: unknown non-empty prose must be
-  included in the material view rather than silently ignored.
+- No test asserts that a satisfied `domain-review` action explains that it was satisfied by `spec-compliance-review`.
+- No test asserts that the explanation survives the command view mapping used by status, validate, and next.
+- Existing stale-evidence tests check failure diagnostics, but not positive traceability for satisfied controls.
 
 ## Verification Plan
 
-- Add focused unit tests in `internal/engine/progression/evidence_digests_test.go`.
-- Cover `intent.md`, `requirements.md`, `research.md`, and `decision.md` through
-  the plan-audit digest path.
-- Include a `research-orchestration` case so the research artifact digest still
-  reacts to authored research content.
-- Run `go test -count=1 ./internal/engine/progression` after implementation,
-  then broaden to `go test -count=1 ./...` before done-ready.
+- Add an engine-level regression in `internal/engine/governance/runtime_actions_test.go` for `domain-review` satisfied by `spec-compliance-review`, including a stable evidence-source field.
+- Add or extend a command-level regression in `cmd/governance_gate_consistency_test.go` to verify status, validate, and next all expose the satisfied-by mapping for the same runtime action.
+- Run `go test -count=1 ./internal/engine/governance ./cmd` after implementation, then broaden as governed closeout requires.

--- a/cmd/governance_gate_consistency_test.go
+++ b/cmd/governance_gate_consistency_test.go
@@ -245,6 +245,39 @@ func TestReviewLayerBlockersStayConsistentAcrossStatusValidateNextAndReview(t *t
 	}
 }
 
+func TestSatisfiedDomainReviewAttributionStaysConsistentAcrossStatusValidateAndNext(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	ensureTestGitRepo(t, root)
+	initTestWorkspace(t, root)
+
+	slug := createGovernedRequest(t, root, "L2", "domain review attribution should stay aligned")
+	change, err := state.LoadChange(root, slug)
+	require.NoError(t, err)
+	change.CurrentState = model.StateS3Review
+	change.PlanSubStep = model.PlanSubStepNone
+	change.GuardrailDomain = string(model.GuardrailDomainAuthAuthZ)
+	require.NoError(t, state.SaveChange(root, change))
+
+	writeAuthReviewGovernedBundle(t, root, slug)
+	writePassingExecutionSummary(t, root, slug, 1, "t-01")
+	materializeWaveExecutionForSummary(t, root, slug)
+	writePassingWaveEvidence(t, root, slug, 1)
+	writeSkillVerification(t, root, slug, "spec-compliance-review", model.VerificationRecord{
+		Verdict:    model.VerificationVerdictPass,
+		Blockers:   []model.ReasonCode{},
+		Timestamp:  time.Now().UTC(),
+		RunVersion: 1,
+		References: []string{"layer:R0=pass"},
+	})
+
+	statusResp, validateResp, nextResp := runReadOnlyGovernanceViewsForChange(t, root, slug)
+
+	requireDomainReviewSatisfiedBySpecCompliance(t, statusResp.RequiredActions)
+	requireDomainReviewSatisfiedBySpecCompliance(t, validateResp.RequiredActions)
+	requireDomainReviewSatisfiedBySpecCompliance(t, nextResp.RequiredActions)
+}
+
 func TestDoneShipGateReasonsStayConsistentWithSharedReadiness(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
@@ -537,4 +570,22 @@ func readGovernedChangeAuthorityBytes(t *testing.T, root, slug string) []byte {
 func requireChangeAuthorityStable(t *testing.T, root, slug string, before []byte) {
 	t.Helper()
 	assert.Equal(t, string(before), string(readGovernedChangeAuthorityBytes(t, root, slug)))
+}
+
+func requireDomainReviewSatisfiedBySpecCompliance(t *testing.T, actions []governanceActionView) {
+	t.Helper()
+
+	for _, action := range actions {
+		if action.ControlID != "domain-review" {
+			continue
+		}
+		require.True(t, action.Satisfied)
+		require.Len(t, action.SatisfiedBy, 1)
+		assert.Equal(t, "skill_evidence", action.SatisfiedBy[0].Kind)
+		assert.Equal(t, "spec-compliance-review", action.SatisfiedBy[0].Name)
+		assert.Contains(t, action.SatisfiedBy[0].EvidenceRef, "verification/spec-compliance-review.yaml")
+		assert.Equal(t, "spec-compliance-review provides the domain-aware review evidence for domain-review", action.SatisfiedBy[0].Reason)
+		return
+	}
+	t.Fatalf("domain-review action not found in %#v", actions)
 }

--- a/cmd/governance_surface.go
+++ b/cmd/governance_surface.go
@@ -50,6 +50,23 @@ func governanceActionViews(actions []governance.RequiredAction) []governanceActi
 			Mode:        string(action.Mode),
 			Description: action.Description,
 			Satisfied:   action.Satisfied,
+			SatisfiedBy: governanceActionSatisfactionViews(action.SatisfiedBy),
+		})
+	}
+	return out
+}
+
+func governanceActionSatisfactionViews(src []governance.SatisfiedBy) []governanceActionSatisfactionView {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make([]governanceActionSatisfactionView, 0, len(src))
+	for _, item := range src {
+		out = append(out, governanceActionSatisfactionView{
+			Kind:        item.Kind,
+			Name:        item.Name,
+			EvidenceRef: item.EvidenceRef,
+			Reason:      item.Reason,
 		})
 	}
 	return out
@@ -59,6 +76,11 @@ func applyGovernanceSurfaceToStatus(readiness progression.GovernanceReadiness, v
 	surface := buildGovernanceSurfaceViewWithReadiness(readiness)
 	view.GovernanceSignals = surface.GovernanceSignals
 	view.ActiveControls = surface.ActiveControls
+	view.RequiredActions = surface.RequiredActions
+}
+
+func applyGovernanceSurfaceToValidate(readiness progression.GovernanceReadiness, view *validateView) {
+	surface := buildGovernanceSurfaceViewWithReadiness(readiness)
 	view.RequiredActions = surface.RequiredActions
 }
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -92,10 +92,18 @@ type governanceControlView struct {
 }
 
 type governanceActionView struct {
-	ControlID   string `json:"control_id"`
-	Mode        string `json:"mode"`
-	Description string `json:"description"`
-	Satisfied   bool   `json:"satisfied"`
+	ControlID   string                             `json:"control_id"`
+	Mode        string                             `json:"mode"`
+	Description string                             `json:"description"`
+	Satisfied   bool                               `json:"satisfied"`
+	SatisfiedBy []governanceActionSatisfactionView `json:"satisfied_by,omitempty"`
+}
+
+type governanceActionSatisfactionView struct {
+	Kind        string `json:"kind"`
+	Name        string `json:"name"`
+	EvidenceRef string `json:"evidence_ref,omitempty"`
+	Reason      string `json:"reason,omitempty"`
 }
 
 type artifactDAGNode struct {

--- a/cmd/status_json.go
+++ b/cmd/status_json.go
@@ -7,9 +7,10 @@ import (
 )
 
 type governanceSummaryView struct {
-	BlockedBy       []string `json:"blocked_by,omitempty"`
-	RequiredActions []string `json:"required_actions,omitempty"`
-	AuthorityRefs   []string `json:"authority_refs,omitempty"`
+	BlockedBy        []string               `json:"blocked_by,omitempty"`
+	RequiredActions  []string               `json:"required_actions,omitempty"`
+	SatisfiedActions []governanceActionView `json:"satisfied_actions,omitempty"`
+	AuthorityRefs    []string               `json:"authority_refs,omitempty"`
 }
 
 type statusJSONView struct {
@@ -45,6 +46,7 @@ func (view statusJSONView) MarshalJSON() ([]byte, error) {
 func buildGovernanceSummaryView(view statusView) *governanceSummaryView {
 	var blockedBy []string
 	var requiredActions []string
+	var satisfiedActions []governanceActionView
 	seenControls := map[string]struct{}{}
 	seenActions := map[string]struct{}{}
 
@@ -81,6 +83,9 @@ func buildGovernanceSummaryView(view statusView) *governanceSummaryView {
 	// independent-review at S2) as blockers, contradicting the real gate.
 	for _, action := range view.RequiredActions {
 		if action.Satisfied {
+			if len(action.SatisfiedBy) > 0 {
+				satisfiedActions = append(satisfiedActions, action)
+			}
 			continue
 		}
 		addAction(action.Description)
@@ -94,14 +99,15 @@ func buildGovernanceSummaryView(view statusView) *governanceSummaryView {
 		addAction(description)
 	}
 
-	if len(blockedBy) == 0 && len(requiredActions) == 0 {
+	if len(blockedBy) == 0 && len(requiredActions) == 0 && len(satisfiedActions) == 0 {
 		return nil
 	}
 
 	summary := &governanceSummaryView{
-		BlockedBy:       blockedBy,
-		RequiredActions: requiredActions,
-		AuthorityRefs:   governanceSummaryAuthorityRefs(view),
+		BlockedBy:        blockedBy,
+		RequiredActions:  requiredActions,
+		SatisfiedActions: satisfiedActions,
+		AuthorityRefs:    governanceSummaryAuthorityRefs(view),
 	}
 	return summary
 }

--- a/cmd/status_json_test.go
+++ b/cmd/status_json_test.go
@@ -99,6 +99,58 @@ func TestStatusJSONResponseOmitsGovernanceSummaryWhenNoGovernanceActions(t *test
 	assert.NotContains(t, payload, "required_actions")
 }
 
+func TestStatusJSONResponseIncludesAttributedSatisfiedActions(t *testing.T) {
+	t.Parallel()
+
+	view := statusView{
+		ExecutionMode:     governedExecutionMode,
+		Slug:              "domain-review-mapping",
+		Phase:             model.PhaseReviewing,
+		LifecycleStatus:   string(model.ChangeStatusActive),
+		CurrentState:      model.StateS3Review,
+		EvidenceFreshness: "fresh",
+		RequiredActions: []governanceActionView{
+			{
+				ControlID:   "domain-review",
+				Mode:        "blocking",
+				Description: "run domain-aware compliance review and attach review evidence",
+				Satisfied:   true,
+				SatisfiedBy: []governanceActionSatisfactionView{
+					{
+						Kind:        "skill_evidence",
+						Name:        "spec-compliance-review",
+						EvidenceRef: "artifacts/changes/domain-review-mapping/verification/spec-compliance-review.yaml",
+						Reason:      "spec-compliance-review provides the domain-aware review evidence for domain-review",
+					},
+				},
+			},
+		},
+	}
+
+	raw, err := json.Marshal(buildStatusJSONResponse(view))
+	require.NoError(t, err)
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(raw, &payload))
+	assert.NotContains(t, payload, "required_actions")
+	summary, ok := payload["governance_summary"].(map[string]any)
+	require.True(t, ok)
+	actions, ok := summary["satisfied_actions"].([]any)
+	require.True(t, ok)
+	require.Len(t, actions, 1)
+	action, ok := actions[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "domain-review", action["control_id"])
+	satisfiedBy, ok := action["satisfied_by"].([]any)
+	require.True(t, ok)
+	require.Len(t, satisfiedBy, 1)
+	source, ok := satisfiedBy[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "skill_evidence", source["kind"])
+	assert.Equal(t, "spec-compliance-review", source["name"])
+	assert.Equal(t, "artifacts/changes/domain-review-mapping/verification/spec-compliance-review.yaml", source["evidence_ref"])
+	assert.Equal(t, "spec-compliance-review provides the domain-aware review evidence for domain-review", source["reason"])
+}
+
 func TestStatusJSONResponseDoesNotTreatNonGovernanceBlockersAsGovernanceSummary(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -46,6 +46,7 @@ type validateView struct {
 	Mode                      string                               `json:"mode,omitempty"`
 	HydrateReferences         []string                             `json:"hydrate_references,omitempty"`
 	ArtifactAmendments        []artifact.AmendmentEvent            `json:"artifact_amendments,omitempty"`
+	RequiredActions           []governanceActionView               `json:"required_actions,omitempty"`
 }
 
 type actionableNextSkillView struct {
@@ -295,6 +296,7 @@ func buildValidateViewForSlug(root, slug string) (validateView, error) {
 	view.ScopeContract = buildScopeContractView(readiness.ScopeContract)
 	view.FreshnessDiagnostics = attachFreshnessDiagnostics(readiness.FreshnessDiagnostics)
 	view.ActionableNextSkill = buildActionableNextSkillView(change, readiness)
+	applyGovernanceSurfaceToValidate(readiness, &view)
 	gateDetails := gateStatusFromEvaluations(readiness.GateEvaluations)
 	gateStatus := map[string]string{}
 	for name, gate := range gateDetails {

--- a/internal/engine/governance/actions.go
+++ b/internal/engine/governance/actions.go
@@ -11,6 +11,15 @@ type RequiredAction struct {
 	Scope       model.ControlScope `json:"scope"`
 	Description string             `json:"description"`
 	Satisfied   bool               `json:"satisfied"`
+	SatisfiedBy []SatisfiedBy      `json:"satisfied_by,omitempty"`
+}
+
+// SatisfiedBy names the evidence source that satisfied a governance action.
+type SatisfiedBy struct {
+	Kind        string `json:"kind"`
+	Name        string `json:"name"`
+	EvidenceRef string `json:"evidence_ref,omitempty"`
+	Reason      string `json:"reason,omitempty"`
 }
 
 // ResolveRequiredActions derives the queue of required governance actions
@@ -45,6 +54,9 @@ func ResolveRequiredActions(input RequiredActionsInput) []RequiredAction {
 		case model.ControlDomainReview:
 			action.Description = "run domain-aware compliance review and attach review evidence"
 			action.Satisfied = input.DomainReviewDone
+			if action.Satisfied {
+				action.SatisfiedBy = append(action.SatisfiedBy, input.DomainReviewSatisfiedBy...)
+			}
 
 		case model.ControlIndependentReview:
 			// Independent review is a review-scope gate (S3/S4), so it runs on
@@ -54,6 +66,9 @@ func ResolveRequiredActions(input RequiredActionsInput) []RequiredAction {
 			// at the S2 handoff (issue #36, comment 1).
 			action.Description = "run independent review after wave execution produces execution evidence"
 			action.Satisfied = input.IndependentReviewDone
+			if action.Satisfied {
+				action.SatisfiedBy = append(action.SatisfiedBy, input.IndependentReviewSatisfiedBy...)
+			}
 
 		case model.ControlWorktreeIsolation:
 			action.Description = "ensure worktree preflight before code execution continues"
@@ -72,16 +87,18 @@ func ResolveRequiredActions(input RequiredActionsInput) []RequiredAction {
 
 // RequiredActionsInput captures the runtime evidence needed to resolve action satisfaction.
 type RequiredActionsInput struct {
-	ActiveControls           []model.ControlActivation
-	CurrentState             model.WorkflowState
-	HasBlockingOpenQuestions bool
-	IntentExists             bool
-	ScopeConfirmed           bool
-	ResearchStructureOK      bool // research.md has all required sections (always true for non-discovery)
-	DomainReviewDone         bool
-	IndependentReviewDone    bool
-	WorktreePreflightDone    bool
-	RollbackSectionExists    bool
+	ActiveControls               []model.ControlActivation
+	CurrentState                 model.WorkflowState
+	HasBlockingOpenQuestions     bool
+	IntentExists                 bool
+	ScopeConfirmed               bool
+	ResearchStructureOK          bool // research.md has all required sections (always true for non-discovery)
+	DomainReviewDone             bool
+	DomainReviewSatisfiedBy      []SatisfiedBy
+	IndependentReviewDone        bool
+	IndependentReviewSatisfiedBy []SatisfiedBy
+	WorktreePreflightDone        bool
+	RollbackSectionExists        bool
 }
 
 func researchActionDescription(state model.WorkflowState) string {

--- a/internal/engine/governance/runtime_actions.go
+++ b/internal/engine/governance/runtime_actions.go
@@ -36,16 +36,33 @@ func ResolveRuntimeRequiredActions(root string, change model.Change, snap model.
 	// Intake clarification is a pre-execution scope-confirmation proof. It must
 	// remain satisfiable before the first execution summary exists, so it is not
 	// bound to run_summary_version.
-	intakeConfirmed, scopeIssues := verifications.skillSatisfied(skillIntakeClarification, executionSummaryCtx.LatestRunVersion, false)
+	intakeConfirmed, _, scopeIssues := verifications.skillSatisfied(
+		skillIntakeClarification,
+		executionSummaryCtx.LatestRunVersion,
+		false,
+		"intake-clarification confirms the scope for research",
+	)
 	// Review-side skills validate execution outputs. They are intentionally tied
 	// to the latest execution summary so stale review evidence cannot satisfy the
 	// current governed run.
-	domainReviewDone, domainIssues := verifications.skillSatisfied(skillSpecComplianceReview, executionSummaryCtx.LatestRunVersion, true)
-	independentReviewDone, independentIssues := verifications.skillSatisfied(skillCodeQualityReview, executionSummaryCtx.LatestRunVersion, true)
+	domainReviewDone, domainSatisfiedBy, domainIssues := verifications.skillSatisfied(
+		skillSpecComplianceReview,
+		executionSummaryCtx.LatestRunVersion,
+		true,
+		"spec-compliance-review provides the domain-aware review evidence for domain-review",
+	)
+	independentReviewDone, independentSatisfiedBy, independentIssues := verifications.skillSatisfied(
+		skillCodeQualityReview,
+		executionSummaryCtx.LatestRunVersion,
+		true,
+		"code-quality-review provides the independent review evidence for independent-review",
+	)
 	if len(executionSummaryCtx.Issues) > 0 {
 		domainReviewDone = false
+		domainSatisfiedBy = nil
 		domainIssues = stringutil.UniqueSorted(append(domainIssues, executionSummaryCtx.Issues...))
 		independentReviewDone = false
+		independentSatisfiedBy = nil
 		independentIssues = stringutil.UniqueSorted(append(independentIssues, executionSummaryCtx.Issues...))
 	}
 
@@ -62,16 +79,18 @@ func ResolveRuntimeRequiredActions(root string, change model.Change, snap model.
 	researchOK := researchStructureSatisfied(root, change)
 
 	actions := ResolveRequiredActions(RequiredActionsInput{
-		ActiveControls:           snap.ActiveControls,
-		CurrentState:             change.CurrentState,
-		HasBlockingOpenQuestions: snap.Traceability.HasBlockingIntentGap(),
-		IntentExists:             artifactExistsInBundle(root, change, "intent.md"),
-		ScopeConfirmed:           changeScopeConfirmed(change, intakeConfirmed),
-		ResearchStructureOK:      researchOK,
-		DomainReviewDone:         domainReviewDone,
-		IndependentReviewDone:    independentReviewDone,
-		WorktreePreflightDone:    worktreeSatisfied,
-		RollbackSectionExists:    hasRollbackDocumentation(root, change),
+		ActiveControls:               snap.ActiveControls,
+		CurrentState:                 change.CurrentState,
+		HasBlockingOpenQuestions:     snap.Traceability.HasBlockingIntentGap(),
+		IntentExists:                 artifactExistsInBundle(root, change, "intent.md"),
+		ScopeConfirmed:               changeScopeConfirmed(change, intakeConfirmed),
+		ResearchStructureOK:          researchOK,
+		DomainReviewDone:             domainReviewDone,
+		DomainReviewSatisfiedBy:      domainSatisfiedBy,
+		IndependentReviewDone:        independentReviewDone,
+		IndependentReviewSatisfiedBy: independentSatisfiedBy,
+		WorktreePreflightDone:        worktreeSatisfied,
+		RollbackSectionExists:        hasRollbackDocumentation(root, change),
 	})
 	for idx := range actions {
 		if actions[idx].Satisfied {
@@ -176,37 +195,60 @@ func artifactExistsInBundle(root string, change model.Change, artifactName strin
 }
 
 type runtimeVerificationState struct {
-	bySkill     map[string]model.VerificationRecord
-	diagnostics []string
+	bySkill      map[string]model.VerificationRecord
+	evidenceRefs map[string]string
+	diagnostics  []string
 }
 
 func loadRuntimeVerificationState(root string, change model.Change) runtimeVerificationState {
 	verifications, err := state.ListVerificationsForChange(root, change)
 	st := runtimeVerificationState{
-		bySkill: verifications,
+		bySkill:      verifications,
+		evidenceRefs: verificationEvidenceRefs(root, change, verifications),
 	}
 	if err != nil {
 		st.bySkill = map[string]model.VerificationRecord{}
+		st.evidenceRefs = map[string]string{}
 		st.diagnostics = []string{"runtime_verification_load_failed"}
 	}
 	return st
 }
 
-func (s runtimeVerificationState) skillSatisfied(skillName string, latestRunVersion int, requireRunSummary bool) (bool, []string) {
+func verificationEvidenceRefs(root string, change model.Change, verifications map[string]model.VerificationRecord) map[string]string {
+	if len(verifications) == 0 {
+		return nil
+	}
+	paths, err := state.ResolveChangePaths(root, change)
+	if err != nil {
+		return nil
+	}
+	refs := make(map[string]string, len(verifications))
+	for skillName := range verifications {
+		refs[skillName] = state.DisplayPath(root, filepath.Join(paths.GovernedBundleDir, "verification", skillName+".yaml"))
+	}
+	return refs
+}
+
+func (s runtimeVerificationState) skillSatisfied(skillName string, latestRunVersion int, requireRunSummary bool, reason string) (bool, []SatisfiedBy, []string) {
 	rec, ok := s.bySkill[skillName]
 	if !ok {
-		return false, nil
+		return false, nil, nil
 	}
 	if !rec.IsPassing() {
-		return false, []string{"runtime_verification_not_passed:" + skillName}
+		return false, nil, []string{"runtime_verification_not_passed:" + skillName}
 	}
 	if requireRunSummary && latestRunVersion < 1 {
-		return false, []string{"runtime_verification_not_ready:" + skillName + ":run_summary_missing"}
+		return false, nil, []string{"runtime_verification_not_ready:" + skillName + ":run_summary_missing"}
 	}
 	if latestRunVersion > 0 && rec.RunVersion != latestRunVersion {
-		return false, []string{fmt.Sprintf("runtime_verification_not_ready:%s:run_version_mismatch(got=%d,want=%d)", skillName, rec.RunVersion, latestRunVersion)}
+		return false, nil, []string{fmt.Sprintf("runtime_verification_not_ready:%s:run_version_mismatch(got=%d,want=%d)", skillName, rec.RunVersion, latestRunVersion)}
 	}
-	return true, nil
+	return true, []SatisfiedBy{{
+		Kind:        "skill_evidence",
+		Name:        skillName,
+		EvidenceRef: s.evidenceRefs[skillName],
+		Reason:      reason,
+	}}, nil
 }
 
 func hasRollbackDocumentation(root string, change model.Change) bool {

--- a/internal/engine/governance/runtime_actions_test.go
+++ b/internal/engine/governance/runtime_actions_test.go
@@ -132,10 +132,66 @@ Pending.
 	}
 
 	assert.False(t, byID[model.ControlDomainReview].Satisfied, "review evidence with stale run summary should not satisfy domain-review")
+	assert.Empty(t, byID[model.ControlDomainReview].SatisfiedBy, "stale review evidence must not be reported as satisfying domain-review")
 	assert.Contains(t, byID[model.ControlDomainReview].Description, "run_version_mismatch")
 	assert.True(t, byID[model.ControlIndependentReview].Satisfied, "independent reviewer evidence with current run summary should satisfy independent-review")
 	assert.True(t, byID[model.ControlWorktreeIsolation].Satisfied, "worktree-isolation is always satisfied after worktree-preflight removal")
 	assert.False(t, byID[model.ControlRollbackRequired].Satisfied, "rollback-required must require explicit rollback documentation in assurance.md, not just requirement coverage")
+}
+
+func TestResolveRuntimeRequiredActionsExplainsDomainReviewSatisfiedBySpecCompliance(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	initGitRepoForRuntimeActionsTests(t, root)
+	change := model.NewChange("runtime-actions-domain-review")
+	change.CurrentState = model.StateS3Review
+	change.PlanSubStep = model.PlanSubStepNone
+	require.NoError(t, state.SaveChange(root, change))
+	require.NoError(t, state.SaveExecutionSummary(root, change.Slug, model.ExecutionSummary{
+		Version:           model.ExecutionSummaryVersion,
+		RunSummaryVersion: 3,
+		CapturedAt:        time.Now().UTC(),
+		OverallVerdict:    model.ExecutionVerdictPass,
+		CompletedTasks:    []string{"task-a"},
+		Tasks: []model.ExecutionTaskSummary{
+			{
+				TaskID:       "task-a",
+				Verdict:      model.TaskVerdictPass,
+				TaskKind:     model.TaskKindCode,
+				ChangedFiles: []string{"internal/engine/governance/runtime_actions.go"},
+				CapturedAt:   time.Now().UTC(),
+			},
+		},
+	}))
+	writeGovernanceVerification(t, root, change.Slug, skillSpecComplianceReview, model.VerificationRecord{
+		Verdict:    model.VerificationVerdictPass,
+		Blockers:   []model.ReasonCode{},
+		Timestamp:  time.Now().UTC(),
+		RunVersion: 3,
+		References: []string{"layer:R0=pass"},
+	})
+
+	snap := model.GovernanceSnapshot{
+		Version: model.GovernanceSnapshotVersion,
+		Traceability: model.TraceabilitySummary{
+			Status: model.TraceabilityStatusOK,
+		},
+		ActiveControls: []model.ControlActivation{
+			makeControl(model.ControlDomainReview, model.ControlModeBlocking, model.ControlScopeReview),
+		},
+		ComputedAt: time.Now().UTC(),
+	}
+
+	actions := ResolveRuntimeRequiredActions(root, change, snap)
+	require.Len(t, actions, 1)
+	action := actions[0]
+	require.True(t, action.Satisfied)
+	require.Len(t, action.SatisfiedBy, 1)
+	assert.Equal(t, "skill_evidence", action.SatisfiedBy[0].Kind)
+	assert.Equal(t, skillSpecComplianceReview, action.SatisfiedBy[0].Name)
+	assert.Equal(t, "artifacts/changes/"+change.Slug+"/verification/spec-compliance-review.yaml", action.SatisfiedBy[0].EvidenceRef)
+	assert.Equal(t, "spec-compliance-review provides the domain-aware review evidence for domain-review", action.SatisfiedBy[0].Reason)
 }
 
 func TestResolveRuntimeRequiredActionsRejectsTemplateOnlyRollbackSections(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add structured `satisfied_by` attribution to governance required actions when another skill evidence record satisfies the control.
- Propagate the mapping through `validate --json`, `next --json --diagnostics`, and `status --json` via `governance_summary.satisfied_actions`.
- Archive the governed change `explain-domain-review-mapping` after passing goal verification and final closeout.

## Root Cause

`domain-review` satisfaction was intentionally derived from current passing `spec-compliance-review` evidence, but the evidence-source mapping was collapsed into a boolean before CLI JSON projection. That made the control look satisfied without naming why or which record satisfied it.

## Validation

- `go test -count=1 ./...`
- `go run github.com/securego/gosec/v2/cmd/gosec@v2.27.1 -fmt=sarif -out=artifacts/changes/explain-domain-review-mapping/verification/sast/gosec.sarif ./...`
- `go run . done --json`
- `go run . status --json --change explain-domain-review-mapping` showed `lifecycle_status=done`, `archived=true`, and no blockers.

Fixes #203
