### PR TITLE
fix(governance): surface scope-contract codebase-map exemption + drop rejected run_summary_version=0 (#207, #211)

### DIFF
--- a/artifacts/changes/archived/make-two-confirmed-downstream-reported-lattice-slipway-gover/change.yaml
+++ b/artifacts/changes/archived/make-two-confirmed-downstream-reported-lattice-slipway-gover/change.yaml
@@ -1,0 +1,38 @@
+version: 1
+slug: make-two-confirmed-downstream-reported-lattice-slipway-gover
+description: 'Make two confirmed downstream-reported (Lattice) Slipway governance-surface transparency gaps self-explaining, without changing underlying behavior. (1) Issue #207: scope_contract silently filters dirty artifacts/codebase/** files out of changed_files while reporting status=pass, so reviewers must infer the hidden exemption from a git-diff disagreement. Surface the codebase-map exemption explicitly in validate/status JSON output (and align docs/help) so the omission is visible rather than inferred; keep the exemption itself intact. (2) Issue #211: status --json exposes progress.run_summary_version=0 (a ''no execution summary yet'' sentinel) but slipway evidence task rejects 0 and requires >=1, so the visible value misleads task-evidence recording. Stop surfacing a value the evidence surface itself refuses and make the correct task-evidence run version unambiguous; keep the >=1 evidence rule intact. Both fixes are to Slipway''s own CLI/JSON/doc surfaces (external contracts consumed downstream); no change to scope-contract exemption behavior or the run-summary-version validation rule.'
+status: done
+current_state: DONE
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-06-14T13:21:55.839554Z
+quality_mode: standard
+workflow_preset: light
+worktree_branch: feat/make-two-confirmed-downstream-reported-lattice-slipway-gover
+artifact_schema: core
+artifacts:
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: 01ebb0bd3a4fa473238e650a74a9dc4817cc9b9a040e61059997a3003a28929a
+        updated_at: 2026-06-14T13:28:55.993993342Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: 10f7cb836c291319cd2b1dcc75a8091a741583ec6350fc577100ede4f5e96340
+        updated_at: 2026-06-14T13:32:29.161520219Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: 0efc7885d2bc0447ec789c3c1badc712dddf6a70958e2bae5729503dcfb98382
+        updated_at: 2026-06-14T14:39:18.720316398Z
+evidence_refs:
+    code-quality-review: .worktrees/make-two-confirmed-downstream-reported-lattice-slipway-gover/artifacts/changes/make-two-confirmed-downstream-reported-lattice-slipway-gover/verification/code-quality-review.yaml
+    goal-verification: .worktrees/make-two-confirmed-downstream-reported-lattice-slipway-gover/artifacts/changes/make-two-confirmed-downstream-reported-lattice-slipway-gover/verification/goal-verification.yaml
+    intake-clarification: .worktrees/make-two-confirmed-downstream-reported-lattice-slipway-gover/artifacts/changes/make-two-confirmed-downstream-reported-lattice-slipway-gover/verification/intake-clarification.yaml
+    plan-audit: .worktrees/make-two-confirmed-downstream-reported-lattice-slipway-gover/artifacts/changes/make-two-confirmed-downstream-reported-lattice-slipway-gover/verification/plan-audit.yaml
+    spec-compliance-review: .worktrees/make-two-confirmed-downstream-reported-lattice-slipway-gover/artifacts/changes/make-two-confirmed-downstream-reported-lattice-slipway-gover/verification/spec-compliance-review.yaml
+    wave-orchestration: .worktrees/make-two-confirmed-downstream-reported-lattice-slipway-gover/artifacts/changes/make-two-confirmed-downstream-reported-lattice-slipway-gover/verification/wave-orchestration.yaml

--- a/artifacts/changes/archived/make-two-confirmed-downstream-reported-lattice-slipway-gover/decision.md
+++ b/artifacts/changes/archived/make-two-confirmed-downstream-reported-lattice-slipway-gover/decision.md
@@ -1,0 +1,71 @@
+# Decision
+
+## Alternatives Considered
+1. **Structured field populated at the readiness layer (selected).** Add
+   `ExemptContextFiles` to `scopecontract.Report` and populate it where the
+   exemption already lives (`internal/engine/progression/readiness.go`,
+   `workspaceChangedFiles`). Surface it through the shared `buildScopeContractView`
+   (one builder backs validate/status/review). For #211, omit the run-version JSON
+   field when it is `0` and add discoverability to the `evidence task` surface.
+   Tradeoff: touches the readiness wiring and a shared view, but is single-source
+   and covers all three report consumers at once.
+2. **Doc-only / static rule statement.** Just document the exemption, or emit a
+   fixed "codebase-map is exempt" note. Rejected: the user explicitly wants the
+   actual omitted files visible in JSON; a static note still forces reviewers to
+   cross-check `git diff` to learn which files were dropped.
+3. **Move the exemption into the scopecontract package.** Relocate
+   `scopeContractContextArtifactChangedFile` into `scopecontract` so the Report is
+   self-populating. Rejected for this change: larger refactor than the objective
+   needs; the dirty-file discovery (git) already lives at the readiness layer.
+4. **#211: make `evidence task` accept `0`, or repurpose status to show the NEXT
+   version.** Rejected: weakening the `>=1` rule loses a real guard, and
+   overloading `progress.run_summary_version` (current persisted) to mean "next to
+   record" is misleading. Omitting the rejected value + discoverable guidance is
+   honest.
+
+## Selected Approach
+Alternative 1. #207: thread the exempted dirty context files from the existing
+filter point into the report and disclose them via a new
+`exempt_context_files` field on the shared scope-contract view; document it.
+#211: stop serializing `run_summary_version` when it is `0` (no execution
+summary) on `status` and `next`, and make the first run version (`1`) discoverable
+through the `evidence task` help/guidance while keeping the `>=1` rejection.
+
+## Interfaces and Data Flow
+- `scopecontract.Report` gains `ExemptContextFiles []string`
+  (`json:"exempt_context_files,omitempty"`); `Report.Clone` copies it. Existing
+  fields are unchanged (additive/back-compatible JSON contract).
+- `readiness.go`: `scopeContractWorkspaceChangedFiles` / `workspaceChangedFiles`
+  also yield the set of dirty files matched by
+  `scopeContractContextArtifactChangedFile`; after
+  `EvaluateBundleWithChangedFiles` returns, the cloned report's
+  `ExemptContextFiles` is set before assignment to `readiness.ScopeContract`.
+- `cmd/validate.go`: `scopeContractView` gains `ExemptContextFiles`;
+  `buildScopeContractView` populates it. This builder is shared by `validate`,
+  `status` (`cmd/status_view_build.go`), and `review` (`cmd/review.go`), so all
+  three surfaces gain the field with one change.
+- `cmd/status.go` / `cmd/next.go`: the `run_summary_version` JSON field becomes
+  omit-on-zero (e.g. `omitempty`); `cmd/status_view_build.go` and
+  `cmd/next_context_build.go` map accordingly. Human-readable status must not print
+  a `0` run version.
+- `cmd/evidence.go`: `evidence task` help/guidance states the first run version is
+  `1`; the existing `runSummary < 1` rejection
+  (`evidence_task_run_summary_version_invalid`) is unchanged.
+
+## Rollout and Rollback
+Rollout: ship behind no flag — additive JSON field plus omit-on-zero. Verify with
+`go build ./... && go vet ./... && go test ./...` and a manual
+`slipway validate --json` / `status --json` against a worktree with a dirty
+`artifacts/codebase/*.md`. Rollback: revert the change commit; the JSON additions
+are back-compatible so no consumer migration is needed. Rollback verification:
+`go test ./...` on the reverted tree.
+
+## Risk
+- Shared `buildScopeContractView` also feeds `review` — confirm the added field is
+  harmless there (it is read-only display). Covered by building/testing the cmd
+  package.
+- `omitempty` on an `int` run-version drops legitimate `0` only; since `0` is never
+  a valid recorded version, this is safe. Guard the human-readable path too.
+- JSON consumers downstream (Lattice) rely on existing field names; the change is
+  strictly additive plus an omit of a value that was never valid as input, so it
+  does not break existing parsers.

--- a/artifacts/changes/archived/make-two-confirmed-downstream-reported-lattice-slipway-gover/intent.md
+++ b/artifacts/changes/archived/make-two-confirmed-downstream-reported-lattice-slipway-gover/intent.md
@@ -1,0 +1,117 @@
+# Intent
+
+## Summary
+Make two confirmed downstream-reported (Lattice) Slipway governance-surface transparency gaps self-explaining, without changing underlying behavior. (1) Issue #207: scope_contract silently filters dirty artifacts/codebase/** files out of changed_files while reporting status=pass, so reviewers must infer the hidden exemption from a git-diff disagreement. Surface the codebase-map exemption explicitly in validate/status JSON output (and align docs/help) so the omission is visible rather than inferred; keep the exemption itself intact. (2) Issue #211: status --json exposes progress.run_summary_version=0 (a 'no execution summary yet' sentinel) but slipway evidence task rejects 0 and requires >=1, so the visible value misleads task-evidence recording. Stop surfacing a value the evidence surface itself refuses and make the correct task-evidence run version unambiguous; keep the >=1 evidence rule intact. Both fixes are to Slipway's own CLI/JSON/doc surfaces (external contracts consumed downstream); no change to scope-contract exemption behavior or the run-summary-version validation rule.
+## Complexity Assessment
+complex
+<!-- Rationale: two distinct governance surfaces (scope_contract reporting; status
+     run_summary_version + evidence-task version discoverability), both change
+     external JSON contracts consumed downstream (Lattice), and both need aligned
+     code + tests + docs. More than a single-surface simple edit. -->
+
+## Guardrail Domains
+<!-- none detected -->
+External API contracts (advisory): `slipway validate`/`status` JSON output is a
+public contract consumed downstream. Changes here are additive/back-compatible
+only — no rename/removal of existing fields, no change to gate pass/fail outcomes.
+
+## In Scope
+Surface-transparency fixes to Slipway's own CLI/JSON/doc surfaces. Behavior of the
+underlying exemption and the evidence-version rule stays unchanged.
+
+#207 — make the scope_contract codebase-map exemption explicit:
+- `internal/engine/scopecontract/evaluate.go`: add a structured field to `Report`
+  (e.g. `ExemptContextFiles []string`, json `exempt_context_files`) and populate it
+  from the evaluate path.
+- `internal/engine/progression/readiness.go`: where `scopeContractContextArtifactChangedFile`
+  filters `artifacts/codebase/**` out of changed files (~L829–845), collect the
+  dirty-but-exempted files and thread them into the Report instead of silently dropping.
+- `cmd/validate.go`: add the field to `scopeContractView` (~L68–76) and populate it in
+  `buildScopeContractView` (~L333–346).
+- `cmd/status*` view builders (e.g. `cmd/status_view_build.go`): ensure `status --json`
+  scope_contract carries the same field.
+- Docs: `docs/commands.md` and/or `docs/operator-guide.md` document the exemption and
+  the new field (and command help if it owns the description).
+
+#211 — stop surfacing a run_summary_version the evidence surface refuses, and make the
+correct value discoverable:
+- `internal/engine/status/view.go`: `Progress.RunSummaryVersion` (~L38, L117–122, L173–184)
+  must not emit `0` when no execution summary exists yet — omit/null it (pointer or
+  omitempty + guard) so the visible value is never one `evidence task` rejects.
+- `cmd/status_view_build.go` (~L484): map the omitted/null value through to JSON and the
+  human status line.
+- Make the correct first task-evidence run version (`1`) discoverable from a public
+  surface: `cmd/evidence.go` (`evidence task` help/remediation, ~L342–349) and/or
+  `next --json` diagnostics — the exact surface is settled at plan-audit; acceptance is
+  that a user in early S2 finds the right run version without guessing.
+- Tests covering both: status omits the field with no summary; evidence-task version-1
+  path is discoverable.
+
+## Out of Scope
+- Changing the exemption itself: `artifacts/codebase/**` stays excluded from
+  `changed_files`/`out_of_scope_files` accounting and scope_contract stays `pass` when
+  only context files are dirty.
+- Changing the `evidence task` rule: `--run-summary-version` must remain `>= 1`.
+- Changing the run_summary_version counter semantics / increment logic.
+- `slipway done` dirty-advisory output (separate surface; this change is validate/status).
+- New lifecycle gates, codebase-map generation, or any gate pass/fail outcome change.
+
+## Constraints
+- JSON output is an external contract: additive/back-compatible only; do not rename or
+  remove existing scope_contract / progress fields.
+- Keep code, generated skills, docs, and help aligned as one product surface.
+- README is contract-tested by `internal/toolgen` (keep required tokens) if touched;
+  prefer `docs/` for prose.
+- Lint gate is golangci-lint gofmt **simplify**: verify with `gofmt -s -l` / local
+  `golangci-lint run`, not plain `gofmt -l`.
+- `go build ./... && go vet ./... && go test ./...` must stay green.
+
+## Acceptance Signals
+- #207: with a dirty `artifacts/codebase/*.md` present, `slipway validate --json` and
+  `status --json` show the new `scope_contract.exempt_context_files` listing that file,
+  while `changed_files` still omits it and `scope_contract.status` stays `pass`
+  (covered by a test).
+- #207: `docs/` (and command help if it owns the text) describe the codebase-map
+  exemption and the new field.
+- #211: `slipway status --json` before any execution summary exists does NOT emit
+  `progress.run_summary_version=0` (field omitted/null), and a public surface makes the
+  correct first task-evidence run version (`1`) discoverable (covered by a test).
+- #211: `slipway evidence task --run-summary-version 0` still fails with
+  `evidence_task_run_summary_version_invalid` (rule intact; covered by a test).
+- `go build ./... && go vet ./... && go test ./...` green; `gofmt -s -l` clean; existing
+  scope_contract / status regression tests stay green.
+
+## Open Questions
+None.
+
+## Deferred Ideas
+- Extend the same explicit-exemption disclosure to `slipway done` dirty-advisory output.
+- Generalize a "context artifacts" concept beyond codebase-map if more advisory dirs appear.
+
+## Approved Summary
+Confirmed 2026-06-14T13:28:44Z.
+
+Make two confirmed downstream-reported (Lattice) Slipway governance-surface
+transparency gaps self-explaining, without changing underlying behavior.
+
+- #207: scope_contract silently drops dirty `artifacts/codebase/**` from
+  `changed_files` while reporting `pass`. Add a structured `exempt_context_files`
+  field to the scope_contract Report, populate it from the exemption point in
+  readiness.go, surface it in both `validate --json` and `status --json`, and
+  document the exemption + field. The exemption itself stays intact.
+- #211: `status --json` exposes `progress.run_summary_version=0` before any
+  execution summary exists, but `evidence task` rejects 0 (requires `>=1`). Stop
+  surfacing the rejected 0 (omit/null when no summary) and make the correct first
+  task-evidence run version (`1`) discoverable from a public surface. The `>=1`
+  rule stays intact.
+
+Scope boundaries: behavior-preserving CLI/JSON/doc surface change only; JSON
+additions are back-compatible (no rename/removal, no gate outcome change). Out of
+scope: the exemption rule, the `>=1` evidence rule, run_summary_version counter
+semantics, `slipway done` advisory, and any new gate.
+
+Primary acceptance signal: with a dirty `artifacts/codebase/*.md`,
+`validate`/`status --json` show `scope_contract.exempt_context_files` listing it
+while `changed_files` still omits it and `status=pass`; and `status --json` no
+longer emits `run_summary_version=0` while the correct version `1` is discoverable
+— all covered by tests, with `go build/vet/test ./...` green.

--- a/artifacts/changes/archived/make-two-confirmed-downstream-reported-lattice-slipway-gover/requirements.md
+++ b/artifacts/changes/archived/make-two-confirmed-downstream-reported-lattice-slipway-gover/requirements.md
@@ -1,0 +1,64 @@
+# Requirements
+
+## Requirements
+
+### Requirement: Scope contract discloses exempted codebase-map files
+REQ-001: The scope-contract report surfaced by `slipway validate --json`,
+`slipway status --json`, and `slipway review --json` MUST explicitly list the
+dirty `artifacts/codebase/**` files it exempts from `changed_files`, in a
+dedicated structured field, so a reviewer no longer has to infer the hidden
+filtering from a `git diff` disagreement. The exemption behavior itself MUST be
+preserved: exempted files MUST stay out of `changed_files`/`out_of_scope_files`,
+and `scope_contract.status` MUST stay `pass` when only context files are dirty.
+The exemption and the new field MUST be documented in the user-facing docs.
+
+#### Scenario: validate surfaces the exempted codebase-map file
+GIVEN an active change whose worktree has a tracked, dirty
+`artifacts/codebase/ARCHITECTURE.md` that is not in any task's target_files
+AND an execution summary exists (run_summary_version >= 1)
+WHEN the user runs `slipway validate --json`
+THEN `scope_contract.exempt_context_files` includes
+`artifacts/codebase/ARCHITECTURE.md`
+AND `scope_contract.changed_files` does NOT include it
+AND `scope_contract.status` is `pass`.
+
+#### Scenario: exemption is documented
+GIVEN the user reads the Slipway command/operator docs
+WHEN they look up scope-contract reporting
+THEN the docs state that `artifacts/codebase/**` is exempt from scope-contract
+changed-file accounting and is disclosed via `scope_contract.exempt_context_files`.
+
+### Requirement: Status does not surface a run version the evidence surface refuses
+REQ-002: When no execution summary exists yet (no recorded wave run), the
+user-facing "current run version" surfaces (`slipway status --json` and
+`slipway next --json`) MUST NOT emit `run_summary_version=0`, because `0` is a
+value that `slipway evidence task` rejects. The field MUST be omitted (or null)
+rather than reported as `0`.
+
+#### Scenario: early S2 status omits the zero run version
+GIVEN an active change in S2_EXECUTE with no execution summary recorded yet
+WHEN the user runs `slipway status --json`
+THEN the output does NOT contain `run_summary_version` equal to `0`
+(the field is omitted).
+
+#### Scenario: status reports the real version once a run exists
+GIVEN an active change with a recorded execution summary at run_summary_version 1
+WHEN the user runs `slipway status --json`
+THEN `progress.run_summary_version` is `1`.
+
+### Requirement: Correct first task-evidence run version is discoverable and enforced
+REQ-003: A public Slipway surface MUST make the correct first task-evidence run
+version (`1`) discoverable so a user does not have to guess it after the status
+field is omitted, and `slipway evidence task` MUST continue to reject
+`--run-summary-version` values below `1`.
+
+#### Scenario: evidence-task surface tells the user the first run version
+GIVEN a user about to record the first task evidence for a change
+WHEN they consult the `slipway evidence task` help / guidance surface
+THEN it states that the first task-evidence run version is `1` (or to pass the
+current wave-orchestration run_version).
+
+#### Scenario: zero is still rejected
+GIVEN a user records task evidence
+WHEN they run `slipway evidence task --run-summary-version 0`
+THEN the command fails with reason `evidence_task_run_summary_version_invalid`.

--- a/artifacts/changes/archived/make-two-confirmed-downstream-reported-lattice-slipway-gover/tasks.md
+++ b/artifacts/changes/archived/make-two-confirmed-downstream-reported-lattice-slipway-gover/tasks.md
@@ -1,0 +1,29 @@
+# Tasks
+
+## Task List
+
+- [x] `t-01` Add `ExemptContextFiles` to `scopecontract.Report` (and `Clone`), and populate it in readiness from the dirty `artifacts/codebase/**` files the scope-contract filter currently drops silently; unit-test that exempted files land in the field while staying out of `changed_files`.
+  - depends_on: []
+  - target_files: [internal/engine/scopecontract/evaluate.go, internal/engine/progression/readiness.go, internal/engine/progression/readiness_optimization_test.go]
+  - task_kind: code
+  - covers: [REQ-001]
+- [x] `t-02` Surface `exempt_context_files` on the shared `scopeContractView` and populate it in `buildScopeContractView` so `validate`/`status`/`review` JSON all disclose it; cmd test asserts the field appears with changed_files still omitting the file and status pass.
+  - depends_on: [t-01]
+  - target_files: [cmd/validate.go, cmd/validate_test.go]
+  - task_kind: code
+  - covers: [REQ-001]
+- [x] `t-03` Document the `artifacts/codebase/**` scope-contract exemption and the new `exempt_context_files` field in the user-facing docs.
+  - depends_on: []
+  - target_files: [docs/commands.md, docs/operator-guide.md]
+  - task_kind: code
+  - covers: [REQ-001]
+- [x] `t-04` Stop emitting `run_summary_version=0` when no execution summary exists: make the `run_summary_version` JSON field omit-on-zero on `status` and `next`, map it through the view builders, and keep human output from printing a 0; cmd test asserts omission with no summary and the real value once a run exists.
+  - depends_on: []
+  - target_files: [cmd/status.go, cmd/status_view_build.go, cmd/next.go, cmd/next_context_build.go, cmd/status_test.go]
+  - task_kind: code
+  - covers: [REQ-002]
+- [x] `t-05` Make the first task-evidence run version (`1`) discoverable via the `evidence task` help/guidance surface while keeping the `>=1` rejection intact; cmd test asserts the guidance text and that `--run-summary-version 0` still fails with `evidence_task_run_summary_version_invalid`.
+  - depends_on: []
+  - target_files: [cmd/evidence.go, cmd/evidence_test.go]
+  - task_kind: code
+  - covers: [REQ-003]

--- a/artifacts/codebase/ARCHITECTURE.md
+++ b/artifacts/codebase/ARCHITECTURE.md
@@ -1,51 +1,72 @@
 # Architecture
 
 Re-authored for change
-`add-engine-enforced-fail-closed-safety-nets-for-shared-workt`.
+`make-two-confirmed-downstream-reported-lattice-slipway-gover`
+(GitHub issues #207 and #211).
 
-Question: which Slipway wave-execution seams must turn host-recorded evidence
-into fail-closed safety gates for shared-worktree parallel wave execution while
-preserving the engine-governs/host-executes boundary?
+Question: which Slipway reporting seams turn two silent governance-surface
+behaviors (a hidden scope-contract exemption; a run version the evidence surface
+refuses) into self-explaining JSON, without changing the underlying behavior?
 
 ## Affected Seams
 
-- `internal/engine/wave/wave.go` owns wave planning, static target conflict
-  checks, target normalization, and the new coverage helper used by the
-  changed-file scope audit.
-- `internal/model/wave_execution.go` owns public wave execution data contracts:
-  dispatch-mode literals, verification-reference parsing, and wave-run JSON/YAML
-  shape.
-- `internal/state/wave_execution.go` builds per-wave run records from the
-  materialized plan and task evidence. It is the seam where silent dispatch-mode
-  inference is removed.
-- `internal/engine/progression/wave_sync.go` is the single assembly point for
-  task evidence, wave runs, execution summaries, and open blockers. The new
-  fail-closed gates attach here so `validate`, `next`, and `status --json`
-  observe the same blockers.
-- `cmd/next.go` and `cmd/next_wave_plan.go` own the public wave-plan view. The
-  new `advisories` field is view-only and must not enter `wave-plan.yaml` or
-  freshness hashes.
-- `internal/tmpl/templates/skills/wave-orchestration/` owns generated host
-  instructions for executor dispatch and evidence references.
+- `internal/engine/scopecontract/evaluate.go` owns the `Report` data contract
+  for the scope-contract audit (`changed_files`, `out_of_scope_files`,
+  `planned_targets`, blockers) and its `Clone`. It gains a new additive
+  `ExemptContextFiles []string` (`json:"exempt_context_files,omitempty"`) field;
+  no existing field changes.
+- `internal/engine/progression/readiness.go` owns workspace changed-file
+  collection and the `artifacts/codebase/**` exemption
+  (`scopeContractContextArtifactChangedFile`, ~L841/L844) that drops dirty
+  codebase-map files from `changed_files` while keeping `scope_contract.status`
+  `pass`. It is the seam (~L829) where the dropped files must be captured and
+  threaded into the cloned `Report.ExemptContextFiles` before the report is
+  assigned to `readiness.ScopeContract` (~L289).
+- `internal/engine/status/view.go` owns the engine Progress model. Its
+  `RunSummaryVersion` is `0` until an execution summary exists (set to the real
+  version only when `summary.RunSummaryVersion >= 1`). `0` is the "no summary
+  yet" sentinel that `evidence task` rejects.
+- `cmd/validate.go` owns the shared `scopeContractView` struct and its single
+  builder `buildScopeContractView`. That one builder backs all three report
+  consumers — `validate` (`cmd/validate.go`), `status`
+  (`cmd/status_view_build.go`), and `review` (`cmd/review.go`) — so the new
+  `exempt_context_files` field reaches every surface from one edit.
+- `cmd/status.go` / `cmd/status_view_build.go` and `cmd/next.go` /
+  `cmd/next_context_build.go` own the user-facing `progress.run_summary_version`
+  JSON. They are the only two surfaces that emit it; the field becomes
+  omit-on-zero and the human-readable line must not print a `0`.
+- `cmd/evidence.go` owns `evidence task --run-summary-version` validation
+  (`runSummary < 1` → `evidence_task_run_summary_version_invalid`, ~L342) and its
+  help. The rejection stays; the help gains discoverability of the correct first
+  run version (`1`).
 
 ## Dependency Flow
 
-`tasks.md` is parsed into wave nodes, materialized as `wave-plan.yaml`, then
-rendered through `slipway next --json` for host execution. The host records task
-evidence plus wave-orchestration references (`dispatch_mode:*`,
-`executor_agent:*`). `SyncGovernedWaveExecution` reads that evidence, builds
-`WaveRun` records, adds safety blockers to `ExecutionSummary.OpenBlockers`, and
-readiness surfaces those blockers without a separate JSON pipeline.
+For #207: readiness gathers dirty workspace files, evaluates the scope contract,
+then filters `artifacts/codebase/**` out of `changed_files`. Today the filtered
+files are discarded silently. The change captures that same dropped set and
+records it on the cloned `Report.ExemptContextFiles`; `buildScopeContractView`
+then maps it onto the shared view, so `validate`/`status`/`review --json` all
+disclose what was exempted while `changed_files` still omits it and the status
+stays `pass`.
+
+For #211: the engine Progress carries `RunSummaryVersion` (0 when no summary).
+The cmd JSON structs in `status` and `next` serialize it as
+`progress.run_summary_version`. Making those fields omit-on-zero stops surfacing
+a value `evidence task` refuses; the correct first version (`1`) is instead made
+discoverable on the `evidence task` help surface, with the `>= 1` rejection
+unchanged.
 
 ## Constraints And Invariants
 
-- The engine signals, records, and gates. It does not spawn executor agents.
-- Shared-worktree safety depends on accurate planned `target_files` and
-  exhaustive recorded `changed_files`.
-- Scope coverage must reuse the same target semantics as wave conflict
-  detection: exact path, parent/child scope, case-folded aliases, and glob scope.
-- Started parallel waves must not infer dispatch mode from plan metadata alone.
-- `parallel_subagents` is a public dispatch token; `degraded_sequential` remains
-  valid explicit evidence.
-- Plan-drift blockers own stale plan/evidence remediation, so the new safety
-  gates stay suppressed while plan drift is present.
+- The exemption behavior is preserved: `artifacts/codebase/**` stays out of
+  `changed_files`/`out_of_scope_files`, and `scope_contract.status` stays `pass`
+  when only context files are dirty. The change only discloses the exemption.
+- The `evidence task` `>= 1` rule and the `run_summary_version` counter semantics
+  are preserved; only the *surfacing* of the rejected `0` changes.
+- JSON output is an external contract consumed downstream (Lattice): changes are
+  additive/back-compatible only — no rename or removal of existing fields, and
+  no gate pass/fail outcome change. `omitempty` on the int run-version drops only
+  the never-valid `0`.
+- One shared `buildScopeContractView` keeps validate/status/review aligned; the
+  field is read-only display on all three.

--- a/artifacts/codebase/CONCERNS.md
+++ b/artifacts/codebase/CONCERNS.md
@@ -1,26 +1,30 @@
 # Concerns
 
 Re-authored for change
-`add-engine-enforced-fail-closed-safety-nets-for-shared-workt`.
+`make-two-confirmed-downstream-reported-lattice-slipway-gover`
+(GitHub issues #207 and #211).
 
-- Public contract drift: `WaveRun.dispatch_mode` changes from `parallel` to
-  `parallel_subagents`, and readiness surfaces four new blocker codes. Tests must
-  pin the new reason-code taxonomy and dispatch parser behavior.
-- Silent-safety regression: a started parallel wave without explicit
-  `dispatch_mode` evidence must fail closed instead of inheriting the plan's
-  `Parallel` flag.
-- Scope-audit false negatives: if task evidence under-reports `changed_files`,
-  the engine cannot detect every collision. The generated host surface must keep
-  exhaustive `changed_files` as an explicit safety requirement.
-- Scope-audit false positives: stale task evidence should not be judged against a
-  changed plan. The safety-net blockers therefore stay behind the existing
-  plan-drift suppression guard.
-- Shared-worktree collision risk: same-wave parallel tasks writing the same
-  canonical path can clobber each other. The overlap audit must bucket paths with
-  the same normalization semantics as planner conflict detection.
-- Evidence-completeness ceiling: `executor_agent` handles prove the host recorded
-  per-task executor claims, not that the engine spawned those agents. The
-  generated docs must avoid implying an engine runtime exists.
-- View freshness risk: wave-plan narrowing advisories are useful for plan audit
-  but must remain display-only; persisting them would churn `wave-plan.yaml` and
-  freshness hashes.
+- Public contract drift (Lattice): `validate`/`status`/`review --json` are an
+  external contract. The change must stay additive/back-compatible — add
+  `scope_contract.exempt_context_files`, never rename or remove existing fields,
+  and never change a gate pass/fail outcome.
+- Behavior-preservation risk: #207 must disclose the exemption, not weaken it.
+  Exempted `artifacts/codebase/**` files must remain out of `changed_files` /
+  `out_of_scope_files`, and `scope_contract.status` must stay `pass` when only
+  context files are dirty. A regression here would silently change scoping.
+- `omitempty` correctness: making `progress.run_summary_version` omit-on-zero
+  drops only the never-valid `0`. Any legitimate version is `>= 1` and still
+  serializes. The human-readable status/next line must also stop printing `0`.
+- Rule-preservation risk: #211 must keep the `evidence task --run-summary-version
+  >= 1` rejection (`evidence_task_run_summary_version_invalid`) and the
+  run-version counter semantics intact; only the *surfacing* of the rejected `0`
+  changes.
+- Shared-view blast radius: `buildScopeContractView` feeds `validate`, `status`,
+  and `review`. The added field is read-only display on all three, so the single
+  edit is intended to reach every surface — confirm review output stays correct.
+- Discoverability completeness: omitting the `0` removes a misleading value, so
+  the correct first run version (`1`) must be discoverable from a public surface
+  (`evidence task` help) or a user is left guessing.
+- Test-fixture fidelity: the exemption and omit-on-zero behaviors are easy to
+  assert at the unit/cmd layer with fixtures; the manual acceptance check needs a
+  real dirty `artifacts/codebase/*.md` present in the worktree.

--- a/artifacts/codebase/STRUCTURE.md
+++ b/artifacts/codebase/STRUCTURE.md
@@ -1,17 +1,41 @@
 # Structure
 
-Re-authored for change `explain-domain-review-mapping` (GitHub issue #203).
+Re-authored for change
+`make-two-confirmed-downstream-reported-lattice-slipway-gover`
+(GitHub issues #207 and #211).
 
-- `internal/engine/governance/`
-  - `actions.go`: required-action domain model and action satisfaction input contract.
-  - `runtime_actions.go`: runtime evidence loading, skill readiness checks, and required-action satisfaction assembly.
-  - `runtime_actions_test.go`: engine-level regressions for review control satisfaction and fail-closed readiness.
+- `internal/engine/scopecontract/`
+  - `evaluate.go`: `Report` struct + `Clone`; the scope-contract audit data
+    contract. Gains `ExemptContextFiles`.
+- `internal/engine/progression/`
+  - `readiness.go`: workspace changed-file collection and the
+    `artifacts/codebase/**` exemption (`scopeContractContextArtifactChangedFile`);
+    threads exempted files into the report.
+  - `readiness_optimization_test.go`: engine-level regressions for the exemption
+    path; gains coverage that exempted files land in `ExemptContextFiles` while
+    staying out of `changed_files`.
+- `internal/engine/status/`
+  - `view.go`: engine Progress model; `RunSummaryVersion` (0 = no execution
+    summary yet).
 - `cmd/`
-  - `status.go`: shared JSON view structs for status/validate/next governance action output.
-  - `validate.go`: validate JSON view assembly, now expected to expose required-action attribution.
-  - `governance_surface.go`: shared mapper from `progression.GovernanceReadiness` to command governance views.
-  - `governance_gate_consistency_test.go`: command-level regressions that compare status, validate, and next behavior.
+  - `validate.go`: shared `scopeContractView` struct and `buildScopeContractView`
+    (single builder backing validate/status/review). Gains/maps
+    `exempt_context_files`.
+  - `validate_test.go`: cmd-level assertion that the field appears with
+    `changed_files` still omitting the file and status `pass`.
+  - `status.go` / `status_view_build.go`: status `progress.run_summary_version`
+    JSON + view mapping (omit-on-zero).
+  - `next.go` / `next_context_build.go`: next `progress.run_summary_version`
+    JSON + view mapping (omit-on-zero).
+  - `status_test.go`: asserts omission with no summary and the real value once a
+    run exists.
+  - `evidence.go`: `evidence task --run-summary-version` validation (`>= 1`) and
+    help/guidance for the first run version.
+  - `evidence_test.go`: asserts the guidance text and that `0` still fails.
+- `docs/`
+  - `commands.md` / `operator-guide.md`: document the `artifacts/codebase/**`
+    scope-contract exemption and the new `exempt_context_files` field.
 - Governed artifact bundle:
-  - `artifacts/changes/explain-domain-review-mapping/requirements.md`: REQ-001 through REQ-003.
-  - `artifacts/changes/explain-domain-review-mapping/decision.md`: selected structured attribution approach.
-  - `artifacts/changes/explain-domain-review-mapping/tasks.md`: two dependent execution tasks.
+  - `artifacts/changes/make-two-confirmed-downstream-reported-lattice-slipway-gover/`:
+    `requirements.md` (REQ-001..003), `decision.md` (selected approach),
+    `tasks.md` (t-01..t-05 across two waves).

--- a/artifacts/codebase/TESTING.md
+++ b/artifacts/codebase/TESTING.md
@@ -1,50 +1,43 @@
 # Testing
 
 Re-authored for change
-`add-engine-enforced-fail-closed-safety-nets-for-shared-workt`.
+`make-two-confirmed-downstream-reported-lattice-slipway-gover`
+(GitHub issues #207 and #211).
 
 ## Existing Coverage
 
-- `internal/engine/wave/wave_test.go` covers wave planning, static target
-  conflict behavior, parsing, and now target coverage plus narrowing advisories.
-- `internal/model/wave_execution_test.go` covers dispatch-mode validation and
-  verification-reference parsing, including conflict handling.
-- `internal/state/wave_execution_test.go` covers wave-run construction and the
-  removal of silent parallel dispatch inference.
-- `internal/engine/progression/wave_sync_test.go` covers task evidence parsing,
-  sync/mutate behavior, execution-summary persistence, read-only readiness, and
-  the new safety-net blockers.
-- `cmd/next_wave_plan_test.go` covers derived and persisted wave-plan views,
-  including view-only `advisories`.
-- `internal/tmpl/wave_isolation_content_test.go` and `internal/toolgen` cover
-  generated host instruction contracts.
+- `internal/engine/progression/readiness_optimization_test.go` covers the
+  readiness changed-file optimization, including the `artifacts/codebase/**`
+  scope-contract exemption path.
+- `internal/engine/progression/scope_contract_gate_test.go` covers scope-contract
+  gate behavior (pass/blocked) at the progression layer.
+- `cmd/validate_test.go` covers the validate JSON view, including the
+  `scope_contract` sub-view assembled by `buildScopeContractView`.
+- `cmd/status_test.go` covers the status JSON/human view, including `progress`.
+- `cmd/evidence_task_test.go` / `cmd/evidence_test.go` cover `evidence task`
+  validation, including the `run_summary_version >= 1` rejection.
 
 ## Gaps Closed By This Change
 
-- `parallel_subagents` is parsed and emitted as the public parallel dispatch
-  token; the retired `parallel` dispatch token is not accepted through the new
-  contract.
-- A started parallel wave without explicit valid dispatch evidence records no
-  inferred dispatch mode and surfaces
-  `dispatch_mode_absent_on_started_parallel_wave`.
-- A `parallel_subagents` wave missing a per-task executor handle surfaces
-  `executor_agent_missing`; `degraded_sequential` requires no handles.
-- A task whose recorded `changed_files` escapes planned `target_files` surfaces
-  `task_changed_file_scope_escape`, including the fail-closed empty
-  `target_files` case.
-- Two tasks in the same parallel wave recording the same canonical changed file
-  surface `parallel_wave_changed_file_overlap`; sequential sharing remains
-  allowed.
-- `broad_target_files` and `fully_serial_plan` advisories are exposed only in
-  the view layer and are excluded from persisted wave plans and freshness hashes.
+- #207: a dirty, tracked `artifacts/codebase/*.md` not in any task's
+  `target_files` is surfaced in `scope_contract.exempt_context_files` (unit test
+  at the readiness layer; cmd test at the view layer) while it stays out of
+  `changed_files` and `scope_contract.status` stays `pass`.
+- #211: `status --json` (and `next --json`) omit `progress.run_summary_version`
+  when no execution summary exists (value `0`), and report the real value once a
+  run exists (cmd test asserts both states).
+- #211: the `evidence task` help/guidance surface states the correct first run
+  version (`1`), and `evidence task --run-summary-version 0` still fails with
+  `evidence_task_run_summary_version_invalid` (cmd test pins both).
 
 ## Verification Plan
 
-- Run the focused progression scope-escape blocker tests after repair.
-- Run affected packages:
-  `go test ./internal/model ./internal/state ./internal/engine/wave ./internal/engine/progression ./cmd ./internal/tmpl ./internal/toolgen`.
-- Run full repository verification:
-  `gofmt -l`, `go test ./...`, and `git diff --check`.
-- Use current-worktree Slipway outputs (`status --json`, `validate --json`,
-  `next --json --diagnostics`) as lifecycle authority after each evidence
-  refresh.
+- Run affected packages after each task:
+  `go test ./internal/engine/scopecontract ./internal/engine/progression ./internal/engine/status ./cmd`.
+- Run full repository verification: `go build ./...`, `go vet ./...`,
+  `go test ./...`, and `gofmt -s -l` (the lint gate is golangci-lint gofmt
+  **simplify**, not plain `gofmt -l`).
+- Manually confirm with current-worktree Slipway: with a dirty
+  `artifacts/codebase/*.md`, `validate --json` / `status --json` show
+  `scope_contract.exempt_context_files` listing it while `changed_files` omits it
+  and status is `pass`; early-S2 `status --json` omits `run_summary_version`.

--- a/cmd/evidence.go
+++ b/cmd/evidence.go
@@ -343,7 +343,7 @@ func makeEvidenceTaskCmd() *cobra.Command {
 					return newInvalidUsageError(
 						"evidence_task_run_summary_version_invalid",
 						"--run-summary-version must be >= 1",
-						"Pass the current wave-orchestration run_version as --run-summary-version.",
+						"Pass the current wave-orchestration run_version as --run-summary-version; the first task-evidence run version is 1.",
 						nil,
 					)
 				}
@@ -546,7 +546,7 @@ func makeEvidenceTaskCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "JSON output")
 	addChangeSelectorFlags(cmd, &changeSlug, "Explicit change slug")
 	cmd.Flags().StringVar(&taskID, "task-id", "", "Task ID from wave-plan.yaml (required)")
-	cmd.Flags().IntVar(&runSummary, "run-summary-version", 0, "Current wave-orchestration run_version (required)")
+	cmd.Flags().IntVar(&runSummary, "run-summary-version", 0, "Run summary version to attribute this task evidence to (>= 1; the first task-evidence run version is 1 -- pass the current wave-orchestration run_version) (required)")
 	cmd.Flags().StringVar(&taskKindRaw, "task-kind", "", "Task kind: code, test, doc, ops, verification, investigation, other (required)")
 	cmd.Flags().StringVar(&verdictRaw, "verdict", "", "Task verdict: pass, fail, blocked, incomplete, timeout (required)")
 	cmd.Flags().StringVar(&evidenceRef, "evidence-ref", "", "Stable transcript, command, artifact, or note reference (required)")

--- a/cmd/evidence_test.go
+++ b/cmd/evidence_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/signalridge/slipway/internal/model"
@@ -8,6 +9,40 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestEvidenceTaskRunSummaryVersionHelpAdvertisesFirstVersionIsOne(t *testing.T) {
+	t.Parallel()
+
+	flag := makeEvidenceTaskCmd().Flags().Lookup("run-summary-version")
+	require.NotNil(t, flag, "evidence task must expose a --run-summary-version flag")
+	assert.Contains(t, flag.Usage, ">= 1",
+		"--run-summary-version help must keep advertising the >= 1 rule, got %q", flag.Usage)
+	assert.Contains(t, strings.ToLower(flag.Usage), "first task-evidence run version is 1",
+		"--run-summary-version help must tell users the first task-evidence run version is 1, got %q", flag.Usage)
+}
+
+func TestEvidenceTaskRunSummaryVersionZeroIsRejected(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		createEvidenceTaskFixture(t, root)
+
+		cmd := commandForRoot(t, root, makeEvidenceCmd())
+		cmd.SetArgs([]string{
+			"task",
+			"--task-id", "t-01",
+			"--run-summary-version", "0",
+			"--task-kind", "verification",
+			"--verdict", "pass",
+			"--evidence-ref", "test:zero-version",
+		})
+		cliErr := asCLIError(cmd.Execute())
+		require.NotNil(t, cliErr)
+		assert.Equal(t, "evidence_task_run_summary_version_invalid", cliErr.ErrorCode)
+	})
+}
 
 func TestEvidenceRestampCommandIsNotRegistered(t *testing.T) {
 	root := t.TempDir()

--- a/cmd/next.go
+++ b/cmd/next.go
@@ -254,7 +254,11 @@ type waveTaskView struct {
 }
 
 type resumeCheckpoint struct {
-	RunSummaryVersion   int      `json:"run_summary_version"`
+	// RunSummaryVersion is omitted when zero. A resume checkpoint only exists once
+	// an execution run has been recorded, so a real version is >=1; zero is the
+	// "no summary yet" sentinel that `evidence task` rejects and must not be
+	// surfaced as a recorded version (issue #211).
+	RunSummaryVersion   int      `json:"run_summary_version,omitempty"`
 	CompletedTaskIDs    []string `json:"completed_task_ids,omitempty"`
 	Freshness           string   `json:"freshness,omitempty"`
 	ResumeWaveIndex     int      `json:"resume_wave_index,omitempty"`

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -116,18 +116,22 @@ type artifactDAGNode struct {
 }
 
 type statusProgress struct {
-	Percentage        int            `json:"percentage"`
-	StageIndex        int            `json:"stage_index"`
-	StageTotal        int            `json:"stage_total"`
-	StageName         string         `json:"stage_name"`
-	CurrentWaveIndex  int            `json:"current_wave_index,omitempty"`
-	CompletedWaves    int            `json:"completed_waves,omitempty"`
-	TotalWaves        int            `json:"total_waves,omitempty"`
-	WavesByVerdict    map[string]int `json:"waves_by_verdict,omitempty"`
-	TasksCompleted    int            `json:"tasks_completed"`
-	TasksTotal        int            `json:"tasks_total"`
-	TasksByVerdict    map[string]int `json:"tasks_by_verdict,omitempty"`
-	RunSummaryVersion int            `json:"run_summary_version"`
+	Percentage       int            `json:"percentage"`
+	StageIndex       int            `json:"stage_index"`
+	StageTotal       int            `json:"stage_total"`
+	StageName        string         `json:"stage_name"`
+	CurrentWaveIndex int            `json:"current_wave_index,omitempty"`
+	CompletedWaves   int            `json:"completed_waves,omitempty"`
+	TotalWaves       int            `json:"total_waves,omitempty"`
+	WavesByVerdict   map[string]int `json:"waves_by_verdict,omitempty"`
+	TasksCompleted   int            `json:"tasks_completed"`
+	TasksTotal       int            `json:"tasks_total"`
+	TasksByVerdict   map[string]int `json:"tasks_by_verdict,omitempty"`
+	// RunSummaryVersion is omitted when zero. Zero is the "no execution summary
+	// recorded yet" sentinel that `evidence task` rejects, so surfacing
+	// run_summary_version=0 would mislead callers; any real recorded version is
+	// >=1 and still serializes (issue #211).
+	RunSummaryVersion int `json:"run_summary_version,omitempty"`
 }
 
 type statusEvidencePointers struct {

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -1,0 +1,123 @@
+package cmd
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/signalridge/slipway/internal/model"
+	"github.com/signalridge/slipway/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStatusProgressOmitsRunSummaryVersionWhenNoExecutionSummary asserts that an
+// execution-state change with no recorded execution summary serializes its
+// progress object WITHOUT a run_summary_version field. Zero is the "no summary
+// yet" sentinel that `evidence task` rejects, so emitting run_summary_version=0
+// misleads callers (issue #211). On the pre-change code the struct tag lacked
+// `,omitempty`, so the marshaled progress included "run_summary_version":0 and
+// this assertion was RED; the `,omitempty` tag makes it GREEN.
+func TestStatusProgressOmitsRunSummaryVersionWhenNoExecutionSummary(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	ensureTestGitRepo(t, root)
+	initTestWorkspace(t, root)
+
+	change := model.NewChange("no-summary-run-version")
+	change.CurrentState = model.StateS2Execute
+	change.PlanSubStep = model.PlanSubStepNone
+	require.NoError(t, state.SaveChange(root, change))
+
+	view, err := buildStatusViewFromChange(root, change)
+	require.NoError(t, err)
+	require.NotNil(t, view.Progress)
+	require.Equal(t, 0, view.Progress.RunSummaryVersion, "fixture must have no recorded run summary")
+
+	raw, err := json.Marshal(view.Progress)
+	require.NoError(t, err)
+
+	var decoded map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+	_, present := decoded["run_summary_version"]
+	assert.False(t, present, "progress must omit run_summary_version when no execution summary is recorded; got %s", raw)
+}
+
+// TestStatusProgressReportsRunSummaryVersionWhenSummaryRecorded asserts that once
+// a real execution summary at run_summary_version 1 exists, the progress object
+// reports run_summary_version == 1 both on the view and in serialized JSON.
+// This is the back-compat half of issue #211: omit-on-zero must not suppress a
+// genuinely recorded version (any real version is >= 1).
+func TestStatusProgressReportsRunSummaryVersionWhenSummaryRecorded(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	ensureTestGitRepo(t, root)
+	initTestWorkspace(t, root)
+
+	change := model.NewChange("recorded-run-version")
+	change.CurrentState = model.StateS2Execute
+	change.PlanSubStep = model.PlanSubStepNone
+	require.NoError(t, state.SaveChange(root, change))
+	require.NoError(t, state.SaveExecutionSummary(root, change.Slug, model.ExecutionSummary{
+		Version:           model.ExecutionSummaryVersion,
+		RunSummaryVersion: 1,
+		CapturedAt:        time.Now().UTC(),
+		OverallVerdict:    model.ExecutionVerdictPass,
+		CompletedTasks:    []string{"task-a"},
+		Tasks: []model.ExecutionTaskSummary{
+			{
+				TaskID:       "task-a",
+				Verdict:      model.TaskVerdictPass,
+				TaskKind:     model.TaskKindCode,
+				ChangedFiles: []string{"cmd/status.go"},
+				CapturedAt:   time.Now().UTC(),
+			},
+		},
+	}))
+
+	view, err := buildStatusViewFromChange(root, change)
+	require.NoError(t, err)
+	require.NotNil(t, view.Progress)
+	assert.Equal(t, 1, view.Progress.RunSummaryVersion)
+
+	raw, err := json.Marshal(view.Progress)
+	require.NoError(t, err)
+
+	var decoded struct {
+		RunSummaryVersion int `json:"run_summary_version"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+	assert.Equal(t, 1, decoded.RunSummaryVersion, "recorded run_summary_version must still serialize; got %s", raw)
+}
+
+// TestResumeCheckpointOmitsRunSummaryVersionWhenZero covers the `next --json`
+// half of REQ-002 (issue #211): the resume checkpoint is the only
+// run_summary_version emitter on the next surface, so it must omit the field when
+// no execution summary has been recorded yet (the zero sentinel `evidence task`
+// rejects) while still serializing a genuinely recorded version (>= 1).
+func TestResumeCheckpointOmitsRunSummaryVersionWhenZero(t *testing.T) {
+	t.Parallel()
+
+	rawZero, err := json.Marshal(&resumeCheckpoint{
+		CompletedTaskIDs: []string{"t-01"},
+		Freshness:        "fresh",
+	})
+	require.NoError(t, err)
+	var decodedZero map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(rawZero, &decodedZero))
+	_, present := decodedZero["run_summary_version"]
+	assert.False(t, present, "resume checkpoint must omit run_summary_version when zero; got %s", rawZero)
+
+	rawReal, err := json.Marshal(&resumeCheckpoint{
+		RunSummaryVersion: 1,
+		CompletedTaskIDs:  []string{"t-01"},
+	})
+	require.NoError(t, err)
+	var decodedReal struct {
+		RunSummaryVersion int `json:"run_summary_version"`
+	}
+	require.NoError(t, json.Unmarshal(rawReal, &decodedReal))
+	assert.Equal(t, 1, decodedReal.RunSummaryVersion, "recorded run_summary_version must still serialize; got %s", rawReal)
+}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -69,6 +69,7 @@ type scopeContractView struct {
 	Status                  string             `json:"status"`
 	PlannedTargets          []string           `json:"planned_targets,omitempty"`
 	ChangedFiles            []string           `json:"changed_files,omitempty"`
+	ExemptContextFiles      []string           `json:"exempt_context_files,omitempty"`
 	OutOfScopeFiles         []string           `json:"out_of_scope_files,omitempty"`
 	MissingContractTasks    []string           `json:"missing_contract_tasks,omitempty"`
 	MissingChangedFileTasks []string           `json:"missing_changed_file_tasks,omitempty"`
@@ -338,6 +339,7 @@ func buildScopeContractView(report *scopecontract.Report) *scopeContractView {
 		Status:                  string(report.Status),
 		PlannedTargets:          append([]string(nil), report.PlannedTargets...),
 		ChangedFiles:            append([]string(nil), report.ChangedFiles...),
+		ExemptContextFiles:      append([]string(nil), report.ExemptContextFiles...),
 		OutOfScopeFiles:         append([]string(nil), report.OutOfScopeFiles...),
 		MissingContractTasks:    append([]string(nil), report.MissingContractTasks...),
 		MissingChangedFileTasks: append([]string(nil), report.MissingChangedFileTasks...),

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/signalridge/slipway/internal/engine/scopecontract"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// REQ-001: the shared scope-contract view must disclose the dirty
+// artifacts/codebase/** files the scope-contract filter exempts from
+// changed_files, so validate/status/review --json all surface the otherwise
+// silent exemption. The exempted file must appear under exempt_context_files,
+// must NOT leak into changed_files, and must not flip the pass status.
+func TestBuildScopeContractViewSurfacesExemptContextFiles(t *testing.T) {
+	t.Parallel()
+
+	report := &scopecontract.Report{
+		Status:             scopecontract.StatusPass,
+		PlannedTargets:     []string{"cmd/validate.go"},
+		ChangedFiles:       []string{"cmd/validate.go"},
+		ExemptContextFiles: []string{"artifacts/codebase/ARCHITECTURE.md"},
+	}
+
+	view := buildScopeContractView(report)
+	require.NotNil(t, view)
+
+	assert.Equal(t, "pass", view.Status)
+	assert.Contains(t, view.ExemptContextFiles, "artifacts/codebase/ARCHITECTURE.md",
+		"exempt_context_files must disclose the dirty codebase-map file the filter exempts")
+	assert.NotContains(t, view.ChangedFiles, "artifacts/codebase/ARCHITECTURE.md",
+		"the exempted file must stay out of changed_files")
+}

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -228,6 +228,15 @@ an archived terminal change, the command fails with
 active-readiness contract: `validate` proves the currently active governed state
 before `done`; it is not a post-archive audit surface for frozen bundles.
 
+The durable codebase map under `artifacts/codebase/**` is exempt from
+scope-contract changed-file accounting. When only those context files are dirty,
+they stay out of `scope_contract.changed_files` and `scope_contract.out_of_scope_files`,
+and `scope_contract.status` stays `pass` — a refreshed codebase map alone does
+not trip scope-contract drift. To keep that filtering visible rather than
+inferred from a `git diff` disagreement, the exempted files are disclosed
+explicitly in the `scope_contract.exempt_context_files` field, surfaced by
+`slipway validate --json`, `slipway status --json`, and `slipway review --json`.
+
 `slipway evidence task` writes the flat runtime task JSON consumed by
 wave-orchestration sync. Required flags: `--task-id`, `--run-summary-version`,
 `--task-kind`, `--verdict`, `--evidence-ref`. Optional: `--changed-file` and

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -28,6 +28,14 @@ go run . status --json
 ```
 
 Avoid deciding readiness from `main...HEAD` alone. Pair branch comparisons with direct worktree status and diff checks.
+The durable codebase map under `artifacts/codebase/**` is exempt from
+scope-contract changed-file accounting: when only those context files are dirty,
+they stay out of `scope_contract.changed_files` and
+`scope_contract.out_of_scope_files`, and `scope_contract.status` stays `pass`.
+To keep that filtering visible rather than inferred from a `git diff`
+disagreement, the exempted files are disclosed in the
+`scope_contract.exempt_context_files` field surfaced by `slipway validate --json`,
+`slipway status --json`, and `slipway review --json`.
 After `slipway done`, Git-safe archived records remain in the owning worktree; commit or merge them before removing that worktree.
 When a worktree-bound change still has uncommitted source or non-active
 governance changes, `done --json` archives anyway and returns a non-blocking

--- a/internal/engine/progression/readiness.go
+++ b/internal/engine/progression/readiness.go
@@ -275,17 +275,22 @@ func evaluateGovernanceReadinessBaseWithReaders(
 		readiness.Blockers = append(readiness.Blockers, model.NewReasonCode(state.StaleExecutionEvidenceBlockerToken, ""))
 	}
 	if state.ExecutionSummaryReady(execCtx.Summary) {
-		workspaceChangedFiles := scopeContractWorkspaceChangedFiles(paths)
+		// workspaceChangedFiles yields both the scope-contract changed set and the
+		// codebase-map context files it exempts from that set, from a single git
+		// scan, so the disclosed exemption can never drift from the set actually
+		// filtered out.
+		changedFiles, exemptContextFiles := workspaceChangedFiles(paths, workspaceChangedFilesOptions{})
 		scopeReport, err := scopecontract.EvaluateBundleWithChangedFiles(
 			paths.GovernedBundleDir,
 			execCtx.Summary,
-			workspaceChangedFiles,
+			changedFiles,
 		)
 		if err != nil {
 			readiness.Blockers = append(readiness.Blockers, model.NewReasonCode(scopecontract.ReasonScopeContractEvaluationFailed, err.Error()))
 			readiness.Diagnostics = append(readiness.Diagnostics, "scope_contract_evaluation_failed: "+err.Error())
 		} else {
 			cloned := scopeReport.Clone()
+			cloned.ExemptContextFiles = exemptContextFiles
 			readiness.ScopeContract = &cloned
 			readiness.Blockers = append(readiness.Blockers, scopeReport.Blockers...)
 			readiness.Diagnostics = append(readiness.Diagnostics, scopeReport.Diagnostics...)
@@ -294,7 +299,7 @@ func evaluateGovernanceReadinessBaseWithReaders(
 			}
 		}
 
-		sensitiveReport := sensitiveevidence.Evaluate(execCtx.Summary, workspaceChangedFiles)
+		sensitiveReport := sensitiveevidence.Evaluate(execCtx.Summary, changedFiles)
 		if sensitiveReport.Status != sensitiveevidence.StatusNotApplicable {
 			cloned := sensitiveReport
 			readiness.SensitiveEvidence = &cloned
@@ -762,7 +767,8 @@ func resolveArtifactEvaluationContext(change model.Change, requiredPreset model.
 }
 
 func scopeContractWorkspaceChangedFiles(paths state.ResolvedChangePaths) []string {
-	return workspaceChangedFiles(paths, workspaceChangedFilesOptions{})
+	changed, _ := workspaceChangedFiles(paths, workspaceChangedFilesOptions{})
+	return changed
 }
 
 type workspaceChangedFilesOptions struct {
@@ -783,17 +789,26 @@ type workspaceChangedFilesOptions struct {
 // rewrites it into the archived bundle. Any other dirty governance artifact is
 // surfaced so the operator can commit it alongside the archived record.
 func WorkspaceChangedFilesForDoneArchive(paths state.ResolvedChangePaths) []string {
-	return workspaceChangedFiles(paths, workspaceChangedFilesOptions{
+	changed, _ := workspaceChangedFiles(paths, workspaceChangedFilesOptions{
 		includeGovernedBundle:  false,
 		includeLocalState:      true,
 		exemptActiveBundleOnly: true,
 	})
+	return changed
 }
 
-func workspaceChangedFiles(paths state.ResolvedChangePaths, opts workspaceChangedFilesOptions) []string {
+// workspaceChangedFiles returns the Git-visible changed files for scope-contract
+// and dirty-advisory accounting. The second result, exemptContext, is the set of
+// dirty codebase-map context artifacts (artifacts/codebase/**) that the
+// scope-contract filter intentionally drops from the changed set. It is collected
+// in the same pass that drops them — and only on the scope-contract path
+// (opts.includeLocalState == false) — so the disclosed exemption is exactly the
+// set filtered out, never a separately re-derived (and potentially divergent) one.
+// Both results are unique-sorted; either may be nil.
+func workspaceChangedFiles(paths state.ResolvedChangePaths, opts workspaceChangedFilesOptions) (changed, exemptContext []string) {
 	workspaceRoot := strings.TrimSpace(paths.WorkspaceRoot)
 	if workspaceRoot == "" {
-		return nil
+		return nil, nil
 	}
 	files := gitNameOnly(workspaceRoot, "diff", "--name-only", "HEAD", "--")
 	for _, file := range gitNameOnly(workspaceRoot, "ls-files", "--others", "--exclude-standard") {
@@ -802,7 +817,7 @@ func workspaceChangedFiles(paths state.ResolvedChangePaths, opts workspaceChange
 		}
 	}
 	if len(files) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	bundleRel := ""
@@ -810,6 +825,7 @@ func workspaceChangedFiles(paths state.ResolvedChangePaths, opts workspaceChange
 		bundleRel = filepath.ToSlash(rel)
 	}
 	filtered := make([]string, 0, len(files))
+	var exempt []string
 	for _, file := range files {
 		file = filepath.ToSlash(strings.TrimSpace(file))
 		file = strings.TrimPrefix(file, "./")
@@ -827,15 +843,19 @@ func workspaceChangedFiles(paths state.ResolvedChangePaths, opts workspaceChange
 				continue
 			}
 			if !opts.includeLocalState && scopeContractContextArtifactChangedFile(file) {
+				exempt = append(exempt, file)
 				continue
 			}
 		}
 		filtered = append(filtered, file)
 	}
-	if len(filtered) == 0 {
-		return nil
+	if len(filtered) > 0 {
+		changed = stringutil.UniqueSorted(filtered)
 	}
-	return stringutil.UniqueSorted(filtered)
+	if len(exempt) > 0 {
+		exemptContext = stringutil.UniqueSorted(exempt)
+	}
+	return changed, exemptContext
 }
 
 func scopeContractContextArtifactChangedFile(file string) bool {

--- a/internal/engine/progression/readiness_optimization_test.go
+++ b/internal/engine/progression/readiness_optimization_test.go
@@ -1,6 +1,7 @@
 package progression
 
 import (
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/signalridge/slipway/internal/bootstrap"
 	"github.com/signalridge/slipway/internal/engine/governance"
+	"github.com/signalridge/slipway/internal/engine/scopecontract"
 	"github.com/signalridge/slipway/internal/model"
 	"github.com/signalridge/slipway/internal/state"
 	"github.com/stretchr/testify/assert"
@@ -439,6 +441,116 @@ func TestScopeContractWorkspaceChangedFilesIncludesWorktreeDiffAndExcludesBundle
 	assert.NotContains(t, files, ".gitignore")
 	assert.NotContains(t, files, "artifacts/codebase/STRUCTURE.md")
 	assert.NotContains(t, files, "artifacts/changes/scope-drift/tasks.md")
+}
+
+func TestEvaluateGovernanceReadinessDisclosesExemptContextFilesWithoutScopeDrift(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	initGitWorkspaceForReadinessOptimizationTests(t, root)
+
+	const inScopeFile = "cmd/next.go"
+	const exemptFile = "artifacts/codebase/ARCHITECTURE.md"
+
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "cmd"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "artifacts", "codebase"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, inScopeFile), []byte("package cmd\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, exemptFile), []byte("# Architecture\n"), 0o644))
+	gitForReadinessOptimizationTests(t, root, "add", inScopeFile, exemptFile)
+	gitForReadinessOptimizationTests(t, root, "commit", "-m", "init")
+
+	change := model.NewChange("scope-contract-exempt-disclosure")
+	change.CurrentState = model.StateS3Review
+	change.PlanSubStep = model.PlanSubStepNone
+	change.WorkflowPreset = model.WorkflowPresetLight
+	require.NoError(t, state.SaveChange(root, change))
+
+	bundleDir, err := state.GovernedBundleDir(root, change)
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(bundleDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(bundleDir, "intent.md"),
+		[]byte("# Intent\n\n## Summary\nDisclose exempted context files.\n"),
+		0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(bundleDir, "requirements.md"),
+		[]byte("# Requirements\n\n### Requirement: Exempt disclosure\nREQ-001: Disclose.\n"),
+		0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(bundleDir, "decision.md"),
+		[]byte("# Decision\n\n## Selected Approach\nDisclose.\n"),
+		0o644,
+	))
+	writeTasksAndMaterializeWavePlan(t, root, change, "# Tasks\n\n"+
+		"- [x] `t-01` Implement in-scope change\n"+
+		"  - target_files: [\""+inScopeFile+"\"]\n"+
+		"  - task_kind: code\n")
+
+	recordedAt := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+	writeVerificationForTest(t, root, change.Slug, SkillWaveOrchestration, model.VerificationRecord{
+		Verdict:    model.VerificationVerdictPass,
+		Blockers:   []model.ReasonCode{},
+		Timestamp:  recordedAt,
+		RunVersion: 1,
+	})
+
+	freshnessInputs := expectedTaskFreshnessInputsForWavePlan(t, root, change, 1, "t-01")
+	taskEvidence := map[string]any{
+		"task_id":             "t-01",
+		"run_summary_version": 1,
+		"task_kind":           "code",
+		"verdict":             "pass",
+		"changed_files":       []string{inScopeFile},
+		"target_files":        []string{inScopeFile},
+		"blockers":            []model.ReasonCode{},
+		"evidence_ref":        "test:t-01",
+		"captured_at":         recordedAt.Format(time.RFC3339Nano),
+		"freshness_inputs":    freshnessInputs,
+	}
+	raw, err := json.Marshal(taskEvidence)
+	require.NoError(t, err)
+	taskPath := filepath.Join(state.EvidenceTasksDir(root, change.Slug), "t-01.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(taskPath), 0o755))
+	require.NoError(t, os.WriteFile(taskPath, raw, 0o644))
+
+	summary := &model.ExecutionSummary{
+		Version:           model.ExecutionSummaryVersion,
+		RunSummaryVersion: 1,
+		CapturedAt:        recordedAt,
+		OverallVerdict:    model.ExecutionVerdictPass,
+		Tasks: []model.ExecutionTaskSummary{{
+			TaskID:       "t-01",
+			Verdict:      model.TaskVerdictPass,
+			TaskKind:     model.TaskKindCode,
+			ChangedFiles: []string{inScopeFile},
+			TargetFiles:  []string{inScopeFile},
+			EvidenceRef:  "test:t-01",
+			CapturedAt:   recordedAt,
+		}},
+	}
+	summary.SyncDerivedFields()
+	summary.Normalize()
+	require.NoError(t, state.SaveExecutionSummary(root, change.Slug, *summary))
+
+	// Dirty both a tracked in-scope file and a tracked exempt context-artifact
+	// file so the scope-contract evaluation observes both as workspace changes.
+	require.NoError(t, os.WriteFile(filepath.Join(root, inScopeFile), []byte("package cmd // changed\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, exemptFile), []byte("# Architecture changed\n"), 0o644))
+
+	readiness, err := EvaluateGovernanceReadiness(root, change, GovernanceReadinessOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, readiness.ScopeContract)
+
+	assert.Equal(t, scopecontract.StatusPass, readiness.ScopeContract.Status,
+		"exempting context-artifact files is a disclosure change and must keep the contract passing")
+	assert.Contains(t, readiness.ScopeContract.ExemptContextFiles, exemptFile,
+		"dirty context-artifact file must be disclosed in ExemptContextFiles")
+	assert.NotContains(t, readiness.ScopeContract.ChangedFiles, exemptFile,
+		"exempted context-artifact file must stay out of ChangedFiles")
+	assert.NotContains(t, readiness.ScopeContract.OutOfScopeFiles, exemptFile,
+		"exempted context-artifact file must not be reported as out-of-scope drift")
 }
 
 func TestWorkspaceChangedFilesForDoneArchiveExcludesBundleAndGeneratedLocalState(t *testing.T) {

--- a/internal/engine/scopecontract/evaluate.go
+++ b/internal/engine/scopecontract/evaluate.go
@@ -28,14 +28,20 @@ const (
 )
 
 type Report struct {
-	Status                  Status             `json:"status"`
-	PlannedTargets          []string           `json:"planned_targets,omitempty"`
-	ChangedFiles            []string           `json:"changed_files,omitempty"`
-	OutOfScopeFiles         []string           `json:"out_of_scope_files,omitempty"`
-	MissingContractTasks    []string           `json:"missing_contract_tasks,omitempty"`
-	MissingChangedFileTasks []string           `json:"missing_changed_file_tasks,omitempty"`
-	Blockers                []model.ReasonCode `json:"blockers,omitempty"`
-	Diagnostics             []string           `json:"diagnostics,omitempty"`
+	Status                  Status   `json:"status"`
+	PlannedTargets          []string `json:"planned_targets,omitempty"`
+	ChangedFiles            []string `json:"changed_files,omitempty"`
+	OutOfScopeFiles         []string `json:"out_of_scope_files,omitempty"`
+	MissingContractTasks    []string `json:"missing_contract_tasks,omitempty"`
+	MissingChangedFileTasks []string `json:"missing_changed_file_tasks,omitempty"`
+	// ExemptContextFiles discloses the dirty codebase-map (artifacts/codebase/**)
+	// files the scope-contract filter intentionally drops from ChangedFiles. The
+	// exemption is preserved (these files stay out of ChangedFiles /
+	// OutOfScopeFiles and never affect Status); this field only makes the
+	// otherwise-silent exemption observable.
+	ExemptContextFiles []string           `json:"exempt_context_files,omitempty"`
+	Blockers           []model.ReasonCode `json:"blockers,omitempty"`
+	Diagnostics        []string           `json:"diagnostics,omitempty"`
 }
 
 func EvaluateWithChangedFiles(plan wave.TaskPlan, summary *model.ExecutionSummary, extraChangedFiles []string) Report {
@@ -281,6 +287,7 @@ func (r Report) Clone() Report {
 		OutOfScopeFiles:         append([]string(nil), r.OutOfScopeFiles...),
 		MissingContractTasks:    append([]string(nil), r.MissingContractTasks...),
 		MissingChangedFileTasks: append([]string(nil), r.MissingChangedFileTasks...),
+		ExemptContextFiles:      append([]string(nil), r.ExemptContextFiles...),
 		Blockers:                append([]model.ReasonCode(nil), r.Blockers...),
 		Diagnostics:             append([]string(nil), r.Diagnostics...),
 	}


### PR DESCRIPTION
## Summary
Two downstream-reported (Lattice) governance-surface transparency fixes to Slipway's own CLI/JSON/doc surfaces — behavior-preserving, additive JSON only.

### #207 — disclose the scope-contract codebase-map exemption
- New `scope_contract.exempt_context_files` lists the dirty `artifacts/codebase/**` files the scope-contract filter drops from `changed_files`, surfaced on `validate`/`status`/`review --json` via the shared view builder, and documented.
- The exemption itself is unchanged: those files stay out of `changed_files`/`out_of_scope_files` and `status` stays `pass`.

### #211 — stop surfacing a run version the evidence surface refuses
- `status`/`next --json` now omit `run_summary_version` when `0` (the "no summary yet" sentinel `evidence task` rejects); a genuinely recorded `>=1` still serializes.
- `evidence task` help advertises the first task-evidence run version (`1`); the `>=1` rejection rule is intact.

## Implementation note
Exempt disclosure derives from the single `workspaceChangedFiles` git scan that drops the files (no duplicate re-scan), so the disclosed set can never drift from the filtered set.

## Verification
- `go build/vet/test ./...` green (25 pkgs); `gofmt -s` clean.
- Live: `validate`/`status`/`review --json` show `exempt_context_files` (dirty codebase docs) while `changed_files` omits them and `status=pass`.
- Driven through the full governed lifecycle (S0 to done) with independent review = PASS.

Closes #207
Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)