### PR TITLE
feat(governance): generalize digest proof reuse

### DIFF
--- a/artifacts/changes/archived/generalize-digest-proof-reuse/assurance.md
+++ b/artifacts/changes/archived/generalize-digest-proof-reuse/assurance.md
@@ -1,0 +1,114 @@
+# Assurance
+
+## Scope Summary
+
+This change delivers the selected Approach D for issue #258: an internal
+proof-reuse edge/check shape in `internal/engine/progression`, with the first
+production edge limited to the existing final-closeout reuse of
+goal-verification proof. The public closeout evidence boundary remains stable:
+`closeout:goal_verification_reuse=pass`,
+`closeout:goal_verification_reuse_run_version=<run_version>`, and
+`closeout_goal_verification_reuse_invalid`.
+
+The delivered scope also includes fail-closed suite-result freshness checks,
+guardrail-domain SAST digest requirements for suite-result reuse, generated
+goal-verification/final-closeout guidance updates, and a narrow evidence CLI
+recovery path for selected reviewers whose prior passing record used a retired
+or malformed context-origin token.
+
+## Verification Verdict
+
+The active change is not done at the time this assurance was authored because
+final-closeout evidence has not yet been recorded. The implementation and
+selected S3 review evidence are ready for closeout:
+
+- `go test ./... -count=1` passed in the bound worktree and is captured in
+  `artifacts/changes/generalize-digest-proof-reuse/verification/full-suite-transcript.txt`.
+- `verification/suite-result.yaml` records run summary version `1` and full
+  suite digest `ac32b2f4747c7ff7713488d419b1600ed4cb3a82810b0d1463b441412e23bd03`.
+- Fresh selected S3 evidence is recorded and stamped for
+  `spec-compliance-review`, `code-quality-review`, `independent-review`, and
+  `goal-verification`.
+- Active `go run . validate --json` after S3 restamping reported
+  `evidence_freshness=fresh`, `scope_contract.status=pass`, and all four
+  selected review skills passing. The remaining blockers at that point were the
+  expected missing `final-closeout` evidence and standard-preset closeout
+  attestations.
+
+## Evidence Index
+
+- Requirements: `artifacts/changes/generalize-digest-proof-reuse/requirements.md`.
+- Decision: `artifacts/changes/generalize-digest-proof-reuse/decision.md`.
+- Tasks: `artifacts/changes/generalize-digest-proof-reuse/tasks.md`.
+- Execution summary:
+  `artifacts/changes/generalize-digest-proof-reuse/verification/execution-summary.yaml`.
+- Full-suite transcript:
+  `artifacts/changes/generalize-digest-proof-reuse/verification/full-suite-transcript.txt`.
+- Suite-result keystone:
+  `artifacts/changes/generalize-digest-proof-reuse/verification/suite-result.yaml`.
+- Fresh S3 review notes:
+  `spec-compliance-review-notes.md`, `code-quality-review-notes.md`,
+  `independent-review-notes.md`, and `goal-verification-notes.md` under
+  `artifacts/changes/generalize-digest-proof-reuse/verification/`.
+- Fresh selected S3 verification records:
+  `spec-compliance-review.yaml`, `code-quality-review.yaml`,
+  `independent-review.yaml`, and `goal-verification.yaml` under
+  `artifacts/changes/generalize-digest-proof-reuse/verification/`.
+- Active lifecycle proof after S3 restamping: `go run . validate --json` and
+  `go run . next --json --diagnostics` run from the bound worktree on
+  2026-06-18.
+
+## Requirement Coverage
+
+- REQ-001 is covered by `proofReuseEdge`, `proofReuseDigestCheck`, and
+  `proofReuseEdgeBlockers` in `internal/engine/progression/authority.go`, with
+  tests covering a non-closeout source/consumer edge.
+- REQ-002 is covered by the closeout compatibility wrapper preserving the
+  existing public reuse references and unchanged
+  `closeout_goal_verification_reuse_invalid` blocker.
+- REQ-003 is covered by strict `verification/suite-result.yaml` loading,
+  run-summary version matching, selected-review suite-result dependency, and
+  guardrail-domain SAST digest enforcement in
+  `internal/engine/progression/evidence_digests.go`.
+- REQ-004 is covered by the generated skill-template updates that make
+  goal-verification a selected S3 peer producing or refreshing
+  `verification/suite-result.yaml`, and make final-closeout reuse depend on
+  engine-validated freshness rather than an unsafe lifecycle advance.
+- REQ-005 is covered by focused engine, command, and template tests, plus the
+  fresh full-suite transcript recorded after the latest code and artifact
+  changes.
+
+## Residual Risks and Exceptions
+
+No blocking product risk is accepted for this change. The selected reviewers
+identified one non-blocking residual: the new evidence CLI recovery path fixes
+retired or malformed selected-review context-origin records, but it does not
+try to repair already well-formed yet colliding review handles. That broader
+`cross_stage_context_not_distinct` recovery ergonomics is outside this scoped
+issue and does not weaken the current proof-reuse gates.
+
+This change has no active guardrail domain, so no SAST baseline token is
+required for this specific change. The guardrail SAST digest requirement is
+nevertheless covered by tests and helper fixture updates.
+
+## Rollback Readiness
+
+Rollback is a normal git revert of the implementation, tests, generated-template
+updates, and governed artifacts in this branch. Because the public closeout
+reuse references and blocker code are preserved, rollback does not require
+migrating existing governed evidence records.
+
+No irreversible data, schema, external API, credential, or deployment operation
+is part of this change.
+
+## Archive Decision
+
+Archive readiness decision: proceed to fresh final-closeout review before done.
+
+Active `go run . validate --json` proof was captured before `done` after S3
+review evidence was refreshed. That active validation showed fresh lifecycle
+evidence, a passing scope contract, and passing selected review skills, with
+only the expected final-closeout and assurance-attestation blockers remaining.
+Archived bundles are not treated as active validation inputs; this assurance is
+for the still-active governed change and must be rechecked by final-closeout
+before archival or done-ready status is claimed.

--- a/artifacts/changes/archived/generalize-digest-proof-reuse/change.yaml
+++ b/artifacts/changes/archived/generalize-digest-proof-reuse/change.yaml
@@ -1,0 +1,61 @@
+version: 1
+slug: generalize-digest-proof-reuse
+description: generalize digest proof reuse
+status: done
+current_state: DONE
+needs_discovery: true
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-06-18T06:14:24.4858Z
+quality_mode: standard
+workflow_profile: code
+workflow_preset: standard
+worktree_branch: feat/generalize-digest-proof-reuse
+artifact_schema: expanded
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: 7fd153d21f608153d2d3c0f569f696c38d82046a80e46a70d2c4110fd7512171
+        updated_at: 2026-06-18T09:05:53.680430409Z
+    decision:
+        id: decision
+        path: decision.md
+        state: frozen
+        content_hash: 17586e3dfe03f79d182b276b4cd4cf18a0401b0663a434fe630854fceffd540b
+        updated_at: 2026-06-18T06:45:26.08653441Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: 7ee39b70e00c90f613198fcccb6f04cbf17067cf37cb47154acca4ec8c717926
+        updated_at: 2026-06-18T06:24:38.181576065Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: 4d623d86c6b16d469fb3d2982e8f12ae67831a71ced5a63b585a6b716d4085ad
+        updated_at: 2026-06-18T06:45:26.086366119Z
+    research:
+        id: research
+        path: research.md
+        state: frozen
+        content_hash: 563b69bb9047c3128f9fe4ec51c15e4fa77851e775c220fa2a5811d36dc41b44
+        updated_at: 2026-06-18T06:43:57.461211241Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: e875a37c8f466124d73526ce35eb0150a389f738f89bd7fafba175110aa06581
+        updated_at: 2026-06-18T08:46:19.972718289Z
+evidence_refs:
+    code-quality-review: .worktrees/generalize-digest-proof-reuse/artifacts/changes/generalize-digest-proof-reuse/verification/code-quality-review.yaml
+    final-closeout: .worktrees/generalize-digest-proof-reuse/artifacts/changes/generalize-digest-proof-reuse/verification/final-closeout.yaml
+    goal-verification: .worktrees/generalize-digest-proof-reuse/artifacts/changes/generalize-digest-proof-reuse/verification/goal-verification.yaml
+    independent-review: .worktrees/generalize-digest-proof-reuse/artifacts/changes/generalize-digest-proof-reuse/verification/independent-review.yaml
+    intake-clarification: .worktrees/generalize-digest-proof-reuse/artifacts/changes/generalize-digest-proof-reuse/verification/intake-clarification.yaml
+    plan-audit: .worktrees/generalize-digest-proof-reuse/artifacts/changes/generalize-digest-proof-reuse/verification/plan-audit.yaml
+    research-orchestration: .worktrees/generalize-digest-proof-reuse/artifacts/changes/generalize-digest-proof-reuse/verification/research-orchestration.yaml
+    spec-compliance-review: .worktrees/generalize-digest-proof-reuse/artifacts/changes/generalize-digest-proof-reuse/verification/spec-compliance-review.yaml
+    wave-orchestration: .worktrees/generalize-digest-proof-reuse/artifacts/changes/generalize-digest-proof-reuse/verification/wave-orchestration.yaml

--- a/artifacts/changes/archived/generalize-digest-proof-reuse/decision.md
+++ b/artifacts/changes/archived/generalize-digest-proof-reuse/decision.md
@@ -1,0 +1,76 @@
+# Decision
+
+## Alternatives Considered
+- Approach A: Extract a small reusable validator from the existing
+  closeout-specific gate while keeping only the current closeout consumer. This
+  is low risk but can become a superficial rename if no real edge abstraction is
+  introduced.
+- Approach B: Build a broad proof-type and stage-edge registry, including
+  execution -> goal-verification reuse in the first pass. This has a stronger
+  long-term shape but introduces too much public vocabulary and implementation
+  surface before the second edge's constraints are proven.
+- Approach C: Change only generated skill guidance so final-closeout is more
+  reuse-first. This reduces rerun pressure but leaves the engine one-off intact.
+- Approach D: Add an internal edge-spec validator and enable only the current
+  closeout -> goal-verification edge in production. This gives the engine a real
+  reusable primitive while keeping the first slice narrow.
+
+## Selected Approach
+Select Approach D.
+
+The implementation will introduce a small internal proof-reuse edge/check shape
+inside `internal/engine/progression`. The first production edge remains the
+existing final-closeout reuse of goal-verification proof. Public evidence tokens
+and blocker vocabulary remain unchanged:
+
+- `closeout:goal_verification_reuse=pass`
+- `closeout:goal_verification_reuse_run_version=<run_version>`
+- `closeout_goal_verification_reuse_invalid`
+
+The design deliberately does not expose a broad public registry in this slice
+and does not change goal-verification's current role as producer of
+`verification/suite-result.yaml`.
+
+## Interfaces and Data Flow
+- `final-closeout` records the existing closeout reuse references.
+- Ship authority calls the compatibility wrapper for closeout reuse.
+- The wrapper constructs an internal proof-reuse edge/check specification:
+  source skill `goal-verification`, consumer skill `final-closeout`, current
+  reuse run version, execution-summary freshness requirement, and digest checks
+  for both source and consumer.
+- The reusable validator checks:
+  - source and consumer passing records exist where required
+  - source, consumer, and execution-summary run versions agree
+  - execution-summary is ready and fresh
+  - source proof is not older than latest execution evidence
+  - source and consumer skill digest inputs are fresh
+- Failures are mapped through the existing closeout blocker factory so G_ship
+  continues to expose `closeout_goal_verification_reuse_invalid`.
+- Proof payload remains `SuiteResult`; no new proof artifact is introduced.
+
+## Rollout and Rollback
+Rollout is a normal code change in the governed worktree.
+
+Verification commands:
+
+```bash
+go test ./internal/engine/wave ./internal/engine/progression -count=1
+```
+
+Rollback is a git revert of the implementation and generated-template changes.
+Because the public closeout references and blocker names are preserved, rollback
+does not require migration of existing governed evidence.
+
+## Risk
+- False reuse could skip required full-suite or SAST proof. Mitigation:
+  preserve run-version equality, execution-summary freshness, suite-result
+  digest inputs, changed-content digest inputs, and SAST digest checks.
+- A too-small extraction could leave the one-off architecture intact. Mitigation:
+  add tests for the internal edge-spec validator shape, not just the
+  closeout-named wrapper.
+- A too-large registry could destabilize lifecycle gates. Mitigation: keep the
+  registry internal and enable only the existing closeout -> goal-verification
+  edge in production.
+- Template wording could imply an unsafe skip. Mitigation: generated guidance
+  must say reuse is allowed only when engine-validated; rerun remains the
+  fail-closed fallback.

--- a/artifacts/changes/archived/generalize-digest-proof-reuse/intent.md
+++ b/artifacts/changes/archived/generalize-digest-proof-reuse/intent.md
@@ -1,0 +1,82 @@
+# Intent
+
+## Summary
+Generalize digest-keyed proof reuse so governed verification can reuse fresh
+full-suite and SAST proof instead of rerunning unchanged proof across S4 stages.
+
+## Complexity Assessment
+complex
+Rationale: this changes engine-owned proof-reuse validation and generated
+governance skill posture. The change must preserve fail-closed freshness,
+run-version, digest, and guardrail safety behavior while reducing redundant
+verification work.
+
+## Guardrail Domains
+<!-- none detected -->
+
+## In Scope
+- Issue #258: generalize the existing closeout -> goal-verification reuse
+  validation into a reusable digest/run-version proof-reuse mechanism.
+- Preserve the existing closeout reuse safety checks while making reuse-first
+  behavior clearer for final-closeout when goal-verification proof is fresh.
+- Evaluate execution-summary -> goal-verification full-suite reuse when review
+  and content state have not changed after execution proof.
+- Update generated skill templates and engine tests so agents cite validated
+  proof reuse instead of rerunning full-suite/SAST proof by default when the
+  engine can prove freshness.
+
+## Out of Scope
+- Host-native subagent dispatch overhead and #240/#114 execution isolation work.
+- Removing S4 full-suite or SAST proof unconditionally.
+- Copying GSD-core architecture wholesale; use it only as comparison context.
+- Docs-only Diataxis work (#170), install transaction/manifest work (#167),
+  install profile/router work (#168), and Go test-lint analyzers (#161).
+
+## Constraints
+- Fail closed on any stale run version, changed content, missing suite-result,
+  missing guardrail SAST proof, or unverifiable digest.
+- Keep exactly one canonical fresh proof path per safe cycle; do not weaken the
+  ship gate or high-risk safety checks.
+- Prefer the current worktree's Slipway behavior and bounded codebase-map refs
+  over remembered workflow assumptions.
+
+## Acceptance Signals
+- Engine tests cover valid reuse plus invalidation by changed source/artifacts,
+  stale run_version, missing suite-result, and guardrail SAST mismatch.
+- Generated goal-verification/final-closeout skill text makes validated reuse the
+  preferred path when conditions hold and rerun the fallback when they do not.
+- `go test ./internal/engine/wave ./internal/engine/progression -count=1` passes.
+- The selected implementation still blocks ship if reuse evidence is missing,
+  stale, or inconsistent.
+
+## Open Questions
+- [x] Determine the smallest reusable proof-reuse API shape that avoids another
+  closeout-specific special case while preserving existing blocker taxonomy.
+  Research resolution: extract the existing closeout validation shape into a
+  small reusable validator while keeping closeout's public blocker for the
+  existing path.
+- [x] Confirm whether execution-summary -> goal-verification reuse is safe in
+  the first slice or should be deferred behind closeout reuse-first behavior.
+  Research resolution: do not make goal-verification unconditionally reuse S2
+  proof; include upstream reuse only behind an explicit, test-proven
+  no-source/content-delta predicate.
+
+## Deferred Ideas
+- Broader proof reuse for coverage, mutation, and reviewer spot-reruns after the
+  suite/SAST path is proven.
+- Token-budget and install-surface work tracked by #168.
+
+## Approved Summary
+Confirmed by user on 2026-06-18T06:21:12Z with "继续帮我推进".
+
+Implement the highest-ROI open issue, #258, by generalizing Slipway's
+digest-keyed proof reuse beyond the current closeout -> goal-verification
+special case. The change should preserve fail-closed run-version, digest,
+suite-result, and guardrail SAST validation while reducing redundant full-suite
+and SAST reruns across S4. The initial scope excludes subagent dispatch work,
+unconditional S4 proof skipping, direct GSD-core architecture copying, docs
+reorganization, install profile/router work, install transaction/manifest work,
+and test-lint analyzer work. Success is proven by targeted engine/template tests
+and `go test ./internal/engine/wave ./internal/engine/progression -count=1`,
+with ship still blocked whenever reuse evidence is stale, missing, or
+inconsistent.

--- a/artifacts/changes/archived/generalize-digest-proof-reuse/requirements.md
+++ b/artifacts/changes/archived/generalize-digest-proof-reuse/requirements.md
@@ -1,0 +1,88 @@
+# Requirements
+
+## Requirements
+
+### Requirement: Internal proof-reuse edge validator
+REQ-001: The system MUST provide an internal proof-reuse validation mechanism
+that can describe a source skill, a consumer skill, the required run version,
+execution-summary freshness, and digest-freshness checks without hardcoding the
+validator to final-closeout.
+
+#### Scenario: reusable validation accepts a fresh edge
+GIVEN goal-verification and final-closeout records for the same current
+run_summary_version
+AND the execution-summary is ready and fresh
+AND the recorded digest inputs for both skills still match current inputs
+WHEN the closeout -> goal-verification proof-reuse edge is evaluated
+THEN the validator reports no blockers.
+
+#### Scenario: reusable validation rejects stale proof
+GIVEN a proof-reuse edge whose source or consumer digest inputs no longer match
+the current content state
+WHEN the edge is evaluated
+THEN the validator returns a fail-closed blocker naming the changed input.
+
+### Requirement: Existing closeout public contract remains stable
+REQ-002: The existing final-closeout reuse contract MUST remain backward
+compatible at the public evidence boundary: final-closeout still records
+`closeout:goal_verification_reuse=pass` and
+`closeout:goal_verification_reuse_run_version=<run_version>`, and invalid reuse
+still surfaces `closeout_goal_verification_reuse_invalid`.
+
+#### Scenario: missing reuse run version blocks ship
+GIVEN final-closeout records `closeout:goal_verification_reuse=pass`
+WITHOUT `closeout:goal_verification_reuse_run_version=<run_version>`
+WHEN ship authority evaluates the change
+THEN `closeout_goal_verification_reuse_invalid` blocks verification and is
+surfaced through G_ship readiness.
+
+#### Scenario: run-version mismatch blocks ship
+GIVEN final-closeout, goal-verification, and execution-summary do not agree on
+the same reuse run version
+WHEN ship authority evaluates the change
+THEN `closeout_goal_verification_reuse_invalid` blocks the change.
+
+### Requirement: Guardrail proof reuse remains fail-closed
+REQ-003: The system MUST NOT reuse full-suite or SAST proof when the
+`suite-result.yaml` proof is missing, malformed, tied to the wrong run version,
+or missing a required guardrail SAST digest for the active safety baseline.
+
+#### Scenario: missing suite-result prevents reuse
+GIVEN goal-verification or selected review proof depends on suite-result inputs
+AND `verification/suite-result.yaml` is absent or invalid
+WHEN proof freshness is evaluated
+THEN the system reports stale or unavailable proof rather than accepting reuse.
+
+#### Scenario: missing SAST digest prevents guardrail reuse
+GIVEN a guardrail-domain change requires `<domain>.safety_baseline`
+AND the suite-result lacks the matching SAST digest
+WHEN the proof-reuse edge is evaluated for that domain
+THEN reuse is rejected and the workflow requires fresh SAST proof.
+
+### Requirement: Host guidance prefers validated reuse without skipping proof
+REQ-004: Generated goal-verification and final-closeout guidance SHALL direct
+agents to reuse proof only when the engine-validated conditions hold, and SHALL
+direct agents to rerun full-suite or SAST proof when validation fails.
+
+#### Scenario: final-closeout reuse-first wording is bounded
+GIVEN goal-verification proof is fresh for the current run version and content
+state
+WHEN final-closeout guidance is read
+THEN it presents validated reuse as the preferred path and records the required
+reuse references.
+
+#### Scenario: goal-verification producer role is preserved
+GIVEN goal-verification is responsible for producing `suite-result.yaml`
+WHEN goal-verification guidance is read
+THEN it does not tell agents to unconditionally reuse S2 execution proof as a
+replacement for producing or refreshing suite-result proof.
+
+### Requirement: Focused verification proves reuse safety
+REQ-005: The change MUST include focused tests proving valid reuse and
+fail-closed invalidation before completion is claimed.
+
+#### Scenario: focused tests pass
+GIVEN the implementation is complete
+WHEN `go test ./internal/engine/wave ./internal/engine/progression -count=1`
+runs
+THEN the command exits successfully and covers the proof-reuse safety cases.

--- a/artifacts/changes/archived/generalize-digest-proof-reuse/research.md
+++ b/artifacts/changes/archived/generalize-digest-proof-reuse/research.md
@@ -1,0 +1,173 @@
+# Research
+
+## Alternatives Considered
+
+### Architecture
+- Affected modules:
+  - `internal/engine/progression/authority.go`: ship authority wires
+    `closeoutGoalVerificationReuseBlockers` into both verification blockers and
+    `G_ship` unresolved reasons; the current validator is closeout-only and
+    consumes final-closeout references.
+  - `internal/engine/progression/evidence_digests.go`: goal-verification digest
+    inputs already include suite-result, planning artifacts, task-plan scope,
+    changed/target file set, and changed/target file content.
+  - `internal/model/evidence_digests.go`: `SuiteResult` stores
+    `run_summary_version`, `full_suite_digest`, and optional `sast_digests`;
+    `SharedReviewerInputDigests` converts them into named digest inputs.
+  - `internal/tmpl/templates/skills/goal-verification/SKILL.md.tmpl` and
+    `internal/tmpl/templates/skills/final-closeout/SKILL.md.tmpl`: host-facing
+    proof production/reuse guidance.
+- Dependency chains:
+  - S2 wave evidence -> `execution-summary.yaml` -> S3 selected review freshness.
+  - Goal-verification -> `suite-result.yaml` plus
+    `high_risk_check:<domain>.safety_baseline` when guardrail domains apply.
+  - Final-closeout -> optional closeout reference tokens ->
+    `closeoutGoalVerificationReuseBlockers` -> `G_ship`.
+- Blast radius:
+  - Narrow engine blast radius in `internal/engine/progression`.
+  - Public evidence/reference vocabulary only if new reuse tokens are introduced.
+  - Generated skill text must stay aligned with the engine contract.
+- Constraints:
+  - Engine remains the only verdict/freshness stamper.
+  - Reuse must fail closed on stale run versions, changed content, missing
+    suite-result proof, missing SAST digest, or digest-evaluation errors.
+  - Do not weaken `high_risk_check:<domain>.safety_baseline`.
+
+### Patterns
+- Existing conventions:
+  - Gate-specific validation returns `[]model.ReasonCode` and is appended to both
+    verification blockers and ship/readiness blockers when the reason must be
+    actionable at `G_ship`.
+  - Verification proof freshness is represented as named digest inputs rather
+    than timestamp-only checks.
+  - Host skill records proof claims through `References`; the CLI owns timestamp
+    and run-version stamping.
+- Reusable abstractions:
+  - Extract the closeout reuse run-version/digest validation shape into a helper
+    that accepts source stage, consumer stage, run-version reference policy, and
+    digest-freshness checks.
+  - Keep `SuiteResult` as the suite/SAST proof carrier instead of creating a new
+    proof artifact.
+- Convention deviations:
+  - A fully generic proof-reuse registry would be a new abstraction. It should be
+    small and locally justified, not a broad scheduler redesign.
+
+### Risks
+- High: false reuse could skip required full-suite or SAST proof. Mitigation:
+  preserve run-version equality, suite-result validation, changed-content digest
+  inputs, and guardrail SAST digest checks.
+- Medium: new public blocker vocabulary could bypass existing recovery contracts.
+  Mitigation: reuse existing closeout blocker for the existing path; add new
+  reason-code/recovery entries only when a new public failure class is required.
+- Medium: execution-summary -> goal-verification reuse could undercut
+  goal-verification's current producer role for `suite-result.yaml`. Mitigation:
+  treat this as a guarded second consumer unless the first slice proves an
+  explicit no-source/content-delta predicate.
+- Low: codebase map was semantically stale for #258 because it was authored for
+  #240. Mitigation: refreshed `ARCHITECTURE.md`, `TESTING.md`, and
+  `CONCERNS.md` with proof-reuse-specific findings.
+- Guardrail domains: none for the change itself, but the implementation must
+  preserve guardrail-domain SAST reuse semantics for future governed changes.
+- Reversibility: source changes are local to progression/model/template tests and
+  can be rolled back by reverting the change; no data migration or irreversible
+  operation is involved.
+
+### Test Strategy
+- Existing coverage:
+  - `TestCloseoutGoalVerificationReuseBlockers` covers valid closeout reuse and
+    invalidation by run-version mismatch, missing reuse run version, newer
+    execution evidence, changed content, and stale execution-summary freshness.
+  - `TestBuildShipAuthoritySurfacesCloseoutReuseBlocker` covers ship-gate
+    surfacing.
+  - `TestGoalVerificationDigestStalesWhenSharedSuiteInputsChange` covers
+    suite-result digest invalidation.
+- Infrastructure needs:
+  - Reuse existing digest fixtures and `writeSuiteResultForDigestTest`.
+  - Add SAST digest fixture coverage where guardrail-domain suite-result reuse is
+    expected.
+- Verification approach:
+  - Focused engine tests for valid and invalid reuse.
+  - Template/toolgen tests for generated skill guidance.
+  - `go test ./internal/engine/wave ./internal/engine/progression -count=1`
+    as the minimum focused command before completion claims.
+
+### Options
+- Approach A: Extract a small reusable proof-reuse validator from the existing
+  closeout gate, keep the existing closeout reference tokens for the first
+  consumer, make final-closeout reuse-first when validation passes, and add
+  targeted tests. Tradeoff: highest safety and fastest ROI, but execution ->
+  goal-verification reuse may remain limited until a follow-up slice. Dialectical
+  concern: if the extraction is only a renamed closeout helper, it satisfies the
+  local cleanup but not the deeper issue #258 root cause that proof reuse is a
+  hand-built one-off.
+- Approach B: Build a registry of reusable proof types and stage edges in one
+  pass, including execution -> goal-verification suite reuse. Tradeoff: stronger
+  long-term shape, but higher blast radius and more public vocabulary before the
+  first consumer is proven. Dialectical concern: it may invent a framework before
+  the second edge has enough empirical constraints, and it risks weakening
+  goal-verification's current suite-result producer role.
+- Approach D: Internal edge-spec validator with one enabled edge first. Extract a
+  real reusable validator around an internal `proofReuseEdge`/`proofReuseCheck`
+  shape that names the source skill, consumer skill, run-version source,
+  execution-summary freshness requirement, digest checks, and blocker factory.
+  Keep `closeoutGoalVerificationReuseBlockers` as a compatibility wrapper and
+  keep the existing closeout public reference tokens for the first consumer.
+  Rename closeout-only content/path helpers to proof-reuse-neutral helpers where
+  they are genuinely shared. Add tests that prove the edge-spec validator is not
+  hardcoded to closeout, but only enable the current closeout -> goal-verification
+  edge in production. Record execution-summary -> goal-verification as a
+  follow-up-capable edge only when a no-source/content-delta predicate and
+  suite-result producer semantics are proven.
+  Tradeoff: slightly more design than Approach A, far less blast radius than
+  Approach B. It gives #258 a real generalized primitive without exposing a broad
+  public registry or changing goal-verification semantics prematurely.
+- Approach C: Template-only reuse-first posture for final-closeout, with no
+  engine generalization. Tradeoff: lowest implementation cost, but it leaves the
+  one-off root cause in place and does not solve #258's generalization ask.
+- Selected: Approach D, confirmed by user on 2026-06-18T06:43:40Z. This keeps
+  Approach A's safety and first-slice discipline while adopting only the useful
+  part of Approach B: a real internal edge abstraction that can host later
+  proof-reuse consumers without committing to a premature public registry or
+  weakening goal-verification.
+
+## Unknowns
+- Resolved: Determine the smallest reusable proof-reuse API shape that avoids
+  another closeout-specific special case while preserving existing blocker
+  taxonomy -> use an internal edge-spec validator over the existing run-version,
+  execution-summary freshness, suite-result, and digest-freshness checks; keep
+  closeout's public blocker and reference tokens for the existing path.
+- Resolved: Confirm whether execution-summary -> goal-verification reuse is safe
+  in the first slice or should be deferred behind closeout reuse-first behavior
+  -> first slice should not make goal-verification unconditionally reuse S2 proof,
+  because goal-verification is currently the suite-result producer. Add only a
+  test-proven, explicit no-source/content-delta predicate if included.
+- Remaining: None.
+
+## Assumptions
+- Issue #258 remains the implementation target. Evidence: live issue triage and
+  approved intake summary in `artifacts/changes/generalize-digest-proof-reuse/intent.md`.
+- The current codebase map was stale for this scope and needed inline refresh.
+  Evidence: `artifacts/codebase/ARCHITECTURE.md`, `TESTING.md`, and
+  `CONCERNS.md` were authored for #240 and now include #258-specific sections.
+- GSD-core is comparison context, not an implementation source for this change.
+  Evidence: local `open-gsd/gsd-core` docs describe thin orchestrator and
+  subagent context isolation, while #258 is a Slipway proof-reuse issue inside
+  existing verification gates.
+
+## Canonical References
+- `internal/engine/progression/authority.go:252`
+- `internal/engine/progression/authority.go:313`
+- `internal/engine/progression/authority.go:394`
+- `internal/engine/progression/authority.go:434`
+- `internal/engine/progression/authority.go:941`
+- `internal/engine/progression/evidence_digests.go:796`
+- `internal/engine/progression/evidence_digests.go:851`
+- `internal/model/evidence_digests.go:25`
+- `internal/model/evidence_digests.go:125`
+- `internal/tmpl/templates/skills/goal-verification/SKILL.md.tmpl:33`
+- `internal/tmpl/templates/skills/final-closeout/SKILL.md.tmpl:45`
+- `internal/tmpl/templates/skills/final-closeout/SKILL.md.tmpl:74`
+- `internal/engine/progression/authority_test.go:202`
+- `internal/engine/progression/authority_test.go:312`
+- `internal/engine/progression/evidence_digests_test.go:1004`
+- `/Users/yixianlu/ghq/github.com/open-gsd/gsd-core/docs/explanation/multi-agent-orchestration.md:21`

--- a/artifacts/changes/archived/generalize-digest-proof-reuse/tasks.md
+++ b/artifacts/changes/archived/generalize-digest-proof-reuse/tasks.md
@@ -1,0 +1,43 @@
+# Tasks
+
+## Task List
+
+- [x] `t-01` Implement the internal proof-reuse edge validator and preserve the closeout wrapper
+  - depends_on: []
+  - target_files: ["internal/engine/progression/authority.go"]
+  - task_kind: code
+  - covers: [REQ-001, REQ-002]
+  - evidence: verdict
+  - acceptance: authority.go contains an internal proof-reuse edge/check validator that is not hardcoded to final-closeout, and the existing closeout wrapper still maps invalid reuse to closeout_goal_verification_reuse_invalid
+
+- [x] `t-02` Rename genuinely shared closeout-only reuse helpers to proof-reuse-neutral helpers
+  - depends_on: ["t-01"]
+  - target_files: ["internal/engine/progression/authority.go", "internal/engine/progression/evidence_digests.go"]
+  - task_kind: code
+  - covers: [REQ-001]
+  - evidence: verdict
+  - acceptance: only helpers shared by the generalized validator use proof-reuse-neutral names; public closeout references and blocker names remain unchanged
+
+- [x] `t-03` Extend focused engine tests for edge validation and fail-closed invalidation
+  - depends_on: ["t-01", "t-02"]
+  - target_files: ["cmd/evidence.go", "cmd/evidence_skill_test.go", "cmd/execution_summary_test_helper_test.go", "internal/engine/progression/authority_test.go", "internal/engine/progression/evidence_digests_test.go", "internal/engine/progression/freshness_guard_test.go"]
+  - task_kind: test
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-005]
+  - evidence: verdict
+  - acceptance: tests cover valid closeout -> goal reuse plus stale run version, missing reuse run version, changed content, source proof older than execution evidence, missing or malformed suite-result proof, command-surface guardrail suite-result fixtures, missing guardrail SAST digest rejection, and selected-review context-origin restamp recovery
+
+- [x] `t-04` Align generated goal-verification and final-closeout guidance with validated reuse
+  - depends_on: ["t-01"]
+  - target_files: ["internal/tmpl/templates/skills/goal-verification/SKILL.md.tmpl", "internal/tmpl/templates/skills/final-closeout/SKILL.md.tmpl", "internal/tmpl/templates_test.go"]
+  - task_kind: code
+  - covers: [REQ-004]
+  - evidence: verdict
+  - acceptance: templates prefer engine-validated final-closeout reuse when current proof is fresh, keep rerun as the fail-closed fallback, and do not tell goal-verification to unconditionally skip suite-result production
+
+- [x] `t-05` Run focused verification and update task evidence
+  - depends_on: ["t-03", "t-04"]
+  - target_files: ["artifacts/changes/generalize-digest-proof-reuse/verification/execution-summary.yaml"]
+  - task_kind: verification
+  - covers: [REQ-005]
+  - evidence: artifact
+  - acceptance: focused verification records the passing command output for go test ./internal/engine/wave ./internal/engine/progression -count=1 and any template test command required by t-04

--- a/artifacts/codebase/ARCHITECTURE.md
+++ b/artifacts/codebase/ARCHITECTURE.md
@@ -1,5 +1,47 @@
 # Architecture
 
+Re-authored for change `generalize-digest-proof-reuse` (#258).
+
+## Current Change Focus: Digest-Keyed Proof Reuse
+
+The active change touches the S3/S4 verification authority path, not the
+subagent-dispatch architecture documented below for #240. The primary seam is
+`internal/engine/progression/authority.go`: `buildShipAuthorityFromReadiness`
+loads fresh goal-verification and final-closeout records, then appends
+`closeoutGoalVerificationReuseBlockers` into both `VerifySkillBlockers` and the
+unresolved ship-gate reason set so a reuse failure reaches `G_ship` as
+`closeout_goal_verification_reuse_invalid`.
+
+The current reuse implementation is closeout-specific. It is activated only when
+final-closeout records `closeout:goal_verification_reuse=pass`, then validates
+the reuse run version against goal-verification, final-closeout, and
+execution-summary, verifies execution-summary freshness, and rechecks both
+goal-verification and final-closeout digest inputs. The helpers that collect
+changed and target file content now use proof-reuse-neutral names:
+`proofReuseContentPaths`, `proofReuseWorkspacePaths`, and
+`proofReuseSkipsContentPath`. The reuse run-version reference parser remains
+closeout-token-specific as `closeoutGoalVerificationReuseRunVersion`.
+
+The proof substrate already exists outside the closeout-specific gate:
+`internal/model/evidence_digests.go` defines `SuiteResult` with
+`run_summary_version`, `full_suite_digest`, and optional `sast_digests`, while
+`SharedReviewerInputDigests` exposes those values as digest inputs. In
+`internal/engine/progression/evidence_digests.go`, goal-verification already
+uses suite-result, planning artifacts, task-plan scope, changed/target file set,
+and changed/target file content as freshness inputs. This makes the smallest
+architecture change an extraction/generalization of the existing validation
+shape, not a second proof system.
+
+### Boundaries
+
+- Keep vocabulary and low-level proof structs in `internal/model` only when they
+  are external/data contracts.
+- Keep lifecycle and ship-gate policy in `internal/engine/progression`.
+- Keep host behavior in `internal/tmpl/templates/skills/*`.
+- Do not copy GSD-core's broader orchestration architecture; it is useful
+  background for context isolation and bounded handoff, but #258 is about
+  reusing already-digest-fresh proof inside Slipway's existing lifecycle gates.
+
 Re-authored for change
 `feat-governance-host-native-subagent-enforced-cross-stage-in` (#240).
 
@@ -171,13 +213,15 @@ chain.
 Each governed stage's host-native subagent runs on the shared worktree and
 returns claims only; the host inspects the written files and records a verdict via
 `slipway evidence skill`, stamping a self-describing handle token onto
-`References`: `context_origin:stage=review=<handle>` for every selected reviewer,
-`context_origin:stage=<stage>=<handle>` for goal/closeout,
+`References`: `context_origin:stage=review=<handle>` for every selected reviewer
+including goal-verification,
 `plan_origin:<handle>` + `audit_origin:<handle>` for the plan-audit author/auditor
 pair, and the reused `executor_agent:` grammar for the S2 wave executor set.
-`cmd/evidence.go` stamps engine-owned `Timestamp`/`RunVersion` and writes
-`verification/<skill>.yaml`. `internal/model/context_attestation.go` parses those
-tokens fail-closed and exposes `CrossStageContextCollisions`. The plan gate
+`cmd/evidence.go` stamps engine-owned `Timestamp`/`RunVersion`, writes
+`verification/<skill>.yaml`, and allows a selected reviewer to restamp when its
+passing evidence has an invalid or retired review context-origin token.
+`internal/model/context_attestation.go` parses those tokens fail-closed and
+exposes `CrossStageContextCollisions`. The plan gate
 (`advance_governed.go` `EvaluatePlanGate`) consumes the local
 `plan_origin`/`audit_origin` pair; the review and ship gates (`authority.go`
 `evaluateReviewAuthorityWithPolicy` / `buildShipAuthorityFromReadiness`) build the

--- a/artifacts/codebase/CONCERNS.md
+++ b/artifacts/codebase/CONCERNS.md
@@ -1,5 +1,29 @@
 # Concerns
 
+Re-authored for change `generalize-digest-proof-reuse` (#258).
+
+## Current Change Risks: Digest-Keyed Proof Reuse
+
+- False skip risk: proof reuse must never become an unconditional shortcut. A
+  stale run version, missing suite-result, changed task/source content, or
+  missing guardrail SAST digest must force a rerun or block ship.
+- Scope creep risk: GSD-core has useful orchestration and context-isolation
+  ideas, but #258 should not copy its multi-agent workflow or expand into
+  subagent dispatch. The local root cause is redundant proof execution inside
+  existing Slipway S4 evidence gates.
+- Taxonomy risk: the current blocker is
+  `closeout_goal_verification_reuse_invalid`. A generalized validator can reuse
+  that code for the existing closeout path, but any new public blocker needs the
+  existing reason-code and recovery contract updated, not an ad hoc string.
+- Guardrail risk: SAST proof is more expensive but higher-risk than the normal
+  suite. Guardrail-domain reuse must require the `SuiteResult.SASTDigests` entry
+  for the exact `<domain>.safety_baseline` that goal-verification used.
+- First-slice risk: execution-summary -> goal-verification reuse is attractive,
+  but it is harder than closeout reuse because goal-verification is the current
+  suite-result producer. The first slice should preserve the producer role and
+  only introduce upstream reuse when the no-source/content-delta predicate is
+  explicit and test-proven.
+
 Re-authored for change
 `feat-governance-host-native-subagent-enforced-cross-stage-in` (#240).
 

--- a/artifacts/codebase/STRUCTURE.md
+++ b/artifacts/codebase/STRUCTURE.md
@@ -1,5 +1,33 @@
 # Structure
 
+Re-authored for change `generalize-digest-proof-reuse` (#258).
+
+## Current Change Focus: Digest-Keyed Proof Reuse
+
+The active change is structurally bounded to the progression engine's proof
+freshness path and the generated governance host templates:
+
+- `internal/engine/progression/authority.go` owns ship authority and the current
+  closeout -> goal-verification reuse validation. It is the target for the
+  internal proof-reuse edge/check extraction and for preserving the existing
+  closeout compatibility wrapper.
+- `internal/engine/progression/evidence_digests.go` owns digest input assembly
+  for goal-verification and final-closeout. It is only in scope for renaming or
+  sharing helpers when the helper is genuinely proof-reuse-neutral.
+- `internal/engine/progression/authority_test.go` and
+  `internal/engine/progression/evidence_digests_test.go` are the focused tests
+  for valid reuse, stale run versions, changed content, missing suite-result
+  proof, and missing guardrail SAST digest behavior.
+- `internal/tmpl/templates/skills/goal-verification/SKILL.md.tmpl` and
+  `internal/tmpl/templates/skills/final-closeout/SKILL.md.tmpl` own the
+  agent-facing proof production/reuse guidance. `internal/tmpl/templates_test.go`
+  pins the generated wording and token contracts.
+
+The change should not introduce a new top-level package, public evidence struct,
+or broad registry. The intended shape is a small internal validator in
+`internal/engine/progression` with only the existing closeout reuse edge enabled
+in production.
+
 Re-authored for change
 `feat-governance-host-native-subagent-enforced-cross-stage-in` (#240).
 
@@ -135,7 +163,10 @@ spec/code/independent trio and optional security from governance controls.
   - `evidence.go`: the producer. `makeEvidenceSkillCmd` ("evidence skill") stamps
     engine-owned `Timestamp`/`RunVersion`, passes host `--reference` values
     verbatim into the saved record, and rejects unselected security-review evidence
-    as not currently selected.
+    as not currently selected. When a selected reviewer already has passing
+    evidence but its `context_origin:stage=review=<handle>` is malformed or
+    retired, `evidence skill` allows the same reviewer to restamp fresh evidence
+    instead of dead-ending behind `evidence_skill_not_current`.
   - `next_skill_view.go`, `status_view_build.go`, `validate.go`, `review.go`,
     stale-evidence recovery, and fixtures expose `selected_review_skills` while
     preserving a conventional `Name` for single-skill consumers.
@@ -148,10 +179,11 @@ spec/code/independent trio and optional security from governance controls.
     `context_origin:stage=review=<handle>`.
   - `security-review/SKILL.md.tmpl`: selected-security S3 host; emits
     `context_origin:stage=review=<handle>` when dispatched.
-  - `goal-verification/SKILL.md.tmpl` (:88-95,166): emits
-    `context_origin:stage=goal=<handle>`.
-  - `final-closeout/SKILL.md.tmpl` (:122-149,161-181): emits
-    `context_origin:stage=closeout=<handle>`; RETAINS the engine-consumed
+  - `goal-verification/SKILL.md.tmpl` (:88-95,188): emits
+    `context_origin:stage=review=<handle>` because goal-verification is folded
+    into the selected S3 reviewer set.
+  - `final-closeout/SKILL.md.tmpl` (:122-149,161-181): no longer emits a
+    `context_origin:stage=closeout=<handle>` token; RETAINS the engine-consumed
     `closeout:reviewer_independence=pass` (#239, REQUIRED on standard/strict) and
     documents the always-on chain-order invariant.
   - `plan-audit/SKILL.md` (static, not .tmpl, :169-203): emits the author/auditor

--- a/artifacts/codebase/TESTING.md
+++ b/artifacts/codebase/TESTING.md
@@ -1,5 +1,46 @@
 # Testing
 
+Re-authored for change `generalize-digest-proof-reuse` (#258).
+
+## Current Change Focus: Digest-Keyed Proof Reuse
+
+The highest-value existing coverage lives in
+`internal/engine/progression/authority_test.go`.
+`TestCloseoutGoalVerificationReuseBlockers` already proves the current
+closeout-only reuse gate accepts a valid reuse case and rejects run-version
+mismatch, missing reuse run-version reference, execution evidence newer than
+goal-verification, changed source content, and stale execution-summary
+freshness. `TestBuildShipAuthoritySurfacesCloseoutReuseBlocker` proves the reuse
+blocker is surfaced through both verification blockers and `G_ship` reason codes.
+
+Digest coverage lives in `internal/engine/progression/evidence_digests_test.go`.
+`TestGoalVerificationDigestStalesWhenSharedSuiteInputsChange` proves changing
+the suite-result full-suite digest stales goal-verification rather than falling
+back to an unavailable generic digest. Fixture helpers already create
+`suite-result.yaml` with `run_summary_version` and `full_suite_digest`, which is
+the right starting point for SAST digest and cross-stage proof-reuse tests.
+
+The implementation should extend these focused suites before broadening to a
+full repository test run:
+
+- Generalized proof-reuse validator accepts the existing closeout -> goal path.
+- Invalidations stay fail-closed for changed artifacts/source, run-version
+  mismatch, missing suite-result proof, missing guardrail SAST digest, and stale
+  execution-summary freshness.
+- `cmd/evidence_skill_test.go` covers selected-review restamp recovery when an
+  existing passing reviewer record has a malformed or retired
+  `context_origin:stage=review=<handle>` token.
+- Final-closeout template tests show reuse-first wording when validation applies
+  and rerun fallback when validation fails.
+- Goal-verification template tests must not imply unconditional S2 proof reuse.
+
+Expected focused command before completion claims:
+
+```bash
+go test ./internal/engine/wave ./internal/engine/progression -count=1
+go test ./cmd -run 'TestEvidenceSkillAllowsSelectedReviewerRestampForInvalidContextOrigin$' -count=1
+```
+
 Re-authored for change
 `feat-governance-host-native-subagent-enforced-cross-stage-in` (#240).
 

--- a/cmd/evidence.go
+++ b/cmd/evidence.go
@@ -815,6 +815,21 @@ func currentS3ReviewAlignmentActive(root string, change model.Change) (bool, err
 	return true, nil
 }
 
+func selectedReviewContextOriginRefreshRequired(root string, change model.Change, skillName string) (bool, error) {
+	record, err := state.LoadVerification(root, change.Slug, skillName)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	if !record.IsPassing() {
+		return false, nil
+	}
+	_, ok := model.ReviewContextOriginHandleFromVerification(record)
+	return !ok, nil
+}
+
 func evidenceTaskWrongStateRemediation(root string, change model.Change) string {
 	switch change.CurrentState {
 	case model.StateS3Review:
@@ -1072,6 +1087,13 @@ func validateEvidenceSkillActionable(root string, change model.Change, def skill
 		}
 		if stringInSlice(selectedReviewSkills, def.Name) {
 			if _, ok := passing[def.Name]; ok {
+				refreshRequired, err := selectedReviewContextOriginRefreshRequired(root, change, def.Name)
+				if err != nil {
+					return err
+				}
+				if refreshRequired {
+					return nil
+				}
 				repairActive, err := currentS3ReviewAlignmentActive(root, change)
 				if err != nil {
 					return err

--- a/cmd/evidence_skill_test.go
+++ b/cmd/evidence_skill_test.go
@@ -222,6 +222,58 @@ func TestEvidenceSkillRecordsSelectedReviewPeerWithoutSpecPredecessor(t *testing
 	})
 }
 
+func TestEvidenceSkillAllowsSelectedReviewerRestampForInvalidContextOrigin(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		slug := createGovernedRequest(t, root, "L2", "evidence skill restamps invalid review origin")
+		setEvidenceSkillChangeState(t, root, slug, model.StateS3Review, model.PlanSubStepNone)
+		writePassingExecutionSummary(t, root, slug, 1, "t-01")
+		writePassingReviewEvidencePack(t, root, slug, 1)
+		writeSkillVerification(t, root, slug, progression.SkillGoalVerification, model.VerificationRecord{
+			Verdict:    model.VerificationVerdictPass,
+			Blockers:   []model.ReasonCode{},
+			Timestamp:  time.Now().UTC(),
+			RunVersion: 1,
+			References: []string{
+				"verification:pass",
+				model.ContextOriginReferencePrefix + model.StageContextGoal + "=retired-goal-context",
+			},
+		})
+		refreshPassingSkillDigestsForTest(t, root, slug, progression.SkillGoalVerification)
+
+		cmd := commandForRoot(t, root, makeEvidenceCmd())
+		cmd.SetArgs([]string{
+			"skill",
+			"--json",
+			"--change", slug,
+			"--skill", progression.SkillGoalVerification,
+			"--verdict", model.VerificationVerdictPass,
+			"--reference", "fresh:command_ref=verification/full-suite-transcript.txt",
+			"--reference", "scope_contract:pass",
+			"--reference", model.ContextOriginReferencePrefix + model.StageContextReview + "=fresh-goal-review-context",
+			"--notes", "Goal verification rerun in fresh review context.",
+		})
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		require.NoError(t, cmd.Execute())
+
+		var view evidenceSkillView
+		require.NoError(t, json.Unmarshal(out.Bytes(), &view))
+		assert.Equal(t, progression.SkillGoalVerification, view.SkillName)
+		assert.True(t, view.Recorded)
+
+		rec, err := state.LoadVerification(root, slug, progression.SkillGoalVerification)
+		require.NoError(t, err)
+		handle, ok := model.ReviewContextOriginHandleFromVerification(rec)
+		require.True(t, ok)
+		assert.Equal(t, "fresh-goal-review-context", handle.Handle)
+		assert.NotContains(t, rec.References, model.ContextOriginReferencePrefix+model.StageContextGoal+"=retired-goal-context")
+	})
+}
+
 func TestEvidenceSkillRejectsUnselectedSecurityReview(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/execution_summary_test_helper_test.go
+++ b/cmd/execution_summary_test_helper_test.go
@@ -97,6 +97,11 @@ func writeSuiteResultForCommandTest(t *testing.T, root, slug string, runVersion 
 		FullSuiteDigest:   "sha256:test-full-suite",
 		CapturedAt:        time.Now().UTC(),
 	}
+	if change.GuardrailDomain != "" {
+		result.SASTDigests = map[string]string{
+			change.GuardrailDomain + ".safety_baseline": "sha256:test-sast-baseline",
+		}
+	}
 	result.Normalize()
 	raw, err := yaml.Marshal(result)
 	require.NoError(t, err)

--- a/internal/engine/progression/authority.go
+++ b/internal/engine/progression/authority.go
@@ -395,6 +395,23 @@ const closeoutGoalVerificationReuseReference = "closeout:goal_verification_reuse
 const closeoutGoalVerificationReuseRunVersionPrefix = "closeout:goal_verification_reuse_run_version="
 const closeoutRecoveryRemediation = "rerun the selected reviewer set, then rerun final-closeout"
 
+type proofReuseEdge struct {
+	sourceSkill                         string
+	sourceLabel                         string
+	consumerSkill                       string
+	consumerLabel                       string
+	reuseRunVersion                     int
+	requireExecutionSummaryFreshness    bool
+	requireSourceAfterExecutionEvidence bool
+	digestChecks                        []proofReuseDigestCheck
+	blocker                             func(string) model.ReasonCode
+}
+
+type proofReuseDigestCheck struct {
+	skillName string
+	label     string
+}
+
 func CloseoutRecoveryRemediation() string {
 	return closeoutRecoveryRemediation
 }
@@ -458,59 +475,115 @@ func closeoutGoalVerificationReuseBlockers(
 		return []model.ReasonCode{closeoutGoalVerificationReuseInvalidBlocker("reuse run_version must be >= 1")}
 	}
 
-	goalRecord, ok := passingSkills[SkillGoalVerification]
-	if !ok || !goalRecord.IsPassing() {
-		return []model.ReasonCode{closeoutGoalVerificationReuseInvalidBlocker(
-			"goal-verification must be passing before final-closeout can reuse it",
+	blockers := proofReuseEdgeBlockers(root, change, passingSkills, summary, proofReuseEdge{
+		sourceSkill:                         SkillGoalVerification,
+		sourceLabel:                         "goal-verification",
+		consumerSkill:                       SkillFinalCloseout,
+		consumerLabel:                       "final-closeout",
+		reuseRunVersion:                     reuseRunVersion,
+		requireExecutionSummaryFreshness:    true,
+		requireSourceAfterExecutionEvidence: true,
+		digestChecks: []proofReuseDigestCheck{
+			{skillName: SkillGoalVerification, label: "goal-verification"},
+			{skillName: SkillFinalCloseout, label: "final-closeout"},
+		},
+		blocker: closeoutGoalVerificationReuseInvalidBlocker,
+	})
+	if len(blockers) > 0 {
+		return blockers
+	}
+	return nil
+}
+
+func proofReuseEdgeBlockers(
+	root string,
+	change model.Change,
+	passingSkills map[string]model.VerificationRecord,
+	summary *model.ExecutionSummary,
+	edge proofReuseEdge,
+) []model.ReasonCode {
+	blocker := edge.blocker
+	if blocker == nil {
+		blocker = func(detail string) model.ReasonCode {
+			return model.NewReasonCode("proof_reuse_invalid", strings.TrimSpace(detail))
+		}
+	}
+	if edge.reuseRunVersion < 1 {
+		return []model.ReasonCode{blocker("reuse run_version must be >= 1")}
+	}
+
+	sourceRecord, ok := passingSkills[edge.sourceSkill]
+	if !ok || !sourceRecord.IsPassing() {
+		return []model.ReasonCode{blocker(
+			proofReuseLabel(edge.sourceLabel, edge.sourceSkill) + " must be passing before " +
+				proofReuseLabel(edge.consumerLabel, edge.consumerSkill) + " can reuse it",
 		)}
 	}
-	if goalRecord.RunVersion != reuseRunVersion {
-		return []model.ReasonCode{closeoutGoalVerificationReuseInvalidBlocker(
-			fmtReuseRunMismatch("goal-verification", reuseRunVersion, goalRecord.RunVersion),
+	consumerRecord, ok := passingSkills[edge.consumerSkill]
+	if !ok || !consumerRecord.IsPassing() {
+		return []model.ReasonCode{blocker(
+			proofReuseLabel(edge.consumerLabel, edge.consumerSkill) + " must be passing before it can reuse " +
+				proofReuseLabel(edge.sourceLabel, edge.sourceSkill),
 		)}
 	}
-	if closeoutRecord.RunVersion != reuseRunVersion {
-		return []model.ReasonCode{closeoutGoalVerificationReuseInvalidBlocker(
-			fmtReuseRunMismatch("final-closeout", reuseRunVersion, closeoutRecord.RunVersion),
+	if sourceRecord.RunVersion != edge.reuseRunVersion {
+		return []model.ReasonCode{blocker(
+			fmtReuseRunMismatch(proofReuseLabel(edge.sourceLabel, edge.sourceSkill), edge.reuseRunVersion, sourceRecord.RunVersion),
+		)}
+	}
+	if consumerRecord.RunVersion != edge.reuseRunVersion {
+		return []model.ReasonCode{blocker(
+			fmtReuseRunMismatch(proofReuseLabel(edge.consumerLabel, edge.consumerSkill), edge.reuseRunVersion, consumerRecord.RunVersion),
 		)}
 	}
 	if !state.ExecutionSummaryReady(summary) {
-		return []model.ReasonCode{closeoutGoalVerificationReuseInvalidBlocker(
-			"execution-summary.yaml must be ready before final-closeout can reuse goal-verification",
+		return []model.ReasonCode{blocker(
+			"execution-summary.yaml must be ready before " +
+				proofReuseLabel(edge.consumerLabel, edge.consumerSkill) + " can reuse " +
+				proofReuseLabel(edge.sourceLabel, edge.sourceSkill),
 		)}
 	}
-	if summary.RunSummaryVersion != reuseRunVersion {
-		return []model.ReasonCode{closeoutGoalVerificationReuseInvalidBlocker(
-			fmtReuseRunMismatch("execution-summary", reuseRunVersion, summary.RunSummaryVersion),
+	if summary.RunSummaryVersion != edge.reuseRunVersion {
+		return []model.ReasonCode{blocker(
+			fmtReuseRunMismatch("execution-summary", edge.reuseRunVersion, summary.RunSummaryVersion),
 		)}
 	}
-	latestExecutionEvidenceAt := summary.LatestRelevantUpdateAt().UTC()
-	if !latestExecutionEvidenceAt.IsZero() && goalRecord.Timestamp.UTC().Before(latestExecutionEvidenceAt) {
-		return []model.ReasonCode{closeoutGoalVerificationReuseInvalidBlocker(
-			"goal-verification timestamp must be at or after latest execution evidence",
-		)}
+	if edge.requireSourceAfterExecutionEvidence {
+		latestExecutionEvidenceAt := summary.LatestRelevantUpdateAt().UTC()
+		if !latestExecutionEvidenceAt.IsZero() && sourceRecord.Timestamp.UTC().Before(latestExecutionEvidenceAt) {
+			return []model.ReasonCode{blocker(
+				proofReuseLabel(edge.sourceLabel, edge.sourceSkill) +
+					" timestamp must be at or after latest execution evidence",
+			)}
+		}
 	}
-	// Selected peer/final-closeout ordering has moved out of this opt-in reuse
-	// gate into the always-on closeoutChainOrderBlockers invariant, which carries
-	// its own distinct reason code.
-	diagnostics := state.ExecutionSummaryFreshnessDiagnostics(root, change, summary)
-	freshness := state.ProjectExecutionFreshnessForState(model.StateS3Review, diagnostics)
-	if freshness != ctxpack.EvidenceFreshnessFresh {
-		return []model.ReasonCode{closeoutGoalVerificationReuseInvalidBlocker(
-			"execution-summary freshness must be fresh, got " + string(freshness),
-		)}
+	if edge.requireExecutionSummaryFreshness {
+		diagnostics := state.ExecutionSummaryFreshnessDiagnostics(root, change, summary)
+		freshness := state.ProjectExecutionFreshnessForState(model.StateS3Review, diagnostics)
+		if freshness != ctxpack.EvidenceFreshnessFresh {
+			return []model.ReasonCode{blocker(
+				"execution-summary freshness must be fresh, got " + string(freshness),
+			)}
+		}
 	}
-	if blockers, err := skillDigestFreshnessBlockersWithSummary(root, change, SkillGoalVerification, summary); err != nil {
-		return []model.ReasonCode{closeoutGoalVerificationReuseInvalidBlocker("goal-verification digest cannot be evaluated: " + err.Error())}
-	} else if len(blockers) > 0 {
-		return []model.ReasonCode{closeoutGoalVerificationReuseInvalidBlocker("goal-verification inputs changed: " + strings.Join(blockers, ","))}
-	}
-	if blockers, err := skillDigestFreshnessBlockersWithSummary(root, change, SkillFinalCloseout, summary); err != nil {
-		return []model.ReasonCode{closeoutGoalVerificationReuseInvalidBlocker("final-closeout digest cannot be evaluated: " + err.Error())}
-	} else if len(blockers) > 0 {
-		return []model.ReasonCode{closeoutGoalVerificationReuseInvalidBlocker("final-closeout inputs changed: " + strings.Join(blockers, ","))}
+	for _, check := range edge.digestChecks {
+		label := proofReuseLabel(check.label, check.skillName)
+		blockers, err := skillDigestFreshnessBlockersWithSummary(root, change, check.skillName, summary)
+		if err != nil {
+			return []model.ReasonCode{blocker(label + " digest cannot be evaluated: " + err.Error())}
+		}
+		if len(blockers) > 0 {
+			return []model.ReasonCode{blocker(label + " inputs changed: " + strings.Join(blockers, ","))}
+		}
 	}
 	return nil
+}
+
+func proofReuseLabel(label, fallback string) string {
+	if trimmed := strings.TrimSpace(label); trimmed != "" {
+		return trimmed
+	}
+	return strings.TrimSpace(fallback)
 }
 
 // closeoutReviewerIndependenceReference is the engine-consumed presence facet of
@@ -938,7 +1011,7 @@ func crossStageContextNotDistinctBlocker(detail string) model.ReasonCode {
 	)
 }
 
-func closeoutGoalVerificationReuseContentPaths(change model.Change, summary *model.ExecutionSummary) []string {
+func proofReuseContentPaths(change model.Change, summary *model.ExecutionSummary) []string {
 	if summary == nil {
 		return nil
 	}
@@ -949,7 +1022,7 @@ func closeoutGoalVerificationReuseContentPaths(change model.Change, summary *mod
 			if trimmed == "" {
 				continue
 			}
-			if closeoutGoalVerificationReuseSkipsContentPath(change, trimmed) {
+			if proofReuseSkipsContentPath(change, trimmed) {
 				continue
 			}
 			paths = append(paths, trimmed)
@@ -962,7 +1035,7 @@ func closeoutGoalVerificationReuseContentPaths(change model.Change, summary *mod
 	return stringutil.UniqueSorted(paths)
 }
 
-func closeoutGoalVerificationReuseSkipsContentPath(change model.Change, rel string) bool {
+func proofReuseSkipsContentPath(change model.Change, rel string) bool {
 	trimmed := strings.Trim(strings.TrimSpace(filepath.ToSlash(rel)), "/")
 	bundleDir := "artifacts/changes/" + strings.TrimSpace(change.Slug)
 	eventsDir := bundleDir + "/events"
@@ -973,7 +1046,7 @@ func closeoutGoalVerificationReuseSkipsContentPath(change model.Change, rel stri
 		strings.HasPrefix(trimmed, verificationDir+"/")
 }
 
-func closeoutGoalVerificationReuseWorkspacePaths(workspaceRoot, rel string) ([]string, bool, error) {
+func proofReuseWorkspacePaths(workspaceRoot, rel string) ([]string, bool, error) {
 	trimmed := strings.TrimSpace(filepath.ToSlash(rel))
 	if trimmed == "" {
 		return nil, false, nil

--- a/internal/engine/progression/authority_test.go
+++ b/internal/engine/progression/authority_test.go
@@ -309,6 +309,115 @@ func TestCloseoutGoalVerificationReuseBlockers(t *testing.T) {
 	assert.Contains(t, blockers[0].Detail, "freshness must be fresh")
 }
 
+func TestProofReuseEdgeBlockersUsesConfiguredSourceAndConsumer(t *testing.T) {
+	t.Parallel()
+
+	change := model.NewChange("generic-proof-reuse-edge")
+	executionAt := time.Date(2026, 6, 4, 2, 0, 0, 0, time.UTC)
+	summary := closeoutReuseExecutionSummary(change, 7, executionAt)
+	passing := map[string]model.VerificationRecord{
+		"source-proof": {
+			Verdict:    model.VerificationVerdictPass,
+			Blockers:   []model.ReasonCode{},
+			Timestamp:  executionAt,
+			RunVersion: 7,
+		},
+		"consumer-proof": {
+			Verdict:    model.VerificationVerdictPass,
+			Blockers:   []model.ReasonCode{},
+			Timestamp:  executionAt.Add(time.Second),
+			RunVersion: 7,
+		},
+	}
+	edge := proofReuseEdge{
+		sourceSkill:                         "source-proof",
+		sourceLabel:                         "source-proof",
+		consumerSkill:                       "consumer-proof",
+		consumerLabel:                       "consumer-proof",
+		reuseRunVersion:                     7,
+		requireSourceAfterExecutionEvidence: true,
+		blocker:                             closeoutGoalVerificationReuseInvalidBlocker,
+	}
+
+	assert.Empty(t, proofReuseEdgeBlockers(t.TempDir(), change, passing, summary, edge))
+
+	missingSource := map[string]model.VerificationRecord{
+		"consumer-proof": passing["consumer-proof"],
+	}
+	blockers := proofReuseEdgeBlockers(t.TempDir(), change, missingSource, summary, edge)
+	require.Len(t, blockers, 1)
+	assert.Equal(t, "closeout_goal_verification_reuse_invalid", blockers[0].Code)
+	assert.Contains(t, blockers[0].Detail, "source-proof must be passing before consumer-proof can reuse it")
+
+	sourceRunMismatch := map[string]model.VerificationRecord{
+		"source-proof":   passing["source-proof"],
+		"consumer-proof": passing["consumer-proof"],
+	}
+	source := sourceRunMismatch["source-proof"]
+	source.RunVersion = 8
+	sourceRunMismatch["source-proof"] = source
+	blockers = proofReuseEdgeBlockers(t.TempDir(), change, sourceRunMismatch, summary, edge)
+	require.Len(t, blockers, 1)
+	assert.Contains(t, blockers[0].Detail, "source-proof run_version mismatch")
+
+	consumerRunMismatch := map[string]model.VerificationRecord{
+		"source-proof":   passing["source-proof"],
+		"consumer-proof": passing["consumer-proof"],
+	}
+	consumer := consumerRunMismatch["consumer-proof"]
+	consumer.RunVersion = 8
+	consumerRunMismatch["consumer-proof"] = consumer
+	blockers = proofReuseEdgeBlockers(t.TempDir(), change, consumerRunMismatch, summary, edge)
+	require.Len(t, blockers, 1)
+	assert.Contains(t, blockers[0].Detail, "consumer-proof run_version mismatch")
+
+	sourceBeforeExecutionEvidence := map[string]model.VerificationRecord{
+		"source-proof":   passing["source-proof"],
+		"consumer-proof": passing["consumer-proof"],
+	}
+	source = sourceBeforeExecutionEvidence["source-proof"]
+	source.Timestamp = executionAt.Add(-time.Second)
+	sourceBeforeExecutionEvidence["source-proof"] = source
+	blockers = proofReuseEdgeBlockers(t.TempDir(), change, sourceBeforeExecutionEvidence, summary, edge)
+	require.Len(t, blockers, 1)
+	assert.Contains(t, blockers[0].Detail, "source-proof timestamp must be at or after latest execution evidence")
+}
+
+func TestCloseoutGoalVerificationReuseRequiresSuiteResult(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	initGitWorkspaceForReadinessOptimizationTests(t, root)
+	require.NoError(t, bootstrap.InitWorkspace(root, nil, false))
+
+	change := model.NewChange("ship-closeout-reuse-missing-suite-result")
+	change.WorkflowPreset = model.WorkflowPresetStandard
+	change.CurrentState = model.StateS3Review
+	require.NoError(t, state.SaveChange(root, change))
+	writeDigestPlanningBundle(t, root, change, uncheckedDigestTasks())
+
+	executionAt := time.Date(2026, 6, 4, 3, 0, 0, 0, time.UTC)
+	passing := passingCloseoutReuseRecords(1)
+	goal := passing[SkillGoalVerification]
+	goal.Timestamp = executionAt.Add(time.Minute)
+	passing[SkillGoalVerification] = goal
+	closeout := passing[SkillFinalCloseout]
+	closeout.Timestamp = executionAt.Add(2 * time.Minute)
+	passing[SkillFinalCloseout] = closeout
+
+	blockers := closeoutGoalVerificationReuseBlockers(
+		root,
+		change,
+		passing,
+		nil,
+		closeoutReuseExecutionSummary(change, 1, executionAt),
+	)
+	require.Len(t, blockers, 1)
+	assert.Equal(t, "closeout_goal_verification_reuse_invalid", blockers[0].Code)
+	assert.Contains(t, blockers[0].Detail, "goal-verification inputs changed")
+	assert.Contains(t, blockers[0].Detail, "required_skill_stale:goal-verification:input_digest_unavailable")
+}
+
 func TestBuildShipAuthoritySurfacesCloseoutReuseBlocker(t *testing.T) {
 	t.Parallel()
 

--- a/internal/engine/progression/evidence_digests.go
+++ b/internal/engine/progression/evidence_digests.go
@@ -750,8 +750,8 @@ func addContentPathInputs(
 	if err != nil {
 		return err
 	}
-	for _, rel := range closeoutGoalVerificationReuseContentPaths(change, summary) {
-		candidates, ok, err := closeoutGoalVerificationReuseWorkspacePaths(paths.WorkspaceRoot, rel)
+	for _, rel := range proofReuseContentPaths(change, summary) {
+		candidates, ok, err := proofReuseWorkspacePaths(paths.WorkspaceRoot, rel)
 		if err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
 				hash, hashErr := deletedFileInputHash(rel)
@@ -774,7 +774,7 @@ func addContentPathInputs(
 					key = filepath.ToSlash(display)
 				}
 			}
-			if closeoutGoalVerificationReuseSkipsContentPath(change, key) {
+			if proofReuseSkipsContentPath(change, key) {
 				continue
 			}
 			var hash string
@@ -837,7 +837,7 @@ func addGoalVerificationInputs(
 }
 
 func addChangedTargetFileSetInput(change model.Change, summary *model.ExecutionSummary, inputs map[string]string) error {
-	contentPaths := closeoutGoalVerificationReuseContentPaths(change, summary)
+	contentPaths := proofReuseContentPaths(change, summary)
 	hash, err := model.ComputeInputHash(map[string]any{
 		"changed_target_files": contentPaths,
 	})
@@ -950,6 +950,9 @@ func addSharedReviewerInputs(
 				summary.RunSummaryVersion,
 			)
 		}
+		if err := requireGuardrailSuiteResultSASTDigest(change, result); err != nil {
+			return err
+		}
 		shared, err := result.SharedReviewerInputDigests()
 		if err != nil {
 			return err
@@ -963,6 +966,26 @@ func addSharedReviewerInputs(
 		return errDigestInputsUnavailable
 	}
 	return addExecutionSummaryInputs(summary, inputs)
+}
+
+func requireGuardrailSuiteResultSASTDigest(change model.Change, result model.SuiteResult) error {
+	required := requiredGuardrailSuiteResultSASTDigestName(change)
+	if required == "" {
+		return nil
+	}
+	result.Normalize()
+	if strings.TrimSpace(result.SASTDigests[required]) == "" {
+		return errDigestInputsUnavailable
+	}
+	return nil
+}
+
+func requiredGuardrailSuiteResultSASTDigestName(change model.Change) string {
+	domain := strings.TrimSpace(change.GuardrailDomain)
+	if domain == "" {
+		return ""
+	}
+	return domain + ".safety_baseline"
 }
 
 func requiresSuiteResultForSharedReviewerInputs(change model.Change) bool {
@@ -1006,7 +1029,7 @@ func addReviewSummaryContentInputs(root string, change model.Change, summary *mo
 	if err != nil {
 		return err
 	}
-	for _, rel := range closeoutGoalVerificationReuseContentPaths(change, summary) {
+	for _, rel := range proofReuseContentPaths(change, summary) {
 		rel = filepath.ToSlash(strings.TrimSpace(rel))
 		if rel == "" || reviewInputPathExcluded(rel) {
 			continue
@@ -1025,7 +1048,7 @@ func addReviewSummaryContentInputs(root string, change model.Change, summary *mo
 			}
 			continue
 		}
-		candidates, ok, err := closeoutGoalVerificationReuseWorkspacePaths(paths.WorkspaceRoot, rel)
+		candidates, ok, err := proofReuseWorkspacePaths(paths.WorkspaceRoot, rel)
 		if err != nil {
 			return err
 		}

--- a/internal/engine/progression/evidence_digests_test.go
+++ b/internal/engine/progression/evidence_digests_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/signalridge/slipway/internal/state"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestPlanAuditInputDigestExcludesAssuranceAndIncludesStructuralTasks(t *testing.T) {
@@ -1024,6 +1025,100 @@ func TestGoalVerificationDigestStalesWhenSharedSuiteInputsChange(t *testing.T) {
 	assert.NotContains(t, blockers, "required_skill_stale:goal-verification:input_digest_unavailable")
 }
 
+func TestGoalVerificationDigestRequiresValidSuiteResult(t *testing.T) {
+	t.Parallel()
+
+	root, change := createReviewInputDigestFixture(t)
+	summary := digestPolicyExecutionSummary(change, []string{"tracked.go"})
+	require.NoError(t, state.SaveExecutionSummary(root, change.Slug, *summary))
+
+	record := model.VerificationRecord{
+		Verdict:    model.VerificationVerdictPass,
+		Blockers:   []model.ReasonCode{},
+		Timestamp:  time.Date(2026, 6, 4, 1, 21, 0, 0, time.UTC),
+		RunVersion: 1,
+	}
+	require.NoError(t, StampEvidenceDigestForSkill(root, change, SkillGoalVerification, record, summary))
+
+	bundleDir, err := state.GovernedBundleDir(root, change)
+	require.NoError(t, err)
+	verificationDir := filepath.Join(bundleDir, "verification")
+	require.NoError(t, os.WriteFile(filepath.Join(verificationDir, suiteResultFileName), []byte(fmt.Sprintf(`version: %d
+run_summary_version: 1
+`, model.SuiteResultVersion)), 0o644))
+
+	blockers, err := skillDigestFreshnessBlockersWithSummary(root, change, SkillGoalVerification, summary)
+	require.NoError(t, err)
+	assert.Contains(t, blockers, "required_skill_stale:goal-verification:input_digest_unavailable")
+}
+
+func TestGoalVerificationDigestRejectsSuiteResultWrongRunVersion(t *testing.T) {
+	t.Parallel()
+
+	root, change := createReviewInputDigestFixtureWithoutSuiteResult(t)
+	writeSuiteResultForDigestTest(t, root, change, 2, "sha256:full-suite-v1")
+	summary := digestPolicyExecutionSummary(change, []string{"tracked.go"})
+	require.NoError(t, state.SaveExecutionSummary(root, change.Slug, *summary))
+
+	blockers, err := skillDigestFreshnessBlockersWithSummary(root, change, SkillGoalVerification, summary)
+	require.NoError(t, err)
+	assert.Contains(t, blockers, "required_skill_stale:goal-verification:input_digest_unavailable")
+}
+
+func TestGoalVerificationDigestRequiresGuardrailSASTDigest(t *testing.T) {
+	t.Parallel()
+
+	root, change := createReviewInputDigestFixtureWithoutSuiteResult(t)
+	change.GuardrailDomain = model.GuardrailDomainExternalAPIContracts
+	require.NoError(t, state.SaveChange(root, change))
+	writeSuiteResultForDigestTest(t, root, change, 1, "sha256:full-suite-v1")
+	summary := digestPolicyExecutionSummary(change, []string{"tracked.go"})
+	require.NoError(t, state.SaveExecutionSummary(root, change.Slug, *summary))
+
+	record := model.VerificationRecord{
+		Verdict:    model.VerificationVerdictPass,
+		Blockers:   []model.ReasonCode{},
+		Timestamp:  time.Date(2026, 6, 4, 1, 21, 30, 0, time.UTC),
+		RunVersion: 1,
+		References: []string{
+			"high_risk_check:external_api_contracts.safety_baseline=pass",
+		},
+	}
+
+	err := StampEvidenceDigestForSkill(root, change, SkillGoalVerification, record, summary)
+	require.ErrorIs(t, err, errDigestInputsUnavailable)
+
+	blockers, err := skillDigestFreshnessBlockersWithSummary(root, change, SkillGoalVerification, summary)
+	require.NoError(t, err)
+	assert.Contains(t, blockers, "required_skill_stale:goal-verification:input_digest_unavailable")
+}
+
+func TestGoalVerificationDigestStalesWhenSuiteResultSASTDigestDisappears(t *testing.T) {
+	t.Parallel()
+
+	root, change := createReviewInputDigestFixtureWithoutSuiteResult(t)
+	writeSuiteResultForDigestTestWithSAST(t, root, change, 1, "sha256:full-suite-v1", map[string]string{
+		"credentials.safety_baseline": "sha256:sast-v1",
+	})
+	summary := digestPolicyExecutionSummary(change, []string{"tracked.go"})
+	require.NoError(t, state.SaveExecutionSummary(root, change.Slug, *summary))
+
+	record := model.VerificationRecord{
+		Verdict:    model.VerificationVerdictPass,
+		Blockers:   []model.ReasonCode{},
+		Timestamp:  time.Date(2026, 6, 4, 1, 22, 0, 0, time.UTC),
+		RunVersion: 1,
+	}
+	require.NoError(t, StampEvidenceDigestForSkill(root, change, SkillGoalVerification, record, summary))
+
+	writeSuiteResultForDigestTest(t, root, change, 1, "sha256:full-suite-v1")
+
+	blockers, err := skillDigestFreshnessBlockersWithSummary(root, change, SkillGoalVerification, summary)
+	require.NoError(t, err)
+	assert.Contains(t, blockers, "required_skill_stale:goal-verification:suite-result:sast:credentials.safety_baseline")
+	assert.NotContains(t, blockers, "required_skill_stale:goal-verification:input_digest_unavailable")
+}
+
 func TestGoalAndCloseoutDigestIgnoresRuntimeOnlyChangeYAMLMutation(t *testing.T) {
 	t.Parallel()
 
@@ -1809,6 +1904,19 @@ func createReviewInputDigestFixtureWithSuiteResult(t *testing.T, withSuiteResult
 func writeSuiteResultForDigestTest(t *testing.T, root string, change model.Change, runVersion int, fullSuiteDigest string) {
 	t.Helper()
 
+	writeSuiteResultForDigestTestWithSAST(t, root, change, runVersion, fullSuiteDigest, nil)
+}
+
+func writeSuiteResultForDigestTestWithSAST(
+	t *testing.T,
+	root string,
+	change model.Change,
+	runVersion int,
+	fullSuiteDigest string,
+	sastDigests map[string]string,
+) {
+	t.Helper()
+
 	bundleDir, err := state.GovernedBundleDir(root, change)
 	require.NoError(t, err)
 	verificationDir := filepath.Join(bundleDir, "verification")
@@ -1816,11 +1924,15 @@ func writeSuiteResultForDigestTest(t *testing.T, root string, change model.Chang
 	if strings.TrimSpace(fullSuiteDigest) == "" {
 		fullSuiteDigest = "sha256:full-suite-v1"
 	}
-	content := fmt.Sprintf(`version: %d
-run_summary_version: %d
-full_suite_digest: %q
-`, model.SuiteResultVersion, runVersion, fullSuiteDigest)
-	require.NoError(t, os.WriteFile(filepath.Join(verificationDir, suiteResultFileName), []byte(content), 0o644))
+	result := model.SuiteResult{
+		Version:           model.SuiteResultVersion,
+		RunSummaryVersion: runVersion,
+		FullSuiteDigest:   fullSuiteDigest,
+		SASTDigests:       sastDigests,
+	}
+	raw, err := yaml.Marshal(result)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(verificationDir, suiteResultFileName), raw, 0o644))
 }
 
 func digestPolicyExecutionSummary(change model.Change, targetFiles []string) *model.ExecutionSummary {

--- a/internal/engine/progression/freshness_guard_test.go
+++ b/internal/engine/progression/freshness_guard_test.go
@@ -84,7 +84,7 @@ func TestGenericEvidenceFreshnessDoesNotUseTimestampOrdering(t *testing.T) {
 	}
 }
 
-func TestAuthorityTimestampOrderingIsLimitedToCloseoutProofOrdering(t *testing.T) {
+func TestAuthorityTimestampOrderingIsLimitedToProofOrderingGates(t *testing.T) {
 	t.Parallel()
 
 	repoRoot := repositoryRootForFreshnessGuard(t)
@@ -94,10 +94,10 @@ func TestAuthorityTimestampOrderingIsLimitedToCloseoutProofOrdering(t *testing.T
 	}
 	if !sourceTokensLimitedToFunctions(string(raw),
 		[]string{".Before(", ".After("},
-		"func closeoutGoalVerificationReuseBlockers(",
+		"func proofReuseEdgeBlockers(",
 		"func closeoutChainOrderBlockers(",
 	) {
-		t.Fatalf("authority timestamp ordering must stay limited to closeout proof-ordering gates")
+		t.Fatalf("authority timestamp ordering must stay limited to proof-ordering gates")
 	}
 }
 

--- a/internal/tmpl/templates/skills/final-closeout/SKILL.md.tmpl
+++ b/internal/tmpl/templates/skills/final-closeout/SKILL.md.tmpl
@@ -16,7 +16,8 @@ rest on stale evidence.
 
 ## Workflow Outline
 1. Re-read the verification index and closeout prerequisites.
-2. Re-run the proving commands, or validate the goal-verification reuse branch.
+2. Prefer engine-validated goal-verification proof reuse when the current proof
+   is fresh; rerun the proving commands when reuse validation fails.
 3. Confirm freshness, completeness, and assurance.
 4. Write the closeout verdict and wait for approval.
 
@@ -46,9 +47,10 @@ freshness/readiness state. Examine:
 Verify ALL of the following before producing closeout verification:
 - [ ] verification records match current `run_version`
 - [ ] every required governance skill has a passing verification record
-- [ ] full test suite runs green (not cached, not partial)
-- [ ] if reusing goal-verification proof, reuse is for the current run_version
-      and active content state
+- [ ] full-suite proof is green, either by engine-validated goal-verification
+      reuse or by rerunning the suite (not cached, not partial)
+- [ ] if reusing goal-verification proof, engine-visible state proves reuse is
+      for the current run_version and active content state
 - [ ] `validate --json` proves active-change freshness/readiness before `done`;
       archived bundles are frozen records, not inputs to this active gate
 - [ ] blocker list is empty
@@ -72,9 +74,16 @@ Minimum record:
 {{template "fresh-evidence-minimum-record"}}
 
 ## Goal-Verification Reuse Branch
-You may avoid rerunning duplicate full-suite proof only when goal-verification is
-already fresh for the current run_version and current content state. Before
-using this branch:
+Prefer this branch before rerunning duplicate full-suite or SAST proof when
+current goal-verification proof is already fresh. Reuse is valid only when the
+engine can validate the edge from engine-visible state: passing
+goal-verification and final-closeout records, matching run_version across
+goal-verification, final-closeout, and execution-summary, ready/fresh
+execution-summary state, goal-verification proof at or after the latest
+execution evidence, and fresh digest inputs for both records, including
+`verification/suite-result.yaml`.
+
+Before recording this branch:
 
 1. Run `slipway validate --json` (freshness/readiness) and `slipway status --json`
    (`progress.run_summary_version`).
@@ -91,9 +100,12 @@ using this branch:
    - `closeout:goal_verification_reuse=pass`
    - `closeout:goal_verification_reuse_run_version=<current run_version>`
 
-If any check fails, rerun the normal closeout proof instead. The ship gate
-rejects reuse when the final-closeout record, goal-verification record, and
-execution-summary.yaml do not agree on the same fresh run_version.
+After recording the references, run `slipway validate --json` and treat the
+engine verdict as authoritative. Lifecycle advancement belongs only to the
+Present and Advance section below after explicit confirmation. If the engine
+returns `closeout_goal_verification_reuse_invalid`, or any preflight check above
+fails, rerun the normal closeout proof instead. Do not override the engine's
+reuse verdict with a manual freshness judgment.
 
 ## Assurance Artifact Verification
 On light preset, skip this section — `assurance.md` is optional.

--- a/internal/tmpl/templates/skills/goal-verification/SKILL.md.tmpl
+++ b/internal/tmpl/templates/skills/goal-verification/SKILL.md.tmpl
@@ -49,6 +49,12 @@ If the file is absent, malformed, or tied to a different run version, stop and
 produce fresh suite-result proof before recording goal-verification evidence.
 Selected S3 peer evidence is not fresh without this keystone.
 
+Do not treat S2 execution proof, execution-summary, or an earlier full-suite
+transcript as a substitute for `verification/suite-result.yaml`. Those artifacts
+may inform the suite-result only after you confirm they match the current
+run_version and content state, and only if you still produce or refresh the
+suite-result record.
+
 ## Read Context
 Run `slipway next --json` for the handoff, `slipway status --json` for the
 current `run_summary_version` (`progress.run_summary_version`), and

--- a/internal/tmpl/templates_test.go
+++ b/internal/tmpl/templates_test.go
@@ -286,6 +286,8 @@ func TestGoalVerificationTemplateEmitsReviewContextOriginHandle(t *testing.T) {
 	assert.Contains(t, content, "context_origin:stage=review=<handle>")
 	assertSelectedS3SuiteResultKeystone(t, content)
 	assert.Contains(t, content, "full_suite_digest")
+	assert.Contains(t, content, "Do not treat S2 execution proof, execution-summary, or an earlier full-suite")
+	assert.Contains(t, content, "only if you still produce or refresh the")
 	assert.NotContains(t, content, "context_origin:stage=goal=<handle>")
 	assert.NotContains(t, content, "review_origin:skill=")
 }
@@ -1190,13 +1192,30 @@ func TestFinalCloseoutSkillDocumentsGoalVerificationReuseContract(t *testing.T) 
 		"Trigger": "/slipway:final-closeout",
 	})
 	require.NoError(t, err)
+	flat := strings.Join(strings.Fields(content), " ")
 
 	assert.Contains(t, content, "## Goal-Verification Reuse Branch")
 	assert.Contains(t, content, "closeout:goal_verification_reuse=pass")
 	assert.Contains(t, content, "closeout:goal_verification_reuse_run_version=<current run_version>")
 	assert.Contains(t, content, "slipway validate --json")
 	assert.Contains(t, content, "captured at or after the latest execution")
-	assert.Contains(t, content, "current `run_version`, freshness inputs, and content state still match")
+	assert.Contains(t, content, "Prefer this branch before rerunning duplicate full-suite or SAST proof")
+	assert.Contains(t, content, "engine-visible state")
+	assert.Contains(t, flat, "If the engine returns")
+	assert.Contains(t, content, "closeout_goal_verification_reuse_invalid")
+	assert.Contains(t, content, "rerun the normal closeout proof instead")
+	assert.Contains(t, flat, "Do not override the engine's reuse")
+	assert.Contains(t, content, "manual freshness judgment")
+
+	reuseBranch := content
+	if start := strings.Index(content, "## Goal-Verification Reuse Branch"); start >= 0 {
+		reuseBranch = content[start:]
+	}
+	if end := strings.Index(reuseBranch, "## Assurance Artifact Verification"); end >= 0 {
+		reuseBranch = reuseBranch[:end]
+	}
+	assert.NotContains(t, reuseBranch, "`slipway run`")
+	assert.Contains(t, reuseBranch, "Present and Advance section below after explicit confirmation")
 }
 
 func TestVariantAnalysisSkillMakesReferenceShelfVisible(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add an internal proof-reuse edge validator for the existing final-closeout -> goal-verification reuse path without changing the public closeout evidence tokens or blocker vocabulary.
- Make selected-review and goal-verification proof reuse fail closed on missing, malformed, wrong-run, or guardrail-incomplete `verification/suite-result.yaml` inputs.
- Update generated final-closeout and goal-verification guidance so agents use the folded S3 review model, preserve `verification/suite-result.yaml` as the suite-result keystone, and avoid retired goal/closeout context-origin tokens.
- Add a narrow evidence CLI recovery path for selected reviewers whose current passing evidence has a retired or malformed review context-origin token.
- Archive the governed change bundle for `generalize-digest-proof-reuse`.

## Why

Issue #258 needed proof reuse to stop being a closeout-only special case while keeping the first production slice conservative. The implementation introduces a reusable internal edge shape, keeps the public final-closeout contract stable, and hardens the suite-result/SAST digest inputs so reuse cannot silently skip stale full-suite or guardrail proof.

## Validation

- `go test ./... -count=1`
- `go test ./internal/tmpl -run 'TestFinalCloseoutTemplate(DoesNotEmitRetiredContextOriginHandle|RequiresReviewerIndependenceAndChainOrder|DocumentsGoalVerificationReuseContract)$' -count=1`
- `go test ./internal/toolgen -run 'Test.*Codex|Test.*Skill' -count=1`
- `git diff --check`
- Governed lifecycle: `go run . validate --json` approved `G_ship`; `go run . done --json` archived the change.

Closes #258
