### PR TITLE
feat(worktree): provision host-adapter surfaces into git worktrees

### DIFF
--- a/artifacts/changes/archived/provision-host-adapter-surfaces-into-git-worktrees-at-worktr/change.yaml
+++ b/artifacts/changes/archived/provision-host-adapter-surfaces-into-git-worktrees-at-worktr/change.yaml
@@ -1,0 +1,38 @@
+version: 1
+slug: provision-host-adapter-surfaces-into-git-worktrees-at-worktr
+description: 'Provision host-adapter surfaces into git worktrees: at worktree creation (and idempotently on reuse) copy each existing adapter dir (.claude/.cursor/.codex/.opencode/.gemini, excluding worktrees/, lock files, and generated sentinels) into the new worktree, then run toolgen.Generate(refresh) so slipway-owned skills/hooks/settings are regenerated from the worktree source. Fixes subagents in change worktrees losing hooks and being unable to read bundled skill references.'
+status: done
+current_state: DONE
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-06-14T03:27:11.715621Z
+quality_mode: standard
+workflow_preset: light
+worktree_branch: feat/provision-host-adapter-surfaces-into-git-worktrees-at-worktr
+artifact_schema: core
+artifacts:
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: 1427895c6d044bcc7001dc66aa60558d31a1a7d9c30a71401be0694c70c8ed8c
+        updated_at: 2026-06-14T03:40:35.784769402Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: 8960f2d37ec9388692a54c5ca030bb7ed041be0ffe212013cf21bfc9a966a66b
+        updated_at: 2026-06-14T04:15:25.784542008Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: 222b132db002f334386aee3f408ba2387fcdec024ccd21b03d1873c6b7c7d3e3
+        updated_at: 2026-06-14T04:22:15.595317489Z
+evidence_refs:
+    code-quality-review: .worktrees/provision-host-adapter-surfaces-into-git-worktrees-at-worktr/artifacts/changes/provision-host-adapter-surfaces-into-git-worktrees-at-worktr/verification/code-quality-review.yaml
+    goal-verification: .worktrees/provision-host-adapter-surfaces-into-git-worktrees-at-worktr/artifacts/changes/provision-host-adapter-surfaces-into-git-worktrees-at-worktr/verification/goal-verification.yaml
+    intake-clarification: .worktrees/provision-host-adapter-surfaces-into-git-worktrees-at-worktr/artifacts/changes/provision-host-adapter-surfaces-into-git-worktrees-at-worktr/verification/intake-clarification.yaml
+    plan-audit: .worktrees/provision-host-adapter-surfaces-into-git-worktrees-at-worktr/artifacts/changes/provision-host-adapter-surfaces-into-git-worktrees-at-worktr/verification/plan-audit.yaml
+    spec-compliance-review: .worktrees/provision-host-adapter-surfaces-into-git-worktrees-at-worktr/artifacts/changes/provision-host-adapter-surfaces-into-git-worktrees-at-worktr/verification/spec-compliance-review.yaml
+    wave-orchestration: .worktrees/provision-host-adapter-surfaces-into-git-worktrees-at-worktr/artifacts/changes/provision-host-adapter-surfaces-into-git-worktrees-at-worktr/verification/wave-orchestration.yaml

--- a/artifacts/changes/archived/provision-host-adapter-surfaces-into-git-worktrees-at-worktr/intent.md
+++ b/artifacts/changes/archived/provision-host-adapter-surfaces-into-git-worktrees-at-worktr/intent.md
@@ -1,0 +1,52 @@
+# Intent
+
+## Summary
+Provision host-adapter surfaces into git worktrees: at worktree creation (and idempotently on reuse/re-bind) copy each existing adapter dir (.claude/.cursor/.codex/.opencode/.gemini, excluding worktrees/, lock files, and generated sentinels) into the new worktree, then run toolgen.Generate(refresh) so slipway-owned skills/hooks/settings are regenerated from the worktree source. Fixes subagents in change worktrees losing hooks and being unable to read bundled skill references.
+
+## Complexity Assessment
+complex
+<!-- Rationale: touches the worktree-provisioning kernel (internal/state/worktree.go) on both create and reuse paths, must generalize across all 5 toolgen adapters, combines a filesystem copy (third-party surfaces toolgen does not own) with a toolgen regeneration (slipway-owned surfaces), and adds fail-closed error handling plus tests. -->
+
+## Guardrail Domains
+<!-- none detected: infra/tooling surface, not auth/credentials/PII/financial/schema/external-API. -->
+
+## In Scope
+- `internal/state/worktree.go`: after a successful `git worktree add` (create path) and on the reuse/re-bind path, provision host-adapter surfaces into the worktree:
+  - For each adapter dir present in the repo root among `.claude .cursor .codex .opencode .gemini`: copy into the worktree, EXCLUDING `<tool>/worktrees/`, lock files (e.g. `scheduled_tasks.lock`), and any generated sentinel (e.g. `.adapter-generated`). This carries the ~75 third-party skills toolgen does not own.
+  - Then call `toolgen.Generate(worktreeRoot, toolgen.DetectExistingTools(repoRoot), refresh=true)` so slipway-owned skills/hooks/settings/commands are regenerated from the worktree's OWN source (not stale main-version copies).
+  - Reuse/re-bind path is idempotent: copy only third-party dirs that are missing (do NOT clobber worktree-local third-party/manual edits), but ALWAYS regenerate `slipway-*` surfaces. This lazily backfills the ~60 already-existing under-provisioned worktrees on their next slipway bind.
+  - Fail-closed: if copy or `toolgen.Generate` fails, return an error with actionable remediation; do not leave a half-provisioned worktree silently bound.
+- Tests covering: a freshly created worktree contains `.<tool>/skills` with both a third-party skill dir and `slipway-*` dirs, plus hooks/settings; `slipway-*` reflect the worktree source; the reuse path backfills a missing surface without clobbering existing worktree-local edits; provisioning failure surfaces as a fail-closed error.
+
+## Out of Scope
+- `.serena/` — MCP cache that re-indexes itself; not provisioned/copied.
+- A one-shot migration command to eagerly backfill all existing worktrees; existing worktrees are backfilled lazily on their next slipway bind, not swept proactively.
+- Changing toolgen's generation logic itself (we only call its existing public API).
+
+## Constraints
+- Must generalize across all 5 toolgen adapters; no hardcoded `.claude`. Adapter set derived from `toolgen.DetectExistingTools` / registry, not a literal list duplicated in worktree.go where avoidable.
+- Use existing toolgen public API only: `Generate(root, tools, refresh)`, `DetectExistingTools(root)`, `Registry()`.
+- Must not recurse into `.<tool>/worktrees/` (Claude isolated-agent worktrees → recursion/bloat).
+- Cost budget: ~2MB across 5 dirs per worktree — acceptable.
+
+## Acceptance Signals
+- New test passes: creating a worktree yields, for each detected tool, `.<tool>/skills` containing both a third-party skill dir and `slipway-*` dirs, plus hooks and settings.
+- The `slipway-*` skills in the worktree reflect the worktree's own source (regenerated), provably distinct from a pure copy of stale main surfaces.
+- Reuse-path test: a worktree missing a surface gets it on next bind, while an existing worktree-local third-party edit is preserved (not clobbered).
+- Provisioning-failure test: an induced copy/generate failure makes worktree provisioning return a fail-closed error rather than binding a degraded worktree.
+- `go build ./... && go vet ./... && go test ./...` green; `gofmt` clean.
+
+## Open Questions
+None.
+
+## Deferred Ideas
+- Optional `slipway worktree refresh` / migration command to eagerly re-provision all existing worktrees in one sweep (lazy backfill covers the need for now).
+
+## Approved Summary
+Provision host-adapter surfaces into git worktrees so subagents working in a change worktree get functioning hooks and readable bundled skill references. In `internal/state/worktree.go`, on both the create path (after `git worktree add`) and the reuse/re-bind path, copy each existing repo-root adapter dir among `.claude .cursor .codex .opencode .gemini` into the worktree — excluding `<tool>/worktrees/`, lock files, and `.adapter-generated` sentinels (this carries the ~75 third-party skills toolgen does not own) — then call `toolgen.Generate(worktreeRoot, DetectExistingTools(repoRoot), refresh=true)` to regenerate `slipway-*` skills/hooks/settings/commands from the worktree's own source.
+
+Scope boundaries — In: both create and reuse paths; generalized across all 5 adapters; reuse is idempotent (copy only missing third-party dirs, never clobber worktree-local edits, always regenerate `slipway-*`), which lazily backfills existing under-provisioned worktrees on next bind; provisioning failure is fail-closed; plus tests. Out: `.serena/` (MCP cache, self-reindexing); no one-shot migration command to eagerly sweep all existing worktrees; no change to toolgen's generation logic itself.
+
+Primary acceptance signal: a freshly created worktree contains, for each detected tool, `.<tool>/skills` with both a third-party skill dir and `slipway-*` dirs plus hooks/settings, with `slipway-*` reflecting the worktree source; reuse backfills without clobbering; provisioning failure returns a fail-closed error; `go build/vet/test ./...` green.
+
+Confirmed by user on 2026-06-14.

--- a/artifacts/changes/archived/provision-host-adapter-surfaces-into-git-worktrees-at-worktr/requirements.md
+++ b/artifacts/changes/archived/provision-host-adapter-surfaces-into-git-worktrees-at-worktr/requirements.md
@@ -1,0 +1,68 @@
+# Requirements
+
+## Requirements
+
+### Requirement: Provision host-adapter surfaces on worktree creation
+REQ-001: When Slipway creates a new git worktree for a governed change, the system MUST provision every host-adapter surface that exists in the repository root into the new worktree, so that an agent (including an isolated subagent) working in that worktree has the same host-adapter skills, hooks, and settings as the main worktree.
+
+#### Scenario: New worktree receives copied third-party skills and regenerated slipway surfaces
+GIVEN the repository root contains `.claude/` with both third-party skill directories and `slipway-*` skill directories
+WHEN Slipway creates a new worktree for a change
+THEN the new worktree contains `.claude/skills/` with the third-party skill directories copied over AND the `slipway-*` skill directories present
+AND the new worktree contains the `.claude` hooks and settings surfaces.
+
+### Requirement: Generalize across all toolgen adapters
+REQ-002: The provisioning MUST cover every toolgen adapter directory present in the repository root among `.claude`, `.cursor`, `.codex`, `.opencode`, and `.gemini`, REQUIRED to be driven by the toolgen adapter registry / detection rather than a single hardcoded `.claude` path.
+
+#### Scenario: All detected adapters are provisioned
+GIVEN the repository root contains `.claude/`, `.codex/`, and `.gemini/` adapter directories
+WHEN Slipway creates a new worktree
+THEN each of `.claude/`, `.codex/`, and `.gemini/` is provisioned into the worktree
+AND an adapter directory absent from the repository root is not created in the worktree.
+
+### Requirement: Exclude non-portable and self-referential paths
+REQ-003: The copy step MUST exclude paths that would cause recursion, lock contention, or carry stale generation state: each `<tool>/worktrees/` subtree (it holds nested git worktrees) and lock files (e.g. `scheduled_tasks.lock`). The copy MUST NOT carry the source's generated `.adapter-generated` sentinel; Slipway regenerates a fresh sentinel via `toolgen.Generate`. The `.serena/` directory MUST NOT be provisioned because it is a self-reindexing MCP cache.
+
+#### Scenario: Worktrees subtree and locks are not present in the provisioned worktree
+GIVEN the repository root `.claude/` contains a `worktrees/` subtree and a `scheduled_tasks.lock` file
+WHEN Slipway provisions the adapter into a new worktree
+THEN the provisioned worktree's `.claude/` does not contain the `worktrees/` subtree or the lock file
+AND the worktree contains no `.serena/` directory produced by provisioning.
+
+### Requirement: Idempotent reuse provisioning without clobbering local edits
+REQ-004: When `EnsureDefaultWorktreeForChange` binds a change onto a worktree path that is already a registered git worktree (the reuse branch), the system MUST provision idempotently: copy only the third-party adapter content that is missing at the destination, MUST NOT overwrite worktree-local third-party or manual edits, and MUST always regenerate the `slipway-*` surfaces. (A one-shot sweep that eagerly re-provisions all pre-existing worktrees is out of scope; reuse provisioning covers a change re-created onto an existing worktree.)
+
+#### Scenario: Reuse backfills a missing surface but preserves a local edit
+GIVEN a registered worktree is missing its `.claude/` adapter surface
+AND it already contains a worktree-local edit inside one third-party skill file
+WHEN `EnsureDefaultWorktreeForChange` binds a change onto that worktree (reuse branch)
+THEN the worktree gains the missing `.claude/` third-party adapter content
+AND the pre-existing worktree-local third-party edit is preserved unchanged
+AND the worktree has freshly regenerated `slipway-*` surfaces.
+
+### Requirement: Fail-closed on provisioning failure
+REQ-005: If copying an adapter directory or regenerating slipway-owned surfaces fails during provisioning, the system MUST fail closed: worktree provisioning returns an error with actionable remediation, and MUST NOT leave a silently degraded worktree bound as if it were fully provisioned.
+
+#### Scenario: Provisioning failure aborts with an error
+GIVEN adapter provisioning will fail (e.g. the copy or regeneration step errors)
+WHEN Slipway attempts to provision a worktree
+THEN the provisioning operation returns a non-nil error describing the failure
+AND the failure is surfaced to the caller rather than swallowed.
+
+### Requirement: slipway-* surfaces reflect the worktree source
+REQ-006: The provisioned `slipway-*` surfaces MUST be regenerated from the worktree's own source via `toolgen.Generate(..., refresh=true)`, so that a worktree whose source differs from main carries its own `slipway-*` surfaces rather than a stale copy of the main worktree's generated output.
+
+#### Scenario: Regenerated slipway surface reflects worktree source
+GIVEN a worktree whose toolgen skill source differs from the main worktree
+WHEN Slipway provisions that worktree
+THEN the worktree's `slipway-*` surfaces reflect the worktree's own source content
+AND not a verbatim copy of the main worktree's generated output.
+
+### Requirement: Provisioning respects the authority/surface dependency direction
+REQ-007: The provisioning implementation MUST live in the surface-renderer layer (`internal/toolgen`) and be injected into the authority layer (`internal/state`) as a function value, so the authority package never imports a surface renderer. This preserves the enforced dependency direction (`internal/architecture`) that forbids `internal/state` and `internal/model` from importing `cmd`, `internal/tmpl`, or `internal/toolgen`. The composition root (`cmd`) wires the concrete provisioner into the worktree-binding call.
+
+#### Scenario: Authority package does not import the surface renderer
+GIVEN the worktree-binding logic in `internal/state` invokes host-surface provisioning
+WHEN the architecture dependency-direction test inspects `internal/state` imports
+THEN `internal/state` does not import `internal/toolgen`
+AND the provisioner is supplied to the binding call by the composition root.

--- a/artifacts/changes/archived/provision-host-adapter-surfaces-into-git-worktrees-at-worktr/tasks.md
+++ b/artifacts/changes/archived/provision-host-adapter-surfaces-into-git-worktrees-at-worktr/tasks.md
@@ -1,0 +1,21 @@
+# Tasks
+
+## Task List
+
+- [x] `t-01` Implement the worktree host-surface provisioning helper in the surface-renderer layer: an exported `toolgen.ProvisionWorktreeHostSurfaces(repoRoot, worktreeRoot)` that iterates `toolgen.Registry()`, and for each adapter whose `ToolRootPath(cfg)` dir exists under repoRoot, recursively copies that tree into the worktree (skip-if-exists per file so worktree-local edits are never clobbered; exclude the `<toolroot>/worktrees` subtree, `*.lock` files, and the `.adapter-generated` sentinel), then calls `toolgen.Generate(worktreeRoot, presentToolIDs, refresh=true)`. Any copy or Generate error is returned to the caller (fail-closed). It lives in toolgen (not internal/state) so the authority layer never imports a surface renderer.
+  - depends_on: []
+  - target_files: [internal/toolgen/worktree_provision.go]
+  - task_kind: code
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-005, REQ-006, REQ-007]
+
+- [x] `t-02` Wire provisioning into `EnsureDefaultWorktreeForChange` via dependency injection: define a `state.WorktreeProvisioner` function type (nil-safe) so `internal/state` declares the seam without importing toolgen; call the injected provisioner on the create branch (after `git worktree add` succeeds / `invalidateWorktreeListCache`, before returning `Created:true`) and on the reuse branch (the already-registered block, after worktree validation passes, before its return), propagating provisioning errors so binding fails closed; and pass `toolgen.ProvisionWorktreeHostSurfaces` from the `cmd/new.go` composition root.
+  - depends_on: [t-01]
+  - target_files: [internal/state/worktree.go, internal/state/worktree_provision.go, cmd/new.go]
+  - task_kind: code
+  - covers: [REQ-001, REQ-004, REQ-005, REQ-007]
+
+- [x] `t-03` Author tests proving the provisioning contract. Unit-test `toolgen.ProvisionWorktreeHostSurfaces` directly: a provisioned worktree gains, for each detected tool, `.<tool>/skills` containing both a copied third-party skill dir and regenerated `slipway-*` dirs plus hooks/settings; the `worktrees/` subtree and `*.lock` files are absent, the source sentinel is not carried verbatim, and no `.serena/` is produced; a stale slipway-* skill in the source is overwritten by regeneration; a worktree-local third-party edit is preserved; an induced copy failure returns a fail-closed error. Integration-test the wiring through `EnsureDefaultWorktreeForChange` (create provisions; reuse backfills while preserving a local edit; an induced provisioning failure surfaces as a fail-closed error from the binding call), and update existing callers for the new signature.
+  - depends_on: [t-01, t-02]
+  - target_files: [internal/toolgen/worktree_provision_test.go, internal/state/worktree_provision_test.go, internal/state/worktree_test.go]
+  - task_kind: test
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004, REQ-005, REQ-006, REQ-007]

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -16,6 +16,7 @@ import (
 	"github.com/signalridge/slipway/internal/engine/progression"
 	"github.com/signalridge/slipway/internal/model"
 	"github.com/signalridge/slipway/internal/state"
+	"github.com/signalridge/slipway/internal/toolgen"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
@@ -472,7 +473,7 @@ func createDirectGovernedChange(
 			return err
 		}
 
-		worktreeBinding, err := state.EnsureDefaultWorktreeForChange(root, &change)
+		worktreeBinding, err := state.EnsureDefaultWorktreeForChange(root, &change, toolgen.ProvisionWorktreeHostSurfaces)
 		if err != nil {
 			return err
 		}

--- a/internal/state/worktree.go
+++ b/internal/state/worktree.go
@@ -243,11 +243,16 @@ func EnsureDefaultWorktreeForChange(root string, change *model.Change, provision
 	}
 	invalidateWorktreeListCache(repoRoot)
 
-	if err := PersistScopeWorktreeMetadata(change, normalizedPath, branch); err != nil {
-		return DefaultWorktreeBinding{}, err
-	}
+	// Provision before persisting the binding: a failed provision on the create
+	// path must not leave change.yaml pointing at a half-provisioned worktree. The
+	// worktree dir git just created is still recoverable — a retry takes the reuse
+	// branch (it is now a registered worktree) and re-provisions idempotently.
+	// (The reuse branch persists first because its validation reads the metadata.)
 	if err := provision.provision(repoRoot, normalizedPath); err != nil {
 		return DefaultWorktreeBinding{}, fmt.Errorf("provision host-adapter surfaces into new worktree %s: %w", normalizedPath, err)
+	}
+	if err := PersistScopeWorktreeMetadata(change, normalizedPath, branch); err != nil {
+		return DefaultWorktreeBinding{}, err
 	}
 	return DefaultWorktreeBinding{
 		Path:    normalizedPath,

--- a/internal/state/worktree.go
+++ b/internal/state/worktree.go
@@ -152,7 +152,7 @@ func DefaultWorktreeBranch(slug string) string {
 	return "feat/" + slug
 }
 
-func EnsureDefaultWorktreeForChange(root string, change *model.Change) (DefaultWorktreeBinding, error) {
+func EnsureDefaultWorktreeForChange(root string, change *model.Change, provision WorktreeProvisioner) (DefaultWorktreeBinding, error) {
 	if change == nil {
 		return DefaultWorktreeBinding{}, fmt.Errorf("change is required")
 	}
@@ -211,6 +211,9 @@ func EnsureDefaultWorktreeForChange(root string, change *model.Change) (DefaultW
 		if len(validation.Blockers) > 0 {
 			return DefaultWorktreeBinding{}, fmt.Errorf("default worktree validation failed: %s", strings.Join(model.ReasonSpecs(validation.Blockers), ", "))
 		}
+		if err := provision.provision(repoRoot, normalizedPath); err != nil {
+			return DefaultWorktreeBinding{}, fmt.Errorf("provision host-adapter surfaces into reused worktree %s: %w", normalizedPath, err)
+		}
 		return DefaultWorktreeBinding{Path: normalizedPath, Branch: branch}, nil
 	}
 
@@ -242,6 +245,9 @@ func EnsureDefaultWorktreeForChange(root string, change *model.Change) (DefaultW
 
 	if err := PersistScopeWorktreeMetadata(change, normalizedPath, branch); err != nil {
 		return DefaultWorktreeBinding{}, err
+	}
+	if err := provision.provision(repoRoot, normalizedPath); err != nil {
+		return DefaultWorktreeBinding{}, fmt.Errorf("provision host-adapter surfaces into new worktree %s: %w", normalizedPath, err)
 	}
 	return DefaultWorktreeBinding{
 		Path:    normalizedPath,

--- a/internal/state/worktree_provision.go
+++ b/internal/state/worktree_provision.go
@@ -1,0 +1,20 @@
+package state
+
+// WorktreeProvisioner materializes host-adapter surfaces (skills, hooks,
+// settings, references) into a worktree so an agent working there — including an
+// isolated subagent — has the same host surface as the main checkout.
+//
+// The concrete implementation lives in the surface-renderer layer
+// (internal/toolgen.ProvisionWorktreeHostSurfaces) and is injected by the
+// composition root (cmd) so that this authority package never imports a surface
+// renderer (enforced by internal/architecture). A nil provisioner is a no-op,
+// which keeps pure state unit tests free of the rendering dependency.
+type WorktreeProvisioner func(repoRoot, worktreeRoot string) error
+
+// provision invokes the provisioner, treating a nil provisioner as a no-op.
+func (p WorktreeProvisioner) provision(repoRoot, worktreeRoot string) error {
+	if p == nil {
+		return nil
+	}
+	return p(repoRoot, worktreeRoot)
+}

--- a/internal/state/worktree_provision_test.go
+++ b/internal/state/worktree_provision_test.go
@@ -60,6 +60,8 @@ func TestEnsureDefaultWorktreeForChange_CreateFailsClosedOnProvisionError(t *tes
 	_, err := EnsureDefaultWorktreeForChange(root, &change, stub)
 	require.Error(t, err, "the create branch must fail closed when provisioning errors")
 	assert.ErrorIs(t, err, boom, "the provisioner error must propagate to the binding caller")
+	assert.Empty(t, change.WorktreePath,
+		"a failed create-path provision must not persist a worktree binding (provision runs before persist)")
 }
 
 func TestEnsureDefaultWorktreeForChange_ReuseBackfillsPreservingLocalEdit(t *testing.T) {

--- a/internal/state/worktree_provision_test.go
+++ b/internal/state/worktree_provision_test.go
@@ -1,0 +1,116 @@
+package state
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/signalridge/slipway/internal/model"
+	"github.com/signalridge/slipway/internal/toolgen"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests exercise the wiring of the injected provisioner through
+// EnsureDefaultWorktreeForChange. The provisioning logic itself is unit-tested in
+// internal/toolgen; here we assert the create and reuse branches invoke it and
+// fail closed on its error. The real toolgen provisioner is injected (a test
+// file may import the surface renderer; production state code may not).
+
+// writeUnder writes data to root/rel, creating parent directories.
+func writeUnder(t *testing.T, root, rel, data string) {
+	t.Helper()
+	full := filepath.Join(root, filepath.FromSlash(rel))
+	require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+	require.NoError(t, os.WriteFile(full, []byte(data), 0o644))
+}
+
+const generatedSlipwaySkillDir = ".claude/skills/slipway-wave-orchestration"
+
+func TestEnsureDefaultWorktreeForChange_ProvisionsHostSurfacesOnCreate(t *testing.T) {
+	root := t.TempDir()
+	initGitRepoAt(t, root)
+	writeUnder(t, root, ".claude/skills/golang-foo/SKILL.md", "third party")
+	writeUnder(t, root, ".codex/skills/golang-foo/SKILL.md", "third party codex")
+
+	change := model.NewChange("provision-me")
+	binding, err := EnsureDefaultWorktreeForChange(root, &change, toolgen.ProvisionWorktreeHostSurfaces)
+	require.NoError(t, err)
+	require.True(t, binding.Created)
+
+	assert.FileExists(t, filepath.Join(binding.Path, ".claude/skills/golang-foo/SKILL.md"))
+	assert.DirExists(t, filepath.Join(binding.Path, generatedSlipwaySkillDir))
+	assert.FileExists(t, filepath.Join(binding.Path, ".claude/settings.json"))
+	assert.FileExists(t, filepath.Join(binding.Path, ".claude/hooks/slipway-session-start.sh"))
+	assert.FileExists(t, filepath.Join(binding.Path, ".codex/skills/golang-foo/SKILL.md"))
+}
+
+func TestEnsureDefaultWorktreeForChange_CreateFailsClosedOnProvisionError(t *testing.T) {
+	root := t.TempDir()
+	initGitRepoAt(t, root)
+
+	// A stub provisioner isolates the create-branch fail-closed wiring: making the
+	// real provisioner fail on a freshly created worktree is awkward, but the
+	// contract under test is only that a provisioner error aborts the binding.
+	boom := errors.New("provision boom")
+	stub := func(_, _ string) error { return boom }
+
+	change := model.NewChange("create-fail")
+	_, err := EnsureDefaultWorktreeForChange(root, &change, stub)
+	require.Error(t, err, "the create branch must fail closed when provisioning errors")
+	assert.ErrorIs(t, err, boom, "the provisioner error must propagate to the binding caller")
+}
+
+func TestEnsureDefaultWorktreeForChange_ReuseBackfillsPreservingLocalEdit(t *testing.T) {
+	root := t.TempDir()
+	initGitRepoAt(t, root)
+	writeUnder(t, root, ".claude/skills/golang-foo/SKILL.md", "repo version")
+
+	repoRoot, err := gitWorkspaceRoot(root)
+	require.NoError(t, err)
+	slug := "reuse-me"
+	branch := DefaultWorktreeBranch(slug)
+	wtPath, err := NormalizePath(DefaultWorktreePath(repoRoot, slug))
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(wtPath), 0o755))
+	runGit(t, repoRoot, "worktree", "add", "-b", branch, wtPath, "HEAD")
+
+	// A worktree-local third-party edit must survive backfill; the rest of
+	// .claude is missing and must be provisioned.
+	writeUnder(t, wtPath, ".claude/skills/golang-foo/SKILL.md", "WORKTREE LOCAL EDIT")
+
+	change := model.NewChange(slug)
+	binding, err := EnsureDefaultWorktreeForChange(root, &change, toolgen.ProvisionWorktreeHostSurfaces)
+	require.NoError(t, err)
+	require.False(t, binding.Created, "an already-registered worktree takes the reuse branch")
+
+	got, err := os.ReadFile(filepath.Join(wtPath, ".claude/skills/golang-foo/SKILL.md"))
+	require.NoError(t, err)
+	assert.Equal(t, "WORKTREE LOCAL EDIT", string(got), "reuse must preserve the worktree-local edit")
+	assert.DirExists(t, filepath.Join(wtPath, generatedSlipwaySkillDir))
+	assert.FileExists(t, filepath.Join(wtPath, ".claude/settings.json"))
+}
+
+func TestEnsureDefaultWorktreeForChange_ReuseFailsClosedOnProvisionError(t *testing.T) {
+	root := t.TempDir()
+	initGitRepoAt(t, root)
+	writeUnder(t, root, ".claude/skills/golang-foo/SKILL.md", "repo version")
+
+	repoRoot, err := gitWorkspaceRoot(root)
+	require.NoError(t, err)
+	slug := "reuse-fail"
+	branch := DefaultWorktreeBranch(slug)
+	wtPath, err := NormalizePath(DefaultWorktreePath(repoRoot, slug))
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(wtPath), 0o755))
+	runGit(t, repoRoot, "worktree", "add", "-b", branch, wtPath, "HEAD")
+
+	// Destination .claude is a regular file → provisioning cannot create the
+	// tool root and must fail closed from the binding call.
+	require.NoError(t, os.WriteFile(filepath.Join(wtPath, ".claude"), []byte("not a dir"), 0o644))
+
+	change := model.NewChange(slug)
+	_, err = EnsureDefaultWorktreeForChange(root, &change, toolgen.ProvisionWorktreeHostSurfaces)
+	require.Error(t, err, "binding must fail closed when worktree provisioning errors")
+}

--- a/internal/state/worktree_test.go
+++ b/internal/state/worktree_test.go
@@ -289,7 +289,7 @@ func TestEnsureDefaultWorktreeForChange_ProvisionsNonDiscoveryByDefault(t *testi
 	change := model.NewChange("my-change")
 	change.NeedsDiscovery = false
 
-	binding, err := EnsureDefaultWorktreeForChange(root, &change)
+	binding, err := EnsureDefaultWorktreeForChange(root, &change, nil)
 	require.NoError(t, err)
 	assert.True(t, binding.Created, "non-discovery change should provision a worktree by default")
 	assert.Empty(t, binding.SkippedReason)
@@ -305,7 +305,7 @@ func TestEnsureDefaultWorktreeForChange_DisabledByConfig(t *testing.T) {
 		[]byte("governance:\n  auto_provision_worktree: false\n"), 0o644))
 
 	change := model.NewChange("my-change")
-	binding, err := EnsureDefaultWorktreeForChange(root, &change)
+	binding, err := EnsureDefaultWorktreeForChange(root, &change, nil)
 	require.NoError(t, err)
 	assert.False(t, binding.Created)
 	assert.Equal(t, "worktree_provisioning_disabled", binding.SkippedReason)
@@ -316,7 +316,7 @@ func TestEnsureDefaultWorktreeForChange_SkipsNonGitRepo(t *testing.T) {
 	root := t.TempDir() // never `git init`ed
 
 	change := model.NewChange("my-change")
-	binding, err := EnsureDefaultWorktreeForChange(root, &change)
+	binding, err := EnsureDefaultWorktreeForChange(root, &change, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "not_git_repository", binding.SkippedReason)
 	assert.False(t, binding.Created)

--- a/internal/toolgen/main_test.go
+++ b/internal/toolgen/main_test.go
@@ -1,0 +1,25 @@
+package toolgen
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain hardens the whole package against the class of bug where a test
+// silently rewrites the developer's real Codex prompt store. Codex prompts are
+// host-global (resolved from $CODEX_HOME/prompts, else ~/.codex/prompts), so any
+// test that generates Codex surfaces without an explicit sandbox would mutate
+// the host. Defaulting CODEX_HOME to a throwaway directory makes that
+// impossible; individual tests still override it with t.Setenv when they need to
+// assert on the generated prompts.
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "slipway-toolgen-codex-home")
+	if err == nil {
+		_ = os.Setenv("CODEX_HOME", dir)
+	}
+	code := m.Run()
+	if dir != "" {
+		_ = os.RemoveAll(dir)
+	}
+	os.Exit(code)
+}

--- a/internal/toolgen/main_test.go
+++ b/internal/toolgen/main_test.go
@@ -1,6 +1,7 @@
 package toolgen
 
 import (
+	"fmt"
 	"os"
 	"testing"
 )
@@ -12,14 +13,22 @@ import (
 // the host. Defaulting CODEX_HOME to a throwaway directory makes that
 // impossible; individual tests still override it with t.Setenv when they need to
 // assert on the generated prompts.
+//
+// If the sandbox cannot be established the package aborts rather than running
+// with an unset CODEX_HOME — running on would leave the very escape hatch this
+// guard exists to close, letting a Codex-generating test write to the real
+// ~/.codex store.
 func TestMain(m *testing.M) {
 	dir, err := os.MkdirTemp("", "slipway-toolgen-codex-home")
-	if err == nil {
-		_ = os.Setenv("CODEX_HOME", dir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "toolgen TestMain: cannot create CODEX_HOME sandbox: %v\n", err)
+		os.Exit(1)
+	}
+	if err := os.Setenv("CODEX_HOME", dir); err != nil {
+		fmt.Fprintf(os.Stderr, "toolgen TestMain: cannot set CODEX_HOME: %v\n", err)
+		os.Exit(1)
 	}
 	code := m.Run()
-	if dir != "" {
-		_ = os.RemoveAll(dir)
-	}
+	_ = os.RemoveAll(dir)
 	os.Exit(code)
 }

--- a/internal/toolgen/toolgen.go
+++ b/internal/toolgen/toolgen.go
@@ -682,12 +682,33 @@ func DetectExistingTools(root string) []string {
 
 // Generate creates tool prompt surfaces and commands for the given tools.
 func Generate(root string, tools []string, refresh bool) error {
+	return generateWithOptions(root, tools, refresh, generateOptions{})
+}
+
+// GenerateWorktreeLocal generates only the worktree-local slipway-owned surfaces
+// for the given tools, skipping every host-global output (notably Codex prompts
+// under $CODEX_HOME / ~/.codex). Provisioning a git worktree must never mutate
+// shared host-level state: those prompts are not worktree-scoped and are owned
+// by `slipway init` on the host, so a worktree that rewrote them would clobber
+// every other checkout's prompts.
+func GenerateWorktreeLocal(root string, tools []string, refresh bool) error {
+	return generateWithOptions(root, tools, refresh, generateOptions{worktreeLocalOnly: true})
+}
+
+// generateOptions tunes a single generation pass.
+type generateOptions struct {
+	// worktreeLocalOnly suppresses host-global outputs so the pass writes only
+	// surfaces under root. Set when provisioning a worktree.
+	worktreeLocalOnly bool
+}
+
+func generateWithOptions(root string, tools []string, refresh bool, opts generateOptions) error {
 	for _, tool := range tools {
 		cfg, ok := toolRegistry[tool]
 		if !ok {
 			return fmt.Errorf("unsupported tool %q", tool)
 		}
-		if err := generateForTool(root, cfg, refresh); err != nil {
+		if err := generateForTool(root, cfg, refresh, opts); err != nil {
 			return err
 		}
 	}
@@ -739,7 +760,7 @@ func SkillIndexPath(cfg ToolConfig) string {
 	)
 }
 
-func generateForTool(root string, cfg ToolConfig, refresh bool) error {
+func generateForTool(root string, cfg ToolConfig, refresh bool, opts generateOptions) error {
 	sentinelPath := filepath.Join(root, GeneratedAdapterMarkerPath(cfg))
 	_, sentinelErr := os.Stat(sentinelPath)
 	hadGeneratedAdapter := sentinelErr == nil
@@ -912,7 +933,9 @@ func generateForTool(root string, cfg ToolConfig, refresh bool) error {
 	}
 
 	// Global prompts (Codex: ~/.codex/prompts/) — writes outside project root.
-	if cfg.PromptsStyle == "global" {
+	// Skipped for worktree-local passes: these prompts are host-global and shared
+	// across every checkout, so provisioning one worktree must not rewrite them.
+	if cfg.PromptsStyle == "global" && !opts.worktreeLocalOnly {
 		if err := generateCodexPrompts(cfg, refresh); err != nil {
 			return err
 		}

--- a/internal/toolgen/worktree_provision.go
+++ b/internal/toolgen/worktree_provision.go
@@ -187,5 +187,5 @@ func copyHostAdapterFileNoClobber(srcPath, dstPath string, d fs.DirEntry) error 
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(dstPath, data, info.Mode().Perm()) // #nosec G306 -- preserves the source mode so adapter hooks remain executable.
+	return os.WriteFile(dstPath, data, info.Mode().Perm()) // #nosec G306 G703 -- preserves the source mode so adapter hooks remain executable; dstPath is filepath.Join(worktreeRoot, toolRel, rel) where rel comes from filepath.Rel against the walked source tree, so the write stays within the worktree's host-adapter surface.
 }

--- a/internal/toolgen/worktree_provision.go
+++ b/internal/toolgen/worktree_provision.go
@@ -1,0 +1,149 @@
+package toolgen
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ProvisionWorktreeHostSurfaces materializes every host-adapter surface that
+// exists in the repository root into a freshly created (or reused) worktree.
+//
+// Git worktrees share only the .git directory; the host-adapter trees
+// (.claude, .cursor, .codex, .opencode, .gemini) are gitignored, so a new
+// worktree starts with none of the skills, hooks, settings, or bundled skill
+// references that an agent — including an isolated subagent — needs. This helper
+// copies the third-party content over (skip-if-exists so worktree-local edits
+// are never clobbered) and then regenerates the slipway-owned surfaces from the
+// worktree's own source via Generate, so a worktree whose source differs from
+// main carries its own slipway-* surfaces rather than a stale copy of main's
+// generated output.
+//
+// Detection is by directory existence rather than the generated sentinel: any
+// adapter root present in the repository is provisioned, even one a user created
+// without ever running init.
+//
+// It lives in the surface-renderer layer (toolgen) and is injected into the
+// authority layer (internal/state) so that state never imports a surface
+// renderer. Provisioning is fail-closed: any copy or regeneration error is
+// returned so the caller can refuse to bind a silently degraded worktree.
+func ProvisionWorktreeHostSurfaces(repoRoot, worktreeRoot string) error {
+	var present []string
+	for _, cfg := range Registry() {
+		toolRel := ToolRootPath(cfg)
+		if toolRel == "" {
+			continue
+		}
+		src := filepath.Join(repoRoot, toolRel)
+		info, err := os.Stat(src)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return fmt.Errorf("stat host-adapter surface %s: %w", toolRel, err)
+		}
+		if !info.IsDir() {
+			continue
+		}
+		dst := filepath.Join(worktreeRoot, toolRel)
+		if err := copyHostAdapterTree(src, dst); err != nil {
+			return fmt.Errorf("provision host-adapter surface %s into worktree: %w", toolRel, err)
+		}
+		present = append(present, cfg.ID)
+	}
+	if len(present) == 0 {
+		return nil
+	}
+	if err := Generate(worktreeRoot, present, true); err != nil {
+		return fmt.Errorf("regenerate slipway-owned worktree surfaces: %w", err)
+	}
+	return nil
+}
+
+// copyHostAdapterTree recursively copies a host-adapter directory into the
+// worktree without clobbering files that already exist at the destination.
+//
+// It excludes paths that must not be carried verbatim into a worktree:
+//   - the nested "worktrees/" subtree, which holds linked git worktrees and
+//     would cause recursion and bloat,
+//   - lock files (e.g. scheduled_tasks.lock), which are host-process state, and
+//   - the generated ".adapter-generated" sentinel, since Generate writes a fresh
+//     one for the worktree.
+func copyHostAdapterTree(srcRoot, dstRoot string) error {
+	return filepath.WalkDir(srcRoot, func(srcPath string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(srcRoot, srcPath)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return os.MkdirAll(dstRoot, 0o755) // #nosec G301 -- host-adapter surfaces are user-facing skill/command trees where searchable mode is intentional.
+		}
+		if excludeFromHostAdapterCopy(rel, d) {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		dstPath := filepath.Join(dstRoot, rel)
+		if d.IsDir() {
+			return os.MkdirAll(dstPath, 0o755) // #nosec G301 -- host-adapter surfaces are user-facing skill/command trees where searchable mode is intentional.
+		}
+		return copyHostAdapterFileNoClobber(srcPath, dstPath, d)
+	})
+}
+
+// excludeFromHostAdapterCopy reports whether a path (relative to the tool root)
+// must be skipped during the copy step.
+func excludeFromHostAdapterCopy(rel string, d fs.DirEntry) bool {
+	if rel == "worktrees" || strings.HasPrefix(rel, "worktrees"+string(filepath.Separator)) {
+		return true
+	}
+	if !d.IsDir() {
+		base := filepath.Base(rel)
+		if strings.HasSuffix(base, ".lock") {
+			return true
+		}
+		if base == ".adapter-generated" {
+			return true
+		}
+	}
+	return false
+}
+
+// copyHostAdapterFileNoClobber copies a single file into the worktree, preserving
+// its mode bits (hooks must stay executable) and never overwriting an existing
+// destination so worktree-local edits survive.
+func copyHostAdapterFileNoClobber(srcPath, dstPath string, d fs.DirEntry) error {
+	if _, err := os.Lstat(dstPath); err == nil {
+		return nil // skip-if-exists: never clobber worktree-local edits
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	info, err := d.Info()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(dstPath), 0o755); err != nil { // #nosec G301 -- host-adapter surfaces are user-facing skill/command trees where searchable mode is intentional.
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		target, err := os.Readlink(srcPath)
+		if err != nil {
+			return err
+		}
+		return os.Symlink(target, dstPath)
+	}
+	if !info.Mode().IsRegular() {
+		return nil // skip sockets, devices, and other irregular files
+	}
+	data, err := os.ReadFile(srcPath) // #nosec G304 -- srcPath is a host-adapter surface under the repository root being provisioned.
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(dstPath, data, info.Mode().Perm()) // #nosec G306 -- preserves the source mode so adapter hooks remain executable.
+}

--- a/internal/toolgen/worktree_provision.go
+++ b/internal/toolgen/worktree_provision.go
@@ -16,10 +16,12 @@ import (
 // worktree starts with none of the skills, hooks, settings, or bundled skill
 // references that an agent — including an isolated subagent — needs. This helper
 // copies the third-party content over (skip-if-exists so worktree-local edits
-// are never clobbered) and then regenerates the slipway-owned surfaces from the
-// worktree's own source via Generate, so a worktree whose source differs from
-// main carries its own slipway-* surfaces rather than a stale copy of main's
-// generated output.
+// are never clobbered) and then regenerates the slipway-owned surfaces with the
+// running Slipway binary's embedded templates via GenerateWorktreeLocal, so the
+// worktree carries freshly generated slipway-* surfaces rather than a stale copy
+// of the source adapter's generated output. Host-global outputs (Codex prompts
+// under $CODEX_HOME / ~/.codex) are deliberately skipped: they are shared across
+// every checkout and must not be rewritten when provisioning one worktree.
 //
 // Detection is by directory existence rather than the generated sentinel: any
 // adapter root present in the repository is provisioned, even one a user created
@@ -48,7 +50,7 @@ func ProvisionWorktreeHostSurfaces(repoRoot, worktreeRoot string) error {
 			continue
 		}
 		dst := filepath.Join(worktreeRoot, toolRel)
-		if err := copyHostAdapterTree(src, dst); err != nil {
+		if err := copyHostAdapterTree(cfg, src, dst); err != nil {
 			return fmt.Errorf("provision host-adapter surface %s into worktree: %w", toolRel, err)
 		}
 		present = append(present, cfg.ID)
@@ -56,7 +58,7 @@ func ProvisionWorktreeHostSurfaces(repoRoot, worktreeRoot string) error {
 	if len(present) == 0 {
 		return nil
 	}
-	if err := Generate(worktreeRoot, present, true); err != nil {
+	if err := GenerateWorktreeLocal(worktreeRoot, present, true); err != nil {
 		return fmt.Errorf("regenerate slipway-owned worktree surfaces: %w", err)
 	}
 	return nil
@@ -68,10 +70,15 @@ func ProvisionWorktreeHostSurfaces(repoRoot, worktreeRoot string) error {
 // It excludes paths that must not be carried verbatim into a worktree:
 //   - the nested "worktrees/" subtree, which holds linked git worktrees and
 //     would cause recursion and bloat,
-//   - lock files (e.g. scheduled_tasks.lock), which are host-process state, and
+//   - lock files (e.g. scheduled_tasks.lock), which are host-process state,
 //   - the generated ".adapter-generated" sentinel, since Generate writes a fresh
-//     one for the worktree.
-func copyHostAdapterTree(srcRoot, dstRoot string) error {
+//     one for the worktree, and
+//   - slipway-owned skill directories, which are regenerated from the running
+//     binary; copying them risks carrying a stale managed skill the generator no
+//     longer produces, which would never be pruned on a first-time provision
+//     (where the sentinel the prune relies on is absent).
+func copyHostAdapterTree(cfg ToolConfig, srcRoot, dstRoot string) error {
+	skillsRel := adapterSkillsRel(cfg)
 	return filepath.WalkDir(srcRoot, func(srcPath string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -83,7 +90,7 @@ func copyHostAdapterTree(srcRoot, dstRoot string) error {
 		if rel == "." {
 			return os.MkdirAll(dstRoot, 0o755) // #nosec G301 -- host-adapter surfaces are user-facing skill/command trees where searchable mode is intentional.
 		}
-		if excludeFromHostAdapterCopy(rel, d) {
+		if excludeFromHostAdapterCopy(rel, d, skillsRel) {
 			if d.IsDir() {
 				return filepath.SkipDir
 			}
@@ -99,8 +106,11 @@ func copyHostAdapterTree(srcRoot, dstRoot string) error {
 
 // excludeFromHostAdapterCopy reports whether a path (relative to the tool root)
 // must be skipped during the copy step.
-func excludeFromHostAdapterCopy(rel string, d fs.DirEntry) bool {
+func excludeFromHostAdapterCopy(rel string, d fs.DirEntry, skillsRel string) bool {
 	if rel == "worktrees" || strings.HasPrefix(rel, "worktrees"+string(filepath.Separator)) {
+		return true
+	}
+	if d.IsDir() && isSlipwayOwnedSkillDir(rel, skillsRel) {
 		return true
 	}
 	if !d.IsDir() {
@@ -113,6 +123,38 @@ func excludeFromHostAdapterCopy(rel string, d fs.DirEntry) bool {
 		}
 	}
 	return false
+}
+
+// adapterSkillsRel returns the adapter's skills directory relative to its tool
+// root (e.g. ".claude/skills" under ".claude" -> "skills"). It returns "" when
+// the skills directory is absent or not under the tool root, which disables
+// slipway-owned skill-dir exclusion for that adapter.
+func adapterSkillsRel(cfg ToolConfig) string {
+	toolRoot := ToolRootPath(cfg)
+	if toolRoot == "" || cfg.SkillsDir == "" {
+		return ""
+	}
+	rel, err := filepath.Rel(toolRoot, cfg.SkillsDir)
+	if err != nil || rel == "." || strings.HasPrefix(rel, "..") {
+		return ""
+	}
+	return rel
+}
+
+// isSlipwayOwnedSkillDir reports whether rel is a slipway-owned skill directory
+// directly under the adapter's skills root. These are regenerated, never copied.
+// The match is by naming convention (the reserved "slipway-" prefix and the
+// workflow entry skill) so it also catches stale managed skills the current
+// generator no longer emits.
+func isSlipwayOwnedSkillDir(rel, skillsRel string) bool {
+	if skillsRel == "" {
+		return false
+	}
+	parent, name := filepath.Split(filepath.Clean(rel))
+	if filepath.Clean(parent) != filepath.Clean(skillsRel) {
+		return false
+	}
+	return strings.HasPrefix(name, "slipway-") || name == workflowEntryPublicName
 }
 
 // copyHostAdapterFileNoClobber copies a single file into the worktree, preserving

--- a/internal/toolgen/worktree_provision_test.go
+++ b/internal/toolgen/worktree_provision_test.go
@@ -48,6 +48,55 @@ func TestProvisionWorktreeHostSurfaces_CopiesThirdPartyAndRegenerates(t *testing
 	assert.NoDirExists(t, filepath.Join(worktreeRoot, ".gemini"))
 }
 
+func TestProvisionWorktreeHostSurfaces_DoesNotMutateCodexHome(t *testing.T) {
+	codexHome := t.TempDir()
+	t.Setenv("CODEX_HOME", codexHome)
+	repoRoot := t.TempDir()
+	worktreeRoot := filepath.Join(t.TempDir(), "wt")
+	require.NoError(t, os.MkdirAll(worktreeRoot, 0o755))
+
+	// A .codex adapter is present, so provisioning generates its worktree-local
+	// skills — but Codex command prompts are host-global, and provisioning one
+	// worktree must never rewrite them.
+	writeUnder(t, repoRoot, ".codex/skills/golang-foo/SKILL.md", "third party codex")
+
+	require.NoError(t, ProvisionWorktreeHostSurfaces(repoRoot, worktreeRoot))
+
+	// Worktree-local Codex skills are generated.
+	assert.DirExists(t, filepath.Join(worktreeRoot, ".codex/skills/slipway-wave-orchestration"))
+	// Host-global Codex prompts under CODEX_HOME must be untouched.
+	promptsDir := filepath.Join(codexHome, "prompts")
+	entries, err := os.ReadDir(promptsDir)
+	if err != nil {
+		require.True(t, os.IsNotExist(err),
+			"CODEX_HOME/prompts must not exist after provisioning, got: %v", err)
+		return
+	}
+	assert.Empty(t, entries,
+		"provisioning a worktree must not write any host-global Codex prompt")
+}
+
+func TestProvisionWorktreeHostSurfaces_DropsStaleManagedSlipwaySkill(t *testing.T) {
+	repoRoot := t.TempDir()
+	worktreeRoot := filepath.Join(t.TempDir(), "wt")
+	require.NoError(t, os.MkdirAll(worktreeRoot, 0o755))
+
+	// A managed-looking slipway-* skill that the current generator does NOT emit
+	// (e.g. a skill removed in a newer Slipway). On a first-time provision the
+	// worktree has no .adapter-generated sentinel, so the gated prune cannot run;
+	// the copy step must therefore never carry it in.
+	writeUnder(t, repoRoot, ".claude/skills/slipway-removed-legacy-skill/SKILL.md", "STALE MANAGED SKILL")
+	writeUnder(t, repoRoot, ".claude/skills/golang-foo/SKILL.md", "third party")
+
+	require.NoError(t, ProvisionWorktreeHostSurfaces(repoRoot, worktreeRoot))
+
+	assert.NoDirExists(t, filepath.Join(worktreeRoot, ".claude/skills/slipway-removed-legacy-skill"),
+		"a stale managed slipway-* skill must not be copied into a freshly provisioned worktree")
+	// The third-party neighbour is still copied, and real generated skills exist.
+	assert.FileExists(t, filepath.Join(worktreeRoot, ".claude/skills/golang-foo/SKILL.md"))
+	assert.DirExists(t, filepath.Join(worktreeRoot, generatedSlipwaySkillDir))
+}
+
 func TestProvisionWorktreeHostSurfaces_ExcludesWorktreesLocksAndSourceSentinel(t *testing.T) {
 	repoRoot := t.TempDir()
 	worktreeRoot := filepath.Join(t.TempDir(), "wt")

--- a/internal/toolgen/worktree_provision_test.go
+++ b/internal/toolgen/worktree_provision_test.go
@@ -1,0 +1,145 @@
+package toolgen
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeUnder writes data to root/rel, creating parent directories.
+func writeUnder(t *testing.T, root, rel, data string) {
+	t.Helper()
+	full := filepath.Join(root, filepath.FromSlash(rel))
+	require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+	require.NoError(t, os.WriteFile(full, []byte(data), 0o644))
+}
+
+// A real generated slipway host-skill dir, used to assert slipway-* surfaces are
+// regenerated into the worktree.
+const generatedSlipwaySkillDir = ".claude/skills/slipway-wave-orchestration"
+
+func TestProvisionWorktreeHostSurfaces_CopiesThirdPartyAndRegenerates(t *testing.T) {
+	repoRoot := t.TempDir()
+	worktreeRoot := filepath.Join(t.TempDir(), "wt")
+	require.NoError(t, os.MkdirAll(worktreeRoot, 0o755))
+
+	// Third-party skills under two distinct adapters.
+	writeUnder(t, repoRoot, ".claude/skills/golang-foo/SKILL.md", "third party claude")
+	writeUnder(t, repoRoot, ".codex/skills/golang-foo/SKILL.md", "third party codex")
+	// .serena is an MCP cache and must never be provisioned.
+	writeUnder(t, repoRoot, ".serena/cache/index.bin", "serena")
+
+	require.NoError(t, ProvisionWorktreeHostSurfaces(repoRoot, worktreeRoot))
+
+	// Third-party content copied for every present adapter.
+	assert.FileExists(t, filepath.Join(worktreeRoot, ".claude/skills/golang-foo/SKILL.md"))
+	assert.FileExists(t, filepath.Join(worktreeRoot, ".codex/skills/golang-foo/SKILL.md"))
+	// slipway-owned surfaces regenerated for each present adapter.
+	assert.DirExists(t, filepath.Join(worktreeRoot, generatedSlipwaySkillDir))
+	assert.FileExists(t, filepath.Join(worktreeRoot, ".claude/settings.json"))
+	assert.FileExists(t, filepath.Join(worktreeRoot, ".claude/hooks/slipway-session-start.sh"))
+	assert.DirExists(t, filepath.Join(worktreeRoot, ".codex/skills/slipway-wave-orchestration"))
+	// .serena is not a toolgen adapter — it must not be provisioned.
+	assert.NoDirExists(t, filepath.Join(worktreeRoot, ".serena"))
+	// An adapter absent from the repo root must not be created in the worktree.
+	assert.NoDirExists(t, filepath.Join(worktreeRoot, ".gemini"))
+}
+
+func TestProvisionWorktreeHostSurfaces_ExcludesWorktreesLocksAndSourceSentinel(t *testing.T) {
+	repoRoot := t.TempDir()
+	worktreeRoot := filepath.Join(t.TempDir(), "wt")
+	require.NoError(t, os.MkdirAll(worktreeRoot, 0o755))
+
+	writeUnder(t, repoRoot, ".claude/skills/golang-foo/SKILL.md", "keep me")
+	writeUnder(t, repoRoot, ".claude/worktrees/nested/inner.txt", "nested worktree content")
+	writeUnder(t, repoRoot, ".claude/scheduled_tasks.lock", "lock state")
+	writeUnder(t, repoRoot, ".claude/slipway/.adapter-generated", "SOURCE-SENTINEL")
+
+	require.NoError(t, ProvisionWorktreeHostSurfaces(repoRoot, worktreeRoot))
+
+	assert.FileExists(t, filepath.Join(worktreeRoot, ".claude/skills/golang-foo/SKILL.md"))
+	// Excluded paths must not be carried into the worktree.
+	assert.NoDirExists(t, filepath.Join(worktreeRoot, ".claude/worktrees"))
+	assert.NoFileExists(t, filepath.Join(worktreeRoot, ".claude/scheduled_tasks.lock"))
+	// Generate writes a fresh sentinel; the source's verbatim sentinel is not carried.
+	got, err := os.ReadFile(filepath.Join(worktreeRoot, ".claude/slipway/.adapter-generated"))
+	require.NoError(t, err)
+	assert.NotEqual(t, "SOURCE-SENTINEL", string(got),
+		"the .adapter-generated sentinel must be regenerated, not copied verbatim")
+}
+
+func TestProvisionWorktreeHostSurfaces_RegenerationOverwritesStaleSlipwaySkill(t *testing.T) {
+	repoRoot := t.TempDir()
+	worktreeRoot := filepath.Join(t.TempDir(), "wt")
+	require.NoError(t, os.MkdirAll(worktreeRoot, 0o755))
+
+	const staleMarker = "STALE-SLIPWAY-CONTENT-DO-NOT-PROPAGATE"
+	staleRel := generatedSlipwaySkillDir + "/SKILL.md"
+	writeUnder(t, repoRoot, staleRel, staleMarker)
+	writeUnder(t, repoRoot, ".claude/skills/golang-foo/SKILL.md", "third party")
+
+	require.NoError(t, ProvisionWorktreeHostSurfaces(repoRoot, worktreeRoot))
+
+	got, err := os.ReadFile(filepath.Join(worktreeRoot, staleRel))
+	require.NoError(t, err)
+	assert.NotContains(t, string(got), staleMarker,
+		"regeneration must overwrite the stale slipway skill rather than copy it verbatim")
+	assert.NotEmpty(t, string(got))
+	// The third-party neighbour is preserved verbatim.
+	tp, err := os.ReadFile(filepath.Join(worktreeRoot, ".claude/skills/golang-foo/SKILL.md"))
+	require.NoError(t, err)
+	assert.Equal(t, "third party", string(tp))
+}
+
+func TestProvisionWorktreeHostSurfaces_PreservesWorktreeLocalThirdPartyEdit(t *testing.T) {
+	repoRoot := t.TempDir()
+	worktreeRoot := filepath.Join(t.TempDir(), "wt")
+	require.NoError(t, os.MkdirAll(worktreeRoot, 0o755))
+
+	writeUnder(t, repoRoot, ".claude/skills/golang-foo/SKILL.md", "repo version")
+	// The worktree already holds a locally-edited copy.
+	writeUnder(t, worktreeRoot, ".claude/skills/golang-foo/SKILL.md", "WORKTREE LOCAL EDIT")
+
+	require.NoError(t, ProvisionWorktreeHostSurfaces(repoRoot, worktreeRoot))
+
+	got, err := os.ReadFile(filepath.Join(worktreeRoot, ".claude/skills/golang-foo/SKILL.md"))
+	require.NoError(t, err)
+	assert.Equal(t, "WORKTREE LOCAL EDIT", string(got),
+		"skip-if-exists must never clobber a worktree-local third-party edit")
+}
+
+func TestProvisionWorktreeHostSurfaces_FailClosedOnCopyError(t *testing.T) {
+	repoRoot := t.TempDir()
+	worktreeRoot := filepath.Join(t.TempDir(), "wt")
+	require.NoError(t, os.MkdirAll(worktreeRoot, 0o755))
+	writeUnder(t, repoRoot, ".claude/skills/golang-foo/SKILL.md", "x")
+	// Destination .claude is a regular file, so creating the tool root dir fails.
+	require.NoError(t, os.WriteFile(filepath.Join(worktreeRoot, ".claude"), []byte("not a dir"), 0o644))
+
+	err := ProvisionWorktreeHostSurfaces(repoRoot, worktreeRoot)
+	require.Error(t, err, "provisioning must fail closed when a copy step errors")
+}
+
+func TestProvisionWorktreeHostSurfaces_FailClosedOnRegenerationError(t *testing.T) {
+	repoRoot := t.TempDir()
+	worktreeRoot := filepath.Join(t.TempDir(), "wt")
+	require.NoError(t, os.MkdirAll(worktreeRoot, 0o755))
+	// Source carries only third-party content, so the copy step succeeds without
+	// ever touching .claude/slipway.
+	writeUnder(t, repoRoot, ".claude/skills/golang-foo/SKILL.md", "third party")
+	// The worktree already holds .claude/slipway as a regular FILE. The copy step
+	// still completes, but Generate cannot create the slipway surface directory,
+	// so provisioning must fail closed on the regeneration step.
+	require.NoError(t, os.MkdirAll(filepath.Join(worktreeRoot, ".claude"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(worktreeRoot, ".claude/slipway"), []byte("not a dir"), 0o644))
+
+	err := ProvisionWorktreeHostSurfaces(repoRoot, worktreeRoot)
+	require.Error(t, err, "provisioning must fail closed when regeneration errors")
+	assert.ErrorContains(t, err, "regenerate",
+		"a regeneration failure must be reported distinctly from a copy failure")
+	// The third-party copy completed before the regeneration step failed.
+	assert.FileExists(t, filepath.Join(worktreeRoot, ".claude/skills/golang-foo/SKILL.md"))
+}


### PR DESCRIPTION
## What

Git worktrees share only `.git`; the host-adapter trees (`.claude`, `.cursor`, `.codex`, `.opencode`, `.gemini`) are gitignored, so a fresh worktree starts with none of the skills, hooks, settings, or bundled references an agent (including an isolated subagent) needs — hooks fail with `$CLAUDE_PROJECT_DIR` unset and skills can't resolve their reference files.

This adds `toolgen.ProvisionWorktreeHostSurfaces`, injected into `state.EnsureDefaultWorktreeForChange` from the composition root (`cmd/new.go`) so `internal/state` never imports the surface renderer (dependency direction enforced by `internal/architecture`). It runs on both the create and reuse branches:

- **copy** each present repo-root adapter dir into the worktree — skip-if-exists so worktree-local edits are never clobbered; excludes the nested `worktrees/` subtree, `*.lock` files, the `.adapter-generated` sentinel, and slipway-owned skill dirs (the generator is their sole author); preserves mode bits and symlinks;
- **regenerate** the slipway-owned surfaces with `GenerateWorktreeLocal` (worktree-local only — see below).

Detection is by adapter-directory existence, so an adapter a user created without running `init` is still provisioned. Provisioning is **fail-closed**: any copy or regeneration error aborts the bind.

## Review fixes (commit `cad5cfa`)

A post-archive adversarial review found three real defects, fixed here:

- **blocker — Codex host-global prompt mutation.** `ProvisionWorktreeHostSurfaces` called `Generate`, which for Codex (`PromptsStyle: global`) writes prompts to `$CODEX_HOME` / `~/.codex/prompts` — *outside* the worktree. Provisioning one worktree therefore rewrote every checkout's shared prompts, and the new test (no `CODEX_HOME` sandbox) rewrote the developer's real `~/.codex/prompts`. Fix: new `GenerateWorktreeLocal` suppresses host-global outputs; provisioning uses it. A package `TestMain` pins `CODEX_HOME` to a throwaway dir so no `toolgen` test can touch the real store (also closes a pre-existing leak in `TestGeneratedWaveOrchestrationCodexDispatchUsesSpawnAgent`).
- **major — stale managed skill copy.** The copy step carried slipway-owned skill dirs verbatim; on a first-time provision (no `.adapter-generated` sentinel) the gated prune can't run, so a stale managed `slipway-*` skill would persist. Fix: exclude slipway-owned skill directories from the copy by naming convention — the generator is their sole author.
- **doc.** Corrected the false claim that surfaces are regenerated "from the worktree's own source"; `Generate` renders from the running binary's embedded templates.

## Follow-up review nits (commit `68dce79`)

A second independent review returned a **pass** with two fail-closed nits, fixed here:

- **create-path bind ordering.** `PersistScopeWorktreeMetadata` ran *before* provisioning, so a failed provision left `change.yaml` pointing at a half-provisioned worktree. Reordered to **provision, then persist** — a failed create now records no binding, and a retry takes the idempotent reuse branch (the worktree git already created is registered) and re-provisions. The reuse branch keeps persist-before-validate because its worktree validation reads the persisted metadata. The create fail-closed test now asserts `change.WorktreePath` stays empty on provision failure.
- **`toolgen` TestMain hardening.** If the `CODEX_HOME` sandbox couldn't be created, `TestMain` ran on with `CODEX_HOME` unset — reopening the exact escape hatch the guard exists to close. It now `os.Exit(1)`s instead of running degraded.

## CI fix (commit `1f2c030`)

gosec `v2.27.1` flags **G703** (path-traversal taint) on the `os.WriteFile(dstPath, …)` provisioning write; the line already had `#nosec G306`, but G703 is a separate rule. Extended the inline annotation to `#nosec G306 G703` with a concrete justification — `dstPath` is `filepath.Join(worktreeRoot, toolRel, rel)` where `rel` comes from `filepath.Rel` against the walked source tree (so it never contains `..`), keeping the write within the worktree's host-adapter surface. No code change, no config weakening, no blanket suppression.

## Scope note — follow-up #209

Already-bound worktrees are **not** backfilled on hydrate, and the engine preflight-bind path (`ApplyWorktreeMetadata`) does not provision — it fires only in a narrow edge (`auto_provision_worktree` disabled **and** the change needs discovery **and** an external worktree is supplied). This is an intentional out-of-scope follow-up: REQ-001 covers only worktrees Slipway *creates*. Tracked in #209.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt` clean
- `go test ./...` — all green (incl. `internal/architecture` dependency-direction guard)
- gosec `v2.27.1` (same invocation as CI) — 0 findings
- New regression tests: `…_DoesNotMutateCodexHome` (asserts `CODEX_HOME/prompts` stays empty), `…_DropsStaleManagedSlipwaySkill`, `…_CreateFailsClosedOnProvisionError` (asserts no binding persisted on failure)
- All PR CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
