### PR TITLE
fix(governance): self-sufficient per-task wave-evidence flow + non-corrupting archived reads (#227 #228 #229 #232)

### DIFF
--- a/cmd/checkpoint.go
+++ b/cmd/checkpoint.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/signalridge/slipway/internal/engine/progression"
 	"github.com/signalridge/slipway/internal/model"
 	"github.com/signalridge/slipway/internal/state"
 	"github.com/spf13/cobra"
@@ -129,7 +130,28 @@ func makeCheckpointCmd() *cobra.Command {
 						}
 						return err
 					}
-					currentWaveIndex = state.ResumeWaveIndex(wavePlan, nil)
+					// No materialized run summary yet — the normal case BETWEEN waves,
+					// before wave-orchestration skill evidence is recorded. Derive the
+					// current incomplete wave from the recorded per-task evidence so a
+					// completed early wave lets its successor become checkpointable; a
+					// bare ResumeWaveIndex(plan, nil) would always pin wave 1 and reject
+					// every next-wave task (issue #227a). With no task evidence yet, the
+					// wave-1 default is correct.
+					evidenceWaveIndex, derived, err := progression.ResumeWaveIndexFromTaskEvidence(root, change, wavePlan)
+					if err != nil {
+						return newStateIntegrityError(
+							"checkpoint_wave_derivation_failed",
+							fmt.Sprintf("failed to derive the current wave from task evidence: %v", err),
+							"Run `slipway repair` to inspect or repair runtime task evidence before setting a checkpoint.",
+							change.Slug,
+							nil,
+						)
+					}
+					if derived {
+						currentWaveIndex = evidenceWaveIndex
+					} else {
+						currentWaveIndex = state.ResumeWaveIndex(wavePlan, nil)
+					}
 				}
 				if currentWaveIndex == 0 {
 					return newInvalidUsageError(

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -348,7 +348,12 @@ func addChangeSelectorFlags(cmd *cobra.Command, target *string, usage string) {
 func resolveExplicitChange(root string, slug string) (changeRef, error) {
 	change, err := state.LoadChange(root, slug)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
+		// An archived DONE change can leave its active bundle directory behind
+		// after its change.yaml is moved to the archive. LoadChange then reports a
+		// missing-authority error rather than os.ErrNotExist, so attempt the
+		// archived fallback for both. This mirrors status's
+		// shouldFallbackToArchivedStatus predicate (issue #196).
+		if errors.Is(err, os.ErrNotExist) || state.IsMissingBundleAuthority(err) {
 			if archived, archiveErr := state.LoadArchivedChange(root, slug); archiveErr == nil {
 				archivePath := filepath.ToSlash(filepath.Join("artifacts", "changes", "archived", slug, "change.yaml"))
 				if path, pathErr := state.ArchivedChangeFilePathForRead(root, slug); pathErr == nil {
@@ -366,16 +371,22 @@ func resolveExplicitChange(root string, slug string) (changeRef, error) {
 					},
 				)
 			}
-			if recoveryErr := deleteRecoveryError(root, slug); recoveryErr != nil {
-				return changeRef{}, recoveryErr
+			// No archived record was found. Only os.ErrNotExist (no bundle at all)
+			// softens to no_active_change. A missing-authority error without an
+			// archive is genuine active-bundle corruption and must fall through to
+			// fail closed on change_state_load_failed.
+			if errors.Is(err, os.ErrNotExist) {
+				if recoveryErr := deleteRecoveryError(root, slug); recoveryErr != nil {
+					return changeRef{}, recoveryErr
+				}
+				return changeRef{}, newPreconditionError(
+					"no_active_change",
+					fmt.Sprintf("no change found for slug %q", slug),
+					"Check the slug with `slipway status`.",
+					slug,
+					nil,
+				)
 			}
-			return changeRef{}, newPreconditionError(
-				"no_active_change",
-				fmt.Sprintf("no change found for slug %q", slug),
-				"Check the slug with `slipway status`.",
-				slug,
-				nil,
-			)
 		}
 		if recoveryErr := deleteRecoveryError(root, slug); recoveryErr != nil {
 			return changeRef{}, recoveryErr

--- a/cmd/evidence.go
+++ b/cmd/evidence.go
@@ -225,6 +225,31 @@ func makeEvidenceSkillCmd() *cobra.Command {
 					)
 				}
 
+				// Materialize execution-summary.yaml from the same public command that
+				// owns wave execution evidence (issue #228). The summary was previously
+				// only written by advance/next or `slipway repair`, so the public
+				// per-task-evidence + wave-orchestration flow left validate blocking on
+				// run_summary_missing until an undocumented repair. The owning stage now
+				// produces the evidence: once the passing wave-orchestration record and
+				// its task evidence are durable at S2_EXECUTE, sync writes the summary.
+				// This is idempotent (sync only rewrites a changed summary) and any
+				// error it returns is surfaced, never swallowed, so a partial or
+				// scope-failing run still fails closed instead of recording a clean
+				// summary.
+				if record.IsPassing() &&
+					skillName == progression.SkillWaveOrchestration &&
+					change.CurrentState == model.StateS2Execute {
+					if _, err := progression.SyncGovernedWaveExecution(root, change); err != nil {
+						return newStateIntegrityError(
+							"evidence_skill_execution_summary_sync_failed",
+							fmt.Sprintf("failed to materialize execution summary after recording %s evidence: %v", skillName, err),
+							"Repair the runtime wave execution evidence and retry the evidence command.",
+							change.Slug,
+							map[string]any{"skill": skillName},
+						)
+					}
+				}
+
 				if err := appendCLILifecycleEvent(root, change, state.LifecycleEvent{
 					Command:     "evidence skill",
 					EventType:   "skill.evidence_recorded",

--- a/cmd/issue227_228_execution_summary_test.go
+++ b/cmd/issue227_228_execution_summary_test.go
@@ -1,0 +1,208 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/signalridge/slipway/internal/engine/progression"
+	"github.com/signalridge/slipway/internal/model"
+	"github.com/signalridge/slipway/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The public per-task-evidence + wave-orchestration flow must materialize
+// execution-summary.yaml by itself, so a downstream validate no longer blocks on
+// run_summary_missing until an undocumented `slipway repair` (issue #228).
+func TestIssue228EvidenceSkillWaveOrchestrationMaterializesExecutionSummary(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		slug, change := createEvidenceTaskFixture(t, root)
+
+		// Before any evidence, the public flow has produced no run summary.
+		summaryBefore, err := state.LoadOptionalRelevantExecutionSummary(root, change)
+		require.NoError(t, err)
+		require.Nil(t, summaryBefore)
+
+		// Step 1: record the per-task evidence through the public command.
+		taskCmd := commandForRoot(t, root, makeEvidenceCmd())
+		taskCmd.SetArgs([]string{
+			"task",
+			"--change", slug,
+			"--task-id", "t-01",
+			"--run-summary-version", "1",
+			"--task-kind", "verification",
+			"--verdict", "pass",
+			"--evidence-ref", "test:t-01",
+			"--changed-file", "cmd/lifecycle_commands_test.go",
+			"--target-file", "cmd/lifecycle_commands_test.go",
+		})
+		require.NoError(t, taskCmd.Execute())
+
+		// Recording task evidence alone does not write the summary; the
+		// wave-orchestration skill step owns that.
+		summaryMid, err := state.LoadOptionalRelevantExecutionSummary(root, change)
+		require.NoError(t, err)
+		require.Nil(t, summaryMid, "task evidence alone must not materialize the run summary")
+
+		// Step 2: record wave-orchestration skill evidence through the public
+		// command. This is the owning public step that must now materialize the
+		// summary.
+		skillCmd := commandForRoot(t, root, makeEvidenceCmd())
+		skillCmd.SetArgs([]string{
+			"skill",
+			"--json",
+			"--change", slug,
+			"--skill", progression.SkillWaveOrchestration,
+			"--verdict", model.VerificationVerdictPass,
+			"--reference", "wave-orchestration:pass",
+			"--notes", "Wave orchestration passed.",
+		})
+		var out bytes.Buffer
+		skillCmd.SetOut(&out)
+		require.NoError(t, skillCmd.Execute())
+
+		var view evidenceSkillView
+		require.NoError(t, json.Unmarshal(out.Bytes(), &view))
+		assert.True(t, view.Recorded)
+		assert.Equal(t, 1, view.RunVersion)
+
+		// The summary is now materialized by the same public command — no repair.
+		summaryAfter, err := state.LoadOptionalRelevantExecutionSummary(root, change)
+		require.NoError(t, err)
+		require.NotNil(t, summaryAfter, "wave-orchestration skill evidence must materialize execution-summary.yaml")
+		assert.Equal(t, 1, summaryAfter.RunSummaryVersion)
+		require.Len(t, summaryAfter.Tasks, 1)
+		assert.Equal(t, "t-01", summaryAfter.Tasks[0].TaskID)
+		assert.True(t, state.ExecutionSummaryReady(summaryAfter))
+	})
+}
+
+// issue227SeedTwoWaveExecution seeds an S2_EXECUTE change with a two-wave plan
+// (task-01 in wave 1, task-02 in wave 2) and no materialized run summary.
+func issue227SeedTwoWaveExecution(t *testing.T, root, slug string) {
+	t.Helper()
+	change, err := state.LoadChange(root, slug)
+	require.NoError(t, err)
+	change.CurrentState = model.StateS2Execute
+	change.PlanSubStep = model.PlanSubStepNone
+	require.NoError(t, state.SaveChange(root, change))
+
+	bundlePath, err := state.GovernedBundleDir(root, change)
+	require.NoError(t, err)
+	require.NoError(t, writeBundleArtifactFile(
+		bundlePath,
+		slug,
+		"tasks.md",
+		[]byte("\n"+
+			"- [ ] `task-01` first wave task\n"+
+			"  - depends_on: []\n"+
+			"  - target_files: [\"cmd/checkpoint.go\"]\n"+
+			"  - task_kind: code\n\n"+
+			"- [ ] `task-02` second wave task\n"+
+			"  - depends_on: [\"task-01\"]\n"+
+			"  - target_files: [\"cmd/evidence.go\"]\n"+
+			"  - task_kind: code\n"),
+	))
+	_, err = state.MaterializeWavePlan(root, change)
+	require.NoError(t, err)
+}
+
+// Mid-wave, after only wave 1's task evidence is recorded (and BEFORE any
+// wave-orchestration skill evidence, so no run summary exists yet), a checkpoint
+// on a wave-2 task must be settable: the documented per-task-evidence flow has
+// completed wave 1, so wave 2 is the current incomplete wave (issue #227a).
+func TestIssue227CheckpointSettableAtWaveBoundaryBeforeSkillEvidence(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		slug := createGovernedRequest(t, root, "L2", "issue227 checkpoint wave boundary")
+		issue227SeedTwoWaveExecution(t, root, slug)
+
+		change, err := state.LoadChange(root, slug)
+		require.NoError(t, err)
+
+		// Record wave 1's task as passing through the public command. No
+		// wave-orchestration skill evidence yet -> no materialized run summary.
+		taskCmd := commandForRoot(t, root, makeEvidenceCmd())
+		taskCmd.SetArgs([]string{
+			"task",
+			"--change", slug,
+			"--task-id", "task-01",
+			"--run-summary-version", "1",
+			"--task-kind", "code",
+			"--verdict", "pass",
+			"--evidence-ref", "test:task-01",
+			"--changed-file", "cmd/checkpoint.go",
+			"--target-file", "cmd/checkpoint.go",
+		})
+		require.NoError(t, taskCmd.Execute())
+
+		summary, err := state.LoadOptionalRelevantExecutionSummary(root, change)
+		require.NoError(t, err)
+		require.Nil(t, summary, "no skill evidence yet means no materialized run summary")
+
+		// Checkpoint on the wave-2 task must now succeed.
+		cmd := commandForRoot(t, root, makeCheckpointCmd())
+		cmd.SetArgs([]string{"--json", "--change", slug, "--task-id", "task-02", "--type", "human_verify"})
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetErr(&buf)
+		require.NoError(t, cmd.Execute(), "checkpoint output: %s", buf.String())
+
+		var view checkpointView
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &view))
+		assert.True(t, view.Set)
+		assert.Equal(t, "task-02", view.PausedTaskID)
+		assert.Equal(t, 2, view.PausedWaveIndex, "wave 2 is the current incomplete wave once wave 1 passed")
+
+		reloaded, err := state.LoadChange(root, slug)
+		require.NoError(t, err)
+		require.NotNil(t, reloaded.ActiveCheckpoint)
+		assert.Equal(t, "task-02", reloaded.ActiveCheckpoint.PausedTaskID)
+		assert.Equal(t, 2, reloaded.ActiveCheckpoint.PausedWaveIndex)
+	})
+}
+
+// Mid-wave with NO task evidence yet, a checkpoint on a wave-1 task is still
+// settable (the wave-1 default holds), while a wave-2 task is correctly rejected
+// as not in the current wave. This guards that issue #227a's evidence-derived
+// path does not regress the no-evidence baseline.
+func TestIssue227CheckpointWaveOneDefaultWithoutTaskEvidence(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		slug := createGovernedRequest(t, root, "L2", "issue227 checkpoint wave one default")
+		issue227SeedTwoWaveExecution(t, root, slug)
+
+		// wave-2 task rejected: wave 1 is still the current incomplete wave.
+		rejectCmd := commandForRoot(t, root, makeCheckpointCmd())
+		rejectCmd.SetArgs([]string{"--change", slug, "--task-id", "task-02"})
+		err := rejectCmd.Execute()
+		require.Error(t, err)
+		cliErr := asCLIError(err)
+		require.NotNil(t, cliErr)
+		assert.Equal(t, "checkpoint_task_not_in_current_wave", cliErr.ErrorCode)
+
+		// wave-1 task accepted.
+		acceptCmd := commandForRoot(t, root, makeCheckpointCmd())
+		acceptCmd.SetArgs([]string{"--json", "--change", slug, "--task-id", "task-01"})
+		var buf bytes.Buffer
+		acceptCmd.SetOut(&buf)
+		acceptCmd.SetErr(&buf)
+		require.NoError(t, acceptCmd.Execute(), "checkpoint output: %s", buf.String())
+
+		var view checkpointView
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &view))
+		assert.True(t, view.Set)
+		assert.Equal(t, 1, view.PausedWaveIndex)
+	})
+}

--- a/cmd/issue229_plan_audit_bundle_handoff_test.go
+++ b/cmd/issue229_plan_audit_bundle_handoff_test.go
@@ -1,0 +1,97 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/signalridge/slipway/internal/engine/progression"
+	"github.com/signalridge/slipway/internal/model"
+	"github.com/signalridge/slipway/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runIssue229NextDiagnostics drives `next --json --diagnostics` for the given
+// change and returns the decoded view. --diagnostics selects the full view that
+// carries agent constraints (allowed_operations / required_outputs).
+func runIssue229NextDiagnostics(t *testing.T, root, slug string) nextView {
+	t.Helper()
+	cmd := commandForRoot(t, root, makeNextCmd())
+	cmd.SetArgs([]string{"--json", "--diagnostics", "--change", slug})
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	require.NoError(t, cmd.Execute())
+
+	var view nextView
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &view))
+	return view
+}
+
+// TestIssue229BundleHandoffDoesNotAdvertiseEvidenceBeforeAudit asserts that at
+// S1_PLAN/bundle the plan-audit handoff does NOT advertise write_evidence /
+// evidence_record. `slipway evidence skill --skill plan-audit` fails closed with
+// evidence_skill_wrong_plan_substep until the substep advances to audit, so
+// advertising evidence recording at bundle is a dead-end handoff. The
+// authoritative next action is to run the lifecycle into S1_PLAN/audit.
+func TestIssue229BundleHandoffDoesNotAdvertiseEvidenceBeforeAudit(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		slug := createGovernedRequest(t, root, "L3", "issue229 bundle handoff")
+		change, err := state.LoadChange(root, slug)
+		require.NoError(t, err)
+		change.PlanSubStep = model.PlanSubStepBundle
+		require.NoError(t, state.SaveChange(root, change))
+
+		view := runIssue229NextDiagnostics(t, root, slug)
+
+		require.NotNil(t, view.NextSkill)
+		assert.Equal(t, progression.SkillPlanAudit, view.NextSkill.Name)
+
+		require.NotNil(t, view.Constraints)
+		assert.NotContains(t, view.Constraints.AllowedOperations, "write_evidence",
+			"bundle handoff must not advertise write_evidence before the substep advances to audit")
+		assert.NotContains(t, view.Constraints.RequiredOutputs, "evidence_record",
+			"bundle handoff must not require an evidence_record the evidence command rejects at bundle")
+
+		warnings := strings.Join(view.Warnings, "\n")
+		assert.Contains(t, warnings, "S1_PLAN/bundle")
+		assert.Contains(t, warnings, "slipway run", "warning must point to running into S1_PLAN/audit")
+		assert.Contains(t, warnings, "S1_PLAN/audit")
+		assert.NotContains(t, warnings, "write plan-audit evidence",
+			"warning must not offer recording evidence as a direct action at bundle")
+	})
+}
+
+// TestIssue229AuditHandoffStillAdvertisesEvidence asserts the audit-substep
+// behavior is unchanged: at S1_PLAN/audit, where `slipway evidence skill --skill
+// plan-audit` is accepted, the handoff still advertises write_evidence and
+// requires the evidence_record output.
+func TestIssue229AuditHandoffStillAdvertisesEvidence(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		slug := createGovernedRequest(t, root, "L3", "issue229 audit handoff")
+		change, err := state.LoadChange(root, slug)
+		require.NoError(t, err)
+		change.PlanSubStep = model.PlanSubStepAudit
+		require.NoError(t, state.SaveChange(root, change))
+
+		view := runIssue229NextDiagnostics(t, root, slug)
+
+		require.NotNil(t, view.NextSkill)
+		assert.Equal(t, progression.SkillPlanAudit, view.NextSkill.Name)
+
+		require.NotNil(t, view.Constraints)
+		assert.Contains(t, view.Constraints.AllowedOperations, "write_evidence",
+			"audit handoff must still advertise write_evidence where evidence recording is accepted")
+		assert.Contains(t, view.Constraints.RequiredOutputs, "evidence_record",
+			"audit handoff must still require the evidence_record output")
+	})
+}

--- a/cmd/issue232_archived_missing_authority_test.go
+++ b/cmd/issue232_archived_missing_authority_test.go
@@ -1,0 +1,111 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/signalridge/slipway/internal/model"
+	"github.com/signalridge/slipway/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIssue232ResolveExplicitChangeFallsBackToArchivedWhenActiveBundleAuthorityMissing
+// reproduces #232: an archived DONE change whose active bundle directory survived
+// (its change.yaml was moved to the archive) made `slipway validate`/`slipway next`
+// dead-end on change_state_load_failed because resolveExplicitChange only attempted
+// the archived fallback on os.ErrNotExist. LoadChange reports a missing-authority
+// error for the surviving directory, so the fallback must also trigger on
+// state.IsMissingBundleAuthority — mirroring status's predicate.
+func TestIssue232ResolveExplicitChangeFallsBackToArchivedWhenActiveBundleAuthorityMissing(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	ensureTestGitRepo(t, root)
+	initTestWorkspace(t, root)
+
+	slug := "issue232-archived-missing-active-authority"
+	change := model.NewChange(slug)
+	change.Status = model.ChangeStatusDone
+	change.CurrentState = model.StateDone
+	change.PlanSubStep = model.PlanSubStepNone
+	require.NoError(t, state.SaveChange(root, change))
+	_, err := state.ArchiveChange(root, change, model.ChangeStatusDone)
+	require.NoError(t, err)
+
+	// Re-create the active bundle directory with a stray file but no change.yaml,
+	// so LoadChange reports a missing-authority error rather than os.ErrNotExist.
+	activePath := state.BundleChangeFilePath(root, slug)
+	require.NoError(t, os.MkdirAll(filepath.Dir(activePath), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(filepath.Dir(activePath), "notes.md"), []byte("orphaned active bundle\n"), 0o644))
+
+	// Precondition: LoadChange surfaces the missing-authority signal (not NotExist).
+	_, loadErr := state.LoadChange(root, slug)
+	require.True(t, state.IsMissingBundleAuthority(loadErr))
+
+	_, resolveErr := resolveExplicitChange(root, slug)
+	cliErr := asCLIError(resolveErr)
+	require.NotNil(t, cliErr)
+	assert.Equal(t, "archived_change_not_validatable", cliErr.ErrorCode)
+	assert.Equal(t, categoryPrecondition, cliErr.Category)
+	assert.Equal(t, exitCodePrecondition, cliErr.ExitCode)
+	assert.Equal(t, slug, cliErr.Slug)
+	assert.Equal(t, string(model.ChangeStatusDone), cliErr.Details["status"])
+	assert.Equal(t, true, cliErr.Details["archived"])
+	assert.Contains(t, cliErr.Remediation, "archived")
+	assert.NotEqual(t, "change_state_load_failed", cliErr.ErrorCode)
+}
+
+// TestIssue232ResolveExplicitChangeMissingAuthorityWithoutArchiveFailsClosed
+// pins the fail-closed nuance from #232: broadening the archived-fallback trigger
+// must NOT soften a genuine missing-authority error into no_active_change when
+// there is no archived record. The surviving orphan directory is real
+// active-bundle corruption and must fail closed to a recovery/integrity blocker.
+func TestIssue232ResolveExplicitChangeMissingAuthorityWithoutArchiveFailsClosed(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	ensureTestGitRepo(t, root)
+	initTestWorkspace(t, root)
+
+	slug := createGovernedRequest(t, root, "L2", "issue232 orphaned active bundle")
+	// Drop change.yaml but leave a stray file so the bundle directory survives;
+	// LoadChange then reports a missing-authority error with no archived record.
+	activePath := state.BundleChangeFilePath(root, slug)
+	require.NoError(t, os.WriteFile(filepath.Join(filepath.Dir(activePath), "notes.md"), []byte("orphaned\n"), 0o644))
+	require.NoError(t, os.Remove(activePath))
+
+	_, loadErr := state.LoadChange(root, slug)
+	require.True(t, state.IsMissingBundleAuthority(loadErr))
+
+	_, resolveErr := resolveExplicitChange(root, slug)
+	cliErr := asCLIError(resolveErr)
+	require.NotNil(t, cliErr)
+	// Must never be softened to a "no change here" precondition.
+	assert.NotEqual(t, "no_active_change", cliErr.ErrorCode)
+	// Fail closed: the operator is routed to discard the orphaned bundle.
+	assert.Equal(t, "orphaned_change_bundle", cliErr.ErrorCode)
+	assert.Equal(t, categoryPrecondition, cliErr.Category)
+	assert.Contains(t, cliErr.Remediation, "slipway delete")
+}
+
+// TestIssue232ResolveExplicitChangeMalformedActiveAuthorityFailsClosed confirms
+// the os.ErrNotExist-only fall-through to change_state_load_failed still fires for
+// genuinely corrupt active state (a malformed change.yaml is neither NotExist nor
+// missing-authority), so the #232 broadening did not mask real corruption.
+func TestIssue232ResolveExplicitChangeMalformedActiveAuthorityFailsClosed(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	ensureTestGitRepo(t, root)
+	initTestWorkspace(t, root)
+
+	slug := createGovernedRequest(t, root, "L2", "issue232 malformed active authority")
+	require.NoError(t, os.WriteFile(state.BundleChangeFilePath(root, slug), []byte("slug: ["), 0o644))
+
+	_, resolveErr := resolveExplicitChange(root, slug)
+	cliErr := asCLIError(resolveErr)
+	require.NotNil(t, cliErr)
+	assert.Equal(t, "change_state_load_failed", cliErr.ErrorCode)
+	assert.Equal(t, categoryStateIntegrity, cliErr.Category)
+	assert.Equal(t, slug, cliErr.Slug)
+	assert.Contains(t, cliErr.Remediation, "slipway repair")
+}

--- a/cmd/next_skill_view.go
+++ b/cmd/next_skill_view.go
@@ -216,6 +216,14 @@ func assembleSkillViewWithOptions(
 		resolutionReason = fmt.Sprintf("blocking skill evidence supersedes already-passing display skill: %s", nextSkillName)
 	}
 
+	// atBundlePlanAuditHandoff records that plan-audit is being surfaced from the
+	// S1_PLAN/bundle authoring step rather than S1_PLAN/audit. plan-audit evidence
+	// is rejected by `slipway evidence skill` until the substep advances to audit
+	// (evidence_skill_wrong_plan_substep), so the bundle handoff must NOT advertise
+	// write_evidence / evidence_record as the immediate action — doing so produces a
+	// dead-end handoff (issue #229). The authoritative next action at bundle is to
+	// run the lifecycle into S1_PLAN/audit first.
+	atBundlePlanAuditHandoff := false
 	if nextSkillName == "" && governedChange != nil &&
 		governedChange.CurrentState == model.StateS1Plan &&
 		governedChange.PlanSubStep == model.PlanSubStepBundle &&
@@ -223,7 +231,8 @@ func assembleSkillViewWithOptions(
 		len(view.Blockers) == 0 {
 		nextSkillName = progression.SkillPlanAudit
 		nextState = string(model.StateS1Plan)
-		view.Warnings = append(view.Warnings, "S1_PLAN/bundle is a machine authoring step; ensure bundle artifacts are complete, then write plan-audit evidence or run `slipway run --json` to enter S1_PLAN/audit.")
+		atBundlePlanAuditHandoff = true
+		view.Warnings = append(view.Warnings, "S1_PLAN/bundle is a machine authoring step; ensure bundle artifacts are complete, then run `slipway run --json` to enter S1_PLAN/audit. plan-audit evidence cannot be recorded until the substep advances to audit.")
 	}
 
 	if nextSkillName == "" {
@@ -338,6 +347,16 @@ func assembleSkillViewWithOptions(
 	}
 	if options.IncludeAgentContext {
 		view.Constraints = deriveAgentConstraints(registry, nextSkillName)
+		if atBundlePlanAuditHandoff {
+			// At S1_PLAN/bundle the authoritative next action is `slipway run` into
+			// S1_PLAN/audit, not recording evidence: `slipway evidence skill --skill
+			// plan-audit` fails closed with evidence_skill_wrong_plan_substep until the
+			// substep advances. Drop write_evidence / evidence_record so the handoff
+			// does not advertise an action the evidence command rejects (issue #229).
+			// The audit-substep handoff keeps the registry constraints unchanged.
+			view.Constraints.AllowedOperations = withoutOperation(view.Constraints.AllowedOperations, "write_evidence")
+			view.Constraints.RequiredOutputs = withoutOperation(view.Constraints.RequiredOutputs, "evidence_record")
+		}
 	}
 
 	if advanced.Action == "blocked" {
@@ -346,6 +365,23 @@ func assembleSkillViewWithOptions(
 	applyContextBudgetGuard(view)
 
 	return nil
+}
+
+// withoutOperation returns values with every occurrence of op removed, preserving
+// order. An emptied list collapses to nil so it serializes as a JSON null rather
+// than carrying a stale entry.
+func withoutOperation(values []string, op string) []string {
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		if v == op {
+			continue
+		}
+		out = append(out, v)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // codebaseMapStatusHasNoDurableDocs reports whether a whole-map status means no

--- a/internal/engine/progression/advance_governed.go
+++ b/internal/engine/progression/advance_governed.go
@@ -135,13 +135,26 @@ func AdvanceGoverned(root, slug string, opts ...AdvanceOptions) (summary Advance
 	// remediation while leaving wave-orchestration/execution-summary intact;
 	// re-running after the file is removed or the plan is rescoped advances
 	// normally (issue #136). Missing task changed-file evidence, by contrast, can
-	// only be repaired by re-recording in the owning stage, so it reopens to
-	// S2_EXECUTE instead of stranding the failure in S3_REVIEW where task evidence
-	// is no longer recordable.
+	// only be repaired by re-recording in the owning stage, so when the failure
+	// surfaces downstream (S3_REVIEW/S4_VERIFY) it reopens to S2_EXECUTE instead
+	// of stranding the failure where task evidence is no longer recordable.
+	//
+	// When the change is still IN S2_EXECUTE, every scope-contract blocker — drift
+	// and missing-changed-file alike — blocks visibly without clearing
+	// execution-summary.yaml / wave-orchestration.yaml. Reopening S2 from S2 is a
+	// no-op transition whose only effect is wiping the summary; once the summary is
+	// gone the scope contract evaluates NotApplicable, so the real
+	// scope_contract_changed_files_missing is masked behind run_summary_missing and
+	// every `slipway run` re-wipes it — an infinite loop only `slipway repair`
+	// escaped (issue #227b). Preserving the summary keeps the real blocker visible
+	// to validate/status/next with actionable remediation (record the task's
+	// --changed-file, or record it as a verification/investigation kind, which is
+	// exempt). This fails closed — the block is kept, only the masking wipe is
+	// removed.
 	if target, err := scopeContractReopenTarget(root, change, executionSummaryCtx.Summary); err != nil {
 		return AdvanceSummary{}, err
 	} else if target.SkillName != "" {
-		if scopeContractDriftOnly(target.Blockers) {
+		if fromState == model.StateS2Execute || scopeContractDriftOnly(target.Blockers) {
 			return blockedAdvanceSummary(fromState, target.Blockers), nil
 		}
 		return reopenToStaleStage(root, &change, target, fromState)

--- a/internal/engine/progression/issue227_wave_boundary_test.go
+++ b/internal/engine/progression/issue227_wave_boundary_test.go
@@ -122,6 +122,60 @@ func TestIssue227ResumeWaveIndexFromTaskEvidenceToleratesMalformedFile(t *testin
 	assert.Equal(t, 0, index)
 }
 
+// Task-evidence files spanning more than one run version are ambiguous: the
+// resolver cannot pick a single authoritative run, so it reports no usable
+// evidence (derived=false) and the caller keeps the safe wave-1 default rather
+// than guessing (issue #227a).
+func TestIssue227ResumeWaveIndexFromTaskEvidenceAmbiguousRunVersions(t *testing.T) {
+	t.Parallel()
+	root, change := issue227TwoWavePlan(t)
+	// task-a at run version 1, task-b at run version 2 — two distinct versions.
+	issue227WriteTaskEvidence(t, root, change, "task-a", []string{"cmd/checkpoint.go"})
+	dir := state.EvidenceTasksDir(root, change.Slug)
+	v2 := map[string]any{
+		"task_id":             "task-b",
+		"run_summary_version": 2,
+		"task_kind":           "code",
+		"verdict":             "pass",
+		"changed_files":       []string{"cmd/evidence.go"},
+		"target_files":        []string{"cmd/evidence.go"},
+		"evidence_ref":        "test:task-b",
+		"captured_at":         time.Now().UTC().Add(-time.Minute).Format(time.RFC3339Nano),
+		"freshness_inputs":    expectedTaskFreshnessInputsForWavePlan(t, root, change, 2, "task-b"),
+	}
+	raw, err := json.Marshal(v2)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "task-b.json"), raw, 0o644))
+
+	plan, err := state.LoadWavePlanForChange(root, change)
+	require.NoError(t, err)
+
+	index, derived, err := ResumeWaveIndexFromTaskEvidence(root, change, plan)
+	require.NoError(t, err, "mixed run versions must not hard-fail")
+	assert.False(t, derived, "ambiguous run versions yield the safe wave-1 default, not a guess")
+	assert.Equal(t, 0, index)
+}
+
+// Non-JSON siblings (and subdirectories) in the task-evidence directory are
+// skipped during run-version detection; a valid wave-1 record alongside them
+// still drives the resume index to wave 2 (issue #227a).
+func TestIssue227ResumeWaveIndexFromTaskEvidenceSkipsNonJSONEntries(t *testing.T) {
+	t.Parallel()
+	root, change := issue227TwoWavePlan(t)
+	issue227WriteTaskEvidence(t, root, change, "task-a", []string{"cmd/checkpoint.go"})
+	dir := state.EvidenceTasksDir(root, change.Slug)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("not evidence\n"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "nested"), 0o755))
+
+	plan, err := state.LoadWavePlanForChange(root, change)
+	require.NoError(t, err)
+
+	index, derived, err := ResumeWaveIndexFromTaskEvidence(root, change, plan)
+	require.NoError(t, err)
+	assert.True(t, derived, "a valid record drives derivation even beside non-JSON entries")
+	assert.Equal(t, 2, index, "the .txt file and subdirectory are ignored for version detection")
+}
+
 // issue227ScopeContractMissingChange seeds an S2_EXECUTE change whose single code
 // task passed but recorded NO changed files, and materializes the matching
 // execution-summary.yaml + passing wave-orchestration evidence. This is the

--- a/internal/engine/progression/issue227_wave_boundary_test.go
+++ b/internal/engine/progression/issue227_wave_boundary_test.go
@@ -1,0 +1,234 @@
+package progression
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/signalridge/slipway/internal/engine/scopecontract"
+	"github.com/signalridge/slipway/internal/model"
+	"github.com/signalridge/slipway/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// issue227TwoWavePlan seeds an S2_EXECUTE change with a two-wave plan: wave 1
+// holds task-a, wave 2 holds task-b (which depends on task-a).
+func issue227TwoWavePlan(t *testing.T) (string, model.Change) {
+	t.Helper()
+	root := t.TempDir()
+	change := model.NewChange("wave-boundary")
+	change.CurrentState = model.StateS2Execute
+	change.PlanSubStep = model.PlanSubStepNone
+	require.NoError(t, state.SaveChange(root, change))
+	writeTasksAndMaterializeWavePlan(t, root, change, "# Tasks\n\n"+
+		"- [ ] `task-a` first wave task\n"+
+		"  - depends_on: []\n"+
+		"  - target_files: [\"cmd/checkpoint.go\"]\n"+
+		"  - task_kind: code\n\n"+
+		"- [ ] `task-b` second wave task\n"+
+		"  - depends_on: [\"task-a\"]\n"+
+		"  - target_files: [\"cmd/evidence.go\"]\n"+
+		"  - task_kind: code\n")
+	return root, change
+}
+
+func issue227WriteTaskEvidence(t *testing.T, root string, change model.Change, taskID string, changedFiles []string) {
+	t.Helper()
+	payload := map[string]any{
+		"task_id":             taskID,
+		"run_summary_version": 1,
+		"task_kind":           "code",
+		"verdict":             "pass",
+		"changed_files":       changedFiles,
+		"target_files":        changedFiles,
+		"evidence_ref":        "test:" + taskID,
+		"captured_at":         time.Now().UTC().Add(-time.Minute).Format(time.RFC3339Nano),
+		"freshness_inputs":    expectedTaskFreshnessInputsForWavePlan(t, root, change, 1, taskID),
+	}
+	raw, err := json.Marshal(payload)
+	require.NoError(t, err)
+	path := filepath.Join(state.EvidenceTasksDir(root, change.Slug), taskID+".json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, raw, 0o644))
+}
+
+// Without any per-task evidence, the resolver reports "no usable evidence" so the
+// caller keeps its wave-1 default (issue #227a).
+func TestIssue227ResumeWaveIndexFromTaskEvidenceNoEvidence(t *testing.T) {
+	t.Parallel()
+	root, change := issue227TwoWavePlan(t)
+	plan, err := state.LoadWavePlanForChange(root, change)
+	require.NoError(t, err)
+
+	index, derived, err := ResumeWaveIndexFromTaskEvidence(root, change, plan)
+	require.NoError(t, err)
+	assert.False(t, derived, "no task evidence means no evidence-derived index")
+	assert.Equal(t, 0, index)
+}
+
+// With only wave 1's task recorded as passing, the resolver derives wave 2 as the
+// current incomplete wave — the boundary that the documented per-task-evidence
+// flow must be able to checkpoint before any run summary exists (issue #227a).
+func TestIssue227ResumeWaveIndexFromTaskEvidenceCompletesFirstWave(t *testing.T) {
+	t.Parallel()
+	root, change := issue227TwoWavePlan(t)
+	issue227WriteTaskEvidence(t, root, change, "task-a", []string{"cmd/checkpoint.go"})
+	plan, err := state.LoadWavePlanForChange(root, change)
+	require.NoError(t, err)
+
+	index, derived, err := ResumeWaveIndexFromTaskEvidence(root, change, plan)
+	require.NoError(t, err)
+	assert.True(t, derived, "recorded task evidence must drive the resume index")
+	assert.Equal(t, 2, index, "a fully-passed wave 1 makes wave 2 the current incomplete wave")
+}
+
+// When every wave's task is recorded passing, the resolver reports index 0
+// (all-waves-passed), distinct from the no-evidence case via the derived flag.
+func TestIssue227ResumeWaveIndexFromTaskEvidenceAllWavesPassed(t *testing.T) {
+	t.Parallel()
+	root, change := issue227TwoWavePlan(t)
+	issue227WriteTaskEvidence(t, root, change, "task-a", []string{"cmd/checkpoint.go"})
+	issue227WriteTaskEvidence(t, root, change, "task-b", []string{"cmd/evidence.go"})
+	plan, err := state.LoadWavePlanForChange(root, change)
+	require.NoError(t, err)
+
+	index, derived, err := ResumeWaveIndexFromTaskEvidence(root, change, plan)
+	require.NoError(t, err)
+	assert.True(t, derived, "recorded task evidence must drive the resume index")
+	assert.Equal(t, 0, index, "all waves passed yields index 0")
+}
+
+// A malformed task-evidence file must be soft-tolerated, exactly like the
+// read-only sibling surfaces (LoadExecutionTasksFromEvidence), instead of making
+// checkpoint hard-fail. The resolver reports the safe wave-1 default
+// (derived=false) with no error (issue #227a review follow-up).
+func TestIssue227ResumeWaveIndexFromTaskEvidenceToleratesMalformedFile(t *testing.T) {
+	t.Parallel()
+	root, change := issue227TwoWavePlan(t)
+	// A valid wave-1 record plus a corrupt sibling file in the same directory.
+	issue227WriteTaskEvidence(t, root, change, "task-a", []string{"cmd/checkpoint.go"})
+	corrupt := filepath.Join(state.EvidenceTasksDir(root, change.Slug), "task-b.json")
+	require.NoError(t, os.WriteFile(corrupt, []byte("{not valid json"), 0o644))
+
+	plan, err := state.LoadWavePlanForChange(root, change)
+	require.NoError(t, err)
+
+	index, derived, err := ResumeWaveIndexFromTaskEvidence(root, change, plan)
+	require.NoError(t, err, "a malformed evidence file must not hard-fail wave derivation")
+	assert.False(t, derived, "unclean evidence yields the safe wave-1 default, not a guess")
+	assert.Equal(t, 0, index)
+}
+
+// issue227ScopeContractMissingChange seeds an S2_EXECUTE change whose single code
+// task passed but recorded NO changed files, and materializes the matching
+// execution-summary.yaml + passing wave-orchestration evidence. This is the
+// self-wiping-mask scenario: scope contract flags scope_contract_changed_files_missing.
+func issue227ScopeContractMissingChange(t *testing.T) (string, model.Change) {
+	t.Helper()
+	root := t.TempDir()
+	change := model.NewChange("scope-missing-s2")
+	change.CurrentState = model.StateS2Execute
+	change.PlanSubStep = model.PlanSubStepNone
+	change.WorkflowPreset = model.WorkflowPresetLight
+	require.NoError(t, state.SaveChange(root, change))
+
+	bundleDir, err := state.GovernedBundleDir(root, change)
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(bundleDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "intent.md"),
+		[]byte("# Intent\n\n## Summary\nProbe scope contract.\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "requirements.md"),
+		[]byte("# Requirements\n\n### Requirement: Scope\nREQ-001: Probe.\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "decision.md"),
+		[]byte("# Decision\n\n## Selected Approach\nProbe.\n"), 0o644))
+
+	writeTasksAndMaterializeWavePlan(t, root, change, "# Tasks\n\n"+
+		"- [x] `task-a` Implement task A\n"+
+		"  - target_files: [\"cmd/next.go\"]\n"+
+		"  - task_kind: code\n")
+
+	recordedAt := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	writeVerificationForTest(t, root, change.Slug, SkillWaveOrchestration, model.VerificationRecord{
+		Verdict:    model.VerificationVerdictPass,
+		Blockers:   []model.ReasonCode{},
+		Timestamp:  recordedAt,
+		RunVersion: 1,
+	})
+
+	freshness := expectedTaskFreshnessInputsForWavePlan(t, root, change, 1, "task-a")
+	taskEvidence := map[string]any{
+		"task_id":             "task-a",
+		"run_summary_version": 1,
+		"task_kind":           "code",
+		"verdict":             "pass",
+		// No changed_files: this is the offending record.
+		"target_files":     []string{"cmd/next.go"},
+		"evidence_ref":     "test:task-a",
+		"captured_at":      recordedAt.Format(time.RFC3339Nano),
+		"freshness_inputs": freshness,
+	}
+	raw, err := json.Marshal(taskEvidence)
+	require.NoError(t, err)
+	taskPath := filepath.Join(state.EvidenceTasksDir(root, change.Slug), "task-a.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(taskPath), 0o755))
+	require.NoError(t, os.WriteFile(taskPath, raw, 0o644))
+
+	summary := &model.ExecutionSummary{
+		Version:           model.ExecutionSummaryVersion,
+		RunSummaryVersion: 1,
+		CapturedAt:        recordedAt,
+		Tasks: []model.ExecutionTaskSummary{{
+			TaskID:      "task-a",
+			Verdict:     model.TaskVerdictPass,
+			TaskKind:    model.TaskKindCode,
+			TargetFiles: []string{"cmd/next.go"},
+			EvidenceRef: "test:task-a",
+			CapturedAt:  recordedAt,
+		}},
+	}
+	summary.SyncDerivedFields()
+	summary.Normalize()
+	require.NoError(t, state.SaveExecutionSummary(root, change.Slug, *summary))
+
+	return root, change
+}
+
+// At S2_EXECUTE, a scope_contract_changed_files_missing failure must block VISIBLY
+// without wiping execution-summary.yaml / wave-orchestration.yaml. Wiping would
+// mask the real blocker behind run_summary_missing and loop forever (issue #227b).
+func TestIssue227AdvanceBlocksScopeContractMissingAtS2WithoutWiping(t *testing.T) {
+	t.Parallel()
+	root, change := issue227ScopeContractMissingChange(t)
+
+	summary, err := AdvanceGoverned(root, change.Slug)
+	require.NoError(t, err)
+
+	assert.Equal(t, "blocked", summary.Action, "advance must fail closed, not reopen-and-wipe")
+	assert.Equal(t, model.StateS2Execute, summary.FromState)
+	assert.NotEqual(t, "stale_evidence_recovery_started", summary.Reason,
+		"the in-S2 scope-contract miss must not route through the summary-wiping reopen")
+	assert.Contains(t, model.ReasonSpecs(summary.Blockers),
+		scopecontract.ReasonScopeContractChangedFilesMissing+":task-a",
+		"the real scope_contract_changed_files_missing blocker must stay visible")
+
+	// The change stays in S2_EXECUTE.
+	reloaded, err := state.LoadChange(root, change.Slug)
+	require.NoError(t, err)
+	assert.Equal(t, model.StateS2Execute, reloaded.CurrentState)
+
+	// And, critically, the engine-owned evidence is preserved so the next read of
+	// validate/status/next still surfaces the real blocker instead of being reset
+	// to the masking run_summary_missing.
+	preservedSummary, err := state.LoadOptionalExecutionSummary(root, change.Slug)
+	require.NoError(t, err)
+	require.NotNil(t, preservedSummary, "execution-summary.yaml must NOT be wiped")
+	assert.Equal(t, 1, preservedSummary.RunSummaryVersion)
+
+	waveRec, found, err := LatestPassingWaveEvidence(root, change.Slug)
+	require.NoError(t, err)
+	assert.True(t, found, "wave-orchestration.yaml must NOT be wiped")
+	assert.Equal(t, 1, waveRec.RunVersion)
+}

--- a/internal/engine/progression/wave_sync.go
+++ b/internal/engine/progression/wave_sync.go
@@ -314,6 +314,88 @@ func LatestPassingWaveEvidence(root, slug string) (model.VerificationRecord, boo
 	return rec, true, nil
 }
 
+// ResumeWaveIndexFromTaskEvidence derives the current incomplete wave index from
+// the per-task evidence on disk, without requiring a materialized
+// execution-summary.yaml. It is the resume-index authority for the documented
+// per-task-evidence flow BETWEEN waves, before wave-orchestration skill evidence
+// has been recorded (issue #227a): in that window no run summary exists yet, so
+// callers that fall back to state.ResumeWaveIndex(plan, nil) always see wave 1
+// and a next-wave task is wrongly rejected as not-in-current-wave. Reconstructing
+// the runs from recorded task evidence lets a fully-passed early wave count as
+// complete so its successor becomes the current incomplete wave.
+//
+// The boolean result reports whether usable task evidence was found and applied.
+// When false, the caller must keep its own default (wave 1) — there is no
+// evidence yet to derive from, the recorded files do not resolve to a single run
+// version, or none of them loaded cleanly; the returned index is 0 and carries no
+// meaning. When true, the index is the authoritative current incomplete wave (0
+// means every planned wave has passed, exactly like state.ResumeWaveIndex). A
+// non-nil error is only returned for a genuine filesystem/parse failure that must
+// fail closed.
+func ResumeWaveIndexFromTaskEvidence(root string, change model.Change, plan model.WavePlan) (int, bool, error) {
+	runVersion, err := singleTaskEvidenceRunVersion(root, change.Slug)
+	if err != nil {
+		return 0, false, err
+	}
+	if runVersion < 1 {
+		return 0, false, nil
+	}
+	tasks, issues, err := LoadExecutionTasksFromEvidence(root, change.Slug, runVersion)
+	if err != nil {
+		return 0, false, err
+	}
+	if len(issues) > 0 || len(tasks) == 0 {
+		return 0, false, nil
+	}
+	plan = state.ApplyEffectiveParallel(plan, state.EffectiveForcedParallel(root))
+	runs, err := state.BuildWaveRuns(plan, runVersion, tasks, nil)
+	if err != nil {
+		return 0, false, err
+	}
+	return state.ResumeWaveIndex(plan, runs), true, nil
+}
+
+// singleTaskEvidenceRunVersion returns the run version shared by every recorded
+// task evidence file, or 0 when none are recorded, an unreadable/malformed file is
+// present, or the recorded files span more than one run version (all ambiguous —
+// caller keeps the wave-1 default rather than guessing). Only a directory-level
+// read failure fails closed via an error.
+func singleTaskEvidenceRunVersion(root, slug string) (int, error) {
+	dir := state.EvidenceTasksDir(root, slug)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	versions := map[int]struct{}{}
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		version, err := taskEvidenceRunVersion(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			// A single unreadable/malformed task-evidence file must not make
+			// checkpoint harder-failing than the read-only sibling surfaces, which
+			// soft-tolerate the same file: LoadExecutionTasksFromEvidence records it
+			// as an issue and continues. Skip it for version detection; the
+			// len(issues) > 0 check in ResumeWaveIndexFromTaskEvidence still forces
+			// derived=false, so the caller keeps the safe, more-restrictive wave-1
+			// default rather than aborting (issue #227a review).
+			continue
+		}
+		versions[version] = struct{}{}
+	}
+	if len(versions) != 1 {
+		return 0, nil
+	}
+	for version := range versions {
+		return version, nil
+	}
+	return 0, nil
+}
+
 func waveRecordStaleTaskEvidenceBlockers(
 	record model.VerificationRecord,
 	tasks []model.ExecutionTaskSummary,


### PR DESCRIPTION
## Summary

Resolves four S2-execution / read-surface defects surfaced from Lattice governed runs. Every fix **fails closed** and reuses the existing reopen/fallback patterns — no bypass, force-close, or private-attestation path is added.

| Issue | Defect | Fix |
|------|--------|-----|
| **#227a** | `slipway checkpoint` cannot set a wave-boundary checkpoint when wave progress is driven by per-task evidence (no run summary ⇒ current wave always pinned to 1 ⇒ every next-wave task rejected) | checkpoint derives the current incomplete wave from recorded per-task evidence (`ResumeWaveIndexFromTaskEvidence`) when no run summary exists yet; a fully-passed early wave makes its successor checkpointable |
| **#227b** | At S2_EXECUTE, `scope_contract_changed_files_missing` reopened S2-from-S2 — a no-op that only wiped `execution-summary.yaml`, masking the real blocker behind `run_summary_missing` and looping until `slipway repair` | advance blocks **visibly while IN S2** (mirroring the adjacent sensitive-evidence reopen guard), preserving the summary so validate/status/next surface the real blocker |
| **#228** | Recording passing `wave-orchestration` skill evidence left `validate` blocking on `run_summary_missing` until an undocumented `slipway repair` | the owning public command now materializes `execution-summary.yaml` via an idempotent sync once the passing record + its task evidence are durable at S2_EXECUTE |
| **#229** | At `S1_PLAN/bundle` the plan-audit handoff advertised `write_evidence` / `evidence_record`, but `slipway evidence skill --skill plan-audit` is rejected until the substep reaches `audit` (dead-end handoff) | the bundle handoff drops those operations and the warning points to `slipway run` into `S1_PLAN/audit`; the audit-substep handoff is unchanged |
| **#232** | `validate --change` / `next --change` reported an archived DONE change (whose active bundle dir survived) as state corruption, because the archived fallback only triggered on `os.ErrNotExist` | `resolveExplicitChange` also falls back on `state.IsMissingBundleAuthority` — the exact predicate `status` uses — returning a clean `archived_change_not_validatable` precondition |

## Fail-closed nuances preserved
- #227a: multi-version / malformed task evidence soft-tolerates to the safe wave-1 default; only a directory read failure errors.
- #227b: downstream (S3/S4) missing-changed-file still reopens to S2; drift-only still blocks visibly (#136 behavior unchanged).
- #228: any sync error is surfaced; partial/scope-failing runs persist their blockers into the summary so read-only readiness re-derives them.
- #232: a missing-authority error with **no** archive still fails closed (`orphaned_change_bundle` → `slipway delete`, or `change_state_load_failed` for a malformed authority).

## Tests
4 new test files (10 tests) covering each issue end-to-end through the public CLI, plus negative guards (wave-1 default without evidence; audit substep still advertises evidence; orphaned-bundle and malformed-authority fail-closed paths).

- `go build ./...`, `go vet`, `gofmt -s -l` — clean
- `go test ./cmd/... ./internal/engine/progression/...` — green

#222 was already fixed on main and needs no change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)