### PR TITLE
docs: reframe README and design around seven advantage axes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 **Governance that keeps your AI coding agent honest: "done" means proven, not promised. You drive it in plain language and never memorize a slash command.**
 
-AI coding agents are fast, but they cut corners. They skip the tests, drift from the plan, and call work "done" that was never verified. Slipway is a local, Git-native governance layer that makes that hard to fake: it turns the agent's work into a durable, inspectable change record and keeps the lifecycle authority in the repository itself, not in a hosted service. Your AI tool does the work; Slipway decides when it is actually done. It works with **Claude Code, Codex, Cursor, Gemini, and OpenCode**.
+AI coding agents are fast — and they cut corners. They skip the tests, drift from the plan, and report work "done" that was never verified. Slipway makes that hard to fake. It's a local, Git-native governance layer that turns each change into a durable, inspectable record and keeps lifecycle authority in your repository, not a hosted service. **Your AI tool does the work; Slipway decides when it's actually done** — across **Claude Code, Codex, Cursor, Gemini, and OpenCode**.
 
 - **The model can't fake "done."** Completion is gated on fresh review *and* verification evidence: checks compiled into the CLI, not advisory prompts the agent can rationalize past. If the evidence goes stale or the work drifts from the plan, Slipway reopens the change instead of waving it through.
 - **No commands to learn.** After a one-time `slipway init`, a generated entry skill routes your ordinary plain-language requests through the governed lifecycle; on tools that support session hooks, live governed state is also surfaced every session, unprompted. You describe the change, and the agent drives the process.
@@ -45,11 +45,10 @@ You talk to your AI tool the way you already do. The agent handles the governanc
 ```text
 You:  Add a --dry-run flag to the export command.
 
-(The agent already knows this repo is governed and that no change is active:
- the entry skill routes it there, and on tools with session hooks that state
- is pushed in automatically, so no action is needed from you.)
+(The repo is governed. The entry skill picks that up and routes the
+ request on its own — no command from you, nothing beyond the one-time init.)
 
-Agent (routing on its own):
+Agent (driving the lifecycle):
   → slipway new        creates the governed change
   → slipway intake     captures intent, scope, and guardrail class
   → slipway plan       writes requirements, decision, tasks, and plan-audit evidence
@@ -68,6 +67,22 @@ the agent drove it.
 
 And if the agent had tried to call it `done` before the tests ran and the review evidence existed? `slipway done` refuses: the gate lives in the CLI, not in a prompt the agent can decide to skip.
 
+## Where Slipway goes deep
+
+Behind the gate, every stage owns evidence the engine **re-derives instead of trusting**. These seven axes are what make a faked "done" fall over — and together, no adjacent tool enforces them in code. Each is stated at its honest enforcement tier; the [Design Philosophy](docs/design.md#advantage-axes) carries the full mechanism and the residual caveats.
+
+| Axis | What the engine does | Why it's hard to fake (and what no peer matches) |
+| --- | --- | --- |
+| **Attested fresh context** | Each stage records the distinct `context_origin` handle it ran under; a per-seam lattice fails closed if the reviewer, plan auditor, or fix collapses into the implementer's context | gsd and superpowers *spawn* fresh subagents; Slipway also *checks the independence held* (audit/structural tier, not cryptographic proof) |
+| **Tamper-evident evidence** | Re-derives freshness from the real inputs — code diff, planning artifacts, run-summary version, shared suite-result — never the verification file's own claims | Peers store state as Markdown/YAML the model can quietly edit; Slipway names the stale input (`required_skill_stale:…`), reopens the change, and stays the sole verdict stamper |
+| **Two-sided parallel safety** | Deterministic file-disjoint waves run concurrently; four safety nets then audit the *actual* changed files (scope escape, wave overlap, dispatch mode, executor handles) | Peers that parallelize check the *plan* before dispatch; Slipway also audits what the agents *actually edited* afterward |
+| **Scope containment** | Declared `target_files` is a contract checked with the planner's own path predicate; out-of-lane edits fail closed (`scope_contract_drift`) | The codebase map under `artifacts/codebase/` is the one *disclosed* exemption (`exempt_context_files`), not a silent gap |
+| **Drift-aware forward recovery** | Plan or evidence drift reopens the change *in place*, forward-only; `slipway next` projects the next repair as a concrete command with the blocker named | No backward cascade can hide the gap, and recovery never depends on the agent knowing a private sequence |
+| **Local-first, git-native audit** | `change.yaml` is the single authority; an append-only, readback-verified `events/lifecycle.jsonl` traces every mutation beside the code under `artifacts/changes/` | Nothing leaves the repository — the audit trail is sovereign by default and re-inspectable by any later human or AI session |
+| **Risk-tiered guardrails** | Sensitive domains (auth, credentials/PII, financial, schema migration, irreversible ops, external-API) require per-domain high-risk checks and gate sensitive evidence at S2 and S3 | No bypass, force-close, or private-attestation path — light on throwaway changes, unforgiving on dangerous ones |
+
+Instead of a single end-of-run checkbox, you get an auditable trail of stage-owned evidence the next session — human or AI — can re-inspect and trust.
+
 ## How Slipway compares
 
 Spec, workflow, and skill toolkits for AI coding are all good at *structuring* work. The axis that sets Slipway apart is **where the rules live and whether the model can ignore them**: almost all of them encode the process as prompts or Markdown the agent is *asked* to follow, so the gates stay advisory. Slipway compiles the process into a deterministic CLI backed by repo evidence, so the gates fail closed.
@@ -81,7 +96,7 @@ Spec, workflow, and skill toolkits for AI coding are all good at *structuring* w
 | [superpowers](https://github.com/obra/superpowers) | Skills auto-fire from a session bootstrap (no commands) | Self-discipline: an "Iron Law" the model is *asked* to obey |
 | **Slipway** | **Plain language; an entry skill auto-fires (no commands)** | **Compiled, fail-closed**: gates live in the CLI and repo evidence |
 
-The pattern is consistent: those tools enforce process by asking the model to comply, while Slipway enforces it in code the model runs but can't rewrite. (superpowers is the closest on *experience*, since its skills also auto-trigger without slash commands, but its rules live in the model's context, not in a binary.) On capability the lines blur, because Slipway also runs dependency-ordered waves, dedicated worktrees, and TDD governance, so the real divide is enforcement, not feature count. Where the peers genuinely lead is **reach and ecosystem**: far more supported agents, more mileage, and models Slipway lacks, like OpenSpec's delta-specs or Spec Kit's large integration catalog.
+The pattern is consistent: those tools enforce process by asking the model to comply, while Slipway enforces it in code the model runs but can't rewrite. (superpowers is the closest on *experience*, since its skills also auto-trigger without slash commands, but its rules live in the model's context, not in a binary.) The capability set overlaps — Slipway also runs dependency-ordered waves, dedicated worktrees, and TDD governance — so the divide is not feature count but enforcement: across the [axes where Slipway goes deep](#where-slipway-goes-deep), the engine re-derives evidence instead of trusting it. Where the peers genuinely lead is **reach and ecosystem**: far more supported agents, more mileage, and models Slipway lacks, like OpenSpec's delta-specs or Spec Kit's large integration catalog.
 
 ### What Slipway deliberately trades off
 
@@ -97,17 +112,6 @@ Several of the differences above are intentional, not gaps. Slipway optimizes fo
 | Failure mode | Skipping a step degrades silently | Missing or stale evidence fails closed | You learn the work isn't done *before* you ship, not after |
 
 One thing is **not** a deliberate trade-off, just where Slipway is today: mileage. It is younger and less battle-tested than Spec Kit or superpowers, and the five-tool list is still growing. The bet is that fail-closed depth is the harder thing to retrofit later, and breadth and mileage come with time.
-
-## Depth, not just a gate
-
-A single "did you run the tests?" check is easy to fake. The point of Slipway is the depth behind the gate: a chain of stage-owned checkpoints that each demand their own evidence, so quality is enforced all the way through instead of rubber-stamped at the end.
-
-- **Intake** fixes intent, scope, open questions, and a **guardrail class**. Sensitive domains (auth, credentials/PII, financial, schema migration, irreversible ops, external-API contracts) fail closed harder and get no bypass, force-close, or private attestation path.
-- **Planning** binds a `requirements.md` / `decision.md` / `tasks.md` bundle that execution is held to, so the agent can't quietly re-scope mid-flight.
-- **Review** uses fresh-context selected S3 peers: spec-compliance and code-quality always run independently of the implementer, goal-verification is an unordered peer, and optional peers join when selected. Final closeout is stamped last before done-ready.
-- **Drift and freshness** are enforced, not trusted: edit the plan or let evidence go stale, and Slipway routes the gap to the owning forward path. In S3, same-intent plan and task amendments stay in review/fix while S2 remains completed. A change can't limp to done on half-stale proof.
-
-That chain is what command-driven spec toolkits and in-context skill packs don't carry. Instead of a single end-of-run checkbox, you get an auditable trail of stage-owned evidence that the next session, human or AI, can re-inspect and trust.
 
 ## Quick start
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -13,6 +13,50 @@ Slipway is a small governance control plane for local AI-assisted development. I
 | Artifact traceability | Intent, research, requirements, decisions, tasks, execution evidence, review evidence, and assurance remain connected. |
 | Fresh verification | A completion claim is valid only when current evidence proves the current worktree state. |
 
+## Advantage Axes
+
+Slipway's value is not one gate; it is that every governed stage owns evidence the engine **re-derives instead of trusting**, across several independent axes. Each axis is stated at its honest enforcement tier — structural where it is structural, genuinely enforced where it is — and never oversold. Adjacent spec, workflow, and skill toolkits structure work well; the divide is that they enforce process by *asking* the model to comply, while these axes are checked in compiled code the model runs but cannot rewrite.
+
+| Axis | Enforcement tier | In one line |
+| --- | --- | --- |
+| 1. Attested fresh context | Audit/structural | A per-seam `context_origin` lattice fails closed when stages that must be independent share a handle |
+| 2. Tamper-evident evidence | Input digest (S3 certs) + structural (execution) | Freshness is re-derived from authoritative inputs, never the verification record's own claims |
+| 3. Two-sided parallel safety | Genuinely enforced | File-disjoint wave planning plus four post-dispatch changed-file safety nets |
+| 4. Scope containment | Genuinely enforced | `target_files` is a contract checked with the planner's own `TargetCoversPath` predicate |
+| 5. Drift-aware forward recovery | Genuinely enforced | Forward-only reopen; `next` projects the repair as a named command |
+| 6. Local-first, git-native audit | Genuinely enforced | `change.yaml` authority plus an append-only, readback-verified `lifecycle.jsonl` |
+| 7. Risk-tiered guardrails | Genuinely enforced (fail-closed) | Sensitive domains require high-risk checks and get no bypass, force-close, or self-attest path |
+
+The honest tier matters: axes 3–7 are mechanisms the engine genuinely enforces, axis 2 mixes an input-digest check (S3 review certificates) with structural freshness (execution summaries), and axis 1 is deliberately the *audit/structural* tier — it raises the cost of faking independence without claiming cryptographic proof. The sections below give each axis its mechanism and competitive boundary.
+
+### 1. Attested fresh context
+
+Every stage records the distinct context handle it ran under (`context_origin:stage=<stage>=<handle>`), and a per-seam collision lattice fails closed when two stages that must be independent share a handle — reviewer versus implementer, plan auditor versus plan author, fix versus either. Recovery is to re-run the owning stage in a fresh native subagent so it re-emits a distinct handle. This is **audit/structural tier**: the handles are host-emitted strings, so the lattice raises the cost and visibility of collapsing the chain into one authoring context, but it is not cryptographic proof of independence. gsd and superpowers *spawn* fresh subagents; Slipway also *checks the independence held*. See [Independence Attestation Tier](#independence-attestation-tier) for the full per-seam edge model and the honest residual.
+
+### 2. Tamper-evident evidence
+
+Freshness is computed from authoritative inputs, not from the verification record's own claims. Selected S3 review certificates are keyed to an engine-owned input digest (code diff, planning artifacts, task-scope hash, run-summary version, and the shared `verification/suite-result.yaml`); execution-summary task freshness is **structural** (`change_id`, `run_summary_version`, `task_id`, `guardrail_domain`), and old hash-only summaries are treated as stale and regenerated. Either way, a hand-edited verdict or a drifted input is detected and named (`required_skill_stale:<skill>:<input>`) rather than trusted. The engine remains the sole verdict and run-version stamper; no gate adds a self-stamp, restamp, or force-close path. Adjacent tools store state as Markdown/YAML the model maintains and could edit freely.
+
+### 3. Two-sided parallel safety
+
+The wave planner buckets tasks into dependency-ordered, file-disjoint waves with a deterministic topological sort; multi-task waves run concurrently by default (`execution.parallelization: off` opts out). The distinguishing half is the *post-dispatch* audit: four fail-closed safety nets check the **actual** recorded `changed_files` — scope escape, parallel-wave file overlap, missing or unjustified dispatch mode, and missing per-task executor handles. Dispatch itself is host-driven (the AI host fans out native subagents per the materialized plan); Slipway runs no concurrent scheduler, it validates the resulting evidence. Peers that parallelize check the plan before dispatch; Slipway also audits what the agents actually edited afterward.
+
+### 4. Scope containment
+
+Each task's declared `target_files` in `tasks.md` is a scope contract, evaluated with the same `TargetCoversPath` predicate the wave planner uses for conflict detection, so "covers" and "conflicts" share one implementation. Recorded changes outside the contract fail closed (`scope_contract_drift` and siblings), each mapped to an actionable remediation. The durable codebase map under `artifacts/codebase/` is the one disclosed exemption: when only those context files are dirty, they stay out of `scope_contract.changed_files` and are surfaced as `scope_contract.exempt_context_files` on `validate`/`status`/`review --json` rather than silently filtered.
+
+### 5. Drift-aware forward recovery
+
+When plan, code, and evidence diverge, the lifecycle reopens the change *in place* and forward-only — there is no backward state cascade that could hide the gap, and same-intent S3 plan or task amendments stay in review/fix while S2 remains completed. Blockers project into a `RecoverySummary` with one primary command and one step per blocker group, surfaced on the read-only `next`/`status`/`validate` JSON so the agent reads the next forward action directly instead of inferring private sequencing. A recovery that only works because the agent memorized a hidden flow is treated as a product defect, not a feature.
+
+### 6. Local-first, git-native audit
+
+`change.yaml` is the single current authority; `events/lifecycle.jsonl` is an append-only trace of every mutating event, written as an atomic rewrite with post-write readback verification and tagged with the acting surface (`actor_kind`, and `skill_id` for skill-driven steps). Evidence lives beside the code in the governed bundle under `artifacts/changes/`. Nothing requires a hosted service to understand a change, so the audit trail is sovereign by default and re-inspectable by any later human or AI session. The lifecycle log is audit evidence only — it never replaces `change.yaml` as current-state authority.
+
+### 7. Risk-tiered guardrails
+
+Sensitive domains — auth/authz, credentials/PII, financial flows, schema/data migration, irreversible operations, and external-API contracts — fail closed harder. They require per-domain high-risk checks before ship authority is granted, gate sensitive evidence at both S2 and S3, and get no bypass, force-close, or private-attestation path. The same lifecycle that is light on a throwaway change is unforgiving on the changes that can actually hurt you; `light` preset relaxes advisory tiers but never the sensitive-domain fail-closed lines.
+
 ## Architecture Model
 
 <div align="center" markdown>

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,8 @@ Slipway keeps three surfaces separate:
 
 `status`, `validate`, and `next` recompute readiness without mutating state. `run` is the primary governed execution surface: it advances until a skill, blocker, checkpoint, or done-ready state is surfaced.
 
+What makes "done" hard to fake is that every stage owns evidence the engine *re-derives instead of trusting*. The [Advantage Axes](design.md#advantage-axes) — attested fresh context, tamper-evident evidence, two-sided parallel safety, scope containment, drift-aware forward recovery, local-first audit, and risk-tiered guardrails — describe the depth behind that claim and the honest enforcement tier of each.
+
 ## First Actions
 
 1. Install or build the CLI using [Installation](installation.md).


### PR DESCRIPTION
## Why

The README under-told Slipway's deepest differentiators — it led on the generic *fail-closed vs advisory* axis while burying the mechanisms that no adjacent tool (gsd, OpenSpec, spec-kitty, Spec Kit, superpowers) enforces in code. This reframes the value proposition around **seven advantage axes**, each stated at its honest enforcement tier.

## Seven axes

1. **Attested fresh context** — `context_origin` per-seam collision lattice fails closed when reviewer/auditor/fix collapses into the implementer's context. *(audit/structural tier, not cryptographic proof)*
2. **Tamper-evident evidence** — engine re-derives freshness from real inputs (code diff, planning artifacts, run-summary version, shared `suite-result.yaml`); never trusts the verification file's own claims. Engine stays the sole verdict stamper.
3. **Two-sided parallel safety** — deterministic file-disjoint wave bucketing **plus** four post-dispatch safety nets that audit the *actual* changed files.
4. **Scope containment** — `target_files` becomes a scope contract via the same `TargetCoversPath` predicate the planner uses; `artifacts/codebase/` is the one disclosed exemption.
5. **Drift-aware forward recovery** — forward-only reopen, with `next` naming the concrete repair command.
6. **Local-first git-native audit** — `change.yaml` authority + append-only `events/lifecycle.jsonl` (atomic, readback-verified).
7. **Risk-tiered guardrails** — sensitive domains fail closed harder; no bypass/force-close/self-attest.

## Changes

- `README.md`: replace *"Depth, not just a gate"* with a seven-axis section; stop the comparison prose from self-minimizing on capability.
- `docs/design.md`: add a deep **Advantage Axes** section (mechanism + honest tier + competitive boundary per axis), reusing the existing Independence Attestation Tier for axis 1.
- `docs/index.md`: point the mental model at the new axes.

## Honesty discipline

Tiering preserved throughout: the `context_origin` lattice is **audit/structural** (not cryptographic distinct-context proof), execution-summary freshness is **structural** while S3 review certs use **input digests**, and the engine remains the sole verdict/run-version stamper (no self-stamp/restamp/force-close).

## Verification

- `go test ./internal/toolgen/ -run TestReadmeAndCommandDescriptionsReflectCurrentEntrySurface` — green (required tokens present, forbidden tokens absent).
- Cross-doc anchors (`#where-slipway-goes-deep`, `#advantage-axes`) resolve.

Docs-only; no code or lifecycle behavior changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)