### PR TITLE
fix: run fresh context boundary

### DIFF
--- a/internal/tmpl/templates/_partials/command-run-body.tmpl
+++ b/internal/tmpl/templates/_partials/command-run-body.tmpl
@@ -61,8 +61,14 @@ policy. Do not let the same long-running execution context review its own prior
 implementation work. `final-closeout` is the last closeout step after the
 selected peer set, not a selected S3 peer.
 
-## Subagent Continuation Rule (HARD RULE)
-After any checkpoint pause, user intervention, or governed review handoff, a fresh subagent MUST be spawned to continue execution. Do not resume in the same context that produced the prior evidence.
+## Fresh Context Boundary Rule (HARD RULE)
+Use a fresh subagent for checkpoint resume that consumes operator input
+(`--resume-response`) and for governed review handoffs, especially selected S3
+peer reviewers. A plain operator confirmation to run an advancing command after
+already-recorded evidence does not by itself require spawning a subagent; the
+current host may run that lifecycle transition and then stop at any review
+batch, checkpoint, blocker, or next-skill handoff. Do not let the same
+implementation context perform its own selected S3 peer review evidence.
 
 ## Failure Handling
 1. On any command/runtime error, stop and show the error details.

--- a/internal/tmpl/templates_test.go
+++ b/internal/tmpl/templates_test.go
@@ -1211,8 +1211,14 @@ func TestRunCommandEntryContainsLoopBehavioralBlocks(t *testing.T) {
 	assert.Contains(t, content, "`final-closeout` is the last closeout step",
 		"run command must classify final-closeout after selected peers")
 
-	assert.Contains(t, content, "Subagent Continuation Rule (HARD RULE)",
-		"run command missing subagent continuation hard rule")
+	assert.Contains(t, content, "Fresh Context Boundary Rule (HARD RULE)",
+		"run command missing fresh-context boundary rule")
+	assert.Contains(t, content, "plain operator confirmation",
+		"run command must not require fresh subagents for plain lifecycle confirmations")
+	assert.Contains(t, content, "does not by itself require spawning a subagent",
+		"run command must distinguish confirmation from checkpoint/review handoff")
+	assert.NotContains(t, content, "After any checkpoint pause, user intervention, or governed review handoff",
+		"run command must not treat every user intervention as a fresh-subagent boundary")
 
 	assert.Contains(t, content, "three consecutive skills fail",
 		"run command missing 3-consecutive-failure exit rule")


### PR DESCRIPTION
## Summary
- Tighten the generated `slipway run` skill guidance so fresh subagents are required for checkpoint resume input and governed review handoffs.
- Clarify that ordinary operator confirmation for an already-evidenced lifecycle advance does not require a fresh subagent.
- Update template coverage to prevent the old overbroad rule from returning.

## Validation
- `git diff --check`
- `go test ./internal/tmpl`
- `go test ./internal/toolgen -run 'TestGeneratedAdapterSurfacesStayInSyncWithRegistry|TestGeneratedWaveOrchestrationCodexDispatchUsesSpawnAgent|TestGeneratedCommandEntriesIncludeClassMetadata'`