### PR TITLE
fix(governance): ignore intake open question resolution in digest

### DIFF
--- a/artifacts/changes/archived/fix-intake-open-question-digest/assurance.md
+++ b/artifacts/changes/archived/fix-intake-open-question-digest/assurance.md
@@ -1,0 +1,80 @@
+# Assurance
+
+## Scope Summary
+This change fixes issue #238 by narrowing only the
+`intake-clarification` freshness input for `intent.md`. Open Questions
+checklist state and resolution notes are treated as research-owned routing
+material for the intake digest, while substantive intake sections remain owned
+by intake clarification.
+
+The implementation is limited to `internal/engine/progression` digest behavior
+and regression tests. It does not change CLI arguments, verification YAML
+schemas, lifecycle stage names, or the meaning of substantive `intent.md`
+sections.
+
+## Verification Verdict
+Current governed execution evidence is passing for the implemented waves.
+Focused regression evidence demonstrates that resolving an Open Question no
+longer reopens S0 intake recovery, while changing `## Summary` still produces
+`required_skill_stale:intake-clarification:intent.md`.
+
+Package-level integration evidence for `internal/engine/progression` is passing.
+S3 review and S4 goal-verification evidence are passing. Final full-suite proof
+was refreshed with `go test -parallel=1 ./...`, which ran the repository test
+suite with test parallelism disabled and returned `ok` for all tested packages.
+Final closeout remains responsible for stamping the active validate and ship-gate
+attestations before archive.
+
+## Evidence Index
+- `verification/execution-summary.yaml`: run_summary_version 1, tasks `t-01`
+  and `t-02` completed with verdict `pass`.
+- `verification/wave-orchestration.yaml`: wave execution recorded as `pass`.
+- `verification/wave-orchestration-notes.md`: records the RED/GREEN path,
+  focused issue #238 tests, and `go test ./internal/engine/progression -count=1`.
+- `verification/spec-compliance-review.yaml`: R0 review passed with
+  `scope_contract:pass` and `negative_path:pass`.
+- `verification/code-quality-review.yaml`: IR1 review passed with a distinct
+  review-origin handle from spec compliance.
+- `verification/goal-verification.yaml`: acceptance verification passed with
+  fresh focused, package, and coverage command references.
+- `internal/engine/progression/evidence_digests.go`: routes only
+  `intake-clarification` through the filtered `intent.md` digest helper.
+- `internal/engine/progression/stale_evidence_recovery_test.go`: verifies the
+  stale recovery behavior for Open Questions resolution and substantive Summary
+  edits.
+- `internal/engine/progression/evidence_digests_test.go`: verifies the digest
+  boundary for intake, research, and plan-audit.
+
+## Requirement Coverage
+- REQ-001 is covered by the intake-specific digest helper in
+  `evidence_digests.go` and by tests asserting that Open Questions resolution
+  does not stale intake evidence.
+- REQ-002 is covered by negative tests that edit `## Summary` and assert S0
+  stale recovery for `required_skill_stale:intake-clarification:intent.md`.
+- REQ-003 is covered by the unchanged research and plan-audit full-file digest
+  paths and by tests asserting their `intent.md` digests still change when Open
+  Questions content changes.
+
+## Residual Risks and Exceptions
+No accepted scope exceptions remain.
+
+One rollout risk remains: existing active changes whose intake evidence was
+stamped with the old full-file digest may need one public recovery and
+re-stamp. That is expected because historical digest values cannot be
+reinterpreted without bypassing engine-owned freshness state.
+
+## Rollback Readiness
+Rollback is a normal revert of the helper and regression tests. The minimum
+rollback verification is `go test ./internal/engine/progression -count=1`.
+Rollback would intentionally reintroduce issue #238, so it should only be used
+if the filtered intake digest causes a broader lifecycle regression.
+
+## Archive Decision
+Archive is not approved until final closeout records active `validate --json`
+freshness/readiness proof in the current worktree and the ship gate accepts the
+closeout references.
+
+At the time this assurance artifact is refreshed, the change is in S4
+verification and has not been archived. Active validation must be run after this
+refresh and before `done`; any failing freshness, scope-contract, review,
+goal-verification, final-closeout, or ship-gate check blocks archive.

--- a/artifacts/changes/archived/fix-intake-open-question-digest/change.yaml
+++ b/artifacts/changes/archived/fix-intake-open-question-digest/change.yaml
@@ -1,0 +1,60 @@
+version: 1
+slug: fix-intake-open-question-digest
+description: fix intake open question digest
+status: done
+current_state: DONE
+needs_discovery: true
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-06-16T06:58:42.752259Z
+quality_mode: standard
+workflow_profile: code
+workflow_preset: strict
+worktree_branch: feat/fix-intake-open-question-digest
+artifact_schema: expanded
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: d3b33f9d42bf3021e644432937e5266812a99db78bb6e78fa4bf13bdca1f9a9d
+        updated_at: 2026-06-16T08:06:55.070526964Z
+    decision:
+        id: decision
+        path: decision.md
+        state: frozen
+        content_hash: aa91e403252f134ba2761802a95a3976c61b08457c5c719c7efbed7711e900a6
+        updated_at: 2026-06-16T07:26:48.940051382Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: eaca25630aa1808b93b68313098d2facd68aec1e535af2f52d7133710721c106
+        updated_at: 2026-06-16T07:16:29.045979777Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: 57a1678840151db5e2ee7a210ec647a22f52f3523798d089b99b77c2c82fc64f
+        updated_at: 2026-06-16T07:24:04.118261865Z
+    research:
+        id: research
+        path: research.md
+        state: frozen
+        content_hash: 658a191a1a7ebb06c4b9f46b5a5f3d1c35992da4196871f44c98f4680fa7f636
+        updated_at: 2026-06-16T07:22:17.691083548Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: cdd9ab5083148a5276553d9dd3d859eb32097b189348df6cfc8c07238439d8fc
+        updated_at: 2026-06-16T07:32:17.698596419Z
+evidence_refs:
+    code-quality-review: .worktrees/fix-intake-open-question-digest/artifacts/changes/fix-intake-open-question-digest/verification/code-quality-review.yaml
+    final-closeout: .worktrees/fix-intake-open-question-digest/artifacts/changes/fix-intake-open-question-digest/verification/final-closeout.yaml
+    goal-verification: .worktrees/fix-intake-open-question-digest/artifacts/changes/fix-intake-open-question-digest/verification/goal-verification.yaml
+    intake-clarification: .worktrees/fix-intake-open-question-digest/artifacts/changes/fix-intake-open-question-digest/verification/intake-clarification.yaml
+    plan-audit: .worktrees/fix-intake-open-question-digest/artifacts/changes/fix-intake-open-question-digest/verification/plan-audit.yaml
+    research-orchestration: .worktrees/fix-intake-open-question-digest/artifacts/changes/fix-intake-open-question-digest/verification/research-orchestration.yaml
+    spec-compliance-review: .worktrees/fix-intake-open-question-digest/artifacts/changes/fix-intake-open-question-digest/verification/spec-compliance-review.yaml
+    wave-orchestration: .worktrees/fix-intake-open-question-digest/artifacts/changes/fix-intake-open-question-digest/verification/wave-orchestration.yaml

--- a/artifacts/changes/archived/fix-intake-open-question-digest/decision.md
+++ b/artifacts/changes/archived/fix-intake-open-question-digest/decision.md
@@ -1,0 +1,59 @@
+# Decision
+
+## Alternatives Considered
+
+- Option A: Add an `intake-clarification`-specific `intent.md` digest helper
+  that reuses the existing prose artifact hash but excludes only the
+  `Open Questions` section. This directly reflects ownership: intake owns
+  clarified scope text; research owns Open Questions resolution state.
+- Option B: Normalize only Open Questions checkbox markers before hashing.
+  This would fix `- [ ]` to `- [x]` churn but not resolution notes, which issue
+  #238 explicitly expects to be safe.
+- Option C: Move Open Questions into a separate research-owned artifact or add
+  section-level ownership metadata. This could be cleaner long-term, but it is a
+  broader artifact-schema and lifecycle redesign than the issue requires.
+
+## Selected Approach
+
+Select Option A. `certifiedSkillInputDigest` routes only
+`intake-clarification` through an intake-specific `intent.md` helper that
+filters out `Open Questions`; `research-orchestration` and `plan-audit` keep the
+existing full governed file input. This is the smallest change that satisfies
+REQ-001 while preserving REQ-002 and REQ-003.
+
+## Interfaces and Data Flow
+
+No public CLI arguments, YAML fields, or verification record schemas change.
+The internal data flow changes as follows:
+
+`StaleEvidenceRecoveryAvailable` -> `skillDigestFreshnessBlockers` ->
+`certifiedSkillInputDigest` -> skill-specific `intent.md` hash.
+
+For `intake-clarification`, the hash input excludes the `Open Questions`
+section before `model.ComputeInputHash`. For research and plan-audit, existing
+full artifact hashing remains unchanged.
+
+## Rollout and Rollback
+
+Rollout is a normal code/test change in the Slipway CLI. Verification is:
+
+- `go test ./internal/engine/progression -run TestStaleEvidenceRecoveryIgnoresIntakeOpenQuestionResolution -count=1`
+- `go test ./internal/engine/progression -count=1`
+- `go test ./...`
+
+Rollback is a revert of the helper and test changes. The rollback verification
+command is `go test ./internal/engine/progression -count=1`; however, reverting
+would intentionally reintroduce issue #238.
+
+## Risk
+
+- If the filtered section is broader than `Open Questions`, real intake scope
+  changes could stop staling evidence. The implementation limits filtering to
+  an exact heading match and tests a Summary edit negative path.
+- If downstream skills accidentally share the intake-specific helper, research
+  or plan-audit could miss material planning changes. A digest boundary test
+  covers this by asserting downstream digests still change on Open Questions
+  edits.
+- Existing active changes with old full-file intake digests may need one public
+  lifecycle recovery/re-stamp after this change lands, because historical digest
+  values were computed with the older input definition.

--- a/artifacts/changes/archived/fix-intake-open-question-digest/intent.md
+++ b/artifacts/changes/archived/fix-intake-open-question-digest/intent.md
@@ -1,0 +1,88 @@
+# Intent
+
+## Summary
+Fix issue #238: resolving an Open Question in `intent.md` during research must
+not stale S0 intake-clarification evidence or force Approved Summary
+reconfirmation when substantive intake scope text is unchanged.
+
+## Complexity Assessment
+complex
+Rationale: this touches Slipway freshness/digest authority boundaries and must
+preserve fail-closed behavior for real scope changes while avoiding a
+disproportionate S0 recovery for research-owned Open Question resolution.
+
+## Guardrail Domains
+Governance lifecycle correctness
+
+## In Scope
+- Investigate the current intake-clarification freshness input/digest path for
+  `intent.md`.
+- Change the intake freshness behavior so Open Questions resolution state
+  changes, such as `- [ ]` to `- [x]` and resolution notes under Open Questions,
+  do not invalidate S0 intake-clarification evidence when substantive intake
+  sections and Approved Summary text are unchanged.
+- Keep Open Questions routing semantics intact: unchecked checklist items still
+  route to research, and resolved items no longer block research completion.
+- Add regression coverage for issue #238 and adjacent negative coverage showing
+  substantive intake changes still stale the relevant upstream evidence.
+- Update any user-facing lifecycle/recovery surface only if the code change
+  requires it for clarity.
+
+## Out of Scope
+- Broad redesign of Slipway evidence freshness, lifecycle stages, or recovery
+  classes.
+- Any bypass/force-close path for stale evidence recovery.
+- Changing the meaning of substantive intake sections such as Summary, In Scope,
+  Out of Scope, Constraints, Acceptance Signals, or Approved Summary.
+
+## Constraints
+- Use the current worktree's Slipway CLI behavior as the authority.
+- Do not hand-edit engine-owned freshness state or verification verdicts.
+- Preserve strict fail-closed governance for real intake scope or Approved
+  Summary changes.
+- Keep the implementation scoped to issue #238.
+
+## Acceptance Signals
+- A focused regression test demonstrates that checking off or documenting a
+  resolved Open Question in `intent.md` does not produce
+  `stale_evidence_recovery_available: S0_INTAKE` for unchanged substantive
+  intake fields.
+- A negative regression test demonstrates that changing a substantive intake
+  section still stales intake-clarification evidence.
+- Relevant Go tests pass in the dedicated worktree.
+- Governed change reaches done-ready and is finalized with fresh evidence.
+
+## Open Questions
+<!-- Track real unknowns as a checklist. An unchecked `- [ ]` item is unresolved
+     and routes intake to S0_INTAKE/research; mark `- [x]` once resolved. Leave the
+     section empty (or write `None`) when there are none. Prose here is
+     documentation, not a blocker — a genuine open question must be a `- [ ]`. -->
+- [x] Where is the narrowest authority boundary for intake-clarification digest
+  inputs: artifact digest canonicalization, skill input mapping, or freshness
+  comparison?
+  Resolved: the narrowest boundary is the skill input mapping in
+  `certifiedSkillInputDigest`; intake-clarification should use an
+  intake-specific `intent.md` digest while research-orchestration and
+  plan-audit keep the full governed file input.
+- [x] Which existing test fixture best reproduces issue #238 without relying on
+  brittle wall-clock or manually stamped freshness state?
+  Resolved: `StaleEvidenceRecoveryAvailable` with a stamped
+  intake-clarification digest directly reproduces the S0 reopen trigger, and a
+  paired substantive Summary edit covers the negative path.
+
+## Deferred Ideas
+- Let research-orchestration own Open Questions resolution writes explicitly if
+  a future lifecycle surface needs stronger ownership metadata.
+
+## Approved Summary
+Confirmed by user at 2026-06-16T07:05:14Z.
+
+Fix issue #238 by changing Slipway intake freshness so research-stage Open
+Questions resolution in `intent.md`, such as checking `- [ ]` to `- [x]` or
+adding a resolution note, does not stale S0 intake-clarification evidence when
+the substantive intake sections and Approved Summary text are unchanged.
+Preserve fail-closed stale-evidence behavior for real changes to Summary,
+scope, constraints, acceptance signals, or Approved Summary. Acceptance requires
+focused regression coverage for both the allowed Open Questions resolution path
+and the negative substantive-change path, plus passing relevant Go tests and
+governed finalization.

--- a/artifacts/changes/archived/fix-intake-open-question-digest/requirements.md
+++ b/artifacts/changes/archived/fix-intake-open-question-digest/requirements.md
@@ -1,0 +1,40 @@
+# Requirements
+
+## Requirements
+
+### Requirement: Intake Digest Excludes Research-Owned Open Questions
+REQ-001: The system MUST compute the `intake-clarification` input digest for
+`intent.md` without treating `## Open Questions` checklist state or resolution
+notes as intake-owned material.
+
+#### Scenario: Open Questions resolution after intake
+GIVEN a governed change has passing `intake-clarification` evidence stamped from
+an `intent.md` with an unresolved Open Question
+WHEN research resolves that question by changing `- [ ]` to `- [x]` and adding a
+resolution note under `## Open Questions`
+THEN stale evidence recovery MUST NOT target `S0_INTAKE` for
+`intake-clarification`.
+
+### Requirement: Substantive Intake Changes Still Reopen Intake
+REQ-002: The system MUST continue to stale `intake-clarification` evidence when
+substantive intake sections such as Summary, scope, constraints, acceptance
+signals, or Approved Summary change after intake evidence is recorded.
+
+#### Scenario: Summary changes after intake
+GIVEN a governed change has passing `intake-clarification` evidence
+WHEN the `## Summary` section in `intent.md` changes after that evidence was
+stamped
+THEN stale evidence recovery MUST target `S0_INTAKE` with
+`required_skill_stale:intake-clarification:intent.md`.
+
+### Requirement: Downstream Planning Inputs Remain Complete
+REQ-003: The system MUST keep downstream discovery and planning skills sensitive
+to the full `intent.md` material they already consume unless a skill-specific
+ownership boundary is explicitly defined.
+
+#### Scenario: Research and plan digests still see Open Questions
+GIVEN research-orchestration and plan-audit input digests are computed from a
+governed bundle
+WHEN `## Open Questions` content in `intent.md` changes
+THEN those downstream digests SHALL continue to change because they consume the
+full planning artifact.

--- a/artifacts/changes/archived/fix-intake-open-question-digest/research.md
+++ b/artifacts/changes/archived/fix-intake-open-question-digest/research.md
@@ -1,0 +1,104 @@
+# Research
+
+## Alternatives Considered
+
+### Architecture
+- Affected modules: `internal/engine/progression/evidence_digests.go`,
+  `internal/engine/progression/stale_evidence_recovery.go`,
+  `internal/stringutil/html.go`, and
+  `internal/engine/progression/stale_evidence_recovery_test.go`.
+- Dependency chains: `StaleEvidenceRecoveryAvailable` checks prior authority
+  freshness through `skillDigestFreshnessBlockers`, which recomputes the
+  skill-specific digest via `certifiedSkillInputDigest`. Intake and research
+  both previously consumed `intent.md`, but research routing itself is driven
+  by the Open Questions checklist parser in `stringutil.HasBlockingOpenQuestions`.
+- Blast radius: limited to governance skill digest inputs for
+  `intake-clarification`; research-orchestration, plan-audit, wave execution,
+  review, and closeout inputs keep their existing behavior.
+- Constraints: engine-owned verification/freshness state must remain
+  fail-closed for substantive intent changes; no bypass or force-close path is
+  allowed.
+
+### Patterns
+- Existing conventions: prose artifacts are hashed structurally through
+  `computeProseFileInputHash`, which normalizes line endings, strips HTML
+  comments, and hashes material markdown sections instead of raw mtime.
+- Reusable abstractions: `proseArtifactMaterialSections` already yields
+  section-level material, so an intake-specific section filter can reuse the
+  same canonical hash pipeline.
+- Convention deviations: no new external metadata field is needed; the change
+  adds a narrow helper for intake evidence rather than changing the generic
+  governed file hash.
+
+### Risks
+- Technical risks: medium if the filter is too broad because real intake scope
+  changes could stop staling evidence; low with an Open Questions-only filter
+  and paired negative regression coverage.
+- Guardrail domains: governance lifecycle correctness and evidence freshness.
+- Reversibility: high; the implementation is a small helper and one call-site
+  change, with a targeted regression test.
+
+### Test Strategy
+- Existing coverage: `evidence_digests_test.go` already covers skill digest
+  input boundaries, and `stale_evidence_recovery_test.go` covers S0 stale
+  intake recovery.
+- Infrastructure needs: no new test framework or clock manipulation; fixture
+  writes an `intent.md`, stamps intake evidence through existing helpers, then
+  queries `StaleEvidenceRecoveryAvailable`.
+- Verification approach: first reproduce the issue by showing Open Questions
+  resolution incorrectly produces an S0 stale recovery target; then assert the
+  fixed path no longer returns a target while a substantive Summary edit still
+  returns `required_skill_stale:intake-clarification:intent.md`.
+
+### Options
+- Option A: add an intake-specific `intent.md` digest input that reuses the
+  existing prose hash and excludes only the `Open Questions` section. Tradeoff:
+  keeps the change small and preserves fail-closed behavior for every other
+  section, but leaves future research-owned fields to be handled explicitly if
+  they appear.
+- Option B: normalize only Open Questions checkbox markers before hashing.
+  Tradeoff: preserves more of the Open Questions prose in intake digest, but it
+  does not satisfy issue #238's resolution-note case.
+- Option C: move Open Questions into a separate research-owned artifact or add
+  lifecycle ownership metadata for individual intent sections. Tradeoff:
+  cleaner ownership model long-term, but broadens the change into artifact
+  schema/lifecycle redesign.
+- Selected: Option A is recommended because it fixes issue #238 exactly at the
+  skill input boundary, keeps research and plan-audit full-file semantics, and
+  preserves fail-closed stale evidence recovery for substantive intake changes.
+
+## Unknowns
+- Resolved: Where is the narrowest authority boundary? -> The skill input
+  mapping in `certifiedSkillInputDigest`; intake-clarification can use a
+  narrower `intent.md` digest while downstream research and planning still
+  consume full governed artifacts.
+- Resolved: Which fixture reproduces issue #238? ->
+  `StaleEvidenceRecoveryAvailable` with stamped intake-clarification evidence
+  directly exercises the S0 reopen target and avoids brittle wall-clock
+  assertions.
+- Remaining: None. User confirmed Option A after reviewing the research
+  alternatives.
+
+## Assumptions
+- The Open Questions section is research-routing state, not substantive intake
+  scope. Evidence: `stringutil.HasBlockingOpenQuestions` gates only unchecked
+  checklist entries under `## Open Questions`, while the intake confirmation
+  checks are separate section-content checks.
+- Substantive intake edits must remain stale-evidence triggers. Evidence: the
+  regression test pairs the Open Questions resolution path with a Summary edit
+  that still returns the S0 intake stale target.
+- The existing codebase map is semantically stale for this issue because it was
+  authored for a prior closeout-attestation change; current planning authority
+  comes from direct code inspection and the issue-specific regression.
+
+## Canonical References
+- `internal/engine/progression/evidence_digests.go:36`
+- `internal/engine/progression/evidence_digests.go:48`
+- `internal/engine/progression/evidence_digests.go:52`
+- `internal/engine/progression/evidence_digests.go:440`
+- `internal/engine/progression/evidence_digests.go:462`
+- `internal/engine/progression/stale_evidence_recovery.go:47`
+- `internal/engine/progression/stale_evidence_recovery.go:79`
+- `internal/stringutil/html.go:66`
+- `internal/engine/progression/advance_intake.go:356`
+- `internal/engine/progression/stale_evidence_recovery_test.go:132`

--- a/artifacts/changes/archived/fix-intake-open-question-digest/tasks.md
+++ b/artifacts/changes/archived/fix-intake-open-question-digest/tasks.md
@@ -1,0 +1,15 @@
+# Tasks
+
+## Task List
+
+- [x] `t-01` Implement the intake-specific `intent.md` digest boundary.
+  - depends_on: []
+  - target_files: ["internal/engine/progression/evidence_digests.go"]
+  - task_kind: code
+  - covers: [REQ-001, REQ-002, REQ-003]
+
+- [x] `t-02` Add regression coverage for issue #238 and downstream digest boundaries.
+  - depends_on: ["t-01"]
+  - target_files: ["internal/engine/progression/stale_evidence_recovery_test.go", "internal/engine/progression/evidence_digests_test.go"]
+  - task_kind: test
+  - covers: [REQ-001, REQ-002, REQ-003]

--- a/internal/engine/progression/evidence_digests.go
+++ b/internal/engine/progression/evidence_digests.go
@@ -46,7 +46,7 @@ func certifiedSkillInputDigest(
 			return model.SkillDigest{}, err
 		}
 	case strings.TrimSpace(skillName) == SkillIntakeClarification:
-		if err := addGovernedFileInput(root, change, "intent.md", inputs); err != nil {
+		if err := addIntakeClarificationIntentInput(root, change, inputs); err != nil {
 			return model.SkillDigest{}, err
 		}
 	case strings.TrimSpace(skillName) == SkillResearchOrchestration:
@@ -437,14 +437,46 @@ func addGovernedFileInput(root string, change model.Change, rel string, inputs m
 	return nil
 }
 
+func addIntakeClarificationIntentInput(root string, change model.Change, inputs map[string]string) error {
+	bundleDir, err := state.GovernedBundleDir(root, change)
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(bundleDir, "intent.md")
+	hash, err := computeFilteredProseFileInputHash(path, func(heading string) bool {
+		// Open Questions are research-routing state. Intake evidence owns the
+		// clarified scope text, so resolving research questions must not reopen S0.
+		return !strings.EqualFold(strings.TrimSpace(heading), "Open Questions")
+	})
+	if err != nil {
+		return err
+	}
+	inputs["intent.md"] = hash
+	return nil
+}
+
 func computeProseFileInputHash(path string) (string, error) {
+	return computeFilteredProseFileInputHash(path, nil)
+}
+
+func computeFilteredProseFileInputHash(path string, includeSection func(heading string) bool) (string, error) {
 	raw, err := os.ReadFile(path) // #nosec G304 -- path is resolved from repository or governed artifact authority before this read.
 	if err != nil {
 		return "", err
 	}
+	sections := proseArtifactMaterialSections(filepath.Base(path), string(raw))
+	if includeSection != nil {
+		filtered := make([]map[string]string, 0, len(sections))
+		for _, section := range sections {
+			if includeSection(section["heading"]) {
+				filtered = append(filtered, section)
+			}
+		}
+		sections = filtered
+	}
 	return model.ComputeInputHash(map[string]any{
 		"artifact":          filepath.Base(path),
-		"material_sections": proseArtifactMaterialSections(filepath.Base(path), string(raw)),
+		"material_sections": sections,
 	})
 }
 

--- a/internal/engine/progression/evidence_digests_test.go
+++ b/internal/engine/progression/evidence_digests_test.go
@@ -180,6 +180,53 @@ func TestGovernedSkillInputDigestsCoverStageAuthorities(t *testing.T) {
 	assert.Contains(t, finalCloseout.Inputs, "tracked.go")
 }
 
+func TestIntakeClarificationInputDigestExcludesOnlyOpenQuestions(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	change := model.NewChange("intake-open-question-digest")
+	require.NoError(t, state.SaveChange(root, change))
+	bundleDir := writeDigestPlanningBundle(t, root, change, uncheckedDigestTasks())
+	intentPath := filepath.Join(bundleDir, "intent.md")
+	require.NoError(t, os.WriteFile(intentPath, []byte(issue238Intent("- [ ] Which digest boundary owns research resolution?\n")), 0o644))
+
+	baseIntake, err := certifiedSkillInputDigest(root, change, SkillIntakeClarification, nil)
+	require.NoError(t, err)
+	baseResearch, err := certifiedSkillInputDigest(root, change, SkillResearchOrchestration, nil)
+	require.NoError(t, err)
+	basePlanAudit, err := certifiedSkillInputDigest(root, change, SkillPlanAudit, nil)
+	require.NoError(t, err)
+
+	resolvedOpenQuestions := "- [x] Which digest boundary owns research resolution?\n" +
+		"  Resolved: intake owns substantive scope; research owns this checklist state.\n"
+	require.NoError(t, os.WriteFile(intentPath, []byte(issue238Intent(resolvedOpenQuestions)), 0o644))
+
+	currentIntake, err := certifiedSkillInputDigest(root, change, SkillIntakeClarification, nil)
+	require.NoError(t, err)
+	currentResearch, err := certifiedSkillInputDigest(root, change, SkillResearchOrchestration, nil)
+	require.NoError(t, err)
+	currentPlanAudit, err := certifiedSkillInputDigest(root, change, SkillPlanAudit, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, baseIntake.Inputs["intent.md"], currentIntake.Inputs["intent.md"],
+		"intake-clarification must not stale on research-owned Open Questions resolution")
+	assert.NotEqual(t, baseResearch.Inputs["intent.md"], currentResearch.Inputs["intent.md"],
+		"research-orchestration must keep consuming full intent.md")
+	assert.NotEqual(t, basePlanAudit.Inputs["intent.md"], currentPlanAudit.Inputs["intent.md"],
+		"plan-audit must keep consuming full intent.md")
+
+	require.NoError(t, os.WriteFile(intentPath, []byte(strings.Replace(
+		issue238Intent(resolvedOpenQuestions),
+		"Fix issue #238.",
+		"Fix issue #238 with revised substantive scope.",
+		1,
+	)), 0o644))
+	substantiveIntake, err := certifiedSkillInputDigest(root, change, SkillIntakeClarification, nil)
+	require.NoError(t, err)
+	assert.NotEqual(t, baseIntake.Inputs["intent.md"], substantiveIntake.Inputs["intent.md"],
+		"substantive intake text must still stale intake-clarification")
+}
+
 func TestLateAssuranceEditDoesNotStalePlanAuditAtS1(t *testing.T) {
 	t.Parallel()
 

--- a/internal/engine/progression/stale_evidence_recovery_test.go
+++ b/internal/engine/progression/stale_evidence_recovery_test.go
@@ -3,6 +3,7 @@ package progression
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -126,4 +127,86 @@ func TestStaleIntakeRecoveryReopensToClarifyFromMachineOnlySubsteps(t *testing.T
 				"stale intake-clarification verification should be cleared, stat err=%v", statErr)
 		})
 	}
+}
+
+func TestStaleEvidenceRecoveryIgnoresIntakeOpenQuestionResolution(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, model.SaveConfig(state.ConfigPath(root), model.DefaultConfig()))
+
+	change := model.NewChange("issue-238-open-question-resolution")
+	change.CurrentState = model.StateS1Plan
+	change.PlanSubStep = model.PlanSubStepResearch
+	change.NeedsDiscovery = true
+	change.ComplexityLevel = "complex"
+	change.WorkflowPreset = model.WorkflowPresetStandard
+	require.NoError(t, state.SaveChange(root, change))
+
+	bundleDir := filepath.Join(root, "artifacts", "changes", change.Slug)
+	require.NoError(t, os.MkdirAll(bundleDir, 0o755))
+	intentPath := filepath.Join(bundleDir, "intent.md")
+	require.NoError(t, os.WriteFile(intentPath, []byte(issue238Intent("- [ ] Which digest boundary owns research resolution?\n")), 0o644))
+
+	record := model.VerificationRecord{
+		Verdict:    model.VerificationVerdictPass,
+		Timestamp:  time.Date(2026, 6, 16, 1, 0, 0, 0, time.UTC),
+		RunVersion: 0,
+		References: []string{"intake:pass"},
+	}
+	writeVerificationForTest(t, root, change.Slug, SkillIntakeClarification, record)
+	require.NoError(t, StampEvidenceDigestForSkill(root, change, SkillIntakeClarification, record, nil))
+
+	resolvedOpenQuestions := "- [x] Which digest boundary owns research resolution?\n" +
+		"  Resolved: intake digest owns substantive scope; research owns this checklist state.\n"
+	require.NoError(t, os.WriteFile(intentPath, []byte(issue238Intent(resolvedOpenQuestions)), 0o644))
+
+	target, ok, err := StaleEvidenceRecoveryAvailable(root, change, nil)
+	require.NoError(t, err)
+	assert.Falsef(t, ok, "Open Questions resolution must not reopen stale intake evidence, got target=%+v", target)
+
+	require.NoError(t, os.WriteFile(intentPath, []byte(strings.Replace(
+		issue238Intent(resolvedOpenQuestions),
+		"Fix issue #238.",
+		"Fix issue #238 with revised substantive scope.",
+		1,
+	)), 0o644))
+
+	target, ok, err = StaleEvidenceRecoveryAvailable(root, change, nil)
+	require.NoError(t, err)
+	require.True(t, ok, "substantive intent changes must still reopen stale intake evidence")
+	assert.Equal(t, SkillIntakeClarification, target.SkillName)
+	assert.Equal(t, model.StateS0Intake, target.State)
+	assert.Contains(t, model.ReasonSpecs(target.Blockers), "required_skill_stale:intake-clarification:intent.md")
+}
+
+func issue238Intent(openQuestions string) string {
+	return `# Intent
+
+## Summary
+Fix issue #238.
+
+## Complexity Assessment
+complex
+
+## Guardrail Domains
+Governance lifecycle correctness
+
+## In Scope
+- Update intake digest behavior.
+
+## Out of Scope
+- Redesign all freshness recovery.
+
+## Constraints
+- Preserve fail-closed behavior for substantive scope changes.
+
+## Acceptance Signals
+- Regression tests cover Open Questions resolution and substantive changes.
+
+## Open Questions
+` + openQuestions + `
+## Approved Summary
+User confirmed the issue #238 scope.
+`
 }


### PR DESCRIPTION
## Summary

- Change the intake-clarification input digest so `intent.md` excludes only the `## Open Questions` section.
- Keep research-orchestration and plan-audit sensitive to the full `intent.md` content.
- Add regression coverage for issue #238, including the negative path where substantive intake changes still reopen S0 intake evidence.
- Commit the finalized governed archive for `fix-intake-open-question-digest`.

## Root Cause

Resolving research-owned Open Questions in `intent.md` changed the same full-file digest used by intake-clarification, so research-stage checklist resolution could stale S0 intake evidence even when the substantive intake scope and Approved Summary were unchanged.

## Validation

- `git diff --check`
- `go test ./internal/engine/progression`
- `go test ./...`