### PR TITLE
fix(hook): make cross-worktree session handoff informational

### DIFF
--- a/artifacts/changes/archived/resolve-github-issue-212-make-session-start-handoff-treat-cr/assurance.md
+++ b/artifacts/changes/archived/resolve-github-issue-212-make-session-start-handoff-treat-cr/assurance.md
@@ -1,0 +1,68 @@
+# Assurance
+
+## Scope Summary
+
+Delivered GitHub issue #212 by changing the shared generated SessionStart hook
+template so a read-only `slipway next --json` result with
+`change_bound_to_other_worktree` is rendered as informational handoff context
+instead of `hook_diagnostic: slipway next --json failed`.
+
+The informational line names the active change, its bound worktree, and the
+action hint to `cd` there or use `--change`. Explicit lifecycle commands remain
+fail-closed from the wrong worktree; no generated host copy was hand-edited.
+
+## Verification Verdict
+
+Current execution evidence is fresh at `run_summary_version: 1`.
+
+- `wave-orchestration`: pass
+- `spec-compliance-review`: pass
+- `code-quality-review`: pass
+- Task evidence: `t-01` through `t-04` pass
+- Scope contract: pass
+
+Fresh verification commands passed:
+
+- `bash -n internal/tmpl/templates/hooks/session-start.sh.tmpl`
+- `go test -count=1 ./internal/tmpl ./internal/toolgen ./cmd`
+
+## Evidence Index
+
+- `verification/execution-summary.yaml`: run summary version 1, all planned tasks pass.
+- `verification/wave-orchestration.yaml`: wave execution evidence with `dispatch_mode:wave=1:degraded_sequential`.
+- `verification/wave-orchestration-notes.md`: implementation root cause, changed-file conflict check, and verification commands.
+- `verification/spec-compliance-review.yaml`: `layer:R0=pass`, `scope_contract:pass`, `negative_path:pass`, `decision_fidelity:pass`.
+- `verification/spec-compliance-review-notes.md`: bidirectional requirements-to-code trace.
+- `verification/code-quality-review.yaml`: `layer:IR1=pass`, `toolchain_compat:pass`.
+- `verification/code-quality-review-notes.md`: implementation quality, test quality, safety, and generated-surface compatibility review.
+
+## Requirement Coverage
+
+- REQ-001: Covered by `internal/tmpl/templates/hooks/session-start.sh.tmpl` and `TestSessionStartHookTreatsBoundWorktreeChangeAsInformational`.
+- REQ-002: Covered by unchanged shared active-change resolution plus `TestResolveActiveChangeRefReportsBoundElsewhereFromRoot`, `TestNextChangeFlagFromRootTargetsBoundWorktree`, and `TestRunFromRootReportsBoundElsewhere`.
+- REQ-003: Covered by the preserved diagnostic branch plus `TestSessionStartHookSurfacesNextFailureDiagnostic` and `TestSessionStartHookSurfacesRootFailureDiagnostic`.
+- REQ-004: Covered by the shared template change, `renderSessionHook`, `TestRenderSessionStartHookTemplate`, adapter contract tests, and `go test ./internal/toolgen`.
+
+## Residual Risks and Exceptions
+
+- The hook uses narrow shell parsing of Slipway's own structured JSON error envelope. This is accepted because it only classifies one stable `error_code`, requires both `slug` and `worktree_path`, and falls back to diagnostics for unrelated or incomplete output.
+- No dependency, manifest, lockfile, external API, schema, auth, secret, or network behavior changed.
+- Wave 1 was planned as parallel but executed as degraded sequential because subagent spawning requires an explicit user request. This is recorded in wave evidence and introduced no changed-file overlap.
+
+## Rollback Readiness
+
+Rollback is a normal source revert of the shared SessionStart hook template and
+the focused tests. No migration, generated copy cleanup, dependency downgrade,
+or external coordination is required.
+
+Rollback verification should run:
+
+- `bash -n internal/tmpl/templates/hooks/session-start.sh.tmpl`
+- `go test -count=1 ./internal/tmpl ./internal/toolgen ./cmd`
+
+## Archive Decision
+
+Ready to proceed toward done-ready after active `validate --json` and lifecycle
+readiness proof are captured in the active worktree. The active bundle has not
+been archived yet, and this assurance does not claim archived-bundle
+revalidation.

--- a/artifacts/changes/archived/resolve-github-issue-212-make-session-start-handoff-treat-cr/change.yaml
+++ b/artifacts/changes/archived/resolve-github-issue-212-make-session-start-handoff-treat-cr/change.yaml
@@ -1,0 +1,60 @@
+version: 1
+slug: resolve-github-issue-212-make-session-start-handoff-treat-cr
+description: 'Resolve GitHub issue #212: make session-start handoff treat cross-worktree active changes as informational'
+status: done
+current_state: DONE
+needs_discovery: true
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-06-14T11:45:13.557864Z
+quality_mode: standard
+workflow_profile: code
+workflow_preset: standard
+worktree_branch: feat/resolve-github-issue-212-make-session-start-handoff-treat-cr
+artifact_schema: expanded
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: d2e64289564f463ddbe178d22aa9c6f13a0366cf733bcc9ea310d7638ab34773
+        updated_at: 2026-06-14T12:20:31.705077091Z
+    decision:
+        id: decision
+        path: decision.md
+        state: frozen
+        content_hash: 4029c2b3bb3789e87300059871d5916c604fc812c2f2498ab01f553101ecd28d
+        updated_at: 2026-06-14T11:57:03.734878382Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: 8b98a80ea4817923e1b75151f57a3e86d0a328a5fd5274722e1f424901c992ef
+        updated_at: 2026-06-14T11:53:31.671754396Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: c07ec30865233e3b1ec2a961cf9dff4621594e3ea5c8c5b58ea2add77bdfda69
+        updated_at: 2026-06-14T11:57:03.734741628Z
+    research:
+        id: research
+        path: research.md
+        state: frozen
+        content_hash: 6f17d28a928f20abf1dcfcbeca26613ae16496cea291f1a6be2bab576ed89aea
+        updated_at: 2026-06-14T11:56:02.490508229Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: 0c4c9d3e5188b83ccea324f5eaa5b9c865c893002efa277adcd54547aa038017
+        updated_at: 2026-06-14T12:07:04.835856542Z
+evidence_refs:
+    code-quality-review: .worktrees/resolve-github-issue-212-make-session-start-handoff-treat-cr/artifacts/changes/resolve-github-issue-212-make-session-start-handoff-treat-cr/verification/code-quality-review.yaml
+    final-closeout: .worktrees/resolve-github-issue-212-make-session-start-handoff-treat-cr/artifacts/changes/resolve-github-issue-212-make-session-start-handoff-treat-cr/verification/final-closeout.yaml
+    goal-verification: .worktrees/resolve-github-issue-212-make-session-start-handoff-treat-cr/artifacts/changes/resolve-github-issue-212-make-session-start-handoff-treat-cr/verification/goal-verification.yaml
+    intake-clarification: .worktrees/resolve-github-issue-212-make-session-start-handoff-treat-cr/artifacts/changes/resolve-github-issue-212-make-session-start-handoff-treat-cr/verification/intake-clarification.yaml
+    plan-audit: .worktrees/resolve-github-issue-212-make-session-start-handoff-treat-cr/artifacts/changes/resolve-github-issue-212-make-session-start-handoff-treat-cr/verification/plan-audit.yaml
+    research-orchestration: .worktrees/resolve-github-issue-212-make-session-start-handoff-treat-cr/artifacts/changes/resolve-github-issue-212-make-session-start-handoff-treat-cr/verification/research-orchestration.yaml
+    spec-compliance-review: .worktrees/resolve-github-issue-212-make-session-start-handoff-treat-cr/artifacts/changes/resolve-github-issue-212-make-session-start-handoff-treat-cr/verification/spec-compliance-review.yaml
+    wave-orchestration: .worktrees/resolve-github-issue-212-make-session-start-handoff-treat-cr/artifacts/changes/resolve-github-issue-212-make-session-start-handoff-treat-cr/verification/wave-orchestration.yaml

--- a/artifacts/changes/archived/resolve-github-issue-212-make-session-start-handoff-treat-cr/decision.md
+++ b/artifacts/changes/archived/resolve-github-issue-212-make-session-start-handoff-treat-cr/decision.md
@@ -1,0 +1,45 @@
+# Decision
+
+## Alternatives Considered
+
+1. Classify `change_bound_to_other_worktree` inside the shared SessionStart hook template and render an informational handoff line.
+   - Pros: smallest blast radius, covers all generated hook hosts through one template, preserves explicit command fail-closed behavior, and matches the confirmed issue scope.
+   - Cons: requires narrow shell-side parsing of the structured JSON error envelope.
+2. Add a new handoff-only CLI command or flag that returns a non-error local-handoff envelope and call that from the hook.
+   - Pros: cleaner long-term API boundary and less shell parsing.
+   - Cons: larger CLI surface and tests for a narrowly scoped defect; risks expanding this issue into lifecycle API design.
+3. Change `slipway next --json` itself to succeed when the active change is bound elsewhere.
+   - Pros: hook becomes simpler.
+   - Cons: directly violates the acceptance criterion that explicit `next` / `run` remain fail-closed from the wrong worktree.
+
+## Selected Approach
+
+Use alternative 1. The shared SessionStart hook template will classify only the structured `change_bound_to_other_worktree` error emitted by `slipway next --json` and convert that case into a compact informational line. All other `next --json` failures remain hook diagnostics.
+
+This keeps the lifecycle command contract unchanged while fixing the read-only handoff framing at the generated surface that every hook host shares.
+
+## Interfaces and Data Flow
+
+- Input stays the existing `slipway next --json` command executed by the hook from `hook_cwd`.
+- On success, the hook continues to pass through `next_json` unchanged.
+- On failure, the hook checks whether the output contains the structured `change_bound_to_other_worktree` envelope and a `bound_changes` entry.
+- For that single case, the hook writes an informational field such as `session_handoff_info: no active change in this worktree; active change <slug> is bound to <path>; cd there or use --change <slug> to act`.
+- For every other failure, the hook preserves the existing `hook_diagnostic: slipway next --json failed:` behavior.
+- No Go command interface changes are required. `resolveActiveChangeRef` remains the command-level authority for fail-closed behavior.
+
+## Rollout and Rollback
+
+Rollout is covered by updating the shared template and tests. Generated host copies are not hand-edited.
+
+Rollback is a normal source revert of the shared template and tests. Verification command for rollback or implementation is:
+
+```bash
+go test ./internal/tmpl ./cmd
+```
+
+## Risk
+
+- Shell parsing risk: the hook must avoid pretending to be a full JSON parser. Mitigation: classify only the stable `error_code` and simple `bound_changes` fields used in the existing error envelope.
+- Hidden-failure risk: the hook must not suppress unrelated errors. Mitigation: tests keep an unrelated `next --json` failure as `hook_diagnostic`.
+- Host drift risk: hand-editing generated copies would diverge. Mitigation: edit only `internal/tmpl/templates/hooks/session-start.sh.tmpl` and verify rendered template behavior.
+- Command regression risk: explicit `run` / `next` could accidentally be relaxed. Mitigation: command tests pin `change_bound_to_other_worktree` resolution.

--- a/artifacts/changes/archived/resolve-github-issue-212-make-session-start-handoff-treat-cr/intent.md
+++ b/artifacts/changes/archived/resolve-github-issue-212-make-session-start-handoff-treat-cr/intent.md
@@ -1,0 +1,57 @@
+# Intent
+
+## Summary
+Resolve GitHub issue #212: make SessionStart handoff treat a cross-worktree active governed change as informational context instead of an error-shaped hook diagnostic.
+
+## Complexity Assessment
+complex
+Rationale: the user-visible defect is narrow, but the fix touches generated hook behavior, cross-worktree lifecycle framing, and tests that must preserve explicit `next` / `run` fail-closed semantics.
+
+## Guardrail Domains
+None detected.
+
+## In Scope
+- Update the generated SessionStart hook surface, primarily `internal/tmpl/templates/hooks/session-start.sh.tmpl`, so `change_bound_to_other_worktree` from read-only handoff is rendered as informational context.
+- Ensure the informational handoff names the other active change, its bound worktree, and how to act from the right place or with `--change`.
+- Keep generated behavior identical for claude, cursor, gemini, and opencode by fixing the shared hook template rather than host-specific shell copies.
+- Add focused tests for the cross-worktree informational path and for preserving diagnostics on genuine failures.
+- Preserve explicit `slipway next` and `slipway run` command behavior: wrong-worktree invocations still fail closed with `change_bound_to_other_worktree` / exit 3.
+
+## Out of Scope
+- Redesigning the global active-change model or multi-active lifecycle semantics.
+- Making explicit lifecycle mutation/query commands silently succeed from the wrong worktree.
+- Adding one-off per-host hook workarounds outside the shared generated template surface.
+- Changing unrelated handoff, context-pressure, or governance evidence behavior.
+
+## Constraints
+- SessionStart remains read-only and must not advance or mutate governed state.
+- Real failures such as `slipway root` failure or broken `next --json` output must still render `hook_diagnostic` lines.
+- The fix should follow the repo's self-optimization principle by improving the owned generated surface.
+- Tests should cover the shell hook behavior without depending on a fragile live workspace layout.
+
+## Acceptance Signals
+- A rendered SessionStart hook receiving `change_bound_to_other_worktree` emits an informational line that includes the active change slug, bound worktree, and action hint, with no `hook_diagnostic: slipway next --json failed:` line.
+- A rendered SessionStart hook still emits `hook_diagnostic` for genuine `slipway root` or unrelated `slipway next --json` failures.
+- Explicit `slipway next --json` and `slipway run --json` from the wrong worktree continue to fail closed with `change_bound_to_other_worktree` and exit 3.
+- Template/tool generation tests demonstrate the shared behavior across generated hook hosts.
+
+## Open Questions
+None.
+
+## Deferred Ideas
+- A future structured handoff-only CLI API could make hooks less dependent on parsing `next --json` error envelopes, but this change should not expand into that redesign unless implementation research shows it is necessary.
+
+## Approved Summary
+Confirmed by user on 2026-06-14T11:53:16Z.
+
+Resolve GitHub issue #212 by changing the shared generated SessionStart hook
+handoff so `change_bound_to_other_worktree` from the read-only handoff path is
+rendered as informational context rather than `hook_diagnostic: slipway next
+--json failed`. The informational line must name the other active change, its
+bound worktree, and how to act from the right place or with `--change`.
+
+Scope is limited to the shared generated hook surface and focused tests for the
+cross-worktree informational path, genuine failure diagnostics, generated host
+parity, and explicit command fail-closed behavior. This change will not redesign
+the global active-change model, make explicit `next` / `run` succeed from the
+wrong worktree, or add per-host shell workarounds.

--- a/artifacts/changes/archived/resolve-github-issue-212-make-session-start-handoff-treat-cr/requirements.md
+++ b/artifacts/changes/archived/resolve-github-issue-212-make-session-start-handoff-treat-cr/requirements.md
@@ -1,0 +1,44 @@
+# Requirements
+
+## Requirements
+
+### Requirement: Cross-worktree handoff is informational
+REQ-001: The generated SessionStart hook MUST render `change_bound_to_other_worktree` from its read-only `slipway next --json` handoff as informational context rather than a failed hook diagnostic.
+
+#### Scenario: Active change bound elsewhere
+GIVEN a SessionStart hook runs from a worktree with no locally bound active governed change
+AND `slipway next --json` exits non-zero with `error_code` equal to `change_bound_to_other_worktree`
+WHEN the hook renders its handoff payload
+THEN the output contains an informational line naming the other active change and its bound worktree
+AND the output does not contain `hook_diagnostic: slipway next --json failed:`.
+
+### Requirement: Explicit lifecycle commands remain fail-closed
+REQ-002: Explicit `slipway next` and `slipway run` invocations from the wrong worktree SHALL continue to fail closed with `change_bound_to_other_worktree` and exit 3 semantics.
+
+#### Scenario: Wrong-worktree command invocation
+GIVEN an active governed change is bound to another worktree
+WHEN an explicit lifecycle command resolves the active change from the current worktree without `--change`
+THEN the command fails with `change_bound_to_other_worktree`
+AND the remediation includes the change slug, bound worktree, and `--change` guidance.
+
+### Requirement: Real hook failures remain diagnostics
+REQ-003: The generated SessionStart hook MUST continue to surface genuine failures as `hook_diagnostic` lines.
+
+#### Scenario: Broken next contract
+GIVEN `slipway next --json` fails with an unrelated error
+WHEN the SessionStart hook renders its payload
+THEN the output includes `hook_diagnostic: slipway next --json failed:`.
+
+#### Scenario: Root resolution failure
+GIVEN `slipway root` fails
+WHEN the SessionStart hook renders its payload
+THEN the output includes `hook_diagnostic: slipway root failed:`.
+
+### Requirement: Generated host parity
+REQ-004: The behavior SHALL be implemented through the shared generated hook template so claude, cursor, gemini, and opencode receive identical SessionStart handoff semantics.
+
+#### Scenario: Shared template generation
+GIVEN the tool generation registry maps host SessionStart hooks to the shared template
+WHEN the hook template is rendered
+THEN the cross-worktree informational classifier is present in the rendered template
+AND no per-host generated hook copy is required to implement the behavior.

--- a/artifacts/changes/archived/resolve-github-issue-212-make-session-start-handoff-treat-cr/research.md
+++ b/artifacts/changes/archived/resolve-github-issue-212-make-session-start-handoff-treat-cr/research.md
@@ -1,0 +1,71 @@
+# Research
+
+## Alternatives Considered
+
+### Architecture
+- Affected modules: `internal/tmpl/templates/hooks/session-start.sh.tmpl` is the shared generated SessionStart hook template. It currently calls `slipway next --json` read-only and treats any non-zero result as `hook_diagnostic: slipway next --json failed` (`internal/tmpl/templates/hooks/session-start.sh.tmpl:37-53`).
+- Dependency chain: `toolgen.ToolConfig.SessionHook` maps the same SessionStart hook template into `.claude/hooks/slipway-session-start.sh`, `.cursor/hooks/slipway-session-start.sh`, `.gemini/hooks/slipway-session-start.sh`, and `.opencode/hooks/slipway-session-start.sh` (`internal/toolgen/toolgen.go:45-124`).
+- Command error source: wrong-worktree active-change resolution is intentionally produced by `wrapResolutionError`, which emits `error_code=change_bound_to_other_worktree`, `details.bound_changes[]`, and remediation with `--change` / `cd` guidance (`cmd/common.go:546-571`).
+- Explicit command callers: `run` resolves the active change before mutation or advancement, so preserving `resolveActiveChangeRef` behavior preserves fail-closed command semantics (`cmd/run.go:35-38`).
+- Blast radius: shared hook template rendering and hook behavior tests. The explicit command behavior should be pinned, not redesigned.
+- Constraints: SessionStart must remain read-only; genuine root/next failures must still surface as diagnostics; generated host parity comes from the shared template, not checked-in per-host generated copies.
+
+### Patterns
+- Existing hook pattern: `run_slipway_readonly` captures command output/status and keeps hook execution non-fatal to the shell (`internal/tmpl/templates/hooks/session-start.sh.tmpl:37-46`).
+- Existing diagnostics pattern: root failures are normalized into `hook_diagnostic` while preserving compact output (`internal/tmpl/templates/hooks/session-start.sh.tmpl:12-23`).
+- Existing test pattern: `internal/tmpl/hooks_behavior_test.go` renders the template, injects a fake `slipway` executable, and asserts observable shell output and delegated commands (`internal/tmpl/hooks_behavior_test.go:176-254`).
+- Existing command-level baseline: `cmd/active_change_resolution_test.go` already verifies `change_bound_to_other_worktree` includes slug, worktree path, and `--change` remediation for root invocations (`cmd/active_change_resolution_test.go:16-39`).
+- Codebase map relevance: `artifacts/codebase/ARCHITECTURE.md`, `TESTING.md`, and `CONCERNS.md` are populated for issue #203, not this hook issue, so they are stale for planning authority and only useful as a warning that populated map status does not imply relevance.
+
+### Risks
+- Technical risks:
+  - Medium: parsing JSON in portable shell can become brittle. Keep classification narrow to `error_code=change_bound_to_other_worktree` and use the existing structured error envelope fields.
+  - Medium: suppressing too much could hide real `next --json` failures. Only this one known precondition error should become informational; all other failures remain `hook_diagnostic`.
+  - Low: output length could grow. Keep the informational line compact and re-run the existing payload-size assertion.
+  - Low: generated host drift. Fixing the shared template should cover all generated hosts; tests should assert the template contains the classifier/rendering path.
+- Guardrail domains: none. This is a read-only developer workflow surface.
+- Reversibility: high. The change is confined to generated hook template behavior and tests.
+
+### Test Strategy
+- Existing coverage:
+  - `TestSessionStartHookSurfacesNextFailureDiagnostic` verifies unrelated `next --json` failure remains a diagnostic (`internal/tmpl/hooks_behavior_test.go:176-211`).
+  - `TestSessionStartHookSetsToolEnvForReadOnlyCommands` verifies successful `next --json` output is passed through, remains compact, and does not call status/hook-lite/preview variants (`internal/tmpl/hooks_behavior_test.go:213-254`).
+  - `TestRenderSessionStartHookTemplate` verifies template rendering and guards against retired command variants (`internal/tmpl/templates_test.go:365-379`).
+  - `TestResolveActiveChangeRefReportsBoundElsewhereFromRoot` verifies explicit active-change resolution remains fail-closed for bound worktrees (`cmd/active_change_resolution_test.go:16-39`).
+- Infrastructure needs: no live multi-worktree fixture is required for hook behavior; a fake `slipway` executable can return the exact JSON error envelope.
+- Verification approach:
+  - Add a hook behavior regression where fake `slipway next --json` exits 3 with `change_bound_to_other_worktree`; assert an informational line names slug/worktree/action and no failed diagnostic appears.
+  - Keep the unrelated failure diagnostic test unchanged or strengthened.
+  - Add or extend command-level coverage so explicit `run` from the wrong worktree still returns `change_bound_to_other_worktree`.
+  - Run focused `go test ./internal/tmpl ./cmd` and broaden before closeout.
+
+### Options
+- Option A: shared hook template classifies the existing structured `change_bound_to_other_worktree` error and renders informational handoff text.
+  - Tradeoffs: smallest change, preserves command semantics, covers all hook hosts through the shared generated template. It relies on narrow shell parsing but avoids new CLI surface area.
+- Option B: add a new handoff-only CLI flag/command that returns a non-error `no_local_active_change` envelope, then call that from the hook.
+  - Tradeoffs: strongest product boundary and avoids shell-side error classification, but expands CLI API and test surface beyond the issue's immediate defect.
+- Option C: alter `slipway next --json` itself to return success when active changes are bound elsewhere.
+  - Tradeoffs: simple for the hook, but violates explicit command fail-closed acceptance criteria and is rejected.
+- Selected: Option A, aligned with the user's confirmed issue scope. It fixes the owned shared generated surface, preserves explicit `next` / `run` behavior, and keeps the change reversible.
+
+## Unknowns
+- Resolved: Is the populated codebase map relevant to this issue? -> No. It is re-authored for issue #203, so this research uses source/test citations as planning authority.
+- Resolved: Does generated host parity require editing each checked-in host copy? -> No. `toolgen.ToolConfig` points claude/cursor/gemini/opencode at the same generated SessionStart hook template.
+- Remaining: None.
+
+## Assumptions
+- The fake-hook test can stand in for a live cross-worktree setup because the issue is about the hook's classification of the structured `next --json` error envelope, not the store's worktree discovery itself. Evidence: existing hook behavior tests already use fake `slipway` scripts for hook-output contracts.
+- The existing command-level active-change resolution path is authoritative for explicit `next` and `run` fail-closed semantics. Evidence: `cmd/common.go:546-571`, `cmd/run.go:35-38`, and `cmd/active_change_resolution_test.go:16-39`.
+
+## Canonical References
+- `https://github.com/signalridge/slipway/issues/212`
+- `internal/tmpl/templates/hooks/session-start.sh.tmpl:37`
+- `internal/tmpl/templates/hooks/session-start.sh.tmpl:49`
+- `internal/tmpl/templates/hooks/session-start.sh.tmpl:52`
+- `internal/tmpl/hooks_behavior_test.go:176`
+- `internal/tmpl/hooks_behavior_test.go:213`
+- `internal/tmpl/templates_test.go:365`
+- `internal/toolgen/toolgen.go:45`
+- `cmd/common.go:546`
+- `cmd/run.go:35`
+- `cmd/active_change_resolution_test.go:16`

--- a/artifacts/changes/archived/resolve-github-issue-212-make-session-start-handoff-treat-cr/tasks.md
+++ b/artifacts/changes/archived/resolve-github-issue-212-make-session-start-handoff-treat-cr/tasks.md
@@ -1,0 +1,27 @@
+# Tasks
+
+## Task List
+
+- [x] `t-01` Update shared SessionStart hook template to render cross-worktree active changes as informational handoff context.
+  - depends_on: []
+  - target_files: [internal/tmpl/templates/hooks/session-start.sh.tmpl]
+  - task_kind: code
+  - covers: [REQ-001, REQ-003, REQ-004]
+
+- [x] `t-02` Add hook behavior regressions for cross-worktree informational output and preserved diagnostics.
+  - depends_on: [t-01]
+  - target_files: [internal/tmpl/hooks_behavior_test.go, internal/tmpl/templates_test.go]
+  - task_kind: test
+  - covers: [REQ-001, REQ-003, REQ-004]
+
+- [x] `t-03` Pin explicit command fail-closed behavior for wrong-worktree `run` / `next` active-change resolution.
+  - depends_on: []
+  - target_files: [cmd/active_change_resolution_test.go]
+  - task_kind: test
+  - covers: [REQ-002]
+
+- [x] `t-04` Run focused verification for hook rendering and command fail-closed behavior.
+  - depends_on: [t-02, t-03]
+  - target_files: [artifacts/changes/resolve-github-issue-212-make-session-start-handoff-treat-cr/verification/wave-orchestration-notes.md]
+  - task_kind: verification
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004]

--- a/cmd/active_change_resolution_test.go
+++ b/cmd/active_change_resolution_test.go
@@ -86,8 +86,10 @@ func TestRunFromRootReportsBoundElsewhere(t *testing.T) {
 
 		cliErr := asCLIError(err)
 		require.NotNil(t, cliErr)
+		normalizedWorktreePath, normalizeErr := state.NormalizePath(worktreePath)
+		require.NoError(t, normalizeErr)
 		assert.Equal(t, "change_bound_to_other_worktree", cliErr.ErrorCode)
 		assert.Contains(t, cliErr.Remediation, "--change run-bound-change")
-		assert.Contains(t, cliErr.Remediation, worktreePath)
+		assert.Contains(t, cliErr.Remediation, normalizedWorktreePath)
 	})
 }

--- a/cmd/active_change_resolution_test.go
+++ b/cmd/active_change_resolution_test.go
@@ -67,3 +67,27 @@ func TestNextChangeFlagFromRootTargetsBoundWorktree(t *testing.T) {
 		assert.Equal(t, "next-bound-change", view.Slug)
 	})
 }
+
+func TestRunFromRootReportsBoundElsewhere(t *testing.T) {
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		initGitRepoForWorktreeTests(t, root)
+
+		worktreePath := filepath.Join(t.TempDir(), "run-bound-worktree")
+		runGit(t, root, "worktree", "add", worktreePath, "-b", "run-bound-worktree")
+		change := model.NewChange("run-bound-change")
+		change.WorktreePath = worktreePath
+		require.NoError(t, state.SaveChange(root, change))
+
+		cmd := commandForRoot(t, root, makeRunCmd())
+		cmd.SetArgs([]string{"--json"})
+		err := cmd.Execute()
+
+		cliErr := asCLIError(err)
+		require.NotNil(t, cliErr)
+		assert.Equal(t, "change_bound_to_other_worktree", cliErr.ErrorCode)
+		assert.Contains(t, cliErr.Remediation, "--change run-bound-change")
+		assert.Contains(t, cliErr.Remediation, worktreePath)
+	})
+}

--- a/internal/tmpl/hooks_behavior_test.go
+++ b/internal/tmpl/hooks_behavior_test.go
@@ -210,6 +210,48 @@ printf '%%s|%%s\n' "$PWD" "$*" >> "${SLIPWAY_HOOK_LOG}"
 	assert.Contains(t, string(out), "hook_diagnostic: slipway next --json failed: next contract broke")
 }
 
+func TestSessionStartHookTreatsBoundWorktreeChangeAsInformational(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, initHookGitRepo(root))
+	writeHookProjectConfig(t, root)
+	writeHookSharedScopeMarker(t, root, "")
+	boundWorktree := filepath.Join(root, ".worktrees", "bound-change")
+
+	logPath, binDir := installHookTestSlipwayScript(t, root, fmt.Sprintf(`#!/usr/bin/env bash
+set -euo pipefail
+printf '%%s|%%s\n' "$PWD" "$*" >> "${SLIPWAY_HOOK_LOG}"
+case "$*" in
+  "root")
+    printf '%%s\n' %q
+    ;;
+  "next --json")
+    printf '{"error_code":"change_bound_to_other_worktree","category":"precondition_blocked","message":"active change is bound to another worktree: bound-change at %s","remediation":"Use --change bound-change, or cd into %s.","exit_code":3,"details":{"bound_changes":[{"slug":"bound-change","worktree_path":"%s"}]}}'
+    exit 3
+    ;;
+esac
+`, root, boundWorktree, boundWorktree, boundWorktree))
+	scriptPath := writeRenderedHook(t, root, "hooks/session-start.sh.tmpl", map[string]string{
+		"ToolID": "claude",
+	})
+
+	cmd := exec.Command("bash", scriptPath)
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"SLIPWAY_HOOK_LOG="+logPath,
+	)
+	out, err := cmd.Output()
+	require.NoError(t, err)
+
+	output := string(out)
+	assert.Contains(t, output, "session_handoff_info: no active change in this worktree")
+	assert.Contains(t, output, "active change bound-change is bound to "+boundWorktree)
+	assert.Contains(t, output, "use --change bound-change to act")
+	assert.NotContains(t, output, "hook_diagnostic: slipway next --json failed:")
+}
+
 func TestSessionStartHookSetsToolEnvForReadOnlyCommands(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tmpl/hooks_behavior_test.go
+++ b/internal/tmpl/hooks_behavior_test.go
@@ -1,6 +1,7 @@
 package tmpl
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -218,6 +219,21 @@ func TestSessionStartHookTreatsBoundWorktreeChangeAsInformational(t *testing.T) 
 	writeHookProjectConfig(t, root)
 	writeHookSharedScopeMarker(t, root, "")
 	boundWorktree := filepath.Join(root, ".worktrees", "bound-change")
+	nextPayload := map[string]any{
+		"error_code":  "change_bound_to_other_worktree",
+		"category":    "precondition_blocked",
+		"message":     "active change is bound to another worktree: bound-change at " + boundWorktree,
+		"remediation": "Use --change bound-change, or cd into " + boundWorktree + ".",
+		"exit_code":   3,
+		"details": map[string]any{
+			"bound_changes": []map[string]string{{
+				"slug":          "bound-change",
+				"worktree_path": boundWorktree,
+			}},
+		},
+	}
+	nextJSON, err := json.Marshal(nextPayload)
+	require.NoError(t, err)
 
 	logPath, binDir := installHookTestSlipwayScript(t, root, fmt.Sprintf(`#!/usr/bin/env bash
 set -euo pipefail
@@ -227,11 +243,13 @@ case "$*" in
     printf '%%s\n' %q
     ;;
   "next --json")
-    printf '{"error_code":"change_bound_to_other_worktree","category":"precondition_blocked","message":"active change is bound to another worktree: bound-change at %s","remediation":"Use --change bound-change, or cd into %s.","exit_code":3,"details":{"bound_changes":[{"slug":"bound-change","worktree_path":"%s"}]}}'
+    cat <<'SLIPWAY_NEXT_JSON'
+%s
+SLIPWAY_NEXT_JSON
     exit 3
     ;;
 esac
-`, root, boundWorktree, boundWorktree, boundWorktree))
+`, root, string(nextJSON)))
 	scriptPath := writeRenderedHook(t, root, "hooks/session-start.sh.tmpl", map[string]string{
 		"ToolID": "claude",
 	})

--- a/internal/tmpl/templates/hooks/session-start.sh.tmpl
+++ b/internal/tmpl/templates/hooks/session-start.sh.tmpl
@@ -13,6 +13,30 @@ normalize_hook_message() {
   printf '%s' "$1" | tr '\r\n' ' ' | sed -e 's/[[:space:]][[:space:]]*/ /g' -e 's/^ //' -e 's/ $//'
 }
 
+extract_json_string_field() {
+  local input="$1"
+  local field="$2"
+  printf '%s' "${input}" | sed -nE 's/.*"'"${field}"'"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' | head -n 1
+}
+
+format_bound_worktree_handoff() {
+  local output
+  local normalized
+  local slug
+  local worktree_path
+  output="$1"
+  normalized="$(normalize_hook_message "${output}")"
+  if ! printf '%s' "${normalized}" | grep -q '"error_code"[[:space:]]*:[[:space:]]*"change_bound_to_other_worktree"'; then
+    return 1
+  fi
+  slug="$(extract_json_string_field "${normalized}" "slug")"
+  worktree_path="$(extract_json_string_field "${normalized}" "worktree_path")"
+  if [ -z "${slug}" ] || [ -z "${worktree_path}" ]; then
+    return 1
+  fi
+  printf 'session_handoff_info: no active change in this worktree; active change %s is bound to %s; cd there or use --change %s to act' "${slug}" "${worktree_path}" "${slug}"
+}
+
 diagnostics=()
 hook_cwd="$(pwd -P 2>/dev/null || pwd)"
 project_root=""
@@ -46,8 +70,11 @@ run_slipway_readonly() {
 }
 
 next_json=""
+handoff_info=""
 if next_output="$(run_slipway_readonly next --json)"; then
   next_json="${next_output}"
+elif handoff_info="$(format_bound_worktree_handoff "${next_output}")"; then
+  :
 else
   diagnostics+=("hook_diagnostic: slipway next --json failed: $(normalize_hook_message "${next_output}")")
 fi
@@ -93,7 +120,7 @@ if [ -n "${handoff_path}" ]; then
   handoff_summary="$(printf 'session_handoff_present: %s\nsession_handoff_path: %s' "${handoff_present}" "${handoff_path}")"
 fi
 
-if [ -z "${next_json}" ] && [ -z "${handoff_summary}" ] && [ -z "${diagnostics_text}" ]; then
+if [ -z "${next_json}" ] && [ -z "${handoff_info}" ] && [ -z "${handoff_summary}" ] && [ -z "${diagnostics_text}" ]; then
   exit 0
 fi
 
@@ -101,6 +128,7 @@ cat <<EOF
 <slipway-session-start tool="{{.ToolID}}">
 slipway_entry_skill: This repository is governed by Slipway. To drive any non-trivial change through the governed lifecycle, load the "{{.EntrySkill}}" skill — the entry point that routes new/next/run/done.
 ${next_json}
+${handoff_info}
 ${diagnostics_text}
 ${handoff_summary}
 </slipway-session-start>

--- a/internal/tmpl/templates/hooks/session-start.sh.tmpl
+++ b/internal/tmpl/templates/hooks/session-start.sh.tmpl
@@ -19,6 +19,10 @@ extract_json_string_field() {
   printf '%s' "${input}" | sed -nE 's/.*"'"${field}"'"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' | head -n 1
 }
 
+unescape_json_string() {
+  printf '%s' "$1" | sed -e 's/\\"/"/g' -e 's/\\\\/\\/g'
+}
+
 format_bound_worktree_handoff() {
   local output
   local normalized
@@ -31,6 +35,8 @@ format_bound_worktree_handoff() {
   fi
   slug="$(extract_json_string_field "${normalized}" "slug")"
   worktree_path="$(extract_json_string_field "${normalized}" "worktree_path")"
+  slug="$(unescape_json_string "${slug}")"
+  worktree_path="$(unescape_json_string "${worktree_path}")"
   if [ -z "${slug}" ] || [ -z "${worktree_path}" ]; then
     return 1
   fi

--- a/internal/tmpl/templates_test.go
+++ b/internal/tmpl/templates_test.go
@@ -369,9 +369,11 @@ func TestRenderSessionStartHookTemplate(t *testing.T) {
 	}
 	content, err := Render("hooks/session-start.sh.tmpl", data)
 	require.NoError(t, err, "failed to render session-start.sh.tmpl")
-	assert.LessOrEqual(t, len([]byte(content)), 4500, "session-start hook template must stay compact")
+	assert.LessOrEqual(t, len([]byte(content)), 5600, "session-start hook template must stay compact")
 	assert.NotContains(t, content, "{{.", "session-start hook has unrendered template vars")
 	assert.Contains(t, content, "slipway next --json")
+	assert.Contains(t, content, "change_bound_to_other_worktree")
+	assert.Contains(t, content, "session_handoff_info")
 	assert.NotContains(t, content, "--hook-lite")
 	assert.NotContains(t, content, "slipway status --json")
 	assert.Contains(t, content, `cd "${hook_cwd}" && slipway "$@"`)


### PR DESCRIPTION
## Summary

- Treat `change_bound_to_other_worktree` from the read-only SessionStart `slipway next --json` handoff as informational context instead of a failed hook diagnostic.
- Keep unrelated `next --json` failures and `slipway root` failures surfaced as `hook_diagnostic` lines.
- Preserve explicit lifecycle command fail-closed behavior for wrong-worktree `next` / `run` invocations.
- Archive the governed change bundle for issue #212.

## Root Cause

The SessionStart hook reused `slipway next --json` as a read-only handoff source. That command correctly fails closed when the workspace-global active change is bound to another worktree, but the hook rendered that expected cross-worktree state as `hook_diagnostic: slipway next --json failed`, which made an unrelated worktree look broken.

## Validation

- `go run . validate --json`
- `go run . done --json`
- `bash -n internal/tmpl/templates/hooks/session-start.sh.tmpl`
- `git diff --check`
- `go test -count=1 ./internal/tmpl ./internal/toolgen ./cmd`

Closes #212.