### PR TITLE
fix: support Windows runtime portability

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,37 @@
+# Normalize all text files to LF in the repository and on checkout.
+# The governance kernel computes content hashes over these files; CRLF drift
+# (e.g. Windows core.autocrlf=true) must never change a hashed artifact.
+* text=auto eol=lf
+
+*.go    text eol=lf
+*.md    text eol=lf
+*.yaml  text eol=lf
+*.yml   text eol=lf
+*.json  text eol=lf
+*.tmpl  text eol=lf
+*.sh    text eol=lf
+*.svg   text eol=lf
+artifacts/** text=auto eol=lf
+
+# Binary assets — never normalize.
+*.bin   binary
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.ico   binary
+*.mp4   binary
+*.mov   binary
+*.pdf   binary
+*.woff  binary
+*.woff2 binary
+*.ttf   binary
+*.zip   binary
+*.gz    binary
+*.tgz   binary
+*.xz    binary
+*.zst   binary
+*.tar   binary
+*.db    binary
+*.sqlite binary
+*.wasm  binary

--- a/README.md
+++ b/README.md
@@ -181,11 +181,11 @@ Generate host-tool surfaces with `slipway init --tools <id>` (`claude`, `codex`,
 
 | Tool | Generated surfaces |
 | --- | --- |
-| Claude | `.claude/skills/slipway-*/SKILL.md`, `.claude/commands/slipway/*.md`, `.claude/hooks/slipway-session-start.sh`, `.claude/settings.json` |
+| Claude | `.claude/skills/slipway-*/SKILL.md`, `.claude/commands/slipway/*.md`, `.claude/hooks/slipway-*` native launchers, `.claude/settings.json` |
 | Codex | `.codex/skills/slipway-*/SKILL.md` (entry, per-command, and governance skills) |
-| Cursor | `.cursor/skills/slipway-*/SKILL.md`, `.cursor/commands/*.md`, `.cursor/hooks/slipway-session-start.sh` |
-| Gemini | `.gemini/skills/slipway-*/SKILL.md`, `.gemini/commands/slipway/*.toml`, `.gemini/hooks/slipway-session-start.sh`, `.gemini/settings.json` |
-| OpenCode | `.opencode/skills/slipway-*/SKILL.md`, `.opencode/commands/slipway-*.md`, `.opencode/hooks/slipway-session-start.sh` |
+| Cursor | `.cursor/skills/slipway-*/SKILL.md`, `.cursor/commands/*.md`, `.cursor/hooks/slipway-session-start` native launchers |
+| Gemini | `.gemini/skills/slipway-*/SKILL.md`, `.gemini/commands/slipway/*.toml`, `.gemini/hooks/slipway-session-start` native launchers, `.gemini/settings.json` |
+| OpenCode | `.opencode/skills/slipway-*/SKILL.md`, `.opencode/commands/slipway-*.md`, `.opencode/hooks/slipway-session-start` native launchers |
 
 Exported generated skill rows are pinned by public skill directory:
 `slipway/SKILL.md`, `slipway-ci-triage/SKILL.md`,

--- a/artifacts/changes/archived/fix-windows-runtime-incompatibilities-found-in-a-deep-cross/change.yaml
+++ b/artifacts/changes/archived/fix-windows-runtime-incompatibilities-found-in-a-deep-cross/change.yaml
@@ -1,0 +1,37 @@
+version: 1
+slug: fix-windows-runtime-incompatibilities-found-in-a-deep-cross
+description: 'Fix Windows runtime incompatibilities found in a deep cross-platform audit. (1) HIGH: internal/model/evidence.go ComputeFileContentHash hashes raw file bytes with no CRLF normalization, while its sibling normalizeCanonical normalizes \r\n->\n; on Windows (git autocrlf, editors) this makes artifact-freshness reconciliation (internal/engine/artifact/manager.go) and goal-verification evidence digests (internal/engine/progression/evidence_digests.go) report false staleness / failed fresh-evidence for semantically-unchanged files. Normalize CRLF before sha256, and add a repo .gitattributes enforcing eol=lf on hashed artifacts/templates. (2) MEDIUM: cmd/process_other.go isPIDAlive hardcoded false on Windows degrades stale-lock cleanup in internal/fsutil/lock.go; add a real Windows liveness check. (3) MEDIUM: internal/fsutil/atomic.go WriteFileAtomic os.Rename has no Windows sharing-violation retry. (4) MEDIUM: internal/toolgen/worktree_provision.go os.Symlink creation fails on Windows without privilege; add dereference fallback. (5) MEDIUM: internal/toolgen/toolgen.go nativeHookPath pins the committed settings.json hook command to the init-host OS. (6) MEDIUM: internal/tmpl/templates/skills/goal-verification/SKILL.md.tmpl prescribes Unix-only grep/perl stub scan.'
+status: done
+current_state: DONE
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-06-15T07:41:57.362105Z
+quality_mode: standard
+workflow_preset: light
+worktree_branch: feat/fix-windows-runtime-incompatibilities-found-in-a-deep-cross
+artifact_schema: core
+artifacts:
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: 565db04e01881015e9de2efef05f6b5bc03817cf78b17b82d2f4cabc451cf7de
+        updated_at: 2026-06-15T07:50:22.265928805Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: ff10c09ee08689061e47d5e4817b0b6617ba1573f402a1f62403fac2b1a5a539
+        updated_at: 2026-06-15T10:52:28.3656639Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: 5f4a76c5426c72761385792ac4e3bcd9decdaa1a227d442f5735078bc92e6aae
+        updated_at: 2026-06-15T11:10:51.956219505Z
+evidence_refs:
+    code-quality-review: .worktrees/fix-windows-runtime-incompatibilities-found-in-a-deep-cross/artifacts/changes/fix-windows-runtime-incompatibilities-found-in-a-deep-cross/verification/code-quality-review.yaml
+    goal-verification: .worktrees/fix-windows-runtime-incompatibilities-found-in-a-deep-cross/artifacts/changes/fix-windows-runtime-incompatibilities-found-in-a-deep-cross/verification/goal-verification.yaml
+    plan-audit: .worktrees/fix-windows-runtime-incompatibilities-found-in-a-deep-cross/artifacts/changes/fix-windows-runtime-incompatibilities-found-in-a-deep-cross/verification/plan-audit.yaml
+    spec-compliance-review: .worktrees/fix-windows-runtime-incompatibilities-found-in-a-deep-cross/artifacts/changes/fix-windows-runtime-incompatibilities-found-in-a-deep-cross/verification/spec-compliance-review.yaml
+    wave-orchestration: .worktrees/fix-windows-runtime-incompatibilities-found-in-a-deep-cross/artifacts/changes/fix-windows-runtime-incompatibilities-found-in-a-deep-cross/verification/wave-orchestration.yaml

--- a/artifacts/changes/archived/fix-windows-runtime-incompatibilities-found-in-a-deep-cross/intent.md
+++ b/artifacts/changes/archived/fix-windows-runtime-incompatibilities-found-in-a-deep-cross/intent.md
@@ -1,0 +1,80 @@
+# Intent
+
+## Summary
+Fix Windows runtime incompatibilities found in a deep cross-platform audit. (1) HIGH: internal/model/evidence.go ComputeFileContentHash hashes raw file bytes with no CRLF normalization, while its sibling normalizeCanonical normalizes \r\n->\n; on Windows (git autocrlf, editors) this makes artifact-freshness reconciliation (internal/engine/artifact/manager.go) and goal-verification evidence digests (internal/engine/progression/evidence_digests.go) report false staleness / failed fresh-evidence for semantically-unchanged files. Normalize CRLF before sha256, and add a repo .gitattributes enforcing eol=lf on hashed artifacts/templates. (2) MEDIUM: cmd/process_other.go isPIDAlive hardcoded false on Windows degrades stale-lock cleanup in internal/fsutil/lock.go; add a real Windows liveness check. (3) MEDIUM: internal/fsutil/atomic.go WriteFileAtomic os.Rename has no Windows sharing-violation retry. (4) MEDIUM: internal/toolgen/worktree_provision.go os.Symlink creation fails on Windows without privilege; add dereference fallback. (5) MEDIUM: internal/toolgen/toolgen.go nativeHookPath pins the committed settings.json hook command to the init-host OS. (6) MEDIUM: internal/tmpl/templates/skills/goal-verification/SKILL.md.tmpl prescribes Unix-only grep/perl stub scan.
+## Complexity Assessment
+complex
+<!-- Rationale: 7 distinct edit sites across model/engine/fsutil/toolgen/tmpl plus
+     a new build-tagged file and .gitattributes; one change alters the governance
+     evidence/digest integrity core (fail-closed, sensitive); two changes alter
+     generated external-contract surfaces (settings.json, goal-verification SKILL).
+     Verified only via CI's windows-latest job (no local Windows). -->
+
+## Guardrail Domains
+<!-- No named sensitive domain (not auth/PII/financial/schema/irreversible). Two
+     integrity-adjacent surfaces require fail-closed care:
+     - evidence/digest integrity core (internal/model/evidence.go + freshness/goal-verify callers)
+     - generated external contracts (settings.json hook command, goal-verification SKILL template) -->
+
+## In Scope
+- **(1, HIGH) `internal/model/evidence.go` `ComputeFileContentHash`** — normalize CRLF→LF before `sha256`, **binary-safe** (skip normalization when content is detected binary, e.g. contains NUL), aligning with the existing `normalizeCanonical` CRLF contract. Fix propagates to callers `internal/engine/artifact/manager.go:762,874,936,992` and `internal/engine/progression/evidence_digests.go:941,958`.
+- **(1, HIGH) new repo-root `.gitattributes`** — enforce `text=auto eol=lf` for hashed/text artifacts & templates (`artifacts/**`, `*.md`, `*.yaml`/`*.yml`, `*.tmpl`, `*.go`), with binary assets marked `binary`.
+- **(2, MED) `cmd/process_other.go` + new `cmd/process_windows.go`** — real `isPIDAlive` on Windows via `golang.org/x/sys/windows` (`OpenProcess`/`GetExitCodeProcess`), replacing hardcoded `false`; restores stale-lock cleanup correctness in `internal/fsutil/lock.go`.
+- **(3, MED) `internal/fsutil/atomic.go` `WriteFileAtomic`** — bounded retry around `os.Rename` for Windows sharing-violation (`ERROR_SHARING_VIOLATION`/`ERROR_ACCESS_DENIED`), GOOS=windows-guarded.
+- **(4, MED) `internal/toolgen/worktree_provision.go` (+ `internal/state/lifecycle.go` `copyDirRecursive`)** — on `os.Symlink` failure, dereference/copy target content as fallback.
+- **(5, MED) `internal/toolgen/toolgen.go` hook command generation (`nativeHookPath`)** — make the committed `settings.json` hook `command` platform-portable instead of pinned to the init-host OS.
+- **(6, MED) `internal/tmpl/templates/skills/goal-verification/SKILL.md.tmpl`** — replace Unix-only `grep`/`perl` stub scan with a portable/tool-agnostic instruction.
+- **Tests** — OS-independent unit tests + dedicated Windows regression/integration tests (per chosen acceptance bar).
+
+## Out of Scope
+- The LOW findings: `cmd/path_helpers.go` slash normalization, `internal/engine/wave/parse.go` trailing `\r`, `syscall.EXDEV` non-match on Windows, unused `.ps1` launcher artifact.
+- Unix-only shell snippets in **SAST/GHA reference skills** (they analyze *other* repos, not Slipway operation).
+- Broad Windows feature parity beyond the six findings — e.g. full mid-run task preemption/kill (`TerminateProcess`); `process_other.go` keeps its clear unsupported-error behavior, only liveness is added.
+- Running on real Windows hardware locally (rely on CI `windows-latest`).
+- Migrating/rewriting existing recorded digests (LF content hashes are unchanged by normalization, so no migration is needed).
+
+## Constraints
+- **Backward compatibility:** for pure-LF content, raw hash == normalized hash, so existing recorded digests stay valid; binary evidence files must remain byte-exact (do not normalize binaries).
+- **Generated-surface contracts:** keep `settings.json` and goal-verification SKILL output coherent across OSes; do not regress the e225088 native-hook (`.sh`/`.cmd`/`.ps1`) migration.
+- **Fail-closed:** evidence/digest changes must not introduce any bypass/force path; sensitive-domain posture preserved.
+- **Dependencies:** prefer `golang.org/x/sys/windows` (already present transitively via `gofrs/flock`); no new top-level deps otherwise.
+- **Gates:** must pass `golangci-lint` and the 3-OS test matrix.
+
+## Acceptance Signals
+- `go test ./... -count=1` green on **ubuntu-latest, macos-latest, AND windows-latest** (CI matrix).
+- `GOOS=windows GOARCH=amd64 go build ./...` and `go vet ./...` green.
+- New OS-independent unit tests: `ComputeFileContentHash` is CRLF-invariant for text and byte-exact for binary; Windows `isPIDAlive` returns true for the running process and false for a non-existent PID.
+- Dedicated Windows regression/integration tests: a CRLF artifact round-tripped through freshness reconciliation is **not** reported stale; evidence digest stable across LF↔CRLF round-trip.
+- `.gitattributes` present and enforcing `eol=lf` on hashed artifact/text paths.
+- `golangci-lint` clean.
+
+## Open Questions
+None — all six fixes are well-understood; no research spike required.
+
+## Deferred Ideas
+- Full Windows process preemption (`TerminateProcess`) for mid-run task kill, beyond liveness.
+- PowerShell equivalents for the SAST/GHA reference-skill shell snippets.
+- Handle `ERROR_NOT_SAME_DEVICE` (Windows `EXDEV` analog) for cross-volume archive moves.
+
+## Approved Summary
+Fix six Windows runtime incompatibilities found in the cross-platform audit, in one
+governed change. The HIGH fix normalizes CRLF→LF (binary-safe) before SHA-256 in
+`internal/model/evidence.go` `ComputeFileContentHash` so artifact-freshness
+reconciliation and goal-verification evidence digests stop reporting false staleness
+on Windows (git autocrlf); adds a repo `.gitattributes` enforcing `eol=lf`. Five
+MEDIUM platform gaps: real Windows `isPIDAlive` (restores stale-lock cleanup),
+`WriteFileAtomic` rename retry on Windows sharing violations, `os.Symlink` dereference
+fallback in worktree provisioning, platform-portable generated `settings.json` hook
+command, and a tool-agnostic goal-verification stub scan replacing Unix-only
+`grep`/`perl`.
+
+Scope boundaries: LOW findings, SAST/GHA reference-skill shell snippets, full mid-run
+task-kill parity, and local real-Windows runs are out of scope. Existing LF digests are
+unchanged by normalization, so no digest migration.
+
+Primary acceptance signal: `go test ./...` green on the 3-OS CI matrix (incl.
+`windows-latest`) + new CRLF-invariance/binary-exact unit tests + dedicated Windows
+regression tests (CRLF artifact → not-stale; LF↔CRLF digest stable) + Windows
+cross-compile green.
+
+Confirmed by user: 2026-06-15T07:50:11Z

--- a/artifacts/changes/archived/fix-windows-runtime-incompatibilities-found-in-a-deep-cross/requirements.md
+++ b/artifacts/changes/archived/fix-windows-runtime-incompatibilities-found-in-a-deep-cross/requirements.md
@@ -1,0 +1,161 @@
+# Requirements
+
+## Requirements
+
+### Requirement: CRLF-invariant, binary-safe content digest
+REQ-001: `internal/model/evidence.go` `ComputeFileContentHash` MUST produce an
+identical SHA-256 digest for two files whose contents differ only in line-ending
+style (LF vs CRLF), by normalizing `\r\n` to `\n` before hashing text content. It
+MUST NOT normalize content detected as binary (e.g. content containing a NUL byte),
+which SHALL be hashed byte-for-byte. The digest for pure-LF text content MUST remain
+unchanged from the pre-change value so existing recorded digests stay valid.
+
+#### Scenario: Text file digest is line-ending invariant
+GIVEN a UTF-8 text file written with LF line endings and a second file with the same
+logical content written with CRLF line endings
+WHEN `ComputeFileContentHash` is called on each
+THEN both calls return the same hex digest.
+
+#### Scenario: Existing LF digests are preserved
+GIVEN a text file containing no `\r\n` sequences
+WHEN `ComputeFileContentHash` is called
+THEN the returned digest equals the raw `sha256` of the file bytes (no behavior change
+for LF-only content).
+
+#### Scenario: Binary content is hashed byte-exact
+GIVEN two binary files that differ only by a `0x0D 0x0A` byte pair somewhere in their
+content, each containing at least one NUL byte
+WHEN `ComputeFileContentHash` is called on each
+THEN the two digests differ (binary content is not CRLF-normalized).
+
+### Requirement: Freshness and goal-verification tolerate CRLF checkout
+REQ-002: Artifact-freshness reconciliation (`internal/engine/artifact/manager.go`) and
+goal-verification evidence digests (`internal/engine/progression/evidence_digests.go`)
+MUST NOT report a governed text artifact as stale solely because it was materialized as
+LF and later re-read as CRLF (the Windows `git core.autocrlf=true` case).
+
+#### Scenario: CRLF re-materialization is not stale
+GIVEN a governed text artifact recorded with its content hash while stored as LF
+WHEN the same artifact is re-read from disk with CRLF line endings and reconciliation runs
+THEN reconciliation reports the artifact as unchanged (not stale) and does not auto-amend it.
+
+#### Scenario: Evidence digest stable across line-ending round-trip
+GIVEN a workspace file digested for goal-verification evidence as LF
+WHEN the same file is digested again after conversion to CRLF
+THEN the recomputed evidence digest equals the recorded digest.
+
+### Requirement: Repository enforces LF for hashed artifacts
+REQ-003: The repository MUST contain a root `.gitattributes` that enforces `eol=lf`
+for the text and artifact paths whose content is hashed by the governance kernel
+(at minimum `artifacts/**`, `*.md`, `*.yaml`/`*.yml`, `*.tmpl`, `*.go`), and MUST mark
+known binary asset types as `binary` so they are never line-ending converted.
+
+#### Scenario: Hashed text paths are pinned to LF
+GIVEN the repository root `.gitattributes`
+WHEN it is inspected for the governed text/artifact globs
+THEN each such glob carries an `eol=lf` (or `text=auto eol=lf`) attribute.
+
+### Requirement: Windows process liveness detection
+REQ-004: `isPIDAlive` MUST return an accurate liveness result on Windows (true for a
+running process, false for a process that has exited), replacing the hardcoded `false`,
+so that stale-lock cleanup in `internal/fsutil/lock.go` does not treat a live lock
+holder as dead. The Unix behavior MUST be unchanged.
+
+#### Scenario: Running process is reported alive on Windows
+GIVEN the current process PID on Windows
+WHEN `isPIDAlive` is called with that PID
+THEN it returns true.
+
+#### Scenario: Non-existent process is reported dead on Windows
+GIVEN a PID that does not correspond to any running process on Windows
+WHEN `isPIDAlive` is called with that PID
+THEN it returns false.
+
+### Requirement: Atomic write survives Windows sharing violations
+REQ-005: `internal/fsutil/atomic.go` `WriteFileAtomic` MUST, on Windows, retry the
+final `os.Rename` for a bounded period when it fails with a sharing-violation /
+access-denied error caused by a concurrent reader holding the destination open, and
+MUST surface the error only after the retry budget is exhausted. Non-Windows behavior
+MUST be unchanged.
+
+#### Scenario: Transient sharing violation is retried
+GIVEN a Windows rename that initially fails with a sharing-violation error and then
+succeeds within the retry budget
+WHEN `WriteFileAtomic` performs the destination rename
+THEN the write completes successfully without returning an error.
+
+### Requirement: Symlink provisioning degrades gracefully on Windows
+REQ-006: When copying a tree that contains a symlink (worktree provisioning in
+`internal/toolgen/worktree_provision.go` and the archive copy in
+`internal/state/lifecycle.go`), an `os.Symlink` failure caused by missing privilege
+MUST fall back to materializing the link target's content at the destination rather
+than aborting the copy.
+
+#### Scenario: Symlink creation failure falls back to dereference
+GIVEN a source tree containing a symlink and a platform where `os.Symlink` returns a
+privilege error
+WHEN the tree is copied during provisioning
+THEN the destination contains a regular file/dir with the link target's content and the
+copy completes without error.
+
+### Requirement: Generated hook command is platform-portable
+REQ-007: The hook `command` that Slipway writes into a tool's generated
+`settings.json` (`internal/toolgen/toolgen.go`) MUST resolve and run correctly on a
+consumer host regardless of which OS ran `slipway init`; it MUST NOT be pinned to the
+init-host OS such that a settings file generated on one OS fails on another. The change
+MUST NOT regress the native `slipway hook` launcher migration (no reintroduction of
+`sh`/`bash`/`python` interpreter prefixes). The registered command MUST avoid
+shell-specific chaining operators (`||`, `&&`, `;`, `&`, `|`) so it parses under POSIX
+`sh`, `cmd.exe`, Windows PowerShell 5.1, and PowerShell 7+.
+
+#### Scenario: Settings generated on one OS work on another
+GIVEN a `settings.json` whose hook command is generated on a non-Windows host
+WHEN that repository is used by a tool on a Windows host
+THEN the hook command resolves and dispatches to the native `slipway hook` invocation.
+
+#### Scenario: Settings command is shell-neutral
+GIVEN a generated `settings.json` hook command
+WHEN it is inspected as a command string
+THEN it contains only the direct `slipway hook ...` invocation and no shell chaining
+operator that would be rejected by Windows PowerShell 5.1.
+
+### Requirement: Goal-verification stub scan is tool-agnostic
+REQ-008: The goal-verification skill template
+(`internal/tmpl/templates/skills/goal-verification/SKILL.md.tmpl`) MUST express its
+placeholder/stub scan step using portable, tool-agnostic instructions rather than
+Unix-only `grep`/`perl` one-liners that cannot run on a stock Windows host.
+
+#### Scenario: Stub scan has no Unix-only hard dependency
+GIVEN the rendered goal-verification SKILL content
+WHEN its prescribed stub-scan step is inspected
+THEN it does not require `perl` or GNU/BSD-specific `grep` alternation as the only way
+to perform the scan.
+
+### Requirement: Adapter hook documentation matches generated contracts
+REQ-010: Public documentation for AI-tool adapters MUST describe the generated
+`settings.json` hook command and native launcher files accurately. It MUST NOT say
+settings-capable adapters register a platform-specific launcher path when the generator
+registers a direct `slipway hook ...` command.
+
+#### Scenario: Public docs do not describe retired launcher registration
+GIVEN the public adapter and installation documentation
+WHEN the hook registration contract is inspected
+THEN docs describe direct shell-neutral `slipway hook ...` settings entries and the
+separate generated native launcher files without claiming `.cmd` or POSIX launchers are
+the registered settings command.
+
+### Requirement: Cross-platform build and test integrity preserved
+REQ-009: After the change, the project MUST build and pass tests on all three CI
+operating systems (`ubuntu-latest`, `macos-latest`, `windows-latest`), MUST cross-compile
+with `GOOS=windows`, and MUST remain `golangci-lint` clean. New platform-specific code
+MUST be isolated behind Go build constraints so each target compiles cleanly.
+
+#### Scenario: Windows cross-compile stays green
+GIVEN the modified source tree
+WHEN `GOOS=windows GOARCH=amd64 go build ./...` and `go vet ./...` run
+THEN both succeed with no errors.
+
+#### Scenario: Test matrix stays green
+GIVEN the modified source tree with new tests
+WHEN `go test ./... -count=1` runs on ubuntu-latest, macos-latest, and windows-latest
+THEN all three jobs pass.

--- a/artifacts/changes/archived/fix-windows-runtime-incompatibilities-found-in-a-deep-cross/tasks.md
+++ b/artifacts/changes/archived/fix-windows-runtime-incompatibilities-found-in-a-deep-cross/tasks.md
@@ -1,0 +1,63 @@
+# Tasks
+
+## Task List
+
+- [x] `t-01` Make `ComputeFileContentHash` binary-safe CRLF-normalizing before SHA-256, with unit tests (CRLF-invariant text, byte-exact binary, LF digest unchanged)
+  - depends_on: []
+  - target_files: [internal/model/evidence.go, internal/model/evidence_test.go]
+  - task_kind: code
+  - covers: [REQ-001]
+
+- [x] `t-02` Add Windows-regression tests: CRLF-re-materialized governed artifact is not reported stale by reconciliation; goal-verification evidence digest is stable across an LF↔CRLF round-trip
+  - depends_on: [t-01]
+  - target_files: [internal/engine/artifact/manager_test.go, internal/engine/progression/evidence_digests_test.go]
+  - task_kind: test
+  - covers: [REQ-002, REQ-009]
+
+- [x] `t-03` Add root `.gitattributes` enforcing `eol=lf` for hashed text/artifact globs (`artifacts/**`, `*.md`, `*.yaml`/`*.yml`, `*.tmpl`, `*.go`) and marking binary asset types `binary`
+  - depends_on: []
+  - target_files: [.gitattributes]
+  - task_kind: code
+  - covers: [REQ-003]
+
+- [x] `t-04` Implement real Windows `isPIDAlive` in a new `//go:build windows` file using `golang.org/x/sys/windows`; narrow `process_other.go` to `!unix && !windows`; add a Windows-only liveness test
+  - depends_on: []
+  - target_files: [cmd/process_windows.go, cmd/process_other.go, cmd/process_windows_test.go]
+  - task_kind: code
+  - covers: [REQ-004, REQ-009]
+
+- [x] `t-05` Add Windows sharing-violation bounded retry around the `os.Rename` in `WriteFileAtomic`, GOOS-guarded; add a test exercising the retry path
+  - depends_on: []
+  - target_files: [internal/fsutil/atomic.go, internal/fsutil/atomic_test.go]
+  - task_kind: code
+  - covers: [REQ-005]
+
+- [x] `t-06` Add `os.Symlink` privilege-failure dereference fallback to worktree provisioning and the archive copy so a symlinked source materializes its target content
+  - depends_on: []
+  - target_files: [internal/toolgen/worktree_provision.go, internal/toolgen/worktree_provision_test.go, internal/state/lifecycle.go, internal/state/lifecycle_test.go, internal/fsutil/symlink.go, internal/fsutil/symlink_test.go]
+  - task_kind: code
+  - covers: [REQ-006]
+
+- [x] `t-07` Make the generated `settings.json` hook `command` platform-portable: register direct `slipway hook <event>` commands (PATH-resolved, OS-uniform, no shell chaining operators) instead of an init-host-OS-pinned launcher path; keep launcher files generated for host-native/manual dispatch; update the toolgen settings-command contract tests
+  - depends_on: []
+  - target_files: [internal/toolgen/toolgen.go, internal/toolgen/toolgen_test.go, internal/toolgen/adapter_contract_test.go]
+  - task_kind: code
+  - covers: [REQ-007]
+
+- [x] `t-08` Replace the Unix-only `grep`/`perl` stub scan in the goal-verification skill template with a portable, tool-agnostic instruction, and update the contract test that pins the old `perl`/`grep` constructs
+  - depends_on: []
+  - target_files: [internal/tmpl/templates/skills/goal-verification/SKILL.md.tmpl, internal/tmpl/templates_test.go]
+  - task_kind: code
+  - covers: [REQ-008]
+
+- [x] `t-09` Regenerate the local generated adapter surfaces affected by t-07/t-08 (portable hook command in settings.json; goal-verification SKILL across all adapter trees) so ignored/local surfaces match the updated generator and template
+  - depends_on: [t-07, t-08]
+  - target_files: [.claude/settings.json, .gemini/settings.json, .claude/skills/slipway-goal-verification/SKILL.md, .codex/skills/slipway-goal-verification/SKILL.md, .cursor/skills/slipway-goal-verification/SKILL.md, .gemini/skills/slipway-goal-verification/SKILL.md, .opencode/skills/slipway-goal-verification/SKILL.md]
+  - task_kind: code
+  - covers: [REQ-007, REQ-008]
+
+- [x] `t-10` Align public adapter documentation with the direct shell-neutral `settings.json` hook command and the separate native launcher file role
+  - depends_on: [t-07]
+  - target_files: [README.md, docs/ai-tools.md, docs/installation.md]
+  - task_kind: code
+  - covers: [REQ-007, REQ-010]

--- a/cmd/process_other.go
+++ b/cmd/process_other.go
@@ -1,4 +1,4 @@
-//go:build !unix
+//go:build !unix && !windows
 
 package cmd
 
@@ -14,7 +14,7 @@ func isPIDAlive(_ int) bool {
 
 // preemptInFlightTasks is not supported on non-Unix platforms once there are
 // active task PIDs to signal. With no recorded task PIDs, it is a no-op so
-// ordinary cancel/abort flows still work on Windows.
+// ordinary cancel/abort flows still work on unsupported platforms.
 func preemptInFlightTasks(root, slug string, _ time.Duration) ([]int, []int, error) {
 	pids, err := loadActiveTaskPIDs(root, slug)
 	if err != nil || len(pids) == 0 {

--- a/cmd/process_windows.go
+++ b/cmd/process_windows.go
@@ -1,0 +1,50 @@
+//go:build windows
+
+package cmd
+
+import (
+	"fmt"
+	"syscall"
+	"time"
+)
+
+// stillActive mirrors the Windows STILL_ACTIVE / STATUS_PENDING value returned
+// by GetExitCodeProcess for a process that has not yet exited.
+const stillActive uint32 = 259
+
+// processQueryLimitedInformation is PROCESS_QUERY_LIMITED_INFORMATION (0x1000).
+// The stdlib syscall package exposes PROCESS_QUERY_INFORMATION, but not this
+// lower-privilege access mask.
+const processQueryLimitedInformation uint32 = 0x1000
+
+// isPIDAlive checks if a process with the given PID is still running.
+//
+// Edge case: a process whose real exit code is exactly 259 (stillActive) would
+// be misreported as alive after it has exited. This is rare and acceptable for
+// stale-lock cleanup purposes.
+func isPIDAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	h, err := syscall.OpenProcess(processQueryLimitedInformation, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	defer syscall.CloseHandle(h)
+	var code uint32
+	if err := syscall.GetExitCodeProcess(h, &code); err != nil {
+		return false
+	}
+	return code == stillActive
+}
+
+// preemptInFlightTasks is not supported on Windows once there are active task
+// PIDs to signal. With no recorded task PIDs, it is a no-op so ordinary
+// cancel/abort flows still work on Windows.
+func preemptInFlightTasks(root, slug string, _ time.Duration) ([]int, []int, error) {
+	pids, err := loadActiveTaskPIDs(root, slug)
+	if err != nil || len(pids) == 0 {
+		return nil, nil, err
+	}
+	return nil, nil, fmt.Errorf("process signaling is not supported on this platform")
+}

--- a/cmd/process_windows_test.go
+++ b/cmd/process_windows_test.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+package cmd
+
+import (
+	"os"
+	"testing"
+)
+
+func TestIsPIDAliveNonPositive(t *testing.T) {
+	if isPIDAlive(0) {
+		t.Error("isPIDAlive(0) = true, want false")
+	}
+	if isPIDAlive(-1) {
+		t.Error("isPIDAlive(-1) = true, want false")
+	}
+}
+
+func TestIsPIDAliveSelf(t *testing.T) {
+	if !isPIDAlive(os.Getpid()) {
+		t.Errorf("isPIDAlive(os.Getpid()=%d) = false, want true", os.Getpid())
+	}
+}
+
+func TestIsPIDAliveDeadPID(t *testing.T) {
+	// A PID that is extremely unlikely to be in use. OpenProcess should fail
+	// (or GetExitCodeProcess should report a non-stillActive exit code),
+	// yielding false.
+	const unlikelyPID = 0x7FFFFFFE
+	if isPIDAlive(unlikelyPID) {
+		t.Errorf("isPIDAlive(%d) = true, want false", unlikelyPID)
+	}
+}

--- a/docs/ai-tools.md
+++ b/docs/ai-tools.md
@@ -145,10 +145,13 @@ and the advisory session hook is generated as platform-native launchers:
 .opencode/hooks/slipway-session-start.cmd
 ```
 
-Settings-capable adapters register the native launcher for the current
-platform. On Unix-like hosts that is the extensionless POSIX entry; on Windows
-it is the `.cmd` entry. The launcher only delegates to `slipway hook ...`; hook
-behavior lives in the Slipway binary.
+Settings-capable adapters register a direct, shell-neutral `slipway hook ...`
+command in `settings.json` instead of a platform-specific launcher path. The
+registered command intentionally contains no shell chaining operators, so the
+same settings file parses under POSIX `sh`, `cmd.exe`, Windows PowerShell 5.1,
+and PowerShell 7+. The generated launcher files remain available for
+host-native dispatch paths and manual inspection; each launcher only delegates
+to `slipway hook ...`, and hook behavior lives in the Slipway binary.
 
 ## Safety Rules
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -345,7 +345,10 @@ OpenCode commands use slash-hyphen spelling such as `/slipway-new`, `/slipway-ne
 
 Hook-capable adapters receive native launchers for POSIX, PowerShell, and
 `cmd.exe`. The launchers only delegate to `slipway hook ...`; no generated hook
-requires bash, Python, `jq`, `gh`, or a Go runtime.
+requires bash, Python, `jq`, `gh`, or a Go runtime. Settings-capable adapters
+register a direct, shell-neutral `slipway hook ...` command in `settings.json`
+instead of a platform-specific launcher path, so one generated settings file
+parses under POSIX `sh`, `cmd.exe`, Windows PowerShell 5.1, and PowerShell 7+.
 
 Generated skill helpers run through `slipway tool ...` rather than generated
 script payloads. Manual helpers may still require explicit authenticated
@@ -372,4 +375,5 @@ Codex command surfaces are generated as skills under
 `$CODEX_HOME/prompts/` (or `~/.codex/prompts/` when `CODEX_HOME` is unset) so
 the retired command surface does not linger. For hook-capable adapters,
 `--refresh` also removes Slipway-owned legacy shell hook launchers and replaces
-retired `bash "<hook>.sh"` settings entries with native launcher entries.
+retired `bash "<hook>.sh"` settings entries with shell-neutral
+`slipway hook ...` settings entries.

--- a/internal/engine/artifact/manager_test.go
+++ b/internal/engine/artifact/manager_test.go
@@ -1030,3 +1030,66 @@ func TestStalePropagationOrderUnknownArtifactError(t *testing.T) {
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrUnknownArtifact))
 }
+
+// TestReconcileFromFilesystemCRLFRematerializationIsNotStale is a Windows
+// regression guard (REQ-002 scenario A / REQ-009). A governed text artifact is
+// frozen with its content hash recorded while stored as LF, then re-read from
+// disk with CRLF line endings (the Windows `git core.autocrlf=true` checkout
+// case). Reconciliation runs in an amendment-eligible state (S2_EXECUTE), where
+// a real content change would unfreeze the artifact to approved and record an
+// AmendmentEvent. Because ComputeFileContentHash CRLF-normalizes text, the
+// CRLF re-materialization must hash identically to the LF original, so
+// reconciliation reports the artifact as UNCHANGED: it stays frozen, keeps its
+// recorded hash, and produces no amendment. If CRLF normalization were removed,
+// the LF-recorded hash would differ from the CRLF disk hash and this test would
+// go RED (an amendment would fire and the state would flip to approved).
+func TestReconcileFromFilesystemCRLFRematerializationIsNotStale(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	slug := "test-change"
+	base := filepath.Join(root, "artifacts", "changes", slug)
+	require.NoError(t, os.MkdirAll(base, 0o755))
+
+	artifactPath := filepath.Join(base, "intent.md")
+	// Record the artifact while stored as LF (the original committed form).
+	require.NoError(t, os.WriteFile(artifactPath, []byte("# Intent\nship the change\nverify it\n"), 0o644))
+	lfHash, err := model.ComputeFileContentHash(artifactPath)
+	require.NoError(t, err)
+
+	// Re-materialize the SAME logical content on disk with CRLF line endings, as
+	// a Windows autocrlf checkout would. The raw bytes differ from the LF form.
+	require.NoError(t, os.WriteFile(artifactPath, []byte("# Intent\r\nship the change\r\nverify it\r\n"), 0o644))
+	crlfBytes, err := os.ReadFile(artifactPath)
+	require.NoError(t, err)
+	require.Contains(t, string(crlfBytes), "\r\n", "test must drive the real CRLF on-disk case")
+
+	// The normalized content hash is line-ending invariant: the regression guard.
+	crlfHash, err := model.ComputeFileContentHash(artifactPath)
+	require.NoError(t, err)
+	require.Equal(t, lfHash, crlfHash,
+		"CRLF re-materialization of identical text must hash equal to its LF form")
+
+	change := &model.Change{
+		Slug:         slug,
+		CurrentState: model.StateS2Execute, // amendment-eligible: a real change would unfreeze.
+		Artifacts: map[string]model.ArtifactState{
+			"intent": {
+				ID:          "intent",
+				State:       model.ArtifactLifecycleFrozen,
+				ContentHash: lfHash,
+				Path:        artifactPath,
+			},
+		},
+	}
+
+	result, reconcileErr := ReconcileFromFilesystem(root, change)
+	require.NoError(t, reconcileErr)
+
+	// UNCHANGED: no auto-amendment for a line-ending-only re-materialization.
+	assert.Empty(t, result.Amendments,
+		"a CRLF-only re-materialization must not auto-amend a frozen artifact")
+	assert.Equal(t, model.ArtifactLifecycleFrozen, change.Artifacts["intent"].State,
+		"frozen artifact must remain frozen across a CRLF checkout")
+	assert.Equal(t, lfHash, change.Artifacts["intent"].ContentHash,
+		"recorded content hash must survive a CRLF round-trip unchanged")
+}

--- a/internal/engine/progression/evidence_digests_test.go
+++ b/internal/engine/progression/evidence_digests_test.go
@@ -1652,3 +1652,39 @@ func deletedInputDigest(digest, rel string) bool {
 	expected, err := deletedFileInputHash(rel)
 	return err == nil && digest == expected
 }
+
+// TestWorkspacePathInputHashStableAcrossLineEndingRoundTrip is a Windows
+// regression guard (REQ-002 scenario B / REQ-009). A workspace file is digested
+// for goal-verification / review evidence via workspacePathInputHash (which
+// hashes file content through model.ComputeFileContentHash). When the SAME
+// logical content is digested again after conversion from LF to CRLF — the
+// Windows `git core.autocrlf=true` checkout case — the recomputed evidence
+// digest must EQUAL the recorded digest. CRLF is simulated OS-independently by
+// writing bytes containing \r\n directly. If CRLF normalization were removed,
+// the LF and CRLF digests would differ and this test would go RED.
+func TestWorkspacePathInputHashStableAcrossLineEndingRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	path := filepath.Join(root, "tracked.go")
+	const rel = "tracked.go"
+
+	// Digest the file while stored as LF (the committed form).
+	require.NoError(t, os.WriteFile(path, []byte("package main\n\nfunc main() {}\n"), 0o644))
+	lfDigest, err := workspacePathInputHash(path, rel)
+	require.NoError(t, err)
+	require.NotEmpty(t, lfDigest)
+
+	// Re-materialize the SAME logical content with CRLF line endings (Windows
+	// autocrlf checkout) and digest again. The raw bytes differ from the LF form.
+	require.NoError(t, os.WriteFile(path, []byte("package main\r\n\r\nfunc main() {}\r\n"), 0o644))
+	crlfBytes, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Contains(t, string(crlfBytes), "\r\n", "test must drive the real CRLF on-disk case")
+
+	crlfDigest, err := workspacePathInputHash(path, rel)
+	require.NoError(t, err)
+
+	assert.Equal(t, lfDigest, crlfDigest,
+		"evidence digest must be stable across an LF<->CRLF line-ending round-trip")
+}

--- a/internal/fsutil/atomic.go
+++ b/internal/fsutil/atomic.go
@@ -8,7 +8,24 @@ import (
 	"runtime"
 	"slices"
 	"strings"
+	"syscall"
 	"time"
+)
+
+const (
+	// renameRetryAttempts bounds how many times the final rename is retried on
+	// Windows when a concurrent reader holds the destination file open.
+	renameRetryAttempts = 10
+	// renameRetryBaseDelay is the per-attempt backoff; the total budget across
+	// all attempts stays well under one second.
+	renameRetryBaseDelay = 5 * time.Millisecond
+
+	// errWindowsSharingViolation is ERROR_SHARING_VIOLATION (32): the file is in
+	// use by another process and cannot be replaced.
+	errWindowsSharingViolation = 32
+	// errWindowsAccessDenied is ERROR_ACCESS_DENIED (5): access to the file is
+	// denied, which Windows also reports for a held destination during rename.
+	errWindowsAccessDenied = 5
 )
 
 // WriteFileAtomic writes the file using temp-in-dir, fsync, rename, fsync-parent.
@@ -52,7 +69,7 @@ func writeFileAtomicImpl(path string, data []byte, perm os.FileMode) error {
 	}
 	closed = true
 
-	if err := os.Rename(tmpName, path); err != nil {
+	if err := renameWithRetry(tmpName, path); err != nil {
 		return err
 	}
 
@@ -71,6 +88,46 @@ func writeFileAtomicImpl(path string, data []byte, perm os.FileMode) error {
 		return err
 	}
 	return nil
+}
+
+// renameWithRetry renames oldPath to newPath. On Windows, a concurrent reader
+// holding the destination open can make the rename fail transiently with a
+// sharing violation; in that case the rename is retried with a bounded backoff.
+// On other platforms it behaves exactly like os.Rename.
+func renameWithRetry(oldPath, newPath string) error {
+	return renameWithRetryFunc(oldPath, newPath, runtime.GOOS, os.Rename, time.Sleep)
+}
+
+func renameWithRetryFunc(
+	oldPath, newPath, goos string,
+	rename func(string, string) error,
+	sleep func(time.Duration),
+) error {
+	err := rename(oldPath, newPath)
+	if err == nil || goos != "windows" {
+		return err
+	}
+
+	for attempt := 0; attempt < renameRetryAttempts && isWindowsSharingViolation(err); attempt++ {
+		sleep(renameRetryBaseDelay)
+		err = rename(oldPath, newPath)
+		if err == nil {
+			return nil
+		}
+	}
+	return err
+}
+
+// isWindowsSharingViolation reports whether err is a Windows error indicating
+// the destination file is held open by another reader during a rename. The
+// numeric errno comparison compiles on every platform, so no build tags are
+// needed; on non-Windows platforms these codes simply never occur.
+func isWindowsSharingViolation(err error) bool {
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		return errno == errWindowsSharingViolation || errno == errWindowsAccessDenied
+	}
+	return false
 }
 
 // CleanupAtomicTempArtifactsOlderThan removes temp files created by

--- a/internal/fsutil/atomic_test.go
+++ b/internal/fsutil/atomic_test.go
@@ -2,15 +2,82 @@ package fsutil
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
+	"syscall"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestIsWindowsSharingViolation(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, isWindowsSharingViolation(syscall.Errno(32)), "ERROR_SHARING_VIOLATION should match")
+	assert.True(t, isWindowsSharingViolation(syscall.Errno(5)), "ERROR_ACCESS_DENIED should match")
+	assert.False(t, isWindowsSharingViolation(syscall.Errno(13)), "unrelated errno should not match")
+	assert.False(t, isWindowsSharingViolation(errors.New("boom")), "plain error should not match")
+}
+
+func TestRenameWithRetryRetriesTransientWindowsSharingViolation(t *testing.T) {
+	t.Parallel()
+
+	renameCalls := 0
+	sleepCalls := 0
+	err := renameWithRetryFunc("old", "new", "windows", func(_, _ string) error {
+		renameCalls++
+		if renameCalls == 1 {
+			return syscall.Errno(32)
+		}
+		return nil
+	}, func(delay time.Duration) {
+		sleepCalls++
+		assert.Equal(t, renameRetryBaseDelay, delay)
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, renameCalls, "initial failure plus one successful retry")
+	assert.Equal(t, 1, sleepCalls)
+}
+
+func TestRenameWithRetrySurfacesErrorAfterWindowsRetryBudget(t *testing.T) {
+	t.Parallel()
+
+	renameCalls := 0
+	sleepCalls := 0
+	err := renameWithRetryFunc("old", "new", "windows", func(_, _ string) error {
+		renameCalls++
+		return syscall.Errno(32)
+	}, func(delay time.Duration) {
+		sleepCalls++
+		assert.Equal(t, renameRetryBaseDelay, delay)
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, syscall.Errno(32))
+	assert.Equal(t, renameRetryAttempts+1, renameCalls, "initial rename plus bounded retries")
+	assert.Equal(t, renameRetryAttempts, sleepCalls)
+}
+
+func TestWriteFileAtomicCreatesAndOverwrites(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	target := filepath.Join(dir, "state.yaml")
+
+	require.NoError(t, WriteFileAtomic(target, []byte("first"), 0o644))
+	got, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, "first", string(got))
+
+	require.NoError(t, WriteFileAtomic(target, []byte("second"), 0o644))
+	got, err = os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, "second", string(got))
+}
 
 func TestWriteFileAtomicReplacesContent(t *testing.T) {
 	t.Parallel()

--- a/internal/fsutil/symlink.go
+++ b/internal/fsutil/symlink.go
@@ -1,0 +1,96 @@
+package fsutil
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var ErrSymlinkTargetOutsideRoot = errors.New("symlink target resolves outside allowed root")
+
+// ResolveSymlinkTarget resolves linkTarget relative to linkPath and returns the
+// target's real path.
+func ResolveSymlinkTarget(linkPath, linkTarget string) (string, os.FileInfo, error) {
+	target := linkTarget
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(filepath.Dir(linkPath), target)
+	}
+	resolved, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		return "", nil, err
+	}
+	resolved, err = filepath.Abs(resolved)
+	if err != nil {
+		return "", nil, err
+	}
+	resolved = filepath.Clean(resolved)
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return "", nil, err
+	}
+	return resolved, info, nil
+}
+
+// ResolveSymlinkTargetWithin resolves linkTarget relative to linkPath and
+// returns the target's real path only when it stays within allowedRoot.
+func ResolveSymlinkTargetWithin(allowedRoot, linkPath, linkTarget string) (string, os.FileInfo, error) {
+	root, err := realExistingPath(allowedRoot)
+	if err != nil {
+		return "", nil, err
+	}
+	resolved, info, err := ResolveSymlinkTarget(linkPath, linkTarget)
+	if err != nil {
+		return "", nil, err
+	}
+	if !PathWithin(root, resolved) {
+		return "", nil, fmt.Errorf("%w: %q outside %q", ErrSymlinkTargetOutsideRoot, resolved, root)
+	}
+	return resolved, info, nil
+}
+
+// PathWithin reports whether path is equal to root or contained by root after
+// both paths are made absolute and clean.
+func PathWithin(root, path string) bool {
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return false
+	}
+	pathAbs, err := filepath.Abs(path)
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(filepath.Clean(rootAbs), filepath.Clean(pathAbs))
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel))
+}
+
+// SymlinkTargetContainsLink reports whether targetDir contains the symlink's
+// parent directory after resolving existing filesystem components.
+func SymlinkTargetContainsLink(targetDir, linkPath string) bool {
+	linkParent, err := realExistingPath(filepath.Dir(linkPath))
+	if err != nil {
+		return PathWithin(targetDir, filepath.Dir(linkPath))
+	}
+	return PathWithin(targetDir, linkParent)
+}
+
+// RealExistingPath returns an absolute, clean path after resolving symlinks.
+func RealExistingPath(path string) (string, error) {
+	return realExistingPath(path)
+}
+
+func realExistingPath(path string) (string, error) {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", err
+	}
+	abs, err := filepath.Abs(resolved)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(abs), nil
+}

--- a/internal/fsutil/symlink_test.go
+++ b/internal/fsutil/symlink_test.go
@@ -1,0 +1,83 @@
+package fsutil
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveSymlinkTargetWithinAcceptsTargetInsideRoot(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	nested := filepath.Join(root, "nested")
+	require.NoError(t, os.MkdirAll(nested, 0o755))
+	target := filepath.Join(root, "target.txt")
+	require.NoError(t, os.WriteFile(target, []byte("target"), 0o644))
+
+	resolved, info, err := ResolveSymlinkTargetWithin(root, filepath.Join(nested, "target.link"), "../target.txt")
+
+	require.NoError(t, err)
+	expected, err := filepath.EvalSymlinks(target)
+	require.NoError(t, err)
+	expected, err = filepath.Abs(expected)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Clean(expected), resolved)
+	assert.False(t, info.IsDir())
+}
+
+func TestResolveSymlinkTargetAcceptsExternalTarget(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside.txt")
+	require.NoError(t, os.WriteFile(outside, []byte("outside"), 0o644))
+
+	resolved, info, err := ResolveSymlinkTarget(filepath.Join(root, "outside.link"), outside)
+
+	require.NoError(t, err)
+	expected, err := filepath.EvalSymlinks(outside)
+	require.NoError(t, err)
+	expected, err = filepath.Abs(expected)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Clean(expected), resolved)
+	assert.False(t, info.IsDir())
+}
+
+func TestResolveSymlinkTargetWithinRejectsTargetOutsideRoot(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside.txt")
+	require.NoError(t, os.WriteFile(outside, []byte("outside"), 0o644))
+
+	_, _, err := ResolveSymlinkTargetWithin(root, filepath.Join(root, "outside.link"), outside)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrSymlinkTargetOutsideRoot)
+}
+
+func TestResolveSymlinkTargetWithinReportsDanglingTarget(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+
+	_, _, err := ResolveSymlinkTargetWithin(root, filepath.Join(root, "dangling.link"), "missing.txt")
+
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, ErrSymlinkTargetOutsideRoot))
+}
+
+func TestPathWithinIsSeparatorAware(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join(t.TempDir(), "root")
+	require.NoError(t, os.MkdirAll(root, 0o755))
+	assert.True(t, PathWithin(root, root))
+	assert.True(t, PathWithin(root, filepath.Join(root, "child")))
+	assert.False(t, PathWithin(root, root+"-sibling"))
+}

--- a/internal/model/evidence.go
+++ b/internal/model/evidence.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -14,6 +15,12 @@ func ComputeFileContentHash(path string) (string, error) {
 	data, err := os.ReadFile(path) // #nosec G304 -- path is resolved from repository or governed artifact authority before this read.
 	if err != nil {
 		return "", err
+	}
+	// Treat content with a NUL byte as binary and hash the raw bytes byte-exact.
+	// Otherwise normalize CRLF to LF before hashing so text digests are
+	// line-ending invariant, matching normalizeCanonical's string contract.
+	if !bytes.Contains(data, []byte{0x00}) {
+		data = bytes.ReplaceAll(data, []byte("\r\n"), []byte("\n"))
 	}
 	sum := sha256.Sum256(data)
 	return hex.EncodeToString(sum[:]), nil

--- a/internal/model/evidence_test.go
+++ b/internal/model/evidence_test.go
@@ -1,0 +1,121 @@
+package model
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func writeTempFile(t *testing.T, name string, content []byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	require.NoError(t, os.WriteFile(path, content, 0o600))
+	return path
+}
+
+// TestComputeFileContentHashIsCRLFInvariant verifies that text content differing
+// only by CRLF vs LF line endings produces the same digest.
+func TestComputeFileContentHashIsCRLFInvariant(t *testing.T) {
+	t.Parallel()
+
+	lfPath := writeTempFile(t, "lf.txt", []byte("alpha\nbeta\ngamma\n"))
+	crlfPath := writeTempFile(t, "crlf.txt", []byte("alpha\r\nbeta\r\ngamma\r\n"))
+
+	lfDigest, err := ComputeFileContentHash(lfPath)
+	require.NoError(t, err)
+	crlfDigest, err := ComputeFileContentHash(crlfPath)
+	require.NoError(t, err)
+
+	require.Equal(t, lfDigest, crlfDigest)
+}
+
+// TestComputeFileContentHashLeavesLFUnchanged verifies that for LF-only text
+// content the digest equals the raw sha256 of the bytes (no behavior change).
+func TestComputeFileContentHashLeavesLFUnchanged(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte("alpha\nbeta\ngamma\n")
+	path := writeTempFile(t, "lf.txt", raw)
+
+	digest, err := ComputeFileContentHash(path)
+	require.NoError(t, err)
+
+	sum := sha256.Sum256(raw)
+	require.Equal(t, hex.EncodeToString(sum[:]), digest)
+}
+
+// TestComputeFileContentHashBinaryIsByteExact verifies that binary content (with
+// a NUL byte) is hashed byte-exact, so content differing only by CRLF vs LF
+// produces different digests.
+func TestComputeFileContentHashBinaryIsByteExact(t *testing.T) {
+	t.Parallel()
+
+	crlfPath := writeTempFile(t, "crlf.bin", []byte("alpha\x00\r\nbeta"))
+	lfPath := writeTempFile(t, "lf.bin", []byte("alpha\x00\nbeta"))
+
+	crlfDigest, err := ComputeFileContentHash(crlfPath)
+	require.NoError(t, err)
+	lfDigest, err := ComputeFileContentHash(lfPath)
+	require.NoError(t, err)
+
+	require.NotEqual(t, lfDigest, crlfDigest)
+}
+
+func TestGitAttributesKeepArtifactBinariesByteExact(t *testing.T) {
+	t.Parallel()
+
+	root := gitRepoRoot(t)
+	attrs := gitCheckAttr(
+		t,
+		root,
+		"artifacts/example.bin",
+		"artifacts/example.mp4",
+		"artifacts/example.dat",
+		"artifacts/changes/example/intent.md",
+	)
+
+	require.Equal(t, "unset", attrs["artifacts/example.bin"]["text"])
+	require.Equal(t, "unset", attrs["artifacts/example.mp4"]["text"])
+	require.NotEqual(t, "set", attrs["artifacts/example.dat"]["text"],
+		"unknown artifact extensions must use text=auto, not forced text normalization")
+	require.Equal(t, "lf", attrs["artifacts/example.dat"]["eol"])
+
+	require.Equal(t, "auto", attrs["artifacts/changes/example/intent.md"]["text"])
+	require.Equal(t, "lf", attrs["artifacts/changes/example/intent.md"]["eol"])
+}
+
+func gitRepoRoot(t *testing.T) string {
+	t.Helper()
+
+	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output() // #nosec G204 -- test executes a fixed git command.
+	require.NoError(t, err)
+	return strings.TrimSpace(string(out))
+}
+
+func gitCheckAttr(t *testing.T, root string, paths ...string) map[string]map[string]string {
+	t.Helper()
+
+	args := append([]string{"-C", root, "check-attr", "text", "eol", "--"}, paths...)
+	out, err := exec.Command("git", args...).CombinedOutput() // #nosec G204 -- test executes a fixed git command with fixed attribute names and test-controlled paths.
+	require.NoError(t, err, string(out))
+
+	result := make(map[string]map[string]string, len(paths))
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		parts := strings.SplitN(line, ": ", 3)
+		require.Len(t, parts, 3, "unexpected git check-attr output line %q", line)
+		if result[parts[0]] == nil {
+			result[parts[0]] = map[string]string{}
+		}
+		result[parts[0]][parts[1]] = parts[2]
+	}
+	return result
+}

--- a/internal/state/lifecycle.go
+++ b/internal/state/lifecycle.go
@@ -19,6 +19,7 @@ import (
 var renameDir = os.Rename
 var promoteDir = os.Rename
 var removeDirAll = os.RemoveAll
+var createSymlink = os.Symlink
 
 // LoadArchivedChange loads an archived change by slug.
 //
@@ -238,6 +239,20 @@ func stageAndMoveDirAcrossFilesystems(src, dst string) error {
 }
 
 func copyDirRecursive(src, dst string) error {
+	return copyDirRecursiveWithin(src, dst, src, make(map[string]struct{}))
+}
+
+func copyDirRecursiveWithin(src, dst, allowedRoot string, active map[string]struct{}) error {
+	realRoot, err := fsutil.RealExistingPath(src)
+	if err != nil {
+		return err
+	}
+	if _, ok := active[realRoot]; ok {
+		return fmt.Errorf("refuse dereference directory %q into %q: symlink cycle through %q", src, dst, realRoot)
+	}
+	active[realRoot] = struct{}{}
+	defer delete(active, realRoot)
+
 	return filepath.WalkDir(src, func(path string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
@@ -263,7 +278,37 @@ func copyDirRecursive(src, dst string) error {
 			if err != nil {
 				return err
 			}
-			return os.Symlink(linkTarget, target) // #nosec G122 -- source and target are bounded to the staged archive copy; preserving symlinks is intentional.
+			symErr := createSymlink(linkTarget, target) // #nosec G122 -- source and target are bounded to the staged archive copy; preserving symlinks is intentional.
+			if symErr == nil {
+				return nil
+			}
+			// On Windows, os.Symlink fails without SeCreateSymbolicLinkPrivilege
+			// (Developer Mode). Rather than abort the whole copy, dereference the
+			// link and materialize the target's content at the destination.
+			resolved, info, statErr := fsutil.ResolveSymlinkTargetWithin(allowedRoot, path, linkTarget)
+			if statErr != nil {
+				if errors.Is(statErr, fsutil.ErrSymlinkTargetOutsideRoot) {
+					return fmt.Errorf("refuse dereference symlink %q into %q: %w", path, target, statErr)
+				}
+				// Dangling/broken link or unreadable: preserve the original failure.
+				return symErr
+			}
+			if info.IsDir() {
+				if fsutil.SymlinkTargetContainsLink(resolved, path) {
+					return fmt.Errorf("refuse dereference symlink %q into %q: target directory %q contains the link", path, target, resolved)
+				}
+				if err := copyDirRecursiveWithin(resolved, target, allowedRoot, active); err != nil {
+					return fmt.Errorf("dereference symlink %q into %q: %w", path, target, err)
+				}
+				return nil
+			}
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil { // #nosec G301 -- directory is a user-facing project or governance artifact location where executable/searchable mode is intentional.
+				return err
+			}
+			if err := copyFile(resolved, target, info.Mode().Perm()); err != nil {
+				return fmt.Errorf("dereference symlink %q into %q: %w", path, target, err)
+			}
+			return nil
 		default:
 			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil { // #nosec G301 -- directory is a user-facing project or governance artifact location where executable/searchable mode is intentional.
 				return err

--- a/internal/state/lifecycle_test.go
+++ b/internal/state/lifecycle_test.go
@@ -531,6 +531,105 @@ func TestCopyDirRecursivePreservesSymlinks(t *testing.T) {
 	assert.Equal(t, "# Tasks\n", string(content))
 }
 
+func TestCopyDirRecursiveDereferencesSymlinkWhenCreateSymlinkFails(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, "source")
+	dst := filepath.Join(root, "target")
+	require.NoError(t, os.MkdirAll(src, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "tasks.md"), []byte("# Tasks\n"), 0o644))
+	if err := os.Symlink("tasks.md", filepath.Join(src, "tasks.link")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	oldCreateSymlink := createSymlink
+	createSymlink = func(_, _ string) error {
+		return errors.New("symlink privilege missing")
+	}
+	t.Cleanup(func() {
+		createSymlink = oldCreateSymlink
+	})
+
+	require.NoError(t, copyDirRecursive(src, dst))
+
+	got, err := os.ReadFile(filepath.Join(dst, "tasks.link"))
+	require.NoError(t, err)
+	assert.Equal(t, "# Tasks\n", string(got))
+}
+
+func TestCopyDirRecursiveRejectsOutsideRootSymlinkFallback(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, "source")
+	dst := filepath.Join(root, "target")
+	outside := filepath.Join(t.TempDir(), "outside.md")
+	require.NoError(t, os.MkdirAll(src, 0o755))
+	require.NoError(t, os.WriteFile(outside, []byte("outside"), 0o644))
+	if err := os.Symlink(outside, filepath.Join(src, "outside.link")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	oldCreateSymlink := createSymlink
+	createSymlink = func(_, _ string) error {
+		return errors.New("symlink privilege missing")
+	}
+	t.Cleanup(func() {
+		createSymlink = oldCreateSymlink
+	})
+
+	err := copyDirRecursive(src, dst)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "outside allowed root")
+}
+
+func TestCopyDirRecursiveRejectsAncestorDirectorySymlinkFallback(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, "source")
+	dst := filepath.Join(root, "target")
+	nested := filepath.Join(src, "nested")
+	require.NoError(t, os.MkdirAll(nested, 0o755))
+	if err := os.Symlink("..", filepath.Join(nested, "root.link")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	oldCreateSymlink := createSymlink
+	createSymlink = func(_, _ string) error {
+		return errors.New("symlink privilege missing")
+	}
+	t.Cleanup(func() {
+		createSymlink = oldCreateSymlink
+	})
+
+	err := copyDirRecursive(src, dst)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "contains the link")
+}
+
+func TestCopyDirRecursiveRejectsMutualDirectorySymlinkFallback(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, "source")
+	dst := filepath.Join(root, "target")
+	dirA := filepath.Join(src, "a")
+	dirB := filepath.Join(src, "b")
+	require.NoError(t, os.MkdirAll(dirA, 0o755))
+	require.NoError(t, os.MkdirAll(dirB, 0o755))
+	if err := os.Symlink("../b", filepath.Join(dirA, "to-b")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if err := os.Symlink("../a", filepath.Join(dirB, "to-a")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	oldCreateSymlink := createSymlink
+	createSymlink = func(_, _ string) error {
+		return errors.New("symlink privilege missing")
+	}
+	t.Cleanup(func() {
+		createSymlink = oldCreateSymlink
+	})
+
+	err := copyDirRecursive(src, dst)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "symlink cycle")
+}
+
 func TestScrubArchivedExecutionSummaryRuntimeEvidenceRefsDirect(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tmpl/templates/skills/goal-verification/SKILL.md.tmpl
+++ b/internal/tmpl/templates/skills/goal-verification/SKILL.md.tmpl
@@ -80,14 +80,25 @@ Delegate these bulky reads when possible:
 - SAST output and finding triage for guardrail safety baseline checks
 
 ## Stub And Placeholder Scan
-Run the following scans against all claimed target files. Any real hit is a blocker.
+Scan every claimed target file for leftover stubs and placeholders. Any real hit
+is a blocker. Use whatever code-search capability is available on this host — the
+editor/agent search, ripgrep (`rg`), or an equivalent — not a hardcoded
+`grep`/`perl` invocation. Search the target files for:
 
+- Stub/placeholder markers: `TODO`, `FIXME`, `HACK`, `XXX`, `PLACEHOLDER`,
+  `NotImplemented`, `not implemented`
+- Unimplemented panics or no-op returns: `panic("... implement")`,
+  `panic("... todo")`, `return nil, nil`
+- Zero-value-only returns: `return ""`, `return 0`, `return false`
+- Empty or no-op bodies: `{ }` with nothing between the braces
+
+For example, ripgrep can cover the marker scan in one pass:
 ```bash
-grep -rn 'TODO\|FIXME\|HACK\|XXX\|PLACEHOLDER\|NotImplemented\|not implemented' <target_files>
-grep -rn 'panic(".*implement\|panic(".*todo\|return nil, nil' <target_files>
-grep -rn 'return ""$\|return 0$\|return false$' <target_files>
-perl -0ne 'print "$ARGV\n" if /\{\s*\n\s*\}/' <target_files>
+rg -n 'TODO|FIXME|HACK|XXX|PLACEHOLDER|NotImplemented|not implemented' <target_files>
 ```
+This is one option only — any portable equivalent (the editor/agent search or
+another tool) is acceptable, and the empty-body check may need a multiline-aware
+search or manual inspection.
 
 Also block:
 - zero-value or hardcoded production responses

--- a/internal/tmpl/templates_test.go
+++ b/internal/tmpl/templates_test.go
@@ -632,9 +632,21 @@ func TestGoalVerificationPlaceholderScanIsMacOSPortable(t *testing.T) {
 	content, err := Render("skills/goal-verification/SKILL.md.tmpl", nil)
 	require.NoError(t, err)
 
+	// The prescribed scan must run on stock Windows: no perl, no BSD/macOS-incompatible
+	// `grep -P`, and no hardcoded GNU `grep ... \|` alternation as the mandated path.
+	assert.NotContains(t, content, "perl -0ne")
 	assert.NotContains(t, content, "grep -P")
-	assert.Contains(t, content, "perl -0ne")
-	assert.Contains(t, content, `\{\s*\n\s*\}`)
+	assert.NotContains(t, content, `grep -E 'TODO`)
+	assert.NotContains(t, content, `\{\s*\n\s*\}`)
+
+	// Portable, tool-agnostic guidance: name the markers and the empty-body check,
+	// and express the HOW via whatever code search is available (editor/agent search or rg).
+	assert.Contains(t, content, "PLACEHOLDER")
+	assert.Contains(t, content, "TODO")
+	assert.Contains(t, content, "code-search capability is available")
+	assert.Contains(t, content, "editor/agent search")
+	assert.Contains(t, content, "ripgrep")
+	assert.Contains(t, content, "rg")
 }
 
 func TestPlanAuditBlocksFutureLifecycleAcceptanceCriteria(t *testing.T) {

--- a/internal/toolgen/adapter_contract_test.go
+++ b/internal/toolgen/adapter_contract_test.go
@@ -22,6 +22,7 @@ const (
 type frozenHookContract struct {
 	Event      string
 	Path       string
+	Command    string // portable settings.json command (empty when not registered)
 	Registered bool
 }
 
@@ -81,11 +82,13 @@ var frozenToolContracts = map[string]frozenToolContract{
 		SessionHook: frozenHookContract{
 			Event:      "SessionStart",
 			Path:       ".claude/hooks/slipway-session-start",
+			Command:    `slipway hook session-start --tool "claude"`,
 			Registered: true,
 		},
 		PostToolHook: frozenHookContract{
 			Event:      "PostToolUse",
 			Path:       ".claude/hooks/slipway-context-pressure-post-tool-use",
+			Command:    "slipway hook context-pressure",
 			Registered: true,
 		},
 	},
@@ -120,6 +123,7 @@ var frozenToolContracts = map[string]frozenToolContract{
 		SessionHook: frozenHookContract{
 			Event:      "SessionStart",
 			Path:       ".gemini/hooks/slipway-session-start",
+			Command:    `slipway hook session-start --tool "gemini"`,
 			Registered: true,
 		},
 	},
@@ -307,13 +311,23 @@ func assertFrozenHookContract(t *testing.T, root, settingsPath string, hook froz
 	_, err = os.Stat(settingsAbsPath)
 	require.NoError(t, err, "missing settings file %s", settingsPath)
 
-	registered, err := hookCommandRegistered(settingsAbsPath, hook.Event, hookInvocationCommand(hook.Path))
+	registered, err := hookCommandRegistered(settingsAbsPath, hook.Event, hook.Command)
 	require.NoError(t, err)
 	assert.Equal(t, hook.Registered, registered, "hook registration drifted for %s", hook.Path)
+	if hook.Registered {
+		assertShellNeutralHookCommand(t, hook.Command)
+	}
 }
 
-func hookInvocationCommand(hookPath string) string {
-	return hookLauncherCommand(nativeHookPath(hookPath))
+func assertShellNeutralHookCommand(t *testing.T, command string) {
+	t.Helper()
+
+	assert.NotContains(t, command, "||")
+	assert.NotContains(t, command, "&&")
+	assert.NotContains(t, command, ";")
+	assert.NotContains(t, command, "|")
+	assert.NotContains(t, command, "&")
+	assert.NotContains(t, command, " exit ")
 }
 
 func hookCommandRegistered(settingsPath, eventName, command string) (bool, error) {

--- a/internal/toolgen/toolgen.go
+++ b/internal/toolgen/toolgen.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"runtime"
 	"slices"
 	"strings"
 
@@ -972,7 +971,9 @@ func generateForTool(root string, cfg ToolConfig, refresh bool, opts generateOpt
 		}
 	}
 
-	// Session-start hook launchers (hook-capable runtimes).
+	// Session-start hook launchers (hook-capable runtimes). Settings-capable
+	// adapters register the shell-neutral `slipway hook ...` command below, but
+	// launcher files remain the native host/manual dispatch surface.
 	if strings.TrimSpace(cfg.SessionHook) != "" {
 		for _, launcher := range hookLauncherOutputs(cfg.SessionHook, "session-start") {
 			content, err := renderHookLauncher(cfg, launcher.template)
@@ -1722,19 +1723,23 @@ func hookLauncherOutputs(basePath, hookTemplateBase string) []hookLauncherOutput
 	}
 }
 
-func nativeHookPath(basePath string) string {
-	basePath = strings.TrimSpace(basePath)
-	if basePath == "" {
-		return ""
-	}
-	if runtime.GOOS == "windows" {
-		return basePath + ".cmd"
-	}
-	return basePath
+// postToolHookSubcommand is the `slipway hook` subcommand the PostToolUse
+// launcher ultimately runs (see hooks/context-pressure-post-tool-use templates).
+const postToolHookSubcommand = "context-pressure"
+
+// sessionHookSubcommand is the `slipway hook` subcommand+args the SessionStart
+// launcher ultimately runs (see hooks/session-start templates).
+func sessionHookSubcommand(toolID string) string {
+	return fmt.Sprintf(`session-start --tool "%s"`, toolID)
 }
 
-func hookLauncherCommand(path string) string {
-	return fmt.Sprintf(`"%s"`, filepath.ToSlash(path))
+// portableHookCommand builds the OS-independent command string registered in a
+// tool's settings.json. It resolves `slipway` from PATH and deliberately avoids
+// shell control operators so the same command parses under sh, cmd.exe,
+// Windows PowerShell 5.1, and PowerShell 7+ instead of pinning an OS-specific
+// launcher file path that breaks for teammates on another OS.
+func portableHookCommand(subcommandArgs string) string {
+	return fmt.Sprintf("slipway hook %s", subcommandArgs)
 }
 
 func renderHookLauncher(cfg ToolConfig, templatePath string) (string, error) {
@@ -1797,12 +1802,14 @@ func mergeHookSettingsJSON(root string, cfg ToolConfig, refresh bool) error {
 	}
 
 	if strings.TrimSpace(cfg.SessionEvent) != "" && strings.TrimSpace(cfg.SessionHook) != "" {
-		pruneLegacySlipwayHookCommands(hooks, cfg.SessionEvent, legacyShellHookPath(cfg.SessionHook))
-		mergeHookEventCommand(hooks, cfg.SessionEvent, hookLauncherCommand(nativeHookPath(cfg.SessionHook)))
+		command := portableHookCommand(sessionHookSubcommand(cfg.ID))
+		pruneStaleSlipwayHookCommands(hooks, cfg.SessionEvent, cfg.SessionHook, command)
+		mergeHookEventCommand(hooks, cfg.SessionEvent, command)
 	}
 	if strings.TrimSpace(cfg.PostToolEvent) != "" && strings.TrimSpace(cfg.PostToolHook) != "" {
-		pruneLegacySlipwayHookCommands(hooks, cfg.PostToolEvent, legacyShellHookPath(cfg.PostToolHook))
-		mergeHookEventCommand(hooks, cfg.PostToolEvent, hookLauncherCommand(nativeHookPath(cfg.PostToolHook)))
+		command := portableHookCommand(postToolHookSubcommand)
+		pruneStaleSlipwayHookCommands(hooks, cfg.PostToolEvent, cfg.PostToolHook, command)
+		mergeHookEventCommand(hooks, cfg.PostToolEvent, command)
 	}
 	settings["hooks"] = hooks
 
@@ -1828,7 +1835,20 @@ func cleanupLegacyHookLauncher(root, basePath string) error {
 	return removePathIfExists(filepath.Join(root, filepath.FromSlash(legacyShellHookPath(basePath))))
 }
 
-func pruneLegacySlipwayHookCommands(hooks map[string]any, eventName, legacyPath string) {
+// pruneStaleSlipwayHookCommands removes every previously generated Slipway hook
+// command for an event so refresh can re-register the current portable form.
+// It prunes BOTH retired shapes:
+//   - the legacy `bash "...slipway-<hook>.sh"` interpreter form, and
+//   - the OS-pinned launcher-path form (the bare launcher, ".sh", ".cmd", or
+//     ".ps1") that earlier versions wrote into the committed settings.json.
+//   - the shell-chained direct form (`slipway hook ... || exit 0`) from the
+//     short-lived portable command shape that PowerShell 5.1 cannot parse.
+//
+// hookBasePath is the launcher base path (e.g. ".claude/hooks/slipway-session-start").
+// The current portable command (`slipway hook <subcommand> ...`) does not contain
+// that path, so it is never pruned by this matcher and mergeHookEventCommand stays
+// idempotent across refreshes.
+func pruneStaleSlipwayHookCommands(hooks map[string]any, eventName, hookBasePath, currentCommand string) {
 	rawEntries, ok := hooks[eventName].([]any)
 	if !ok {
 		return
@@ -1847,7 +1867,7 @@ func pruneLegacySlipwayHookCommands(hooks map[string]any, eventName, legacyPath 
 		}
 		var keptHooks []any
 		for _, hook := range hookList {
-			if isLegacySlipwayHookCommand(hook, legacyPath) {
+			if isStaleSlipwayHookCommand(hook, hookBasePath, currentCommand) {
 				continue
 			}
 			keptHooks = append(keptHooks, hook)
@@ -1865,27 +1885,27 @@ func pruneLegacySlipwayHookCommands(hooks map[string]any, eventName, legacyPath 
 	hooks[eventName] = keptEntries
 }
 
-func isLegacySlipwayHookCommand(hook any, legacyPath string) bool {
+func isStaleSlipwayHookCommand(hook any, hookBasePath, currentCommand string) bool {
 	hookMap, ok := hook.(map[string]any)
 	if !ok {
 		return false
 	}
 	command, _ := hookMap["command"].(string)
 	command = filepath.ToSlash(strings.TrimSpace(command))
-	if !strings.Contains(command, legacyPath) {
+	basePath := filepath.ToSlash(strings.TrimSpace(hookBasePath))
+	// A command that references the Slipway-owned launcher base path is a
+	// previously generated form: the bare launcher path, any ".sh"/".cmd"/".ps1"
+	// variant, and the legacy `bash "...sh"` interpreter form all embed it.
+	if basePath != "" && strings.Contains(command, basePath) {
+		return true
+	}
+
+	currentCommand = strings.TrimSpace(currentCommand)
+	if currentCommand == "" || command == currentCommand {
 		return false
 	}
-	fields := strings.Fields(command)
-	if len(fields) == 0 {
-		return false
-	}
-	first := strings.Trim(fields[0], `"'`)
-	// Match the interpreter by basename so an absolute path (e.g. /bin/bash) is
-	// pruned too, not just the bare "bash"/"sh" Slipway historically generated.
-	// A direct exec of the legacy script (first token ends with the
-	// Slipway-owned .sh path) also qualifies.
-	firstBase := path.Base(first)
-	return firstBase == "bash" || firstBase == "sh" || strings.HasSuffix(first, legacyPath)
+	suffix := strings.TrimSpace(strings.TrimPrefix(command, currentCommand))
+	return suffix == "|| exit 0"
 }
 
 func mergeHookEventCommand(hooks map[string]any, eventName, command string) {

--- a/internal/toolgen/toolgen_test.go
+++ b/internal/toolgen/toolgen_test.go
@@ -446,12 +446,16 @@ func TestGenerateProducesAllExpectedFiles(t *testing.T) {
 			assert.NoError(t, err, "%s: missing settings file", toolID)
 			settings := string(content)
 			assert.Contains(t, settings, "SessionStart", "%s: missing session-start registration", toolID)
+			assert.Contains(t, settings, "slipway hook session-start", "%s: missing portable session-start command", toolID)
+			assert.NotContains(t, settings, "||", "%s: settings command must parse in Windows PowerShell 5.1", toolID)
 			if toolID == "claude" {
 				assert.Contains(t, settings, "PostToolUse", "%s: missing post-tool registration", toolID)
-				assert.Contains(t, settings, "slipway-context-pressure-post-tool-use", "%s: missing context-pressure hook", toolID)
+				assert.Contains(t, settings, "slipway hook context-pressure", "%s: missing portable context-pressure command", toolID)
 				assert.NotContains(t, settings, "bash", "%s: settings must not require bash", toolID)
+				// The portable command is OS-independent: no pinned launcher path.
+				assert.NotContains(t, settings, "slipway-context-pressure-post-tool-use", "%s: settings must not pin launcher path", toolID)
 			} else {
-				assert.NotContains(t, settings, "slipway-context-pressure-post-tool-use", "%s: unexpected post-tool registration", toolID)
+				assert.NotContains(t, settings, "context-pressure", "%s: unexpected post-tool registration", toolID)
 			}
 		default:
 			settingsPath := filepath.Join(root, "."+toolID, "settings.json")
@@ -795,7 +799,7 @@ func TestGeneratedAdapterSurfacesStayInSyncWithRegistry(t *testing.T) {
 				t,
 				filepath.Join(root, cfg.SettingsPath),
 				cfg.SessionEvent,
-				hookLauncherCommand(nativeHookPath(cfg.SessionHook)),
+				portableHookCommand(sessionHookSubcommand(cfg.ID)),
 			)
 		}
 	}
@@ -1008,22 +1012,52 @@ func TestHookSettingsRegistrationForClaudeAndGemini(t *testing.T) {
 	t.Setenv("CODEX_HOME", t.TempDir())
 	require.NoError(t, Generate(root, []string{"claude", "gemini"}, true))
 
+	// Assert the registered command via the parsed JSON value so the embedded
+	// quotes in `--tool "<id>"` are compared decoded, not against the
+	// backslash-escaped raw bytes JSON marshaling produces.
+	assertHookCommandRegistered(
+		t,
+		filepath.Join(root, ".claude", "settings.json"),
+		"SessionStart",
+		portableHookCommand(sessionHookSubcommand("claude")),
+	)
+	assertHookCommandRegistered(
+		t,
+		filepath.Join(root, ".claude", "settings.json"),
+		"PostToolUse",
+		portableHookCommand(postToolHookSubcommand),
+	)
+
 	claudeSettings, err := os.ReadFile(filepath.Join(root, ".claude", "settings.json"))
 	require.NoError(t, err)
 	assert.Contains(t, string(claudeSettings), "SessionStart")
-	assert.Contains(t, string(claudeSettings), "slipway-session-start")
-	assert.NotContains(t, string(claudeSettings), "slipway-session-start.sh")
+	assert.Contains(t, string(claudeSettings), "slipway hook session-start --tool")
 	assert.Contains(t, string(claudeSettings), "PostToolUse")
-	assert.Contains(t, string(claudeSettings), "slipway-context-pressure-post-tool-use")
+	assert.Contains(t, string(claudeSettings), "slipway hook context-pressure")
+	// Portable command is OS-independent: no pinned launcher file path or bash.
+	assert.NotContains(t, string(claudeSettings), "slipway-session-start.sh")
+	assert.NotContains(t, string(claudeSettings), ".claude/hooks/slipway-session-start")
+	assert.NotContains(t, string(claudeSettings), "slipway-context-pressure-post-tool-use")
 	assert.NotContains(t, string(claudeSettings), "bash")
+	assert.NotContains(t, string(claudeSettings), "||")
+	assert.NotContains(t, string(claudeSettings), "&&")
+
+	assertHookCommandRegistered(
+		t,
+		filepath.Join(root, ".gemini", "settings.json"),
+		"SessionStart",
+		portableHookCommand(sessionHookSubcommand("gemini")),
+	)
 
 	geminiSettings, err := os.ReadFile(filepath.Join(root, ".gemini", "settings.json"))
 	require.NoError(t, err)
 	assert.Contains(t, string(geminiSettings), "SessionStart")
-	assert.Contains(t, string(geminiSettings), "slipway-session-start")
+	assert.Contains(t, string(geminiSettings), "slipway hook session-start --tool")
 	assert.NotContains(t, string(geminiSettings), "slipway-session-start.sh")
+	assert.NotContains(t, string(geminiSettings), ".gemini/hooks/slipway-session-start")
 	assert.NotContains(t, string(geminiSettings), "PostToolUse")
-	assert.NotContains(t, string(geminiSettings), "slipway-context-pressure-post-tool-use")
+	assert.NotContains(t, string(geminiSettings), "context-pressure")
+	assert.NotContains(t, string(geminiSettings), "||")
 }
 
 func TestGenerateRefreshRemovesLegacyShellHookLaunchers(t *testing.T) {
@@ -2132,16 +2166,22 @@ func TestToolConfigInvocationSummary(t *testing.T) {
 	})
 }
 
-func TestMergeHookSettingsPrunesLegacyShellHookAndPreservesUserHooks(t *testing.T) {
+func TestMergeHookSettingsPrunesStaleHookFormsAndPreservesUserHooks(t *testing.T) {
 	root := t.TempDir()
 	cfg := ToolConfig{
+		ID:           "claude",
 		SettingsPath: filepath.Join(".claude", "settings.json"),
 		SessionEvent: "SessionStart",
 		SessionHook:  filepath.Join(".claude", "hooks", "slipway-session-start"),
 	}
 
-	// Seed settings with the retired bash launcher for the slipway hook plus an
-	// unrelated user-authored hook (with a matcher) that must survive the refresh.
+	// Seed settings with every retired hook shape that must be replaced on refresh:
+	//   - the legacy `bash "...sh"` (and sh / direct exec / abs-path) launcher forms,
+	//   - the OS-pinned launcher-path forms (bare POSIX launcher and Windows ".cmd")
+	//     that earlier versions wrote and that break for teammates on another OS,
+	//   - the shell-chained direct `slipway hook ... || exit 0` form, which is
+	//     not parseable by Windows PowerShell 5.1,
+	// plus an unrelated user-authored hook (with a matcher) that must survive.
 	seed := `{
 	  "hooks": {
 	    "SessionStart": [
@@ -2149,6 +2189,9 @@ func TestMergeHookSettingsPrunesLegacyShellHookAndPreservesUserHooks(t *testing.
 	      {"hooks":[{"type":"command","command":"sh \"$CLAUDE_PROJECT_DIR/.claude/hooks/slipway-session-start.sh\""}]},
 	      {"hooks":[{"type":"command","command":"\"$CLAUDE_PROJECT_DIR/.claude/hooks/slipway-session-start.sh\""}]},
 	      {"hooks":[{"type":"command","command":"/bin/bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/slipway-session-start.sh\""}]},
+	      {"hooks":[{"type":"command","command":"\".claude/hooks/slipway-session-start\""}]},
+	      {"hooks":[{"type":"command","command":"\".claude/hooks/slipway-session-start.cmd\""}]},
+	      {"hooks":[{"type":"command","command":"slipway hook session-start --tool \"claude\" || exit 0"}]},
 	      {"matcher":"*","hooks":[{"type":"command","command":"echo user-owned-hook"}]}
 	    ]
 	  }
@@ -2163,19 +2206,21 @@ func TestMergeHookSettingsPrunesLegacyShellHookAndPreservesUserHooks(t *testing.
 	require.NoError(t, err)
 	got := string(first)
 
-	// The legacy bash/.sh launcher is pruned.
+	// Both retired shapes are pruned: no bash interpreter and no pinned launcher path.
 	assert.NotContains(t, got, "slipway-session-start.sh")
+	assert.NotContains(t, got, "slipway-session-start.cmd")
+	assert.NotContains(t, got, ".claude/hooks/slipway-session-start")
 	assert.NotContains(t, got, "bash ")
 	// The unrelated user hook (and its matcher) is preserved verbatim.
 	assert.Contains(t, got, "echo user-owned-hook")
 	assert.Contains(t, got, `"matcher": "*"`)
-	// The native binary-backed launcher is registered in its place.
-	assertHookCommandRegistered(
-		t,
-		settingsPath,
-		cfg.SessionEvent,
-		hookLauncherCommand(nativeHookPath(cfg.SessionHook)),
-	)
+	// The portable, PATH-resolved command is registered in its place. Assert the
+	// decoded command value (the raw bytes carry backslash-escaped quotes).
+	assertHookCommandRegistered(t, settingsPath, cfg.SessionEvent, portableHookCommand(sessionHookSubcommand(cfg.ID)))
+	assert.Contains(t, got, "slipway hook session-start --tool")
+	assert.NotContains(t, got, "||")
+	assert.NotContains(t, got, "&&")
+	assert.NotContains(t, got, " exit ")
 
 	// Refresh is idempotent: a second merge does not duplicate or mutate.
 	require.NoError(t, mergeHookSettingsJSON(root, cfg, true))

--- a/internal/toolgen/worktree_provision.go
+++ b/internal/toolgen/worktree_provision.go
@@ -228,7 +228,7 @@ func dereferenceSymlinkCopy(srcPath, dstPath, linkTarget string, symErr error) e
 	if err != nil {
 		return fmt.Errorf("dereference symlink %q into %q: %w", srcPath, dstPath, err)
 	}
-	if err := os.WriteFile(dstPath, data, info.Mode().Perm()); err != nil { // #nosec G306 -- preserves the dereferenced target's mode; dstPath stays within the worktree's host-adapter surface.
+	if err := os.WriteFile(dstPath, data, info.Mode().Perm()); err != nil { // #nosec G306 G703 -- preserves the dereferenced target's mode; dstPath is produced by the caller-owned host-adapter copy target.
 		return fmt.Errorf("dereference symlink %q into %q: %w", srcPath, dstPath, err)
 	}
 	return nil
@@ -280,11 +280,11 @@ func copyDereferencedDirWithin(srcRoot, dstRoot, allowedRoot string, active map[
 		if err := os.MkdirAll(filepath.Dir(dstPath), 0o755); err != nil { // #nosec G301 -- host-adapter surfaces are user-facing skill/command trees where searchable mode is intentional.
 			return err
 		}
-		data, err := os.ReadFile(srcPath) // #nosec G304 -- srcPath is under the accepted dereferenced host-adapter symlink target.
+		data, err := os.ReadFile(srcPath) // #nosec G304 G122 -- srcPath is supplied by WalkDir under the accepted dereferenced host-adapter symlink target.
 		if err != nil {
 			return err
 		}
-		return os.WriteFile(dstPath, data, info.Mode().Perm()) // #nosec G306 -- preserves the source mode; dstPath stays within the worktree's host-adapter surface.
+		return os.WriteFile(dstPath, data, info.Mode().Perm()) // #nosec G306 G703 -- preserves the source mode; dstPath is derived from filepath.Rel(srcRoot, srcPath) under the caller-owned host-adapter copy target.
 	})
 }
 
@@ -313,7 +313,7 @@ func dereferenceNestedSymlinkCopy(allowedRoot, srcPath, dstPath string, active m
 	if err != nil {
 		return fmt.Errorf("dereference nested symlink %q into %q: %w", srcPath, dstPath, err)
 	}
-	if err := os.WriteFile(dstPath, data, info.Mode().Perm()); err != nil { // #nosec G306 -- preserves the dereferenced target's mode; dstPath stays within the worktree's host-adapter surface.
+	if err := os.WriteFile(dstPath, data, info.Mode().Perm()); err != nil { // #nosec G306 G703 -- preserves the dereferenced target's mode; resolved source is bounded to allowedRoot and dstPath is the caller-owned host-adapter copy target.
 		return fmt.Errorf("dereference nested symlink %q into %q: %w", srcPath, dstPath, err)
 	}
 	return nil

--- a/internal/toolgen/worktree_provision.go
+++ b/internal/toolgen/worktree_provision.go
@@ -1,12 +1,17 @@
 package toolgen
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/signalridge/slipway/internal/fsutil"
 )
+
+var createSymlink = os.Symlink
 
 // ProvisionWorktreeHostSurfaces materializes every host-adapter surface that
 // exists in the repository root into a freshly created (or reused) worktree.
@@ -179,7 +184,13 @@ func copyHostAdapterFileNoClobber(srcPath, dstPath string, d fs.DirEntry) error 
 		if err != nil {
 			return err
 		}
-		return os.Symlink(target, dstPath)
+		if symErr := createSymlink(target, dstPath); symErr != nil {
+			// On Windows, os.Symlink fails without SeCreateSymbolicLinkPrivilege
+			// (Developer Mode). Rather than abort the whole copy, dereference the
+			// link and materialize the target's content at the destination.
+			return dereferenceSymlinkCopy(srcPath, dstPath, target, symErr)
+		}
+		return nil
 	}
 	if !info.Mode().IsRegular() {
 		return nil // skip sockets, devices, and other irregular files
@@ -189,4 +200,121 @@ func copyHostAdapterFileNoClobber(srcPath, dstPath string, d fs.DirEntry) error 
 		return err
 	}
 	return os.WriteFile(dstPath, data, info.Mode().Perm()) // #nosec G306 G703 -- preserves the source mode so adapter hooks remain executable; dstPath is filepath.Join(worktreeRoot, toolRel, rel) where rel comes from filepath.Rel against the walked source tree, so the write stays within the worktree's host-adapter surface.
+}
+
+// dereferenceSymlinkCopy materializes a symlink target's content at dstPath when
+// os.Symlink fails (e.g. Windows without SeCreateSymbolicLinkPrivilege). Host
+// adapter trees commonly contain third-party skill symlinks that point outside
+// the repository, so the top-level target is allowed to resolve outside srcRoot.
+// Nested symlinks inside a dereferenced directory are constrained to that
+// directory's real root so one accepted skill link cannot pull in arbitrary
+// additional filesystem content.
+func dereferenceSymlinkCopy(srcPath, dstPath, linkTarget string, symErr error) error {
+	resolved, info, statErr := fsutil.ResolveSymlinkTarget(srcPath, linkTarget)
+	if statErr != nil {
+		// Dangling/broken link or unreadable: preserve the original failure.
+		return symErr
+	}
+	if info.IsDir() {
+		if fsutil.SymlinkTargetContainsLink(resolved, srcPath) {
+			return fmt.Errorf("refuse dereference symlink %q into %q: target directory %q contains the link", srcPath, dstPath, resolved)
+		}
+		if err := copyDereferencedDir(resolved, dstPath, resolved); err != nil {
+			return fmt.Errorf("dereference symlink %q into %q: %w", srcPath, dstPath, err)
+		}
+		return nil
+	}
+	data, err := os.ReadFile(resolved) // #nosec G304 -- resolved is the explicit target of a host-adapter symlink being materialized.
+	if err != nil {
+		return fmt.Errorf("dereference symlink %q into %q: %w", srcPath, dstPath, err)
+	}
+	if err := os.WriteFile(dstPath, data, info.Mode().Perm()); err != nil { // #nosec G306 -- preserves the dereferenced target's mode; dstPath stays within the worktree's host-adapter surface.
+		return fmt.Errorf("dereference symlink %q into %q: %w", srcPath, dstPath, err)
+	}
+	return nil
+}
+
+// copyDereferencedDir recursively copies the real contents of a directory that a
+// symlink pointed at into dstRoot, preserving file modes. Nested symlinks are
+// materialized only when their targets resolve within allowedRoot.
+func copyDereferencedDir(srcRoot, dstRoot, allowedRoot string) error {
+	return copyDereferencedDirWithin(srcRoot, dstRoot, allowedRoot, make(map[string]struct{}))
+}
+
+func copyDereferencedDirWithin(srcRoot, dstRoot, allowedRoot string, active map[string]struct{}) error {
+	realRoot, err := fsutil.RealExistingPath(srcRoot)
+	if err != nil {
+		return err
+	}
+	if _, ok := active[realRoot]; ok {
+		return fmt.Errorf("refuse dereference directory %q into %q: symlink cycle through %q", srcRoot, dstRoot, realRoot)
+	}
+	active[realRoot] = struct{}{}
+	defer delete(active, realRoot)
+
+	return filepath.WalkDir(srcRoot, func(srcPath string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(srcRoot, srcPath)
+		if err != nil {
+			return err
+		}
+		dstPath := dstRoot
+		if rel != "." {
+			dstPath = filepath.Join(dstRoot, rel)
+		}
+		if d.IsDir() {
+			return os.MkdirAll(dstPath, 0o755) // #nosec G301 -- host-adapter surfaces are user-facing skill/command trees where searchable mode is intentional.
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return dereferenceNestedSymlinkCopy(allowedRoot, srcPath, dstPath, active)
+		}
+		if !info.Mode().IsRegular() {
+			return nil // skip sockets, devices, and other irregular files
+		}
+		if err := os.MkdirAll(filepath.Dir(dstPath), 0o755); err != nil { // #nosec G301 -- host-adapter surfaces are user-facing skill/command trees where searchable mode is intentional.
+			return err
+		}
+		data, err := os.ReadFile(srcPath) // #nosec G304 -- srcPath is under the accepted dereferenced host-adapter symlink target.
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(dstPath, data, info.Mode().Perm()) // #nosec G306 -- preserves the source mode; dstPath stays within the worktree's host-adapter surface.
+	})
+}
+
+func dereferenceNestedSymlinkCopy(allowedRoot, srcPath, dstPath string, active map[string]struct{}) error {
+	linkTarget, err := os.Readlink(srcPath)
+	if err != nil {
+		return err
+	}
+	resolved, info, err := fsutil.ResolveSymlinkTargetWithin(allowedRoot, srcPath, linkTarget)
+	if err != nil {
+		if errors.Is(err, fsutil.ErrSymlinkTargetOutsideRoot) {
+			return fmt.Errorf("refuse dereference nested symlink %q into %q: %w", srcPath, dstPath, err)
+		}
+		return fmt.Errorf("dereference nested symlink %q into %q: %w", srcPath, dstPath, err)
+	}
+	if info.IsDir() {
+		if fsutil.SymlinkTargetContainsLink(resolved, srcPath) {
+			return fmt.Errorf("refuse dereference nested symlink %q into %q: target directory %q contains the link", srcPath, dstPath, resolved)
+		}
+		if err := copyDereferencedDirWithin(resolved, dstPath, allowedRoot, active); err != nil {
+			return fmt.Errorf("dereference nested symlink %q into %q: %w", srcPath, dstPath, err)
+		}
+		return nil
+	}
+	data, err := os.ReadFile(resolved) // #nosec G304 -- resolved is bounded to the accepted dereferenced directory root.
+	if err != nil {
+		return fmt.Errorf("dereference nested symlink %q into %q: %w", srcPath, dstPath, err)
+	}
+	if err := os.WriteFile(dstPath, data, info.Mode().Perm()); err != nil { // #nosec G306 -- preserves the dereferenced target's mode; dstPath stays within the worktree's host-adapter surface.
+		return fmt.Errorf("dereference nested symlink %q into %q: %w", srcPath, dstPath, err)
+	}
+	return nil
 }

--- a/internal/toolgen/worktree_provision_test.go
+++ b/internal/toolgen/worktree_provision_test.go
@@ -1,6 +1,7 @@
 package toolgen
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -48,6 +49,122 @@ func TestProvisionWorktreeHostSurfaces_CopiesThirdPartyAndRegenerates(t *testing
 	assert.NoDirExists(t, filepath.Join(worktreeRoot, ".serena"))
 	// An adapter absent from the repo root must not be created in the worktree.
 	assert.NoDirExists(t, filepath.Join(worktreeRoot, ".gemini"))
+}
+
+func TestCopyHostAdapterTreeDereferencesSymlinkWhenCreateSymlinkFails(t *testing.T) {
+	repoRoot := t.TempDir()
+	srcRoot := filepath.Join(repoRoot, ".claude")
+	dstRoot := filepath.Join(t.TempDir(), ".claude")
+	require.NoError(t, os.MkdirAll(srcRoot, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(srcRoot, "target.txt"), []byte("target content"), 0o644))
+	if err := os.Symlink("target.txt", filepath.Join(srcRoot, "target.link")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	oldCreateSymlink := createSymlink
+	createSymlink = func(_, _ string) error {
+		return errors.New("symlink privilege missing")
+	}
+	t.Cleanup(func() {
+		createSymlink = oldCreateSymlink
+	})
+
+	require.NoError(t, copyHostAdapterTree(ToolConfig{}, srcRoot, dstRoot))
+
+	got, err := os.ReadFile(filepath.Join(dstRoot, "target.link"))
+	require.NoError(t, err)
+	assert.Equal(t, "target content", string(got))
+}
+
+func TestCopyHostAdapterTreeDereferencesExternalSkillSymlinkWhenCreateSymlinkFails(t *testing.T) {
+	repoRoot := t.TempDir()
+	srcRoot := filepath.Join(repoRoot, ".claude")
+	dstRoot := filepath.Join(t.TempDir(), ".claude")
+	externalSkill := filepath.Join(t.TempDir(), "golang-security")
+	writeUnder(t, externalSkill, "SKILL.md", "# external skill\n")
+	require.NoError(t, os.MkdirAll(filepath.Join(srcRoot, "skills"), 0o755))
+	if err := os.Symlink(externalSkill, filepath.Join(srcRoot, "skills", "golang-security")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	oldCreateSymlink := createSymlink
+	createSymlink = func(_, _ string) error {
+		return errors.New("symlink privilege missing")
+	}
+	t.Cleanup(func() {
+		createSymlink = oldCreateSymlink
+	})
+
+	require.NoError(t, copyHostAdapterTree(ToolConfig{}, srcRoot, dstRoot))
+
+	got, err := os.ReadFile(filepath.Join(dstRoot, "skills", "golang-security", "SKILL.md"))
+	require.NoError(t, err)
+	assert.Equal(t, "# external skill\n", string(got))
+}
+
+func TestDereferenceSymlinkCopyMaterializesNestedSymlinkInsideTargetDir(t *testing.T) {
+	srcRoot := t.TempDir()
+	targetDir := filepath.Join(t.TempDir(), "skill")
+	require.NoError(t, os.MkdirAll(targetDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(targetDir, "target.md"), []byte("nested target"), 0o644))
+	if err := os.Symlink("target.md", filepath.Join(targetDir, "nested.link")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	dstPath := filepath.Join(t.TempDir(), "skill")
+
+	err := dereferenceSymlinkCopy(filepath.Join(srcRoot, "skill.link"), dstPath, targetDir, errors.New("symlink privilege missing"))
+
+	require.NoError(t, err)
+	got, err := os.ReadFile(filepath.Join(dstPath, "nested.link"))
+	require.NoError(t, err)
+	assert.Equal(t, "nested target", string(got))
+}
+
+func TestDereferenceSymlinkCopyRejectsNestedSymlinkOutsideTargetDir(t *testing.T) {
+	srcRoot := t.TempDir()
+	targetDir := filepath.Join(t.TempDir(), "skill")
+	outside := filepath.Join(t.TempDir(), "outside.md")
+	require.NoError(t, os.MkdirAll(targetDir, 0o755))
+	require.NoError(t, os.WriteFile(outside, []byte("outside"), 0o644))
+	if err := os.Symlink(outside, filepath.Join(targetDir, "outside.link")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	dstPath := filepath.Join(t.TempDir(), "skill")
+
+	err := dereferenceSymlinkCopy(filepath.Join(srcRoot, "skill.link"), dstPath, targetDir, errors.New("symlink privilege missing"))
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "outside allowed root")
+}
+
+func TestDereferenceSymlinkCopyRejectsAncestorDirectoryTarget(t *testing.T) {
+	srcRoot := t.TempDir()
+	nested := filepath.Join(srcRoot, "nested")
+	require.NoError(t, os.MkdirAll(nested, 0o755))
+	symErr := errors.New("symlink privilege missing")
+
+	err := dereferenceSymlinkCopy(filepath.Join(nested, "root.link"), filepath.Join(t.TempDir(), "root.link"), "..", symErr)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "contains the link")
+}
+
+func TestDereferenceSymlinkCopyRejectsMutualDirectorySymlinkCycle(t *testing.T) {
+	srcRoot := t.TempDir()
+	targetDir := filepath.Join(t.TempDir(), "skill")
+	dirA := filepath.Join(targetDir, "a")
+	dirB := filepath.Join(targetDir, "b")
+	require.NoError(t, os.MkdirAll(dirA, 0o755))
+	require.NoError(t, os.MkdirAll(dirB, 0o755))
+	if err := os.Symlink("../b", filepath.Join(dirA, "to-b")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if err := os.Symlink("../a", filepath.Join(dirB, "to-a")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	err := dereferenceSymlinkCopy(filepath.Join(srcRoot, "skill.link"), filepath.Join(t.TempDir(), "skill"), targetDir, errors.New("symlink privilege missing"))
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "symlink cycle")
 }
 
 func TestProvisionWorktreeHostSurfaces_DoesNotMutateCodexHome(t *testing.T) {


### PR DESCRIPTION
## Summary

- Make governance content hashing CRLF-invariant for text while preserving byte-exact hashes for binary content.
- Add Windows runtime fixes for process liveness, bounded atomic rename retries, and symlink dereference fallback with fail-closed cycle/outside-root handling.
- Make generated adapter hook commands shell-neutral (`slipway hook ...`), update goal-verification scan instructions, and align public docs.
- Add `.gitattributes` coverage that pins governed text to LF without forcing unknown artifact payloads through text conversion.
- Archive the governed Slipway change after `slipway done`.

## Review closeout

- Refreshed repo-root ignored generated surfaces with the rebuilt current binary.
- Confirmed root settings no longer use the retired launcher path and root goal-verification SKILLs no longer contain `perl -0ne`.
- Confirmed direct `slipway hook session-start --tool claude` exits 0 in a non-Slipway directory and only reports a diagnostic.

## Validation

- `git diff --cached --check`
- `git check-attr text eol -- artifacts/example.bin artifacts/example.dat artifacts/example.png artifacts/example.mp4 artifacts/changes/example/intent.md docs/example.md internal/model/evidence.go`
- `go test ./internal/model -run TestGitAttributesKeepArtifactBinariesByteExact -count=1`
- `go test ./internal/model -run TestComputeFileContentHash -count=1`
- `go vet ./...`
- `GOOS=windows GOARCH=amd64 go build ./...`
- `GOOS=windows GOARCH=amd64 go vet ./...`
- `GOOS=windows GOARCH=amd64 go test -c -o /tmp/slipway-cmd-windows.test.exe ./cmd`
- `golangci-lint run` (`0 issues`)
- `go test ./... -count=1`
- `slipway done` archived `fix-windows-runtime-incompatibilities-found-in-a-deep-cross`