### PR TITLE
feat: expand AI tool adapters

### DIFF
--- a/artifacts/changes/archived/expand-ai-tool-adapters/assurance.md
+++ b/artifacts/changes/archived/expand-ai-tool-adapters/assurance.md
@@ -1,0 +1,142 @@
+# Assurance
+
+## Scope Summary
+
+This change adds the P1 AI-tool adapter set selected for
+`expand-ai-tool-adapters`: `pi`, `qwen`, `kiro`, `copilot`, `windsurf`, and
+`kilo`. The P1 adapters join the existing `claude`, `codex`, `cursor`,
+`gemini`, and `opencode` adapters, and are available through explicit
+`slipway init --tools <id>` selection and through deterministic `--tools all`
+expansion.
+
+The delivered implementation keeps adapters thin and project-local. Generated
+host files route users back to the `slipway` CLI and do not implement a
+parallel lifecycle engine. The implementation adds narrow generator axes for
+Copilot `.prompt.md` command files, Pi registration settings, Qwen/Kiro
+command-skill surfaces, and Windsurf/Kilo workflow-style surfaces. Refresh
+behavior remains sentinel/ownership controlled and preserves user-owned files in
+shared host directories, including Copilot's shared `.github` root.
+
+The governed scope includes toolgen implementation, adapter contract and
+generation tests, adapter documentation, installation documentation, the public
+surface manifest, implementation verification notes, and exempt codebase-map
+context updates.
+
+## Verification Verdict
+
+Verdict: pass for the governed P1 adapter objective.
+
+All selected S3 review skills have passing Slipway evidence at
+`run_version: 1`:
+
+- `spec-compliance-review`: pass, recorded at
+  `artifacts/changes/expand-ai-tool-adapters/verification/spec-compliance-review.yaml`.
+- `code-quality-review`: pass, recorded at
+  `artifacts/changes/expand-ai-tool-adapters/verification/code-quality-review.yaml`.
+- `independent-review`: pass, recorded at
+  `artifacts/changes/expand-ai-tool-adapters/verification/independent-review.yaml`.
+- `goal-verification`: pass, recorded at
+  `artifacts/changes/expand-ai-tool-adapters/verification/goal-verification.yaml`.
+
+The final shared full-suite proof is
+`artifacts/changes/expand-ai-tool-adapters/verification/goal-verification-full-suite.txt`.
+It records `go test -count=1 -timeout=20m ./...` exiting 0, including
+`cmd 313.718s`, `internal/toolgen 207.466s`, and
+`internal/toolgen/cmd/gen-surface-manifest 1.320s`. The suite digest in
+`artifacts/changes/expand-ai-tool-adapters/verification/suite-result.yaml` is
+`7ad511145d33124a74970c16162dd3a5c3ba1d3adc40c8e758d10a1eb771bacd` and
+matches `run_summary_version: 1`.
+
+`slipway validate --json` after recording the selected S3 review evidence
+reported `skills_ready` pass for the four selected reviewers, fresh evidence,
+valid requirements/tasks/decision contracts, and `scope_contract.status: pass`.
+The remaining blockers at that point were limited to the expected final-closeout
+and assurance controls.
+
+## Evidence Index
+
+- Requirements: `artifacts/changes/expand-ai-tool-adapters/requirements.md`
+  defines REQ-001 through REQ-005.
+- Tasks: `artifacts/changes/expand-ai-tool-adapters/tasks.md` records completed
+  tasks `t-01` through `t-04`, including the S3 repair scope update for
+  `docs/installation.md`.
+- Decision: `artifacts/changes/expand-ai-tool-adapters/decision.md` selects the
+  full P1 adapter set and the thin-adapter generator approach.
+- Implementation evidence:
+  `artifacts/changes/expand-ai-tool-adapters/verification/implementation.md`.
+- S3 repair evidence:
+  `artifacts/changes/expand-ai-tool-adapters/verification/review-fix-notes.md`.
+- Execution summary:
+  `artifacts/changes/expand-ai-tool-adapters/verification/execution-summary.yaml`.
+- Suite result:
+  `artifacts/changes/expand-ai-tool-adapters/verification/suite-result.yaml`.
+- Full-suite transcript:
+  `artifacts/changes/expand-ai-tool-adapters/verification/goal-verification-full-suite.txt`.
+- Spec review:
+  `artifacts/changes/expand-ai-tool-adapters/verification/spec-compliance-review.yaml`.
+- Code-quality review:
+  `artifacts/changes/expand-ai-tool-adapters/verification/code-quality-review.yaml`.
+- Independent review:
+  `artifacts/changes/expand-ai-tool-adapters/verification/independent-review.yaml`.
+- Goal verification:
+  `artifacts/changes/expand-ai-tool-adapters/verification/goal-verification.yaml`.
+
+## Requirement Coverage
+
+| Requirement | Coverage |
+| --- | --- |
+| REQ-001 P1 adapter selection | Covered by the P1 registry entries for `copilot`, `kilo`, `kiro`, `pi`, `qwen`, and `windsurf`, deterministic registry sorting, `ResolveTools("all")`, and tests asserting the 11-adapter order. Evidence: `spec-compliance-review.yaml`, `goal-verification.yaml`, and `implementation.md`. |
+| REQ-002 P1 generated surfaces | Covered by generated Pi prompts/skills/settings, Copilot prompts/skills, Qwen/Kiro command skills, Windsurf/Kilo workflows, and contract tests for generated paths, triggers, settings, and command invocation text. Evidence: `spec-compliance-review.yaml`, `code-quality-review.yaml`, `goal-verification.yaml`, and `implementation.md`. |
+| REQ-003 adapter ownership and refresh safety | Covered by sentinel/ownership generation, modified-managed-file refusal, bare P1 host directory non-detection, unknown cleanup preservation, and Copilot shared `.github` preservation tests. Evidence: `review-fix-notes.md`, `spec-compliance-review.yaml`, `independent-review.yaml`, and `goal-verification.yaml`. |
+| REQ-004 documentation and manifest visibility | Covered by `docs/ai-tools.md`, `docs/reference/ai-tools.md`, repaired `docs/installation.md`, regenerated `docs/SURFACE-MANIFEST.json`, manifest derivation tests, committed manifest checks, and docs-token tests. Evidence: `review-fix-notes.md`, `code-quality-review.yaml`, `spec-compliance-review.yaml`, and `goal-verification.yaml`. |
+| REQ-005 verification | Covered by focused toolgen tests, adapter contract tests, docs/manifest checks, `git diff --check`, and the final uncached full-suite run `go test -count=1 -timeout=20m ./...` with digest `7ad511145d33124a74970c16162dd3a5c3ba1d3adc40c8e758d10a1eb771bacd`. Evidence: `suite-result.yaml`, `goal-verification-full-suite.txt`, `goal-verification.yaml`, and `implementation.md`. |
+
+## Residual Risks and Exceptions
+
+- Some broad overview docs outside the governed REQ-004 surfaces still use
+  pre-P1 wording that mentions only the original adapter set. The S3
+  code-quality review classified this as non-blocking because the scoped
+  adapter reference, installation guidance, and surface manifest are current.
+  A later docs cleanup can refresh those overview summaries.
+- The adapter ecosystem may continue to evolve outside this change. This change
+  intentionally validates the current P1 set and keeps the generator extensible
+  through narrow adapter config fields, not host-specific lifecycle engines.
+- Copilot uses the shared `.github` directory. The implemented mitigation is a
+  dedicated `.github/copilot/slipway` sentinel/ownership root plus refresh tests
+  proving user-owned `.github` files are not claimed or overwritten.
+- Pi settings registration is not hook registration. The implemented mitigation
+  is a distinct Pi settings mode that merges `enableSkillCommands`, `skills`,
+  and `prompts` while preserving unrelated settings.
+
+No accepted exception bypasses a requirement, review gate, ownership check, or
+full-suite verification.
+
+## Rollback Readiness
+
+Rollback is file-level and does not require a data migration, credential
+rotation, schema change, or external service rollback. To roll back, revert the
+toolgen registry/model changes, adapter tests, adapter docs,
+`docs/installation.md`, `docs/SURFACE-MANIFEST.json`, and this change bundle's
+governed artifacts. If the manifest is changed during rollback, rerun
+`go run ./internal/toolgen/cmd/gen-surface-manifest --write` and verify with
+`go test ./internal/toolgen/...`.
+
+Generated adapter files in user workspaces are opt-in, project-local surfaces.
+They remain under Slipway sentinel/ownership control and can be removed or
+refreshed by users without changing repository runtime state.
+
+## Archive Decision
+
+Archive readiness decision: ready for final-closeout review, not yet archived.
+
+Active `slipway validate --json` proof was captured after selected S3 reviewer
+evidence was recorded and before `done`; it reported fresh evidence, valid
+requirements/tasks/decision contracts, `scope_contract.status: pass`, and the
+four selected review skills ready. The only remaining active blockers are the
+expected final-closeout controls that must be recorded before lifecycle
+advancement.
+
+Before `slipway done`, final-closeout must still record fresh
+`closeout:reviewer_independence=pass` and `closeout:assurance_complete=pass`
+attestations, and the active validation gate must be checked again. Archived
+bundles are not used as active validation input.

--- a/artifacts/changes/archived/expand-ai-tool-adapters/change.yaml
+++ b/artifacts/changes/archived/expand-ai-tool-adapters/change.yaml
@@ -1,0 +1,61 @@
+version: 1
+slug: expand-ai-tool-adapters
+description: expand ai tool adapters
+status: done
+current_state: DONE
+needs_discovery: true
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-06-19T04:41:01.073301Z
+quality_mode: standard
+workflow_profile: code
+workflow_preset: standard
+worktree_branch: feat/expand-ai-tool-adapters
+artifact_schema: expanded
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: ff22ced2ef3583889e27e432db8fbbabb3d7acd83486d9a3d7045a36951761c4
+        updated_at: 2026-06-19T08:58:56.930983152Z
+    decision:
+        id: decision
+        path: decision.md
+        state: frozen
+        content_hash: 9787b378d88a82cdc0924c4e617dfa903be4419e33e4eab1a272957ef60e33f8
+        updated_at: 2026-06-19T05:34:13.300692527Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: fa176760e066d210d6f77a5a4f79639c3e63a67fcabb082a3e7baefad530885f
+        updated_at: 2026-06-19T05:47:16.187811775Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: d4592987b285e099295d04e6bc5e760a7ffb7c547de6ed345137ba49b25f5fc0
+        updated_at: 2026-06-19T05:34:13.300428568Z
+    research:
+        id: research
+        path: research.md
+        state: frozen
+        content_hash: a2a363cd9b54b4ede37f4d9fd46cc4f66376a75f90c989bfdfff54408b113fc5
+        updated_at: 2026-06-19T05:31:03.201095763Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: c358bcf879af1760a8a8ee32c90b4b0e34221e9bb38aa404024fd6b270394005
+        updated_at: 2026-06-19T07:45:13.325382245Z
+evidence_refs:
+    code-quality-review: .worktrees/expand-ai-tool-adapters/artifacts/changes/expand-ai-tool-adapters/verification/code-quality-review.yaml
+    final-closeout: .worktrees/expand-ai-tool-adapters/artifacts/changes/expand-ai-tool-adapters/verification/final-closeout.yaml
+    goal-verification: .worktrees/expand-ai-tool-adapters/artifacts/changes/expand-ai-tool-adapters/verification/goal-verification.yaml
+    independent-review: .worktrees/expand-ai-tool-adapters/artifacts/changes/expand-ai-tool-adapters/verification/independent-review.yaml
+    intake-clarification: .worktrees/expand-ai-tool-adapters/artifacts/changes/expand-ai-tool-adapters/verification/intake-clarification.yaml
+    plan-audit: .worktrees/expand-ai-tool-adapters/artifacts/changes/expand-ai-tool-adapters/verification/plan-audit.yaml
+    research-orchestration: .worktrees/expand-ai-tool-adapters/artifacts/changes/expand-ai-tool-adapters/verification/research-orchestration.yaml
+    spec-compliance-review: .worktrees/expand-ai-tool-adapters/artifacts/changes/expand-ai-tool-adapters/verification/spec-compliance-review.yaml
+    wave-orchestration: .worktrees/expand-ai-tool-adapters/artifacts/changes/expand-ai-tool-adapters/verification/wave-orchestration.yaml

--- a/artifacts/changes/archived/expand-ai-tool-adapters/decision.md
+++ b/artifacts/changes/archived/expand-ai-tool-adapters/decision.md
@@ -1,0 +1,92 @@
+# Decision
+
+## Alternatives Considered
+
+- Implement only `pi`: lowest implementation risk and satisfies the original
+  must-have, but does not meet the user's later request to reach P1.
+- Implement `pi`, `qwen`, and `kiro`: adds common skill-first adapters with
+  relatively low generator risk, but still defers Copilot, Windsurf, and Kilo.
+- Implement P1 in one change: `pi`, `qwen`, `kiro`, `copilot`, `windsurf`, and
+  `kilo`. This matches the user's selected scope, but requires extending the
+  adapter model for Copilot `.prompt.md`, Pi non-hook settings registration, and
+  workflow-style roots for Windsurf/Kilo.
+
+## Selected Approach
+
+Implement P1 in one governed change. Keep each adapter thin and project-local:
+generated prompts, workflows, skills, settings, sentinels, and ownership
+manifests route agents back to `slipway` CLI commands and do not introduce
+host-specific lifecycle engines.
+
+Extend `ToolConfig` narrowly instead of adding per-host branches:
+
+- add a command filename extension override so Copilot can generate
+  `.github/prompts/slipway-*.prompt.md`;
+- add a typed settings mode so Pi can merge/register `enableSkillCommands`,
+  `skills`, and `prompts` without using hook-settings semantics;
+- keep Qwen/Kiro command surfaces as generated command skills;
+- keep Windsurf/Kilo command surfaces as flat workflow-style Markdown files;
+- keep all generated files manifest-owned and sentinel-detected.
+
+This preserves the existing Slipway pattern while absorbing the host layout
+differences found in Trellis, gsd-core, and official docs.
+
+## Interfaces and Data Flow
+
+Changed interfaces:
+
+- `ToolConfig` gains minimal adapter axes for command filename extension and
+  settings behavior.
+- `toolRegistry` gains P1 entries for `pi`, `qwen`, `kiro`, `copilot`,
+  `windsurf`, and `kilo`.
+- Command path generation, cleanup, refresh invalidation, contract tests, and
+  docs derive from the same path helper to avoid mismatched generated paths.
+- Pi settings generation writes/merges project-local `.pi/settings.json` with
+  skills and prompts registration while preserving unrelated settings.
+
+Data flow:
+
+1. `ResolveTools` accepts explicit P1 IDs or expands `all`.
+2. `GenerateWithInstallProfile` calls `generateForTool` for each selected
+   adapter.
+3. `generateForTool` writes generated skills, command prompts/workflows or
+   command skills, optional settings, skill index, ownership manifest, and
+   sentinel.
+4. Refresh reads the ownership manifest, removes/replaces only trusted generated
+   files, and refuses unknown or modified user-owned files.
+
+No runtime lifecycle state, evidence semantics, or CLI command behavior changes.
+
+## Rollout and Rollback
+
+Rollout:
+
+- ship the registry/model changes, tests, docs, and regenerated
+  `docs/SURFACE-MANIFEST.json` together;
+- verify with `go test ./internal/toolgen/...` and `go test ./...`;
+- users opt in with `slipway init --tools <id>` or `slipway init --tools all`.
+
+Rollback:
+
+- revert the toolgen registry/model changes, tests, docs, and manifest update;
+- rerun `go run ./internal/toolgen/cmd/gen-surface-manifest --write` if needed
+  after rollback;
+- verify with `go test ./internal/toolgen/...`.
+
+Generated adapter files in user workspaces remain project-local and can be
+removed by users or refreshed only when still proven by Slipway ownership
+manifest.
+
+## Risk
+
+- Copilot's `.github` root is shared with CI and other project configuration.
+  Mitigation: sentinel/manifest under a dedicated Copilot adapter root and
+  tests proving unowned `.github` files survive refresh.
+- Pi settings are not hook settings. Mitigation: typed settings mode for Pi
+  registration arrays, not reuse of `mergeHookSettingsJSON`.
+- Copilot `.prompt.md` differs from existing `.md`/`.toml` command extensions.
+  Mitigation: explicit command extension helper covered by contract tests.
+- Kiro/Qwen command skills need non-Codex invocation text. Mitigation: derive
+  command triggers and invocation summaries from each tool config.
+- The expanded P1 set increases docs and manifest drift risk. Mitigation:
+  surface manifest check and docs-token tests remain required verification.

--- a/artifacts/changes/archived/expand-ai-tool-adapters/intent.md
+++ b/artifacts/changes/archived/expand-ai-tool-adapters/intent.md
@@ -1,0 +1,82 @@
+# Intent
+
+## Summary
+expand Slipway AI tool adapters for common modern coding tools
+
+## Complexity Assessment
+complex
+Rationale: this changes generated adapter contracts, refresh ownership, docs,
+and tests across multiple host layouts. Some target hosts have materially
+different command, skill, agent, hook, and settings surfaces.
+
+## Guardrail Domains
+None detected.
+
+## In Scope
+- Define an implementation standard for new AI tool adapters based on current
+  Slipway contracts plus investigated patterns from `gsd-core` and Trellis.
+- Investigate common target tools, including `kiro`, `copilot`, `qwen`, and
+  similar current coding agents, then select a practical first implementation
+  set from the evidence.
+- Treat `pi` as the only must-have adapter target for this change.
+- Extend Slipway's generated adapter registry, deterministic file generation,
+  refresh ownership, auto-detection, tests, docs, and surface manifest for the
+  implemented tools.
+- Preserve Slipway's thin-adapter rule: generated host files route agents back
+  to the CLI and do not become separate lifecycle engines.
+
+## Out of Scope
+- Replacing Slipway's compiled fail-closed lifecycle with Markdown-only
+  workflows, external daemons, or host-specific governance logic.
+- Adding agent orchestration, marketplace, memory, or channel runtime features
+  copied from Trellis/GSD unless strictly necessary for adapter discovery.
+- Treating lower-priority tools as blocking when they require a distinct
+  product capability beyond the first implementation standard.
+
+## Constraints
+- Use current worktree CLI behavior as lifecycle authority.
+- Keep generated adapters deterministic and owned by Slipway markers/manifests
+  so refresh can preserve user-owned files.
+- Prefer a declarative adapter capability model over scattered host-specific
+  conditionals.
+- Do not add tool surfaces that cannot be verified locally by generation tests.
+
+## Acceptance Signals
+- `slipway init --tools pi` generates the expected adapter surfaces in a
+  temporary workspace.
+- Any additional common tools selected from the investigation generate their
+  expected adapter surfaces in a temporary workspace.
+- `slipway init --tools all` includes the implemented tools and remains sorted,
+  deterministic, and documented.
+- Refresh and auto-detection tests cover the new tool roots without treating
+  bare host directories as Slipway-owned.
+- Toolgen contract tests and `docs/SURFACE-MANIFEST.json` are updated and pass.
+- Relevant docs name the new tool IDs, generated paths, invocation style, and
+  refresh behavior.
+
+## Open Questions
+<!-- Track real unknowns as a checklist. An unchecked `- [ ]` item is unresolved
+     and routes intake to S0_INTAKE/research; mark `- [x]` once resolved. Leave the
+     section empty (or write `None`) when there are none. Prose here is
+     documentation, not a blocker — a genuine open question must be a `- [ ]`. -->
+- [x] Must-have set corrected: `pi` is the only required target; `kiro`,
+  `copilot`, `qwen`, and similar tools are investigation candidates.
+
+## Deferred Ideas
+- Later broaden to additional common hosts after the adapter capability model
+  proves stable.
+- Consider Trellis/GSD-style memory, channel, marketplace, and agent-pack
+  features separately from thin adapter support.
+
+## Approved Summary
+Confirmed by user on 2026-06-19T05:18:05Z.
+
+This change will investigate common modern AI coding tools using `gsd-core`,
+Trellis, and current Slipway adapter contracts, define a standard for adding
+thin Slipway adapters, and implement the practical first set. `pi` is the only
+required adapter target for this change. `kiro`, `copilot`, `qwen`, and similar
+tools are investigation candidates, not pre-declared must-haves. Implemented
+adapters must route agents back to the Slipway CLI, keep generated files
+deterministic and refresh-owned, update docs and the surface manifest, and pass
+toolgen verification. Marketplace, memory, channel runtime, and independent
+host-specific governance engines are out of scope.

--- a/artifacts/changes/archived/expand-ai-tool-adapters/requirements.md
+++ b/artifacts/changes/archived/expand-ai-tool-adapters/requirements.md
@@ -1,0 +1,104 @@
+# Requirements
+
+## Requirements
+
+### Requirement: P1 adapter selection
+REQ-001: The system MUST support the P1 adapter IDs `pi`, `qwen`, `kiro`,
+`copilot`, `windsurf`, and `kilo` through `slipway init --tools`, and
+`--tools all` MUST include those IDs with the existing adapters in deterministic
+sorted order.
+
+#### Scenario: explicit P1 tool selection
+GIVEN a workspace without generated adapter files
+WHEN `slipway init --tools pi,qwen,kiro,copilot,windsurf,kilo` is run
+THEN Slipway generates adapter surfaces for exactly those tool IDs without
+rejecting them as unsupported.
+
+#### Scenario: all tools selection
+GIVEN the adapter registry contains the existing adapters plus the P1 adapters
+WHEN `slipway init --tools all` is run
+THEN the generated adapter set includes every registered adapter once, sorted
+deterministically by tool ID.
+
+### Requirement: P1 generated surfaces
+REQ-002: The system MUST generate host-appropriate, project-local adapter
+surfaces for each P1 tool while preserving the thin-adapter rule that generated
+files route to the `slipway` CLI rather than implementing governance inside the
+host.
+
+#### Scenario: Pi prompts, skills, and settings
+GIVEN a temporary workspace
+WHEN `slipway init --tools pi` is run
+THEN Slipway writes `.pi/prompts/slipway-*.md`,
+`.pi/skills/slipway-*/SKILL.md`, `.pi/settings.json`, and the `.pi/slipway`
+sentinel/ownership files.
+
+#### Scenario: Copilot prompts and skills
+GIVEN a temporary workspace
+WHEN `slipway init --tools copilot` is run
+THEN Slipway writes `.github/prompts/slipway-*.prompt.md`,
+`.github/skills/slipway-*/SKILL.md`, and a dedicated Copilot sentinel/ownership
+surface without requiring hook launchers.
+
+#### Scenario: skill-first and workflow-style tools
+GIVEN a temporary workspace
+WHEN `slipway init --tools qwen,kiro,windsurf,kilo` is run
+THEN Qwen and Kiro expose generated command skills, and Windsurf/Kilo expose
+workflow-style command files plus generated skills at the documented paths.
+
+### Requirement: adapter ownership and refresh safety
+REQ-003: The system MUST keep generated P1 adapter files under Slipway
+sentinel/ownership control, MUST auto-detect only previously generated adapters,
+and MUST preserve user-owned files in adjacent host directories.
+
+#### Scenario: bare host directories are not owned
+GIVEN a workspace containing bare `.pi`, `.qwen`, `.kiro`, `.github`,
+`.windsurf`, or `.kilocode` directories without Slipway sentinels
+WHEN `slipway init --refresh` is run without explicit `--tools`
+THEN Slipway does not treat those bare directories as generated adapters.
+
+#### Scenario: refresh refuses modified generated files
+GIVEN a workspace with generated P1 adapter files and a user-modified generated
+file recorded in the ownership manifest
+WHEN `slipway init --tools <tool> --refresh` is run
+THEN Slipway refuses to overwrite the modified generated file and preserves its
+contents.
+
+#### Scenario: shared Copilot directory is preserved
+GIVEN a workspace with user-owned files under `.github`
+WHEN `slipway init --tools copilot --refresh` is run
+THEN Slipway only updates Slipway-owned Copilot adapter files and preserves
+unowned `.github` files.
+
+### Requirement: documentation and manifest visibility
+REQ-004: The system MUST document the P1 adapter IDs, generated paths,
+invocation styles, settings behavior, refresh behavior, and surface manifest
+entries.
+
+#### Scenario: docs name P1 adapters
+GIVEN the implementation is complete
+WHEN a user reads the AI tool adapter reference docs
+THEN `pi`, `qwen`, `kiro`, `copilot`, `windsurf`, and `kilo` are listed with
+their generated paths and invocation styles.
+
+#### Scenario: surface manifest is current
+GIVEN adapter registry entries have changed
+WHEN the surface manifest check is run
+THEN `docs/SURFACE-MANIFEST.json` matches the live manifest derived from
+Slipway authorities.
+
+### Requirement: verification
+REQ-005: The system MUST include automated verification for P1 adapter
+generation, registry contracts, ownership/refresh behavior, docs tokens, and the
+committed surface manifest.
+
+#### Scenario: targeted toolgen proof
+GIVEN the P1 adapter implementation is complete
+WHEN `go test ./internal/toolgen/...` is run
+THEN the tests pass.
+
+#### Scenario: full repository proof
+GIVEN targeted toolgen proof passes
+WHEN `go test ./...` is run
+THEN the repository test suite passes or any unrelated harness failure is
+reported with concrete evidence.

--- a/artifacts/changes/archived/expand-ai-tool-adapters/research.md
+++ b/artifacts/changes/archived/expand-ai-tool-adapters/research.md
@@ -1,0 +1,95 @@
+# Research
+
+## Alternatives Considered
+
+### Architecture
+- Affected modules: `internal/toolgen/toolgen.go`, `internal/toolgen/install_profiles.go`, `internal/toolgen/ownership_manifest.go`, `internal/toolgen/surface_manifest.go`, `internal/toolgen/*_test.go`, `docs/ai-tools.md`, `docs/reference/ai-tools.md`, and `docs/SURFACE-MANIFEST.json`.
+- Dependency chains: `slipway init --tools` -> `ResolveTools` -> `GenerateWithInstallProfile` -> `generateForTool` -> host skill/command/settings emission -> ownership manifest/sentinel. Evidence: `internal/toolgen/toolgen.go:711-719`, `internal/toolgen/toolgen.go:763-786`, `internal/toolgen/toolgen.go:834-1137`.
+- Blast radius: add adapter registry entries and small generator axes for command filename extension, static/non-hook settings registration, and possibly non-Codex command skills. Keep lifecycle and command semantics in the CLI. Evidence: `docs/reference/ai-tools.md:7-9`, `artifacts/changes/expand-ai-tool-adapters/intent.md`.
+- Constraints: generated files must be deterministic, sorted, and manifest-owned; refresh must preserve user-owned files. Evidence: `internal/toolgen/toolgen.go:652-668`, `internal/toolgen/toolgen.go:789-800`, `internal/toolgen/ownership_manifest.go:193-214`, `internal/toolgen/ownership_manifest.go:394-414`.
+
+### Patterns
+- Existing Slipway pattern: one declarative `ToolConfig` per host defines skills, commands, settings, hooks, trigger style, and auto-detect roots. Generated host files invoke `slipway ...` rather than reimplementing governance. Evidence: `internal/toolgen/toolgen.go:23-43`, `internal/toolgen/toolgen.go:45-124`.
+- Existing Slipway pattern: `Registry()` is sorted, but `ResolveTools("all")` is currently hardcoded to the five existing IDs; adding tools should either derive from registry or update the pinned list and tests. Evidence: `internal/toolgen/toolgen.go:652-668`, `internal/toolgen/toolgen.go:711-719`, `internal/toolgen/toolgen_test.go:61-78`.
+- Trellis pattern: common adapter universe includes `kiro`, `copilot`, `pi`, `kilo`, `windsurf`, plus other current hosts. It models Kiro as skill-centric, Copilot as prompts plus skills under `.github`, Pi as `.pi/prompts`, `.pi/skills`, agents, extension, and settings, Kilo as `.kilocode/workflows` plus `.kilocode/skills`, and Windsurf as `.windsurf/workflows` plus `.windsurf/skills`. Evidence: `/Users/yixianlu/ghq/github.com/mindfold-ai/Trellis/packages/cli/src/types/ai-tools.ts:10-25`, `/Users/yixianlu/ghq/github.com/mindfold-ai/Trellis/packages/cli/src/types/ai-tools.ts:203-235`, `/Users/yixianlu/ghq/github.com/mindfold-ai/Trellis/packages/cli/src/types/ai-tools.ts:270-285`, `/Users/yixianlu/ghq/github.com/mindfold-ai/Trellis/packages/cli/src/types/ai-tools.ts:319-340`, `/Users/yixianlu/ghq/github.com/mindfold-ai/Trellis/packages/cli/src/types/ai-tools.ts:357-372`.
+- Trellis Pi detail: Pi prompts are `.pi/prompts/trellis-<name>.md`, skills are under `.pi/skills`, settings register skills/prompts/extensions, and Pi does not use Python hooks. Evidence: `/Users/yixianlu/ghq/github.com/mindfold-ai/Trellis/packages/cli/src/configurators/pi.ts:21-55`, `/Users/yixianlu/ghq/github.com/mindfold-ai/Trellis/packages/cli/src/templates/pi/settings.json:1-12`, `/Users/yixianlu/ghq/github.com/mindfold-ai/Trellis/docs-site/zh/advanced/multi-platform.mdx:210-226`.
+- Trellis command detail: Pi command prompts use `/trellis-<name>`, Copilot prompt files use `.prompt.md`, and Kiro can be skill-only with `@trellis:<name>`. Evidence: `/Users/yixianlu/ghq/github.com/mindfold-ai/Trellis/docs-site/zh/advanced/custom-commands.mdx:11-28`, `/Users/yixianlu/ghq/github.com/mindfold-ai/Trellis/docs-site/zh/advanced/custom-commands.mdx:38-43`.
+- GSD pattern: runtime adapters are descriptor-axis driven (`installSurface`, `writesSharedSettings`, `hooksSurface`, `sandboxTier`, artifact layout) and derive supported runtimes from capability descriptors rather than a separate hand list. Evidence: `/Users/yixianlu/ghq/github.com/open-gsd/gsd-core/src/runtime-config-adapter-registry.cts:13-28`, `/Users/yixianlu/ghq/github.com/open-gsd/gsd-core/src/runtime-config-adapter-registry.cts:65-92`, `/Users/yixianlu/ghq/github.com/open-gsd/gsd-core/src/runtime-config-adapter-registry.cts:124-144`.
+- GSD Qwen detail: Qwen has `.qwen` config home, `settings-json`, skills under `skills`, slash-hyphen command style, settings-json hook surface, and Claude hook event dialect. Evidence: `/Users/yixianlu/ghq/github.com/open-gsd/gsd-core/capabilities/qwen/capability.json:1-47`.
+- GSD Copilot detail: Copilot is modeled as markdown config, skills under `skills`, slash-hyphen command style, `copilot-instructions` install surface, and no shared settings write. Evidence: `/Users/yixianlu/ghq/github.com/open-gsd/gsd-core/capabilities/copilot/capability.json:1-46`.
+- GSD Kilo/Windsurf detail: Kilo is modeled as flat commands plus recursive skills under Kilo config homes; Windsurf is modeled as skills-only with no hook surface. Evidence: `/Users/yixianlu/ghq/github.com/open-gsd/gsd-core/capabilities/kilo/capability.json:1-67`, `/Users/yixianlu/ghq/github.com/open-gsd/gsd-core/capabilities/windsurf/capability.json:1-47`.
+- Official freshness check: Pi currently advertises extensibility through skills and prompt templates under `.pi`, Kiro documents open Agent Skills with progressive disclosure, Copilot/VS Code documents `.github/skills` and `.github/prompts/*.prompt.md`, Qwen documents project `.qwen/settings.json` plus `.qwen/skills`, Windsurf documents workflows, skills, hooks, and AGENTS.md, and Kilo documents Agent Skills. Sources: https://pi.dev/, https://github.com/earendil-works/pi/blob/main/packages/coding-agent/README.md, https://kiro.dev/docs/skills/, https://code.visualstudio.com/docs/agent-customization/agent-skills, https://code.visualstudio.com/docs/copilot/customization/prompt-files, https://qwenlm.github.io/qwen-code-docs/en/users/configuration/settings/, https://docs.windsurf.com/plugins/cascade/workflows, https://docs.windsurf.com/windsurf/cascade/skills, https://kilo.ai/docs/customize/skills.
+
+### Risks
+- Medium: Pi settings are not hook settings. Current `SettingsPath` merges a `hooks` object and should not be reused for Pi's `skills`/`prompts` arrays without a typed setting kind. Evidence: `internal/toolgen/toolgen.go:1078-1098`, `internal/toolgen/toolgen.go:1994-2044`, `/Users/yixianlu/ghq/github.com/mindfold-ai/Trellis/packages/cli/src/templates/pi/settings.json:1-12`.
+- Medium: Copilot shares `.github` with existing repository configuration. Generated ownership must be scoped to Slipway-prefixed prompts/skills and a dedicated sentinel/manifest path, not a whole-tree cleanup. Evidence: `internal/toolgen/ownership_manifest.go:193-214`, `internal/toolgen/ownership_manifest.go:255-268`, `/Users/yixianlu/ghq/github.com/mindfold-ai/Trellis/docs-site/zh/advanced/multi-platform.mdx:182-196`.
+- Medium: Copilot prompt files require `.prompt.md`; current command extension handling only supports `.md` and `.toml`. Evidence: `internal/toolgen/toolgen.go:1030-1048`, `/Users/yixianlu/ghq/github.com/mindfold-ai/Trellis/docs-site/zh/advanced/custom-commands.mdx:15-27`.
+- Low/medium: Kiro and Qwen can likely use the Agent Skills shape, but their manual invocation text differs from Codex. Current command-skill summary hardcodes Codex wording. Evidence: `internal/toolgen/toolgen.go:2304-2315`, `/Users/yixianlu/ghq/github.com/mindfold-ai/Trellis/docs-site/zh/advanced/custom-commands.mdx:38-43`.
+- Low/medium: Kilo and Windsurf have workflow/skill surfaces rather than the exact existing Claude/Cursor command layout. Their command roots need explicit command style/path coverage, not inference from current nested/flat command assumptions. Evidence: `/Users/yixianlu/ghq/github.com/mindfold-ai/Trellis/docs-site/zh/advanced/custom-commands.mdx:30-36`, `/Users/yixianlu/ghq/github.com/open-gsd/gsd-core/capabilities/kilo/capability.json:20-58`, `/Users/yixianlu/ghq/github.com/open-gsd/gsd-core/capabilities/windsurf/capability.json:15-39`.
+- Low: `--tools all` and tests currently pin five IDs. This is intentional contract coverage, but it means every selected tool must update tests/docs/manifest together. Evidence: `internal/toolgen/toolgen_test.go:61-78`, `internal/toolgen/adapter_contract_test.go:77-83`, `docs/SURFACE-MANIFEST.json:4-38`.
+- Guardrail domains: no auth/authz, credentials, PII, financial, schema migration, irreversible operation, or external API contract changes are introduced by the planned thin adapter generation. The change writes project files, so generated ownership remains the main safety concern.
+- Reversibility: additive registry/docs/test changes are straightforward to revert; generated refresh behavior must be proven because it affects user workspaces.
+
+### Test Strategy
+- Existing coverage: registry count/order, `ResolveTools`, generated files, command surface sync, settings/hook behavior, refresh ownership, adapter contract freeze, and surface manifest freshness. Evidence: `internal/toolgen/toolgen_test.go:61-78`, `internal/toolgen/toolgen_test.go:403-575`, `internal/toolgen/toolgen_test.go:943-983`, `internal/toolgen/adapter_contract_test.go:38-176`, `internal/toolgen/surface_manifest_test.go:15-160`.
+- New coverage required for Pi: `LookupTool("pi")`, `ResolveTools("pi")`, `ResolveTools("all")`, `.pi/prompts/slipway-*.md`, `.pi/skills/slipway-*/SKILL.md`, `.pi/settings.json` with `enableSkillCommands`, `skills`, and `prompts`, sentinel/manifest under `.pi/slipway`, refresh refusal for modified generated prompts/skills, and no Python hook launcher emission.
+- New coverage required for selected P1 tools: exact generated skill/command/workflow paths, trigger strings, `--tools all` inclusion, auto-detection by sentinel only, refresh preservation beside shared roots, and docs/manifest tokens. Copilot must additionally prove `.github` preservation and `.prompt.md` prompt filenames.
+- Infrastructure needs: small helper functions for command extension/name derivation and adapter setting registration so tests do not duplicate path logic.
+- Verification approach: run `go test ./internal/toolgen/...`, regenerate/check `docs/SURFACE-MANIFEST.json`, then run `go test ./...`.
+
+### Options
+- Option A: implement only `pi` now. Tradeoffs: lowest risk and satisfies the must-have, but leaves the user's "common tools" investigation mostly as documentation and delays Qwen/Kiro/Copilot adoption.
+- Option B: implement `pi`, `qwen`, and `kiro`; defer `copilot`. Tradeoffs: covers the required Pi plus two low-friction common adapters. Pi gets prompt files plus static settings; Qwen and Kiro use Agent Skills/command-skill surfaces with host-specific trigger text. Copilot is deferred because `.github` sharing and `.prompt.md` need a filename axis and stricter ownership tests.
+- Option C: implement `pi`, `qwen`, `kiro`, and `copilot`. Tradeoffs: broadest common coverage and matches Trellis' current platform set better, but higher blast radius because Copilot needs `.github/prompts/*.prompt.md`, `.github/skills`, and shared-root safety in the same change.
+- Option D: implement P1 scope: `pi`, `qwen`, `kiro`, `copilot`, `windsurf`, and `kilo`. Tradeoffs: covers the must-have plus the highest-priority common tools identified by the user after research, but increases generator work: Copilot needs `.prompt.md` filename support and shared `.github` safety, while Kilo/Windsurf need workflow-style command roots in addition to skills.
+- Selected: Option D. User selected P1 scope after reviewing the recommendation. Planning must implement `pi`, `qwen`, `kiro`, `copilot`, `windsurf`, and `kilo` in one governed change, with extra acceptance on Copilot shared-root ownership and command filename extension support.
+
+## Unknowns
+- Resolved: Is `pi` the only must-have target? -> Yes. User confirmed `pi` is the only required adapter; `kiro`, `copilot`, `qwen`, and similar tools are investigation candidates. Evidence: `artifacts/changes/expand-ai-tool-adapters/intent.md`.
+- Resolved: Does Slipway need to copy Trellis' Pi extension/agents? -> No for this change. Intent preserves thin adapters and excludes agent orchestration unless required for adapter discovery; Pi can start with prompts, skills, and settings registration. Evidence: `artifacts/changes/expand-ai-tool-adapters/intent.md`, `/Users/yixianlu/ghq/github.com/mindfold-ai/Trellis/docs-site/zh/advanced/multi-platform.mdx:216-226`.
+- Resolved: Which common candidates are best evidenced? -> Pi, Kiro, Copilot, and Qwen. Trellis lists Pi/Kiro/Copilot among supported tools; GSD has Qwen and Copilot runtime descriptors; official docs confirm Agent Skills/prompt/settings surfaces for these hosts.
+- Resolved: Which option should advance? -> Option D / P1 scope, confirmed by user after alternatives were presented.
+- Remaining: None.
+
+## Assumptions
+- New adapters must remain project-local and deterministic. Evidence: `artifacts/changes/expand-ai-tool-adapters/intent.md`, `internal/toolgen/ownership_manifest.go:394-414`.
+- Generated host files are adapter surfaces only and must route to the current-worktree Slipway CLI. Evidence: `docs/reference/ai-tools.md:7-9`.
+- For Pi, static registration of skills/prompts is sufficient for a first thin adapter; Pi extensions and agents are not required to expose Slipway commands and governed skills. Evidence: `artifacts/changes/expand-ai-tool-adapters/intent.md`, `/Users/yixianlu/ghq/github.com/mindfold-ai/Trellis/packages/cli/src/configurators/pi.ts:26-52`.
+- For Qwen/Kiro, Agent Skills-compatible `SKILL.md` surfaces are a valid first adapter shape. Evidence: `/Users/yixianlu/ghq/github.com/open-gsd/gsd-core/capabilities/qwen/capability.json:15-39`, `/Users/yixianlu/ghq/github.com/open-gsd/gsd-core/tests/qwen-skills-migration.test.cjs:5-11`, `/Users/yixianlu/ghq/github.com/mindfold-ai/Trellis/docs-site/zh/advanced/custom-commands.mdx:38-43`.
+- For Kilo/Windsurf, a first Slipway adapter can use project-local workflow/command files plus skills where supported, without hooks. Evidence: `/Users/yixianlu/ghq/github.com/mindfold-ai/Trellis/docs-site/zh/advanced/custom-commands.mdx:30-36`, `/Users/yixianlu/ghq/github.com/mindfold-ai/Trellis/docs-site/zh/advanced/multi-platform.mdx:228-236`.
+
+## Canonical References
+- `artifacts/changes/expand-ai-tool-adapters/intent.md`
+- `artifacts/codebase/ARCHITECTURE.md`
+- `artifacts/codebase/TESTING.md`
+- `artifacts/codebase/CONCERNS.md`
+- `internal/toolgen/toolgen.go`
+- `internal/toolgen/ownership_manifest.go`
+- `internal/toolgen/install_profiles.go`
+- `internal/toolgen/surface_manifest.go`
+- `internal/toolgen/toolgen_test.go`
+- `internal/toolgen/adapter_contract_test.go`
+- `internal/toolgen/surface_manifest_test.go`
+- `docs/ai-tools.md`
+- `docs/reference/ai-tools.md`
+- `docs/SURFACE-MANIFEST.json`
+- `/Users/yixianlu/ghq/github.com/mindfold-ai/Trellis/packages/cli/src/types/ai-tools.ts`
+- `/Users/yixianlu/ghq/github.com/mindfold-ai/Trellis/packages/cli/src/configurators/pi.ts`
+- `/Users/yixianlu/ghq/github.com/mindfold-ai/Trellis/packages/cli/src/templates/pi/settings.json`
+- `/Users/yixianlu/ghq/github.com/mindfold-ai/Trellis/docs-site/zh/advanced/custom-commands.mdx`
+- `/Users/yixianlu/ghq/github.com/mindfold-ai/Trellis/docs-site/zh/advanced/multi-platform.mdx`
+- `/Users/yixianlu/ghq/github.com/open-gsd/gsd-core/capabilities/qwen/capability.json`
+- `/Users/yixianlu/ghq/github.com/open-gsd/gsd-core/capabilities/copilot/capability.json`
+- `/Users/yixianlu/ghq/github.com/open-gsd/gsd-core/capabilities/kilo/capability.json`
+- `/Users/yixianlu/ghq/github.com/open-gsd/gsd-core/capabilities/windsurf/capability.json`
+- `/Users/yixianlu/ghq/github.com/open-gsd/gsd-core/src/runtime-config-adapter-registry.cts`
+- `/Users/yixianlu/ghq/github.com/open-gsd/gsd-core/tests/qwen-skills-migration.test.cjs`
+- `https://pi.dev/`
+- `https://github.com/earendil-works/pi/blob/main/packages/coding-agent/README.md`
+- `https://kiro.dev/docs/skills/`
+- `https://code.visualstudio.com/docs/agent-customization/agent-skills`
+- `https://code.visualstudio.com/docs/copilot/customization/prompt-files`
+- `https://qwenlm.github.io/qwen-code-docs/en/users/configuration/settings/`
+- `https://docs.windsurf.com/plugins/cascade/workflows`
+- `https://docs.windsurf.com/windsurf/cascade/skills`
+- `https://kilo.ai/docs/customize/skills`

--- a/artifacts/changes/archived/expand-ai-tool-adapters/tasks.md
+++ b/artifacts/changes/archived/expand-ai-tool-adapters/tasks.md
@@ -1,0 +1,27 @@
+# Tasks
+
+## Task List
+
+- [x] `t-01` Extend the toolgen adapter model and registry for P1 tools.
+  - depends_on: []
+  - target_files: [`internal/toolgen/toolgen.go`, `internal/toolgen/surface_manifest.go`]
+  - task_kind: code
+  - covers: [REQ-001, REQ-002, REQ-003]
+
+- [x] `t-02` Update generated adapter contract and refresh tests for P1 paths, triggers, settings, and ownership behavior.
+  - depends_on: [`t-01`]
+  - target_files: [`internal/toolgen/toolgen_test.go`, `internal/toolgen/adapter_contract_test.go`]
+  - task_kind: test
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-005]
+
+- [x] `t-03` Update adapter reference documentation and regenerate the public surface manifest for P1 adapters.
+  - depends_on: [`t-01`]
+  - target_files: [`docs/ai-tools.md`, `docs/reference/ai-tools.md`, `docs/installation.md`, `docs/SURFACE-MANIFEST.json`]
+  - task_kind: doc
+  - covers: [REQ-004]
+
+- [x] `t-04` Run targeted and full verification for the P1 adapter implementation and capture implementation evidence.
+  - depends_on: [`t-02`, `t-03`]
+  - target_files: [`artifacts/changes/expand-ai-tool-adapters/verification/implementation.md`]
+  - task_kind: verification
+  - covers: [REQ-005]

--- a/artifacts/codebase/ARCHITECTURE.md
+++ b/artifacts/codebase/ARCHITECTURE.md
@@ -1,25 +1,37 @@
 # Architecture
 
-- Module responsibilities: CLI behavior lives in `cmd/`; generated host
-  content is authored in `internal/tmpl/templates/`; adapter emission and
-  cross-host assertions live in `internal/toolgen`. Evidence: `cmd/root.go:28-90`,
-  `internal/tmpl/templates/skills/workflow/SKILL.md.tmpl:1-114`,
-  `internal/toolgen/toolgen_test.go:631-666`.
-- Dependency flow: workflow and command surfaces route agents into the CLI;
-  they are not lifecycle authority. The workflow skill states that the CLI owns
-  transitions, gates, and command semantics. Evidence:
-  `internal/tmpl/templates/skills/workflow/SKILL.md.tmpl:10-12`,
-  `internal/tmpl/templates/skills/workflow/SKILL.md.tmpl:66-70`.
-- Coupling hotspots: `SessionStart` currently surfaces only handoff presence
-  and path, not body content; context pressure currently says to preserve a
-  handoff without defining its authoring contract. Evidence:
-  `cmd/session_start_hook.go:126-135`,
-  `cmd/context_pressure_hook.go:435-440`.
-- Current change blast radius: expected changes should be limited to authored
-  templates, hook wording if needed, artifact/checklist templates, and tests
-  that pin generated AI-facing contracts. Evidence:
-  `internal/tmpl/templates_test.go:53-71`,
-  `internal/tmpl/templates_test.go:586-612`,
-  `cmd/context_pressure_hook_test.go:68-117`.
-- Notes: do not add a new lifecycle state or treat `handoff.md` as evidence;
-  this belongs in agent-facing guidance and regression tests.
+- Module responsibilities: adapter definitions and generation live in
+  `internal/toolgen/toolgen.go`. `ToolConfig` describes each host's skills,
+  commands, settings, hooks, trigger style, and auto-detect roots; `Registry()`
+  returns the sorted public adapter set. Evidence:
+  `internal/toolgen/toolgen.go:23-43`,
+  `internal/toolgen/toolgen.go:45-124`,
+  `internal/toolgen/toolgen.go:652-668`.
+- Dependency flow: `slipway init --tools` resolves tool IDs through
+  `ResolveTools`, then `GenerateWithInstallProfile` iterates selected
+  `ToolConfig` entries and writes host files. Generated surfaces route back to
+  the Slipway CLI; they are not lifecycle engines. Evidence:
+  `internal/toolgen/toolgen.go:711-719`,
+  `internal/toolgen/toolgen.go:763-786`,
+  `docs/reference/ai-tools.md:7-9`.
+- Generation boundary: host skills use `SkillPath(cfg, id)` and command prompts
+  are emitted from `CommandsDir` using either flat or nested style. Codex is the
+  existing exception that emits per-command skills via `CommandSkillSurface`.
+  Evidence: `internal/toolgen/toolgen.go:819-827`,
+  `internal/toolgen/toolgen.go:1030-1069`,
+  `internal/toolgen/toolgen_test.go:1829-1878`.
+- Ownership and refresh boundary: generated adapters are trusted only through a
+  per-tool sentinel plus project-local ownership manifest under
+  `<ToolRootPath>/slipway/`. Refresh writes generated files through
+  `toolRefreshPlan`, refuses unknown or user-modified files, and detects
+  existing adapters by sentinel, not by bare host directories. Evidence:
+  `internal/toolgen/toolgen.go:789-800`,
+  `internal/toolgen/toolgen.go:740-755`,
+  `internal/toolgen/ownership_manifest.go:74-80`,
+  `internal/toolgen/ownership_manifest.go:193-214`,
+  `internal/toolgen/ownership_manifest.go:394-414`.
+- Current change blast radius: adding Pi and any additional selected common
+  tools should stay inside the toolgen registry, command filename/extension
+  helpers, optional adapter settings support, docs, surface manifest, and
+  tests. It should not add new lifecycle states or host-specific governance.
+  Evidence: `artifacts/changes/expand-ai-tool-adapters/intent.md`.

--- a/artifacts/codebase/CONCERNS.md
+++ b/artifacts/codebase/CONCERNS.md
@@ -1,19 +1,37 @@
 # Concerns
 
-- Architectural pressure points: AI-facing prose can accidentally become
-  pseudo-authority. The workflow skill explicitly says CLI gates and command
-  semantics live in the CLI, so new handoff prose must preserve that boundary.
-  Evidence: `internal/tmpl/templates/skills/workflow/SKILL.md.tmpl:10-12`,
-  `internal/tmpl/templates/skills/workflow/SKILL.md.tmpl:66-70`.
-- Brittle areas: `SessionStart` surfaces handoff path only; embedding or
-  trusting handoff body content would expand hook output and weaken the narrow
-  contract. Evidence: `cmd/session_start_hook.go:126-135`,
-  `cmd/session_start_hook.go:166-170`.
-- Migration traps: shared reference docs are copied only when SKILL.md names
-  the doc. If adding a new shared skill-quality reference, either wire it into
-  `sharedReferenceDocs` or use the existing checklist reference deliberately.
-  Evidence: `internal/toolgen/toolgen.go:1633-1678`.
-- Recheck routing: use `slipway next --json` and generated host skills for
-  lifecycle routing; do not route from stale chat or `handoff.md` prose.
-- Notes: user explicitly requested preserving useful skill guidance; prose
-  cleanup should be local, high-ROI, and backed by tests.
+- Shared directory risk: Copilot uses `.github/...`, which often already
+  contains user-authored CI, prompts, agents, and instructions. A Copilot
+  adapter must own only Slipway-prefixed files and its sentinel/manifest, never
+  the whole `.github` tree. Evidence:
+  `docs/reference/ai-tools.md:31-32`,
+  `internal/toolgen/ownership_manifest.go:193-214`,
+  `internal/toolgen/ownership_manifest.go:255-268`.
+- Settings risk: current `SettingsPath` means "merge hook settings.json" for
+  Claude/Gemini. Pi settings are registration arrays (`skills`, `prompts`, and
+  optionally `extensions`), and Copilot/Qwen have different config surfaces.
+  Do not overload hook-only settings semantics without a typed adapter setting
+  kind. Evidence: `internal/toolgen/toolgen.go:1078-1098`,
+  `internal/toolgen/toolgen.go:1994-2044`.
+- Command filename risk: Copilot prompt files require `.prompt.md`; current
+  command extension logic only supports `.md` and Gemini `.toml`. Add an
+  explicit filename/extension axis before implementing Copilot prompts.
+  Evidence: `internal/toolgen/toolgen.go:1030-1048`,
+  `internal/toolgen/toolgen.go:1263-1279`.
+- Workflow root risk: Kilo and Windsurf use workflow-style command files in
+  Trellis, not the existing nested command root used by Claude/Gemini. Add an
+  explicit command path style or keep the mapping narrow and pinned by frozen
+  adapter contract tests.
+- Trigger prose risk: `InvocationSummary()` special-cases command-skill
+  surfaces as Codex-flavored `$slipway-*`. If Kiro or Qwen also use skill
+  command surfaces, summaries and generated references must derive from each
+  tool's trigger axes. Evidence: `internal/toolgen/toolgen.go:2279-2284`,
+  `internal/toolgen/toolgen.go:2304-2315`.
+- Compatibility risk: Trellis implements Pi via a TypeScript extension and
+  agents, but this Slipway change is scoped to thin adapters. Pi support should
+  start with prompts, skills, and minimal settings registration; extension and
+  agent orchestration remain out of scope unless a later requirement proves
+  they are necessary.
+- Reversibility: adapter changes are mostly additive and reversible by removing
+  tool registry entries and regenerated docs, but generated-file refresh logic
+  must remain fail-closed because it can touch user project files.

--- a/artifacts/codebase/TESTING.md
+++ b/artifacts/codebase/TESTING.md
@@ -1,24 +1,40 @@
 # Testing
 
-- Test layout: Go `*_test.go` files across `cmd/`, `internal/tmpl/`, and
-  `internal/toolgen/`.
-- Coverage hotspots: template content contracts are pinned in
-  `internal/tmpl/templates_test.go`; generated adapter workflow contracts are
-  pinned in `internal/toolgen/toolgen_test.go`; hook messages are pinned in
-  `cmd/session_start_hook_test.go` and `cmd/context_pressure_hook_test.go`.
-  Evidence: `internal/tmpl/templates_test.go:53-71`,
-  `internal/tmpl/templates_test.go:586-612`,
-  `internal/toolgen/toolgen_test.go:631-666`,
-  `cmd/context_pressure_hook_test.go:68-117`.
-- Coverage gaps: there is not yet a test that defines the `handoff.md`
-  authoring contract or asserts it remains non-authoritative; this change
-  should add those assertions.
-- Verification commands: targeted tests should include `go test ./internal/tmpl/...`,
-  `go test ./internal/toolgen/...`, and relevant `go test ./cmd/...` when hook
-  text changes; final verification can include `go test ./...`.
-- Fixture patterns: render templates with `Render(...)` for templated content
-  and `Content(...)` for static template files. Evidence:
-  `internal/tmpl/templates_test.go:56-70`,
-  `internal/tmpl/templates_test.go:596-607`.
-- Notes: add negative tests for governance bypass wording, because prior
-  template regressions have come from positive-only assertions.
+- Test layout: this adapter change is primarily covered in
+  `internal/toolgen`. Product docs and generated-surface inventory are checked
+  by docs/surface-manifest tests. Evidence:
+  `internal/toolgen/toolgen_test.go`,
+  `internal/toolgen/adapter_contract_test.go`,
+  `internal/toolgen/surface_manifest_test.go`.
+- Registry and selection tests currently pin the five supported tools and the
+  hardcoded `all` expansion; these must change when new IDs are added.
+  Evidence: `internal/toolgen/toolgen_test.go:61-78`,
+  `internal/toolgen/toolgen.go:711-719`.
+- File generation tests assert every selected tool gets sentinels, skills,
+  command prompts or command skills, settings/hook behavior, and skill indexes.
+  Add Pi and any other selected tools to these expectations rather than only
+  smoke-testing registry membership. Evidence:
+  `internal/toolgen/toolgen_test.go:403-575`,
+  `internal/toolgen/toolgen_test.go:943-983`.
+- Frozen adapter contracts pin command roots, styles, extensions, trigger
+  strings, settings paths, and hook launcher behavior. New adapters need frozen
+  rows so path or invocation drift is caught. Evidence:
+  `internal/toolgen/adapter_contract_test.go:38-159`,
+  `internal/toolgen/adapter_contract_test.go:161-176`.
+- Ownership/refresh coverage already includes manifest-backed refusal for
+  modified generated files and preservation of legacy/user prompt files without
+  ownership proof. New roots such as `.pi`, `.qwen`, `.kiro`, `.github`,
+  `.windsurf`, and `.kilocode` need explicit auto-detect and refresh
+  assertions. Evidence:
+  `internal/toolgen/toolgen_test.go:1028-1069`,
+  `internal/toolgen/toolgen_test.go:1147-1165`,
+  `internal/toolgen/toolgen_test.go:1880-1905`.
+- Surface manifest tests derive adapter rows from `Registry()` and fail if the
+  committed `docs/SURFACE-MANIFEST.json` is stale or docs tokens are missing.
+  Any added adapter requires regenerating the manifest and updating docs first.
+  Evidence: `internal/toolgen/surface_manifest.go:31-56`,
+  `internal/toolgen/surface_manifest_test.go:15-57`,
+  `internal/toolgen/surface_manifest_test.go:134-160`.
+- Verification commands: targeted proof should include
+  `go test ./internal/toolgen/...`; final proof should include `go test ./...`
+  unless an unrelated harness issue blocks it.

--- a/docs/SURFACE-MANIFEST.json
+++ b/docs/SURFACE-MANIFEST.json
@@ -17,6 +17,13 @@
     },
     {
       "kind": "adapter",
+      "name": "copilot",
+      "source": "internal/toolgen/toolgen.go:toolRegistry",
+      "docs": "docs/reference/ai-tools.md",
+      "token": "`copilot`"
+    },
+    {
+      "kind": "adapter",
       "name": "cursor",
       "source": "internal/toolgen/toolgen.go:toolRegistry",
       "docs": "docs/reference/ai-tools.md",
@@ -31,10 +38,45 @@
     },
     {
       "kind": "adapter",
+      "name": "kilo",
+      "source": "internal/toolgen/toolgen.go:toolRegistry",
+      "docs": "docs/reference/ai-tools.md",
+      "token": "`kilo`"
+    },
+    {
+      "kind": "adapter",
+      "name": "kiro",
+      "source": "internal/toolgen/toolgen.go:toolRegistry",
+      "docs": "docs/reference/ai-tools.md",
+      "token": "`kiro`"
+    },
+    {
+      "kind": "adapter",
       "name": "opencode",
       "source": "internal/toolgen/toolgen.go:toolRegistry",
       "docs": "docs/reference/ai-tools.md",
       "token": "`opencode`"
+    },
+    {
+      "kind": "adapter",
+      "name": "pi",
+      "source": "internal/toolgen/toolgen.go:toolRegistry",
+      "docs": "docs/reference/ai-tools.md",
+      "token": "`pi`"
+    },
+    {
+      "kind": "adapter",
+      "name": "qwen",
+      "source": "internal/toolgen/toolgen.go:toolRegistry",
+      "docs": "docs/reference/ai-tools.md",
+      "token": "`qwen`"
+    },
+    {
+      "kind": "adapter",
+      "name": "windsurf",
+      "source": "internal/toolgen/toolgen.go:toolRegistry",
+      "docs": "docs/reference/ai-tools.md",
+      "token": "`windsurf`"
     },
     {
       "kind": "command",

--- a/docs/ai-tools.md
+++ b/docs/ai-tools.md
@@ -4,7 +4,7 @@
 
 <div align="center" markdown>
 
-![Slipway tool adapters: slipway init --tools generates per-tool adapter bundles for Claude, Codex, Cursor, Gemini and OpenCode plus the .slipway.yaml runtime config; each adapter's generated skills and commands route governed actions to the slipway CLI](assets/diagrams/tool-adapters.svg)
+![Slipway tool adapters: slipway init --tools generates per-tool adapter bundles for Claude, Codex, Copilot, Cursor, Gemini, Kilo, Kiro, OpenCode, Pi, Qwen, and Windsurf plus the .slipway.yaml runtime config; each adapter's generated skills and commands route governed actions to the slipway CLI](assets/diagrams/tool-adapters.svg)
 
 </div>
 
@@ -14,11 +14,23 @@
 | --- | --- | --- | --- |
 | `claude` | `.claude/skills/slipway-*/SKILL.md` | `.claude/commands/slipway/*.md` | `/slipway:<command>` |
 | `codex` | `.codex/skills/slipway-*/SKILL.md` | `.codex/skills/slipway-*/SKILL.md` | `$slipway-<command>` (or `/skills`) |
+| `copilot` | `.github/skills/slipway-*/SKILL.md` | `.github/prompts/slipway-<command>.prompt.md` | `/slipway-<command>` |
 | `cursor` | `.cursor/skills/slipway-*/SKILL.md` | `.cursor/commands/*.md` | `/slipway-<command>` |
 | `gemini` | `.gemini/skills/slipway-*/SKILL.md` | `.gemini/commands/slipway/*.toml` | `/slipway-<command>` |
+| `kilo` | `.kilocode/skills/slipway-*/SKILL.md` | `.kilocode/workflows/slipway-<command>.md` | `/slipway:<command>` |
+| `kiro` | `.kiro/skills/slipway-*/SKILL.md` | `.kiro/skills/slipway-<command>/SKILL.md` | `@slipway:<command>` or host skill picker |
 | `opencode` | `.opencode/skills/slipway-*/SKILL.md` | `.opencode/commands/slipway-*.md` | `/slipway-<command>` |
+| `pi` | `.pi/skills/slipway-*/SKILL.md` | `.pi/prompts/slipway-<command>.md` | `/slipway-<command>` |
+| `qwen` | `.qwen/skills/slipway-*/SKILL.md` | `.qwen/skills/slipway-<command>/SKILL.md` | `/slipway-<command>` or host skill picker |
+| `windsurf` | `.windsurf/skills/slipway-*/SKILL.md` | `.windsurf/workflows/slipway-<command>.md` | `/slipway-<command>` |
 
-Codex commands are generated as discoverable per-command skills under `.codex/skills/slipway-<command>/SKILL.md` (invoked `$slipway-<command>` or via `/skills`). Slipway no longer writes global prompt files, and `--refresh` removes the legacy generated command prompts left by older versions.
+Codex, Kiro, and Qwen commands are generated as discoverable per-command
+skills under each adapter's skills directory. Prompt-backed and workflow-backed
+hosts generate command files instead. All generated command surfaces call the
+`slipway` CLI; host files do not implement separate lifecycle, review, or
+evidence behavior. Slipway no longer writes global Codex prompt files, and
+`--refresh` removes the legacy generated command prompts left by older
+versions.
 
 ## Generate Adapters
 
@@ -41,16 +53,23 @@ Refresh auto-detected managed adapters:
 slipway init --refresh
 ```
 
-Slipway detects adapters by its generated markers, not by a bare `.claude`,
-`.codex`, `.cursor`, `.gemini`, or `.opencode` directory alone. Refresh removes
-Slipway-owned legacy shell hook launchers and retired `bash "<hook>.sh"` hook
-settings entries while preserving user-owned hooks.
+Slipway detects adapters by its generated sentinel and ownership manifest, not
+by a bare `.claude`, `.codex`, `.cursor`, `.gemini`, `.opencode`, `.pi`,
+`.qwen`, `.kiro`, `.windsurf`, or `.kilocode` directory alone. Copilot keeps
+that managed state under `.github/copilot/slipway` instead of treating the
+shared `.github` tree as adapter-owned. Refresh removes Slipway-owned legacy
+shell hook launchers and retired `bash "<hook>.sh"` hook settings entries while
+preserving user-owned hooks, prompts, workflows, and skills beside generated
+files.
 
 ## Generated Command Surface
 
 Commands that opt into generated host prompts ship a command surface on every
-tool: a command prompt file on Claude, Cursor, Gemini, and OpenCode, and a
-per-command skill (`.codex/skills/slipway-<command>/SKILL.md`) on Codex.
+tool:
+
+- Prompt and workflow files on Claude, Copilot, Cursor, Gemini, Kilo, OpenCode,
+  Pi, and Windsurf.
+- Per-command skills on Codex, Kiro, and Qwen.
 
 CLI-only helper namespaces such as `slipway tool` stay public in the Slipway
 binary but do not generate host command wrappers; generated skills invoke
@@ -165,18 +184,40 @@ Cursor follows the same pattern, shipping
 These launchers only delegate to `slipway hook ...`; hook behavior lives in the
 Slipway binary.
 
+## P1 Adapter Notes
+
+Copilot stores command prompts in `.github/prompts/` with the
+`.prompt.md` extension and generated skills in `.github/skills/`. Its sentinel
+and ownership manifest live under `.github/copilot/slipway`.
+
+Pi stores command prompts in `.pi/prompts/` and generated skills in
+`.pi/skills/`. Slipway also merges `.pi/settings.json` so `enableSkillCommands`
+is `true`, `./skills` is listed in `skills`, and `./prompts` is listed in
+`prompts`.
+
+Qwen and Kiro expose commands as generated command skills rather than separate
+prompt files. Qwen writes `.qwen/settings.json` for the session-start hook.
+Kiro command skills use `@slipway:<command>`.
+
+Windsurf and Kilo expose commands as workflow files under
+`.windsurf/workflows/` and `.kilocode/workflows/`. Kilo uses the
+`/slipway:<command>` trigger even though its workflow files are named
+`slipway-<command>.md`.
+
 ## Settings-Capable Hosts
 
-Claude (`.claude/settings.json`) and Gemini (`.gemini/settings.json`) register
-hooks inline in their own settings file rather than through a launcher script.
-Slipway writes bare `slipway hook ...` commands directly into `settings.json`:
+Claude (`.claude/settings.json`), Gemini (`.gemini/settings.json`), and Qwen
+(`.qwen/settings.json`) register hooks inline in their own settings file rather
+than through launcher scripts. Slipway writes bare `slipway hook ...` commands
+directly into `settings.json`:
 
 - `slipway hook context-pressure` on `PostToolUse`
 - `slipway hook session-start` on `SessionStart`
 
-No launcher file is generated under `.claude/hooks/` or `.gemini/hooks/`; the
-command resolves the `slipway` binary on `PATH` and the hook behavior lives in
-that binary.
+Claude registers both hooks. Gemini and Qwen register `SessionStart` only. No
+launcher file is generated for these settings-registered hooks; the command
+resolves the `slipway` binary on `PATH` and hook behavior lives in that binary.
+Pi settings are registration-only for skills and prompts, not hook settings.
 
 ## Safety Rules
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -259,11 +259,20 @@ does not generate any AI-tool surfaces unless you pass `--tools`:
 ```bash
 slipway init --tools claude
 slipway init --tools codex,opencode
+slipway init --tools copilot,pi,qwen,windsurf
 slipway init --tools all
 slipway init --tools none
 ```
 
-Supported tool IDs are `claude`, `codex`, `cursor`, `gemini`, and `opencode`.
+Supported tool IDs are `claude`, `codex`, `copilot`, `cursor`, `gemini`,
+`kilo`, `kiro`, `opencode`, `pi`, `qwen`, and `windsurf`.
+
+Representative generated adapter directories include `.claude/skills`,
+`.codex/skills`, `.github/skills`, `.cursor/skills`, `.gemini/skills`,
+`.kilocode/skills`, `.kiro/skills`, `.opencode/skills`, `.pi/skills`,
+`.qwen/skills`, and `.windsurf/skills`. Copilot also writes command prompts
+under `.github/prompts` and keeps its generated ownership state under
+`.github/copilot/slipway`.
 
 Use `--refresh` to regenerate Slipway-managed adapter files:
 
@@ -294,7 +303,8 @@ applies, stop and report.
 
 After installing, run `slipway --version`, `slipway status --json`, and
 `git status --short --branch`. Report which install path succeeded and what
-files were generated (especially `.slipway.yaml` and adapter directories).
+files were generated (especially `.slipway.yaml` and adapter directories for
+the selected tool IDs).
 ```
 
 The rest of this section is the canonical guidance the agent will read after fetching this page.
@@ -317,8 +327,8 @@ The rest of this section is the canonical guidance the agent will read after fet
 
 ### Initialize
 
-- Ask which AI-tool adapters this repository uses if it is unclear. Supported tool IDs are `claude`, `codex`, `cursor`, `gemini`, and `opencode`.
-- Run one of `slipway init --tools <tool-id>`, `slipway init --tools claude,codex,opencode`, or `slipway init --tools all`.
+- Ask which AI-tool adapters this repository uses if it is unclear. Supported tool IDs are `claude`, `codex`, `copilot`, `cursor`, `gemini`, `kilo`, `kiro`, `opencode`, `pi`, `qwen`, and `windsurf`.
+- Run one of `slipway init --tools <tool-id>`, `slipway init --tools claude,codex,opencode`, `slipway init --tools copilot,kiro,pi,qwen,windsurf,kilo`, or `slipway init --tools all`.
 - If Slipway-generated adapter files already exist, use `slipway init --tools <detected-tools> --refresh` instead.
 - Do NOT overwrite unrelated user-owned AI-tool files. If a generated path would collide with user-owned content, stop and report instead of overwriting.
 
@@ -331,7 +341,7 @@ The rest of this section is the canonical guidance the agent will read after fet
 ### Report
 
 - Which install path succeeded, and which earlier paths were skipped or failed.
-- Newly generated files, especially `.slipway.yaml` and any tool directories such as `.claude/skills`, `.codex/skills`, `.cursor/skills`, `.gemini/skills`, or `.opencode/skills`.
+- Newly generated files, especially `.slipway.yaml` and any selected adapter directories such as `.claude/skills`, `.codex/skills`, `.github/skills`, `.cursor/skills`, `.gemini/skills`, `.kilocode/skills`, `.kiro/skills`, `.opencode/skills`, `.pi/skills`, `.qwen/skills`, or `.windsurf/skills`.
 - Any unresolved follow-ups the user should know about (for example, a missing release on this platform or `slipway init` choices that still need a human decision).
 
 For OpenCode specifically, the expected generated project surfaces are:
@@ -344,12 +354,13 @@ For OpenCode specifically, the expected generated project surfaces are:
 
 OpenCode commands use slash-hyphen spelling such as `/slipway-new`, `/slipway-next`, and `/slipway-run`. Some OpenCode builds display project commands with a project prefix in the command picker; the generated file path is the stable contract.
 
-Hosts without a `settings.json` (Cursor, OpenCode) receive native launcher
-files for POSIX, PowerShell, and `cmd.exe` under their `hooks/` directory.
-Settings-capable hosts (Claude, Gemini) instead register bare inline
-`slipway hook ...` commands directly in `settings.json` and get no launcher
-file. Either way, no generated hook requires bash, Python, `jq`, `gh`, or a Go
-runtime.
+Adapters that use generated hook launchers, including Cursor and OpenCode,
+receive native launcher files for POSIX, PowerShell, and `cmd.exe` under their
+`hooks/` directory. Settings-capable hook hosts (Claude, Gemini, and Qwen)
+instead register bare inline `slipway hook ...` commands directly in
+`settings.json` and get no launcher file. Pi settings register skills and
+prompts, not hooks. Either way, no generated hook requires bash, Python, `jq`,
+`gh`, or a Go runtime.
 
 Generated skill helpers run through `slipway tool ...` rather than generated
 script payloads. Manual helpers may still require explicit authenticated
@@ -367,7 +378,7 @@ git status --short --branch
 In a repository initialized with adapters, inspect generated files:
 
 ```bash
-find .claude .codex .cursor .gemini .opencode -maxdepth 3 -type f 2>/dev/null
+find .claude .codex .github/skills .github/prompts .github/copilot .cursor .gemini .kilocode .kiro .opencode .pi .qwen .windsurf -maxdepth 3 -type f 2>/dev/null
 ```
 
 Codex command surfaces are generated as skills under

--- a/docs/reference/ai-tools.md
+++ b/docs/reference/ai-tools.md
@@ -14,9 +14,15 @@ files route back to the CLI; they are not separate governance engines.
 | --- | --- | --- |
 | `claude` | `.claude/skills/slipway-*/SKILL.md` | `/slipway:<command>` |
 | `codex` | `.codex/skills/slipway-*/SKILL.md` | `$slipway-<command>` or `/skills` |
+| `copilot` | `.github/skills/slipway-*/SKILL.md` | `/slipway-<command>` |
 | `cursor` | `.cursor/skills/slipway-*/SKILL.md` | `/slipway-<command>` |
 | `gemini` | `.gemini/skills/slipway-*/SKILL.md` | `/slipway-<command>` |
+| `kilo` | `.kilocode/skills/slipway-*/SKILL.md` | `/slipway:<command>` |
+| `kiro` | `.kiro/skills/slipway-*/SKILL.md` | `@slipway:<command>` or host skill picker |
 | `opencode` | `.opencode/skills/slipway-*/SKILL.md` | `/slipway-<command>` |
+| `pi` | `.pi/skills/slipway-*/SKILL.md` | `/slipway-<command>` |
+| `qwen` | `.qwen/skills/slipway-*/SKILL.md` | `/slipway-<command>` or host skill picker |
+| `windsurf` | `.windsurf/skills/slipway-*/SKILL.md` | `/slipway-<command>` |
 
 ## Generate Or Refresh
 
@@ -33,8 +39,21 @@ generated adapter directories.
 
 ## Generated Command Surface
 
-Commands that opt into host prompts generate command surfaces. Codex exposes
-them as command skills; other hosts expose prompt or command files.
+Commands that opt into host prompts generate command surfaces. Codex, Kiro, and
+Qwen expose them as command skills. Other hosts expose prompt, command, or
+workflow files:
+
+- Claude: `.claude/commands/slipway/<id>.md`
+- Copilot: `.github/prompts/slipway-<id>.prompt.md`
+- Cursor: `.cursor/commands/slipway-<id>.md`
+- Gemini: `.gemini/commands/slipway/<id>.toml`
+- Kilo: `.kilocode/workflows/slipway-<id>.md`
+- OpenCode: `.opencode/commands/slipway-<id>.md`
+- Pi: `.pi/prompts/slipway-<id>.md`
+- Windsurf: `.windsurf/workflows/slipway-<id>.md`
+
+Generated adapter files route to the `slipway` CLI. The host surfaces do not
+implement separate lifecycle, review, or evidence engines.
 
 Codex command-skill tokens:
 
@@ -67,6 +86,21 @@ $slipway-init
 
 `slipway tool` is CLI-only. It has no generated host command wrapper; generated
 skills call helper subcommands directly when required.
+
+## Settings And Ownership
+
+Settings-capable adapters merge host settings instead of asking agents to
+hand-edit generated files:
+
+- Claude and Gemini register bare inline `slipway hook ...` settings commands.
+- Pi writes `.pi/settings.json` with `enableSkillCommands=true` and registers
+  `./skills` and `./prompts`.
+- Qwen writes `.qwen/settings.json` to register the session-start hook.
+
+Each adapter is tracked by a Slipway generated sentinel and ownership manifest
+under the adapter root's `slipway/` directory. Copilot stores that managed
+state under `.github/copilot/slipway` so refresh does not treat the rest of
+`.github` as Slipway-owned.
 
 ## Safety Rules
 

--- a/internal/toolgen/adapter_contract_test.go
+++ b/internal/toolgen/adapter_contract_test.go
@@ -36,6 +36,7 @@ type frozenHookContract struct {
 }
 
 type frozenToolContract struct {
+	OwnershipRoot string
 	CommandBase   frozenSurfaceBase
 	CommandRoot   string
 	CommandStyle  string
@@ -43,6 +44,7 @@ type frozenToolContract struct {
 	TriggerPrefix string
 	TriggerStyle  string
 	SettingsPath  string
+	SettingsKind  string
 	SessionHook   frozenHookContract
 	PostToolHook  frozenHookContract
 }
@@ -77,13 +79,20 @@ var frozenAdapterCommandIDs = []string{
 var frozenToolOrder = []string{
 	"claude",
 	"codex",
+	"copilot",
 	"cursor",
 	"gemini",
+	"kilo",
+	"kiro",
 	"opencode",
+	"pi",
+	"qwen",
+	"windsurf",
 }
 
 var frozenToolContracts = map[string]frozenToolContract{
 	"claude": {
+		OwnershipRoot: ".claude",
 		CommandBase:   frozenSurfaceRoot,
 		CommandRoot:   ".claude/commands",
 		CommandStyle:  "nested",
@@ -107,6 +116,7 @@ var frozenToolContracts = map[string]frozenToolContract{
 		},
 	},
 	"codex": {
+		OwnershipRoot: ".codex",
 		CommandBase:   frozenSurfaceRoot,
 		CommandRoot:   ".codex/skills",
 		CommandStyle:  "skill",
@@ -114,7 +124,17 @@ var frozenToolContracts = map[string]frozenToolContract{
 		TriggerPrefix: "$slipway-",
 		TriggerStyle:  "dollar-mention",
 	},
+	"copilot": {
+		OwnershipRoot: ".github/copilot",
+		CommandBase:   frozenSurfaceRoot,
+		CommandRoot:   ".github/prompts",
+		CommandStyle:  "flat",
+		CommandExt:    ".prompt.md",
+		TriggerPrefix: "/slipway-",
+		TriggerStyle:  "slash-hyphen",
+	},
 	"cursor": {
+		OwnershipRoot: ".cursor",
 		CommandBase:   frozenSurfaceRoot,
 		CommandRoot:   ".cursor/commands",
 		CommandStyle:  "flat",
@@ -128,6 +148,7 @@ var frozenToolContracts = map[string]frozenToolContract{
 		},
 	},
 	"gemini": {
+		OwnershipRoot: ".gemini",
 		CommandBase:   frozenSurfaceRoot,
 		CommandRoot:   ".gemini/commands",
 		CommandStyle:  "nested",
@@ -143,7 +164,26 @@ var frozenToolContracts = map[string]frozenToolContract{
 			EmitsLauncher: false,
 		},
 	},
+	"kilo": {
+		OwnershipRoot: ".kilocode",
+		CommandBase:   frozenSurfaceRoot,
+		CommandRoot:   ".kilocode/workflows",
+		CommandStyle:  "flat",
+		CommandExt:    ".md",
+		TriggerPrefix: "/slipway",
+		TriggerStyle:  "slash-colon",
+	},
+	"kiro": {
+		OwnershipRoot: ".kiro",
+		CommandBase:   frozenSurfaceRoot,
+		CommandRoot:   ".kiro/skills",
+		CommandStyle:  "skill",
+		CommandExt:    ".md",
+		TriggerPrefix: "@slipway",
+		TriggerStyle:  "at-colon",
+	},
 	"opencode": {
+		OwnershipRoot: ".opencode",
 		CommandBase:   frozenSurfaceRoot,
 		CommandRoot:   ".opencode/commands",
 		CommandStyle:  "flat",
@@ -155,6 +195,43 @@ var frozenToolContracts = map[string]frozenToolContract{
 			Registered:    false,
 			EmitsLauncher: true,
 		},
+	},
+	"pi": {
+		OwnershipRoot: ".pi",
+		CommandBase:   frozenSurfaceRoot,
+		CommandRoot:   ".pi/prompts",
+		CommandStyle:  "flat",
+		CommandExt:    ".md",
+		TriggerPrefix: "/slipway-",
+		TriggerStyle:  "slash-hyphen",
+		SettingsPath:  ".pi/settings.json",
+		SettingsKind:  settingsKindPiRegistration,
+	},
+	"qwen": {
+		OwnershipRoot: ".qwen",
+		CommandBase:   frozenSurfaceRoot,
+		CommandRoot:   ".qwen/skills",
+		CommandStyle:  "skill",
+		CommandExt:    ".md",
+		TriggerPrefix: "/slipway-",
+		TriggerStyle:  "slash-hyphen",
+		SettingsPath:  ".qwen/settings.json",
+		SessionHook: frozenHookContract{
+			Event:         "SessionStart",
+			Path:          ".qwen/hooks/slipway-session-start",
+			Registered:    true,
+			InlineCommand: sessionStartHookCommand,
+			EmitsLauncher: false,
+		},
+	},
+	"windsurf": {
+		OwnershipRoot: ".windsurf",
+		CommandBase:   frozenSurfaceRoot,
+		CommandRoot:   ".windsurf/workflows",
+		CommandStyle:  "flat",
+		CommandExt:    ".md",
+		TriggerPrefix: "/slipway-",
+		TriggerStyle:  "slash-hyphen",
 	},
 }
 
@@ -169,9 +246,11 @@ func TestAdapterContractsRemainStable(t *testing.T) {
 		toolID := toolID
 		t.Run(toolID, func(t *testing.T) {
 			contract := frozenToolContracts[toolID]
+			assertFrozenOwnershipContract(t, root, toolID, contract)
 			assertFrozenCommandSet(t, root, codexHome, toolID, contract)
 			assertFrozenHookContract(t, root, contract.SettingsPath, contract.SessionHook)
 			assertFrozenHookContract(t, root, contract.SettingsPath, contract.PostToolHook)
+			assertFrozenSettingsContract(t, root, contract)
 		})
 	}
 }
@@ -191,8 +270,11 @@ func assertFrozenCommandSet(t *testing.T, root, codexHome, toolID string, contra
 			content, err := os.ReadFile(absPath)
 			require.NoError(t, err, "missing generated command skill for %s/%s", toolID, id)
 			assert.Contains(t, string(content), contract.commandContentMarker(id), "%s/%s contract marker drifted", toolID, id)
+			assert.Contains(t, string(content), contract.commandTrigger(id), "%s/%s command trigger drifted", toolID, id)
 		}
-		assertNoFrozenCodexCommandPrompts(t, codexHome)
+		if toolID == "codex" {
+			assertNoFrozenCodexCommandPrompts(t, codexHome)
+		}
 		return
 	}
 
@@ -267,10 +349,32 @@ func (c frozenToolContract) commandContentMarker(id string) string {
 }
 
 func (c frozenToolContract) commandTrigger(id string) string {
-	if c.TriggerStyle == "slash-colon" {
+	if c.TriggerStyle == "slash-colon" || c.TriggerStyle == "at-colon" {
 		return c.TriggerPrefix + ":" + id
 	}
 	return c.TriggerPrefix + id
+}
+
+func assertFrozenOwnershipContract(t *testing.T, root, toolID string, contract frozenToolContract) {
+	t.Helper()
+
+	cfg, ok := toolRegistry[toolID]
+	require.True(t, ok, "missing tool registry config for %s", toolID)
+	assert.Equal(t, contract.OwnershipRoot, filepath.ToSlash(ToolRootPath(cfg)), "%s ownership root drifted", toolID)
+
+	markerRel := filepath.ToSlash(filepath.Join(contract.OwnershipRoot, "slipway", ".adapter-generated"))
+	manifestRel := filepath.ToSlash(filepath.Join(contract.OwnershipRoot, "slipway", ownershipManifestFileName))
+	assert.Equal(t, markerRel, filepath.ToSlash(GeneratedAdapterMarkerPath(cfg)), "%s sentinel path drifted", toolID)
+	assert.Equal(t, manifestRel, filepath.ToSlash(generatedOwnershipManifestPath(cfg)), "%s ownership manifest path drifted", toolID)
+	assert.FileExists(t, filepath.Join(root, filepath.FromSlash(markerRel)), "%s missing ownership sentinel", toolID)
+	assert.FileExists(t, filepath.Join(root, filepath.FromSlash(manifestRel)), "%s missing ownership manifest", toolID)
+
+	if toolID == "copilot" {
+		_, err := os.Stat(filepath.Join(root, ".github", "slipway", ".adapter-generated"))
+		assert.True(t, os.IsNotExist(err), "copilot must not claim shared .github sentinel ownership")
+		_, err = os.Stat(filepath.Join(root, ".github", "slipway", ownershipManifestFileName))
+		assert.True(t, os.IsNotExist(err), "copilot must not claim shared .github manifest ownership")
+	}
 }
 
 func collectRelativeFiles(t *testing.T, absRoot string, base frozenSurfaceBase, root, codexHome string) []string {
@@ -352,6 +456,20 @@ func assertFrozenHookContract(t *testing.T, root, settingsPath string, hook froz
 	registered, err := hookCommandRegistered(settingsAbsPath, hook.Event, hook.InlineCommand)
 	require.NoError(t, err)
 	assert.Equal(t, hook.Registered, registered, "hook registration drifted for %s", hook.Path)
+}
+
+func assertFrozenSettingsContract(t *testing.T, root string, contract frozenToolContract) {
+	t.Helper()
+
+	switch contract.SettingsKind {
+	case "":
+		return
+	case settingsKindPiRegistration:
+		require.NotEmpty(t, contract.SettingsPath, "Pi registration settings require a settings path")
+		assertPiRegistrationSettings(t, filepath.Join(root, filepath.FromSlash(contract.SettingsPath)))
+	default:
+		t.Fatalf("unsupported frozen settings kind %q", contract.SettingsKind)
+	}
 }
 
 func assertShellNeutralHookCommand(t *testing.T, command string) {

--- a/internal/toolgen/surface_manifest.go
+++ b/internal/toolgen/surface_manifest.go
@@ -181,21 +181,27 @@ func jsonContractRows() []SurfaceManifestRow {
 }
 
 func commandSkillRows() []SurfaceManifestRow {
-	rows := []SurfaceManifestRow{}
+	hasCommandSkillSurface := false
 	for _, cfg := range Registry() {
-		if !cfg.CommandSkillSurface {
-			continue
+		if cfg.CommandSkillSurface {
+			hasCommandSkillSurface = true
+			break
 		}
-		for _, id := range commandIDs() {
-			name := adapterSkillName(id)
-			rows = append(rows, SurfaceManifestRow{
-				Kind:   "skill",
-				Name:   name,
-				Source: "internal/toolgen/toolgen.go:commandRegistry",
-				Docs:   "docs/reference/ai-tools.md",
-				Token:  commandSkillDocsToken(id),
-			})
-		}
+	}
+	if !hasCommandSkillSurface {
+		return nil
+	}
+
+	rows := []SurfaceManifestRow{}
+	for _, id := range commandIDs() {
+		name := adapterSkillName(id)
+		rows = append(rows, SurfaceManifestRow{
+			Kind:   "skill",
+			Name:   name,
+			Source: "internal/toolgen/toolgen.go:commandRegistry",
+			Docs:   "docs/reference/ai-tools.md",
+			Token:  commandSkillDocsToken(id),
+		})
 	}
 	return rows
 }

--- a/internal/toolgen/toolgen.go
+++ b/internal/toolgen/toolgen.go
@@ -20,19 +20,22 @@ import (
 // exported host skills to external agents.
 const skillIndexFileName = "skill-index.md"
 
-// ToolConfig describes a tool adapter target (Claude, Cursor, Codex, OpenCode, Gemini).
+// ToolConfig describes a tool adapter target (Claude, Cursor, Codex, OpenCode,
+// Gemini, and other generated AI-tool hosts).
 type ToolConfig struct {
-	ID            string
-	SkillsDir     string
-	CommandsDir   string // "" = no project-local commands (Codex)
-	CommandStyle  string // "nested", "flat", "" = no project-local commands
-	CommandFormat string // "md" (default), "toml" (Gemini)
+	ID               string
+	SkillsDir        string
+	CommandsDir      string // "" = no project-local commands (Codex/Qwen/Kiro)
+	CommandStyle     string // "nested", "flat", "" = no project-local commands
+	CommandFormat    string // "md" (default), "toml" (Gemini)
+	CommandExtension string // optional full extension override, for example ".prompt.md"
 	// CommandSkillSurface, when true, generates one host skill per Slipway command
 	// under SkillsDir (slipway-<command>/SKILL.md) instead of project-local command
-	// prompt files. Codex uses this: its current CLI discovers skills, not the
-	// deprecated custom-prompt surface.
+	// prompt files. Skill-first hosts use this when their CLI discovers skills
+	// instead of prompt/workflow command files.
 	CommandSkillSurface bool
 	SettingsPath        string
+	SettingsKind        string
 	SessionEvent        string
 	SessionHook         string
 	PostToolEvent       string
@@ -41,6 +44,10 @@ type ToolConfig struct {
 	TriggerStyle        string
 	AutoDetectPath      []string
 }
+
+const (
+	settingsKindPiRegistration = "pi-registration"
+)
 
 var toolRegistry = map[string]ToolConfig{
 	"claude": {
@@ -91,6 +98,22 @@ var toolRegistry = map[string]ToolConfig{
 			".codex",
 		},
 	},
+	"copilot": {
+		ID:               "copilot",
+		SkillsDir:        ".github/skills",
+		CommandsDir:      ".github/prompts",
+		CommandStyle:     "flat",
+		CommandFormat:    "md",
+		CommandExtension: ".prompt.md",
+		SettingsPath:     "",
+		SessionEvent:     "",
+		SessionHook:      "",
+		TriggerPrefix:    "/slipway-",
+		TriggerStyle:     "slash-hyphen",
+		AutoDetectPath: []string{
+			".github/copilot",
+		},
+	},
 	"opencode": {
 		ID:            "opencode",
 		SkillsDir:     ".opencode/skills",
@@ -119,6 +142,84 @@ var toolRegistry = map[string]ToolConfig{
 		TriggerStyle:  "slash-hyphen",
 		AutoDetectPath: []string{
 			".gemini",
+		},
+	},
+	"kilo": {
+		ID:            "kilo",
+		SkillsDir:     ".kilocode/skills",
+		CommandsDir:   ".kilocode/workflows",
+		CommandStyle:  "flat",
+		CommandFormat: "md",
+		SettingsPath:  "",
+		SessionEvent:  "",
+		SessionHook:   "",
+		TriggerPrefix: "/slipway",
+		TriggerStyle:  "slash-colon",
+		AutoDetectPath: []string{
+			".kilocode",
+		},
+	},
+	"kiro": {
+		ID:                  "kiro",
+		SkillsDir:           ".kiro/skills",
+		CommandsDir:         "",
+		CommandStyle:        "",
+		CommandFormat:       "",
+		CommandSkillSurface: true,
+		SettingsPath:        "",
+		SessionEvent:        "",
+		SessionHook:         "",
+		TriggerPrefix:       "@slipway",
+		TriggerStyle:        "at-colon",
+		AutoDetectPath: []string{
+			".kiro",
+		},
+	},
+	"pi": {
+		ID:            "pi",
+		SkillsDir:     ".pi/skills",
+		CommandsDir:   ".pi/prompts",
+		CommandStyle:  "flat",
+		CommandFormat: "md",
+		SettingsPath:  ".pi/settings.json",
+		SettingsKind:  settingsKindPiRegistration,
+		SessionEvent:  "",
+		SessionHook:   "",
+		TriggerPrefix: "/slipway-",
+		TriggerStyle:  "slash-hyphen",
+		AutoDetectPath: []string{
+			".pi",
+		},
+	},
+	"qwen": {
+		ID:                  "qwen",
+		SkillsDir:           ".qwen/skills",
+		CommandsDir:         "",
+		CommandStyle:        "",
+		CommandFormat:       "",
+		CommandSkillSurface: true,
+		SettingsPath:        ".qwen/settings.json",
+		SessionEvent:        "SessionStart",
+		SessionHook:         ".qwen/hooks/slipway-session-start",
+		TriggerPrefix:       "/slipway-",
+		TriggerStyle:        "slash-hyphen",
+		AutoDetectPath: []string{
+			".qwen",
+		},
+	},
+	"windsurf": {
+		ID:            "windsurf",
+		SkillsDir:     ".windsurf/skills",
+		CommandsDir:   ".windsurf/workflows",
+		CommandStyle:  "flat",
+		CommandFormat: "md",
+		SettingsPath:  "",
+		SessionEvent:  "",
+		SessionHook:   "",
+		TriggerPrefix: "/slipway-",
+		TriggerStyle:  "slash-hyphen",
+		AutoDetectPath: []string{
+			".windsurf",
 		},
 	},
 }
@@ -715,7 +816,11 @@ func ResolveTools(selection string) ([]string, error) {
 		return nil, nil
 	}
 	if strings.EqualFold(selection, "all") {
-		return []string{"claude", "codex", "cursor", "gemini", "opencode"}, nil
+		tools := make([]string, 0, len(toolRegistry))
+		for _, cfg := range Registry() {
+			tools = append(tools, cfg.ID)
+		}
+		return tools, nil
 	}
 	if strings.EqualFold(selection, "none") {
 		return nil, nil
@@ -829,6 +934,33 @@ func SkillIndexPath(cfg ToolConfig) string {
 		"references",
 		skillIndexFileName,
 	)
+}
+
+func commandFileExtension(cfg ToolConfig) string {
+	if ext := strings.TrimSpace(cfg.CommandExtension); ext != "" {
+		if strings.HasPrefix(ext, ".") {
+			return ext
+		}
+		return "." + ext
+	}
+	if cfg.CommandFormat == "toml" {
+		return ".toml"
+	}
+	return ".md"
+}
+
+func commandEntryRelPath(cfg ToolConfig, id string) string {
+	ext := commandFileExtension(cfg)
+	switch cfg.CommandStyle {
+	case "flat":
+		return filepath.ToSlash(filepath.Join(cfg.CommandsDir, "slipway-"+id+ext))
+	default:
+		return filepath.ToSlash(filepath.Join(cfg.CommandsDir, "slipway", id+ext))
+	}
+}
+
+func commandEntryPath(root string, cfg ToolConfig, id string) string {
+	return filepath.Join(root, filepath.FromSlash(commandEntryRelPath(cfg, id)))
 }
 
 func generateForTool(root string, cfg ToolConfig, refresh bool, closure skillInstallClosure) (err error) {
@@ -1030,23 +1162,12 @@ func generateForTool(root string, cfg ToolConfig, refresh bool, closure skillIns
 	// Command prompt surfaces (inline command prompts for prompt-backed adapters).
 	// Skip when CommandsDir is empty (Codex uses command skills instead).
 	if cfg.CommandsDir != "" {
-		ext := ".md"
-		if cfg.CommandFormat == "toml" {
-			ext = ".toml"
-		}
 		for _, id := range commandIDs() {
 			content, err := renderCommandEntry(cfg, id)
 			if err != nil {
 				return fmt.Errorf("render command prompt %q for %s: %w", id, cfg.ID, err)
 			}
-			var p string
-			switch cfg.CommandStyle {
-			case "flat":
-				p = filepath.Join(root, cfg.CommandsDir, "slipway-"+id+ext)
-			default: // "nested"
-				p = filepath.Join(root, cfg.CommandsDir, "slipway", id+ext)
-			}
-			if err := writeDeterministicWithPlan(plan, p, content, refresh); err != nil {
+			if err := writeDeterministicWithPlan(plan, commandEntryPath(root, cfg, id), content, refresh); err != nil {
 				return err
 			}
 		}
@@ -1075,26 +1196,35 @@ func generateForTool(root string, cfg ToolConfig, refresh bool, closure skillIns
 		}
 	}
 
-	// Hook registration is keyed on whether the host owns a settings.json.
+	// Settings registration is keyed on whether the host owns a settings.json.
 	//
 	//   - Settings-capable hosts (claude, gemini): register each hook event as a
 	//     bare inline `slipway hook <subcommand>` command directly in
 	//     settings.json. No launcher script files are written, and on refresh any
 	//     previously generated launcher files are pruned.
+	//   - Pi registers generated skills/prompts in settings.json without hook
+	//     semantics.
 	//   - Settings-less hosts (cursor, opencode): keep emitting the advisory
 	//     session-start launcher files (extensionless + .ps1 + .cmd), since they
 	//     have no settings.json to register an inline command in.
 	if strings.TrimSpace(cfg.SettingsPath) != "" {
-		if refresh {
-			if err := pruneHookLauncherFiles(root, cfg.SessionHook, plan); err != nil {
+		switch cfg.SettingsKind {
+		case settingsKindPiRegistration:
+			if err := mergePiRegistrationSettingsJSONWithPlan(root, cfg, refresh, plan); err != nil {
 				return err
 			}
-			if err := pruneHookLauncherFiles(root, cfg.PostToolHook, plan); err != nil {
+		default:
+			if refresh {
+				if err := pruneHookLauncherFiles(root, cfg.SessionHook, plan); err != nil {
+					return err
+				}
+				if err := pruneHookLauncherFiles(root, cfg.PostToolHook, plan); err != nil {
+					return err
+				}
+			}
+			if err := mergeHookSettingsJSONWithPlan(root, cfg, refresh, plan); err != nil {
 				return err
 			}
-		}
-		if err := mergeHookSettingsJSONWithPlan(root, cfg, refresh, plan); err != nil {
-			return err
 		}
 	} else if strings.TrimSpace(cfg.SessionHook) != "" {
 		for _, launcher := range hookLauncherOutputs(cfg.SessionHook, "session-start") {
@@ -1143,19 +1273,8 @@ func purgeCommandPromptSurfaces(root string, cfg ToolConfig, plan *toolRefreshPl
 	if cfg.CommandsDir == "" {
 		return nil
 	}
-	ext := ".md"
-	if cfg.CommandFormat == "toml" {
-		ext = ".toml"
-	}
 	for _, id := range commandIDs() {
-		var p string
-		switch cfg.CommandStyle {
-		case "flat":
-			p = filepath.Join(root, cfg.CommandsDir, "slipway-"+id+ext)
-		default:
-			p = filepath.Join(root, cfg.CommandsDir, "slipway", id+ext)
-		}
-		if err := removePathIfExistsWithPlan(plan, p); err != nil {
+		if err := removePathIfExistsWithPlan(plan, commandEntryPath(root, cfg, id)); err != nil {
 			return err
 		}
 	}
@@ -1169,19 +1288,8 @@ func invalidateFailedRefreshTrustSurfaces(root string, cfg ToolConfig, sentinelP
 	if cfg.CommandsDir == "" {
 		return nil
 	}
-	ext := ".md"
-	if cfg.CommandFormat == "toml" {
-		ext = ".toml"
-	}
 	for _, id := range commandIDs() {
-		var p string
-		switch cfg.CommandStyle {
-		case "flat":
-			p = filepath.Join(root, cfg.CommandsDir, "slipway-"+id+ext)
-		default:
-			p = filepath.Join(root, cfg.CommandsDir, "slipway", id+ext)
-		}
-		if err := plan.invalidateTrustedGeneratedFile(p); err != nil {
+		if err := plan.invalidateTrustedGeneratedFile(commandEntryPath(root, cfg, id)); err != nil {
 			return err
 		}
 	}
@@ -1265,17 +1373,10 @@ func cleanupStaleCommandEntries(root string, cfg ToolConfig, hadGeneratedAdapter
 		return nil
 	}
 
-	ext := ".md"
-	if cfg.CommandFormat == "toml" {
-		ext = ".toml"
-	}
+	ext := commandFileExtension(cfg)
 	expected := map[string]struct{}{}
 	for _, id := range commandIDs() {
-		name := id + ext
-		if cfg.CommandStyle == "flat" {
-			name = "slipway-" + id + ext
-		}
-		expected[name] = struct{}{}
+		expected[filepath.Base(commandEntryRelPath(cfg, id))] = struct{}{}
 	}
 
 	switch cfg.CommandStyle {
@@ -1991,6 +2092,68 @@ func mergeHookSettingsJSON(root string, cfg ToolConfig, refresh bool) error {
 	return mergeHookSettingsJSONWithPlan(root, cfg, refresh, nil)
 }
 
+func mergePiRegistrationSettingsJSONWithPlan(root string, cfg ToolConfig, refresh bool, plan *toolRefreshPlan) error {
+	settingsPath := filepath.Join(root, cfg.SettingsPath)
+	if !refresh {
+		if _, err := os.Stat(settingsPath); err == nil {
+			return nil
+		}
+	}
+
+	settings := map[string]any{}
+	existing, err := os.ReadFile(settingsPath) // #nosec G304 -- path is resolved from repository or governed artifact authority before this read.
+	if err == nil {
+		if err := json.Unmarshal(existing, &settings); err != nil {
+			return fmt.Errorf("parse %s: %w", cfg.SettingsPath, err)
+		}
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+
+	settings["enableSkillCommands"] = true
+	if err := mergeStringArraySetting(settings, "skills", "./skills"); err != nil {
+		return fmt.Errorf("%s: %w", cfg.SettingsPath, err)
+	}
+	if err := mergeStringArraySetting(settings, "prompts", "./prompts"); err != nil {
+		return fmt.Errorf("%s: %w", cfg.SettingsPath, err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil { // #nosec G301 -- directory is a user-facing project or governance artifact location where searchable mode is intentional.
+		return err
+	}
+	content, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return err
+	}
+	content = append(content, '\n')
+	if refresh && plan != nil {
+		return plan.writeUnmanagedFile(settingsPath, content, 0o644)
+	}
+	return os.WriteFile(settingsPath, content, 0o644) // #nosec G306 -- file is a user-facing project artifact where operator-readable mode is intentional.
+}
+
+func mergeStringArraySetting(settings map[string]any, key, value string) error {
+	raw, ok := settings[key]
+	if !ok || raw == nil {
+		settings[key] = []any{value}
+		return nil
+	}
+
+	items, ok := raw.([]any)
+	if !ok {
+		return fmt.Errorf("%s field must be an array", key)
+	}
+	for _, item := range items {
+		existing, ok := item.(string)
+		if ok && existing == value {
+			settings[key] = items
+			return nil
+		}
+	}
+	settings[key] = append(items, value)
+	return nil
+}
+
 func mergeHookSettingsJSONWithPlan(root string, cfg ToolConfig, refresh bool, plan *toolRefreshPlan) error {
 	settingsPath := filepath.Join(root, cfg.SettingsPath)
 	if !refresh {
@@ -2277,7 +2440,8 @@ func mergeHookEventCommand(hooks map[string]any, eventName, command string) {
 }
 
 func commandTrigger(cfg ToolConfig, commandID string) string {
-	if cfg.TriggerStyle == "slash-colon" {
+	switch cfg.TriggerStyle {
+	case "slash-colon", "at-colon":
 		return fmt.Sprintf("%s:%s", cfg.TriggerPrefix, commandID)
 	}
 	return fmt.Sprintf("%s%s", cfg.TriggerPrefix, commandID)
@@ -2306,9 +2470,13 @@ func hasGeneratedAdapter(root string, cfg ToolConfig) bool {
 // invocation surface is explicit at setup time.
 func (c ToolConfig) InvocationSummary() string {
 	if c.CommandSkillSurface {
+		if c.TriggerStyle != "" && c.TriggerStyle != "dollar-mention" {
+			return fmt.Sprintf("invoke command skills as %s or via host skill picker", commandTrigger(c, "<command>"))
+		}
 		return "invoke skills: $slipway (entry), $slipway-<command> per command, or /skills"
 	}
-	if c.TriggerStyle == "slash-colon" {
+	switch c.TriggerStyle {
+	case "slash-colon", "at-colon":
 		return fmt.Sprintf("invoke commands as %s:<command>", c.TriggerPrefix)
 	}
 	return fmt.Sprintf("invoke commands as %s<command>", c.TriggerPrefix)

--- a/internal/toolgen/toolgen_test.go
+++ b/internal/toolgen/toolgen_test.go
@@ -58,23 +58,47 @@ func loadHydrateReferencesFromFS(t *testing.T, src fs.FS, name string) []hydrate
 	return fm.HydrateReferences
 }
 
-func TestRegistryHasFiveTools(t *testing.T) {
+func TestRegistryHasElevenTools(t *testing.T) {
 	t.Parallel()
 	registry := Registry()
-	require.Len(t, registry, 5)
+	require.Len(t, registry, 11)
 
 	ids := make([]string, len(registry))
 	for i, cfg := range registry {
 		ids[i] = cfg.ID
 	}
-	assert.Equal(t, []string{"claude", "codex", "cursor", "gemini", "opencode"}, ids)
+	assert.Equal(t, []string{
+		"claude",
+		"codex",
+		"copilot",
+		"cursor",
+		"gemini",
+		"kilo",
+		"kiro",
+		"opencode",
+		"pi",
+		"qwen",
+		"windsurf",
+	}, ids)
 }
 
 func TestResolveTools(t *testing.T) {
 	t.Parallel()
 	all, err := ResolveTools("all")
 	require.NoError(t, err)
-	assert.Equal(t, []string{"claude", "codex", "cursor", "gemini", "opencode"}, all)
+	assert.Equal(t, []string{
+		"claude",
+		"codex",
+		"copilot",
+		"cursor",
+		"gemini",
+		"kilo",
+		"kiro",
+		"opencode",
+		"pi",
+		"qwen",
+		"windsurf",
+	}, all)
 
 	none, err := ResolveTools("none")
 	require.NoError(t, err)
@@ -389,6 +413,26 @@ func TestDetectExistingTools(t *testing.T) {
 	assert.Equal(t, []string{"claude", "cursor"}, detected)
 }
 
+func TestDetectExistingToolsIgnoresBareP1HostDirectories(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	for _, dir := range []string{
+		".pi",
+		".qwen",
+		".kiro",
+		".github",
+		".github/copilot",
+		".windsurf",
+		".kilocode",
+	} {
+		require.NoError(t, os.MkdirAll(filepath.Join(root, filepath.FromSlash(dir)), 0o755))
+	}
+
+	assert.Empty(t, DetectExistingTools(root),
+		"bare P1 host directories must not trigger refresh auto-detection without Slipway sentinels")
+}
+
 func TestHasGeneratedAdapter(t *testing.T) {
 	t.Parallel()
 
@@ -403,14 +447,16 @@ func TestHasGeneratedAdapter(t *testing.T) {
 func TestGenerateProducesAllExpectedFiles(t *testing.T) {
 	root := t.TempDir()
 	t.Setenv("CODEX_HOME", t.TempDir())
-	require.NoError(t, Generate(root, []string{"claude", "cursor", "codex", "gemini", "opencode"}, true))
+	toolIDs, err := ResolveTools("all")
+	require.NoError(t, err)
+	require.NoError(t, Generate(root, toolIDs, true))
 
-	for _, toolID := range []string{"claude", "cursor", "codex", "gemini", "opencode"} {
+	for _, toolID := range toolIDs {
 		cfg := toolRegistry[toolID]
 
 		// Sentinel marker
 		sentinelPath := filepath.Join(root, GeneratedAdapterMarkerPath(cfg))
-		_, err := os.Stat(sentinelPath)
+		_, err = os.Stat(sentinelPath)
 		assert.NoError(t, err, "%s: missing adapter sentinel", toolID)
 
 		// Governance skills (static) + standalone governance guidance skills
@@ -438,18 +484,8 @@ func TestGenerateProducesAllExpectedFiles(t *testing.T) {
 
 		// Command entries — per-tool path and format assertions
 		if cfg.CommandsDir != "" {
-			ext := ".md"
-			if cfg.CommandFormat == "toml" {
-				ext = ".toml"
-			}
 			for _, id := range commandIDs() {
-				var path string
-				switch cfg.CommandStyle {
-				case "flat":
-					path = filepath.Join(root, cfg.CommandsDir, "slipway-"+id+ext)
-				default:
-					path = filepath.Join(root, cfg.CommandsDir, "slipway", id+ext)
-				}
+				path := filepath.Join(root, filepath.FromSlash(commandEntryRelPath(cfg, id)))
 				_, err := os.Stat(path)
 				assert.NoError(t, err, "%s: missing command entry %s", toolID, id)
 			}
@@ -522,12 +558,13 @@ func TestGenerateProducesAllExpectedFiles(t *testing.T) {
 			}
 		}
 
-		// Hook emission is keyed on whether the host owns a settings.json.
-		// Settings-capable hosts (claude, gemini) register a bare inline command
-		// and emit NO launcher files. File-by-path hosts (cursor, opencode) still
-		// emit the session-start launcher family. Codex has no session hook.
+		// Hook emission is keyed on whether the host owns hook settings.
+		// Settings-capable hook hosts (claude, gemini, qwen) register a bare
+		// inline command and emit NO launcher files. Pi has settings registration
+		// without hook semantics. File-by-path hosts (cursor, opencode) still emit
+		// the session-start launcher family. Skill-only/no-hook hosts emit none.
 		switch {
-		case cfg.SettingsPath != "":
+		case cfg.SettingsPath != "" && cfg.SettingsKind != settingsKindPiRegistration:
 			// Settings-capable hosts must not write any launcher file for either
 			// hook (the extensionless POSIX entry or its .ps1/.cmd/.sh variants).
 			for _, base := range []string{cfg.SessionHook, cfg.PostToolHook} {
@@ -556,6 +593,8 @@ func TestGenerateProducesAllExpectedFiles(t *testing.T) {
 		}
 
 		switch {
+		case cfg.SettingsKind == settingsKindPiRegistration:
+			assertPiRegistrationSettings(t, filepath.Join(root, cfg.SettingsPath))
 		case cfg.SettingsPath != "":
 			settingsPath := filepath.Join(root, cfg.SettingsPath)
 			content, err := os.ReadFile(settingsPath)
@@ -588,6 +627,33 @@ func TestGenerateProducesAllExpectedFiles(t *testing.T) {
 			assert.True(t, os.IsNotExist(err), "%s: unexpected settings file generated", toolID)
 		}
 	}
+
+	copilotCfg := toolRegistry["copilot"]
+	assert.Equal(t,
+		".github/prompts/slipway-new.prompt.md",
+		commandEntryRelPath(copilotCfg, "new"),
+		"copilot command prompts must use GitHub Copilot's .prompt.md extension",
+	)
+	assert.FileExists(t,
+		filepath.Join(root, ".github", "prompts", "slipway-new.prompt.md"),
+		"copilot command prompt must be written under the shared .github prompts root",
+	)
+	assert.FileExists(t,
+		filepath.Join(root, ".github", "copilot", "slipway", ".adapter-generated"),
+		"copilot ownership sentinel must stay under .github/copilot, not shared .github",
+	)
+	_, err = os.Stat(filepath.Join(root, ".github", "slipway", ".adapter-generated"))
+	assert.True(t, os.IsNotExist(err), "copilot must not claim the shared .github root")
+
+	assert.FileExists(t, filepath.Join(root, ".kilocode", "workflows", "slipway-new.md"))
+	assert.FileExists(t, filepath.Join(root, ".windsurf", "workflows", "slipway-new.md"))
+
+	qwenNew, err := os.ReadFile(filepath.Join(root, ".qwen", "skills", "slipway-new", "SKILL.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(qwenNew), "/slipway-new")
+	kiroNew, err := os.ReadFile(filepath.Join(root, ".kiro", "skills", "slipway-new", "SKILL.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(kiroNew), "@slipway:new")
 }
 
 // referenceSectionFor returns a command-reference section or command body.
@@ -626,7 +692,9 @@ func TestWorkflowSkillGenerationAndReference(t *testing.T) {
 	codexHome := t.TempDir()
 	t.Setenv("CODEX_HOME", codexHome)
 
-	require.NoError(t, Generate(root, []string{"claude", "codex", "cursor", "gemini", "opencode"}, true))
+	toolIDs, err := ResolveTools("all")
+	require.NoError(t, err)
+	require.NoError(t, Generate(root, toolIDs, true))
 
 	for _, cfg := range Registry() {
 		skillPath := filepath.Join(root, cfg.SkillsDir, "slipway", "SKILL.md")
@@ -749,7 +817,7 @@ func TestWorkflowSkillGenerationAndReference(t *testing.T) {
 		}
 	}
 
-	_, err := os.Stat(filepath.Join(codexHome, "prompts", "slipway.md"))
+	_, err = os.Stat(filepath.Join(codexHome, "prompts", "slipway.md"))
 	assert.True(t, os.IsNotExist(err), "codex should not emit a workflow global prompt")
 }
 
@@ -1257,6 +1325,54 @@ func TestGenerateRefreshDoesNotPruneSkillDirsWithoutGeneratedAdapterMarker(t *te
 
 	_, err := os.Stat(filepath.Join(userOwnedSlipwayDir, "SKILL.md"))
 	assert.NoError(t, err, "refresh without a generated adapter marker must not prune user-owned slipway-* skill dirs")
+}
+
+func TestGenerateRefreshPreservesUserOwnedCopilotGitHubFiles(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("CODEX_HOME", t.TempDir())
+
+	userFiles := map[string]string{
+		".github/workflows/ci.yml":           "name: ci\n",
+		".github/prompts/user.prompt.md":     "# user prompt\n",
+		".github/skills/user-skill/SKILL.md": "# user skill\n",
+		".github/copilot/user-note.md":       "keep user note\n",
+	}
+	for rel, content := range userFiles {
+		p := filepath.Join(root, filepath.FromSlash(rel))
+		require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+		require.NoError(t, os.WriteFile(p, []byte(content), 0o644))
+	}
+
+	require.NoError(t, Generate(root, []string{"copilot"}, true))
+	require.NoError(t, Generate(root, []string{"copilot"}, true))
+
+	assert.FileExists(t, filepath.Join(root, ".github", "copilot", "slipway", ".adapter-generated"))
+	assert.FileExists(t, filepath.Join(root, ".github", "prompts", "slipway-new.prompt.md"))
+	assert.FileExists(t, filepath.Join(root, ".github", "skills", "slipway", "SKILL.md"))
+	_, err := os.Stat(filepath.Join(root, ".github", "slipway", ".adapter-generated"))
+	assert.True(t, os.IsNotExist(err), "copilot refresh must not claim shared .github ownership")
+
+	manifest, found, err := loadOwnershipManifest(root, toolRegistry["copilot"])
+	require.NoError(t, err)
+	require.True(t, found, "copilot refresh must write an ownership manifest")
+	owned := manifest.index()
+	assert.Contains(t, owned, ".github/copilot/slipway/.adapter-generated")
+	assert.Contains(t, owned, ".github/prompts/slipway-new.prompt.md")
+	assert.Contains(t, owned, ".github/skills/slipway/SKILL.md")
+
+	for rel, want := range userFiles {
+		got, readErr := os.ReadFile(filepath.Join(root, filepath.FromSlash(rel)))
+		require.NoError(t, readErr, "refresh must preserve user-owned %s", rel)
+		assert.Equal(t, want, string(got), "refresh must not rewrite user-owned %s", rel)
+		assert.NotContains(t, owned, rel, "refresh must not mark user-owned %s as generated", rel)
+	}
+	for rel := range owned {
+		assert.Truef(t,
+			strings.HasPrefix(rel, ".github/copilot/slipway/") ||
+				strings.HasPrefix(rel, ".github/prompts/slipway-") ||
+				strings.HasPrefix(rel, ".github/skills/slipway"),
+			"copilot ownership manifest must not claim non-generated shared .github path %s", rel)
+	}
 }
 
 func TestGenerateRefreshPreservesUnknownCleanupTargetsAndRefusesManagedModified(t *testing.T) {
@@ -1920,7 +2036,9 @@ func assertNoCodexLegacyCommandPrompts(t *testing.T, codexHome string) {
 }
 
 func TestByteStabilityAllTools(t *testing.T) {
-	for _, toolID := range []string{"claude", "codex", "cursor", "gemini", "opencode"} {
+	toolIDs, err := ResolveTools("all")
+	require.NoError(t, err)
+	for _, toolID := range toolIDs {
 		t.Run(toolID, func(t *testing.T) {
 			root := t.TempDir()
 			t.Setenv("CODEX_HOME", t.TempDir())
@@ -2138,18 +2256,31 @@ func commandSurfacePath(root, codexHome string, cfg ToolConfig, id string) (stri
 		return rel, filepath.Join(root, filepath.FromSlash(rel))
 	}
 
-	ext := ".md"
-	if cfg.CommandFormat == "toml" {
-		ext = ".toml"
-	}
-	var rel string
-	switch cfg.CommandStyle {
-	case "flat":
-		rel = filepath.ToSlash(filepath.Join(cfg.CommandsDir, "slipway-"+id+ext))
-	default:
-		rel = filepath.ToSlash(filepath.Join(cfg.CommandsDir, "slipway", id+ext))
-	}
+	rel := commandEntryRelPath(cfg, id)
 	return rel, filepath.Join(root, filepath.FromSlash(rel))
+}
+
+func assertPiRegistrationSettings(t *testing.T, settingsPath string) {
+	t.Helper()
+
+	content, err := os.ReadFile(settingsPath)
+	require.NoError(t, err, "missing Pi settings file")
+
+	settings := map[string]any{}
+	require.NoError(t, json.Unmarshal(content, &settings))
+	assert.Equal(t, true, settings["enableSkillCommands"])
+	assertJSONSettingArrayContains(t, settings, "skills", "./skills")
+	assertJSONSettingArrayContains(t, settings, "prompts", "./prompts")
+	assert.NotContains(t, settings, "hooks", "Pi settings register skills/prompts, not hooks")
+	assert.NotContains(t, string(content), "slipway hook", "Pi settings must not register hook commands")
+}
+
+func assertJSONSettingArrayContains(t *testing.T, settings map[string]any, name, want string) {
+	t.Helper()
+
+	raw, ok := settings[name].([]any)
+	require.True(t, ok, "settings missing %s array", name)
+	assert.Contains(t, raw, want, "settings %s must contain %q", name, want)
 }
 
 func assertHookCommandRegistered(t *testing.T, settingsPath, eventName, command string) {
@@ -2627,6 +2758,11 @@ func TestToolConfigInvocationSummary(t *testing.T) {
 		assert.Contains(t, summary, "invoke skills:")
 		assert.Contains(t, summary, "$slipway-<command>")
 		assert.NotContains(t, summary, "prompts")
+	})
+	t.Run("kiro command skills use at-colon triggers", func(t *testing.T) {
+		cfg, ok := LookupTool("kiro")
+		require.True(t, ok)
+		assert.Equal(t, "invoke command skills as @slipway:<command> or via host skill picker", cfg.InvocationSummary())
 	})
 }
 


### PR DESCRIPTION
## Summary

- Add P1 AI tool adapters for `pi`, `qwen`, `kiro`, `copilot`, `windsurf`, and `kilo` alongside the existing adapters.
- Extend toolgen with narrow adapter axes for Copilot `.prompt.md` files, Pi registration settings, Qwen/Kiro command skills, and Windsurf/Kilo workflow-style files.
- Update adapter docs, installation guidance, surface manifest, contract tests, and archived Slipway governance artifacts.

## Why

The governed change investigated current AI-tool adapter layouts and implements the user-selected P1 scope while preserving Slipway's thin-adapter model: generated host files route users back to the `slipway` CLI and do not implement separate lifecycle engines.

## User Impact

Users can now initialize the new adapters explicitly, for example `slipway init --tools pi,qwen,kiro,copilot,windsurf,kilo`, or include them through `slipway init --tools all`. Refresh remains sentinel/ownership controlled, including Copilot's shared `.github` root and Pi's settings registration behavior.

## Verification

- `slipway validate --json`: `G_ship=approved`, `blockers=null`, `evidence_freshness=fresh`.
- `slipway done --json`: archived `expand-ai-tool-adapters` successfully.
- Final closeout proof: `go test -count=1 -timeout=20m ./...` exited 0 (`cmd 441.003s`, `internal/toolgen 237.854s`).
- Goal verification proof: `go test -count=1 -timeout=20m ./...` exited 0 with digest `7ad511145d33124a74970c16162dd3a5c3ba1d3adc40c8e758d10a1eb771bacd`.
- `git diff --check`: exited 0.
