### PR TITLE
fix(governance): clarify lifecycle timeline transitions

### DIFF
--- a/cmd/next_eval_fixture_test.go
+++ b/cmd/next_eval_fixture_test.go
@@ -82,7 +82,7 @@ Docs render.
 				return view
 			},
 			wantBlockers: []string{"no_skill_required:S0_INTAKE"},
-			wantEvents:   []string{"state.transitioned", "skill.evidence_recorded"},
+			wantEvents:   []string{"state.substep_transitioned", "skill.evidence_recorded"},
 		},
 	}
 

--- a/cmd/status_timeline_test.go
+++ b/cmd/status_timeline_test.go
@@ -39,3 +39,126 @@ func TestStatusViewIncludesLifecycleTimeline(t *testing.T) {
 	assert.Equal(t, "state.transitioned", view.Timeline[0].EventType)
 	assert.Equal(t, "2026-05-24T01:02:03Z", view.Timeline[0].OccurredAt)
 }
+
+func TestStatusTimelineMarksDuplicateTransitionReplay(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	ensureTestGitRepo(t, root)
+	initTestWorkspace(t, root)
+
+	change := model.NewChange("timeline-duplicate-transition")
+	change.CurrentState = model.StateS3Review
+	require.NoError(t, state.SaveChange(root, change))
+
+	evidenceRefs := map[string]string{
+		"wave-orchestration": "artifacts/changes/timeline-duplicate-transition/verification/wave-orchestration.yaml",
+	}
+	firstTransition := state.LifecycleEvent{
+		EventID:      "event-transition-1",
+		OccurredAt:   time.Date(2026, 6, 15, 16, 24, 40, 0, time.UTC),
+		Command:      "run",
+		EventType:    "state.transitioned",
+		Action:       "advanced",
+		Reason:       "state_progression",
+		Result:       "advanced",
+		BeforeState:  model.StateS2Execute,
+		AfterState:   model.StateS3Review,
+		EvidenceRefs: evidenceRefs,
+	}
+	_, err := state.AppendLifecycleEvent(root, change, firstTransition)
+	require.NoError(t, err)
+	_, err = state.AppendLifecycleEvent(root, change, state.LifecycleEvent{
+		EventID:      "event-wave-evidence-1",
+		OccurredAt:   time.Date(2026, 6, 15, 16, 24, 41, 0, time.UTC),
+		Command:      "run",
+		EventType:    "skill.evidence_recorded",
+		Action:       "advanced",
+		Reason:       "verification_evidence_consumed",
+		Result:       "recorded",
+		BeforeState:  model.StateS2Execute,
+		AfterState:   model.StateS3Review,
+		SkillID:      "wave-orchestration",
+		EvidenceRefs: evidenceRefs,
+	})
+	require.NoError(t, err)
+
+	duplicateTransition := firstTransition
+	duplicateTransition.EventID = "event-transition-2"
+	duplicateTransition.OccurredAt = time.Date(2026, 6, 15, 16, 30, 23, 0, time.UTC)
+	_, err = state.AppendLifecycleEvent(root, change, duplicateTransition)
+	require.NoError(t, err)
+	_, err = state.AppendLifecycleEvent(root, change, state.LifecycleEvent{
+		EventID:     "event-recovery-1",
+		OccurredAt:  time.Date(2026, 6, 15, 17, 11, 12, 0, time.UTC),
+		Command:     "run",
+		EventType:   "state.transitioned",
+		Action:      "advanced",
+		Reason:      "stale_evidence_recovery_started",
+		Result:      "advanced",
+		BeforeState: model.StateS4Verify,
+		AfterState:  model.StateS1Plan,
+	})
+	require.NoError(t, err)
+	_, err = state.AppendLifecycleEvent(root, change, state.LifecycleEvent{
+		EventID:     "event-plan-to-execute-1",
+		OccurredAt:  time.Date(2026, 6, 15, 17, 16, 38, 0, time.UTC),
+		Command:     "run",
+		EventType:   "state.transitioned",
+		Action:      "advanced",
+		Reason:      "state_progression",
+		Result:      "advanced",
+		BeforeState: model.StateS1Plan,
+		AfterState:  model.StateS2Execute,
+	})
+	require.NoError(t, err)
+	reexecutedTransition := firstTransition
+	reexecutedTransition.EventID = "event-transition-3"
+	reexecutedTransition.OccurredAt = time.Date(2026, 6, 15, 17, 21, 35, 0, time.UTC)
+	_, err = state.AppendLifecycleEvent(root, change, reexecutedTransition)
+	require.NoError(t, err)
+
+	view, err := buildStatusViewFromChange(root, change)
+	require.NoError(t, err)
+	require.Len(t, view.Timeline, 6)
+	assert.Equal(t, "state.transitioned", view.Timeline[0].EventType)
+	assert.Equal(t, "skill.evidence_recorded", view.Timeline[1].EventType)
+	assert.Equal(t, "state.transition.replayed", view.Timeline[2].EventType)
+	assert.Equal(t, "event-transition-2", view.Timeline[2].EventID)
+	assert.Equal(t, model.StateS2Execute, view.Timeline[2].FromState)
+	assert.Equal(t, model.StateS3Review, view.Timeline[2].ToState)
+	assert.Equal(t, "state.transitioned", view.Timeline[5].EventType)
+	assert.Equal(t, "event-transition-3", view.Timeline[5].EventID)
+}
+
+func TestStatusTimelineKeepsSubstepTransitionDistinct(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	ensureTestGitRepo(t, root)
+	initTestWorkspace(t, root)
+
+	change := model.NewChange("timeline-substep-transition")
+	change.CurrentState = model.StateS0Intake
+	change.IntakeSubStep = model.IntakeSubStepConfirm
+	require.NoError(t, state.SaveChange(root, change))
+	_, err := state.AppendLifecycleEvent(root, change, state.LifecycleEvent{
+		EventID:       "event-substep-1",
+		OccurredAt:    time.Date(2026, 6, 15, 16, 3, 58, 0, time.UTC),
+		Command:       "run",
+		EventType:     "state.substep_transitioned",
+		Action:        "advanced",
+		Reason:        "clarification_complete",
+		Result:        "advanced",
+		BeforeState:   model.StateS0Intake,
+		AfterState:    model.StateS0Intake,
+		BeforeSubStep: string(model.IntakeSubStepClarify),
+		AfterSubStep:  string(model.IntakeSubStepConfirm),
+	})
+	require.NoError(t, err)
+
+	view, err := buildStatusViewFromChange(root, change)
+	require.NoError(t, err)
+	require.Len(t, view.Timeline, 1)
+	assert.Equal(t, "state.substep_transitioned", view.Timeline[0].EventType)
+	assert.Equal(t, model.StateS0Intake, view.Timeline[0].FromState)
+	assert.Equal(t, model.StateS0Intake, view.Timeline[0].ToState)
+}

--- a/cmd/status_view_build.go
+++ b/cmd/status_view_build.go
@@ -291,6 +291,7 @@ func buildStatusTimeline(root string, change model.Change, limit int) ([]statusT
 	if len(events) == 0 {
 		return nil, nil
 	}
+	events = markDuplicateTransitionReplays(events)
 	if limit > 0 && len(events) > limit {
 		events = events[len(events)-limit:]
 	}
@@ -314,6 +315,77 @@ func buildStatusTimeline(root string, change model.Change, limit int) ([]statusT
 		timeline = append(timeline, entry)
 	}
 	return timeline, nil
+}
+
+func markDuplicateTransitionReplays(events []state.LifecycleEvent) []state.LifecycleEvent {
+	if len(events) == 0 {
+		return nil
+	}
+	presented := make([]state.LifecycleEvent, 0, len(events))
+	var lastTransition state.LifecycleEvent
+	hasLastTransition := false
+	for _, event := range events {
+		next := event
+		if hasLastTransition && duplicateLifecycleTransition(lastTransition, event) {
+			next.EventType = "state.transition.replayed"
+			next.Result = "replayed"
+			presented = append(presented, next)
+			continue
+		}
+		presented = append(presented, next)
+		if event.EventType == "state.transitioned" {
+			lastTransition = event
+			hasLastTransition = true
+		}
+	}
+	return presented
+}
+
+func duplicateLifecycleTransition(previous, current state.LifecycleEvent) bool {
+	if previous.EventType != "state.transitioned" || current.EventType != "state.transitioned" {
+		return false
+	}
+	if previous.Command != current.Command ||
+		previous.Action != current.Action ||
+		previous.Reason != current.Reason ||
+		previous.Result != current.Result ||
+		previous.BeforeState != current.BeforeState ||
+		previous.AfterState != current.AfterState ||
+		previous.BeforeSubStep != current.BeforeSubStep ||
+		previous.AfterSubStep != current.AfterSubStep ||
+		previous.GateID != current.GateID ||
+		previous.ControlID != current.ControlID ||
+		previous.SkillID != current.SkillID {
+		return false
+	}
+	if !lifecycleEvidenceRefsEqual(previous.EvidenceRefs, current.EvidenceRefs) {
+		return false
+	}
+	return lifecycleSideEffectsEqual(previous.SideEffects, current.SideEffects)
+}
+
+func lifecycleEvidenceRefsEqual(left, right map[string]string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for key, leftValue := range left {
+		if right[key] != leftValue {
+			return false
+		}
+	}
+	return true
+}
+
+func lifecycleSideEffectsEqual(left, right []state.LifecycleSideEffect) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i].Kind != right[i].Kind || left[i].Detail != right[i].Detail {
+			return false
+		}
+	}
+	return true
 }
 
 func buildStatusNarrative(view statusView) string {

--- a/internal/engine/progression/advance_governed.go
+++ b/internal/engine/progression/advance_governed.go
@@ -656,6 +656,9 @@ func recordAdvanceLifecycleEvent(root string, before, after model.Change, summar
 func advanceLifecycleEventType(summary AdvanceSummary) string {
 	switch summary.Action {
 	case "advanced":
+		if isSubstepAdvance(summary) {
+			return "state.substep_transitioned"
+		}
 		if len(summary.AutoPassedStates) > 0 {
 			return "auto_pass.applied"
 		}
@@ -670,6 +673,14 @@ func advanceLifecycleEventType(summary AdvanceSummary) string {
 	default:
 		return "advance." + summary.Action
 	}
+}
+
+func isSubstepAdvance(summary AdvanceSummary) bool {
+	return summary.FromState != "" &&
+		summary.FromState == summary.ToState &&
+		summary.FromSubStep != "" &&
+		summary.ToSubStep != "" &&
+		summary.FromSubStep != summary.ToSubStep
 }
 
 func advanceGateID(before model.Change, summary AdvanceSummary) string {

--- a/internal/engine/progression/advance_test.go
+++ b/internal/engine/progression/advance_test.go
@@ -275,8 +275,8 @@ func TestAdvanceGovernedWritesLifecycleEvent(t *testing.T) {
 		t.Fatalf("expected transition and skill evidence lifecycle events, got %d: %+v", len(events), events)
 	}
 	event := events[0]
-	if event.EventType != "state.transitioned" {
-		t.Fatalf("expected state.transitioned event, got %q", event.EventType)
+	if event.EventType != "state.substep_transitioned" {
+		t.Fatalf("expected state.substep_transitioned event, got %q", event.EventType)
 	}
 	if event.Command != "run" {
 		t.Fatalf("expected run command, got %q", event.Command)


### PR DESCRIPTION
Fixes #234.

## Summary
- Mark duplicate lifecycle transition entries in `status --json` as `state.transition.replayed` instead of a second independent `state.transitioned`.
- Keep legitimate later re-execution transitions visible when an intervening recovery or re-execution happened.
- Record same-state lifecycle substep advances as `state.substep_transitioned` so S0/S1 substeps do not look like full state transitions.

## Root Cause
Issue #234 historical Lattice log shows a repeated `S2_EXECUTE -> S3_REVIEW` transition with the same command, reason, result, evidence refs, and no intervening primary transition. Current main did not reproduce new duplicate S2-to-S3 creation in ordinary repeated-run or mixed root/worktree scenarios, but the status timeline still presented historical duplicates as independent transitions. While tracing this, same-state substep advances were also found to use `state.transitioned`.

## Validation
- `go test ./cmd ./internal/engine/progression -run 'TestStatusTimeline|TestAdvanceGovernedWritesLifecycleEvent|TestNextEvalFixture' -count=1 -v`
- `go test ./cmd`
- `go test ./...`
