### PR TITLE
fix(ci): stabilize hook path assertion on Windows

### DIFF
--- a/cmd/tool_test.go
+++ b/cmd/tool_test.go
@@ -196,8 +196,14 @@ func TestToolFindPolluterGoRejectsExistingPollutionPath(t *testing.T) {
 
 	_, stderr, err := runRootCommandWithInput([]string{"tool", "find-polluter-go", pollutionPath, "./..."}, "")
 	require.Error(t, err)
-	assert.Contains(t, stderr, "find_polluter_go_pollution_present")
-	assert.Contains(t, stderr, pollutionPath)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stderr), &payload))
+	assert.Equal(t, "find_polluter_go_pollution_present", payload["error_code"])
+	assert.Contains(t, fmt.Sprint(payload["message"]), pollutionPath)
+	details, ok := payload["details"].(map[string]any)
+	require.True(t, ok, "details must be present")
+	assert.Equal(t, pollutionPath, details["path"])
 }
 
 func TestToolFindPolluterGoFailsWhenGoListFails(t *testing.T) {

--- a/internal/toolgen/toolgen_test.go
+++ b/internal/toolgen/toolgen_test.go
@@ -2170,7 +2170,12 @@ func TestMergeHookSettingsPrunesLegacyShellHookAndPreservesUserHooks(t *testing.
 	assert.Contains(t, got, "echo user-owned-hook")
 	assert.Contains(t, got, `"matcher": "*"`)
 	// The native binary-backed launcher is registered in its place.
-	assert.Contains(t, got, nativeHookPath(cfg.SessionHook))
+	assertHookCommandRegistered(
+		t,
+		settingsPath,
+		cfg.SessionEvent,
+		hookLauncherCommand(nativeHookPath(cfg.SessionHook)),
+	)
 
 	// Refresh is idempotent: a second merge does not duplicate or mutate.
 	require.NoError(t, mergeHookSettingsJSON(root, cfg, true))


### PR DESCRIPTION
Summary:
- Fix Windows-only CI assertions by verifying structured hook/error data instead of matching raw JSON path text.
- Preserve the existing slash-normalized native hook launcher behavior and JSON error payload behavior.

Verification:
- go test -count=1 ./internal/toolgen -run TestMergeHookSettingsPrunesLegacyShellHookAndPreservesUserHooks
- go test -count=1 ./cmd -run TestToolFindPolluterGoRejectsExistingPollutionPath
- go test -count=1 ./cmd
- go test -count=1 ./...
- git diff --check