### PR TITLE
fix(plan-audit): flag shared-type changes whose target_files omit the blast radius

### DIFF
--- a/internal/tmpl/templates/skills/plan-audit/SKILL.md
+++ b/internal/tmpl/templates/skills/plan-audit/SKILL.md
@@ -154,7 +154,7 @@ dimension:
 2. **Completeness**: each task has objective, dependencies, and expected outputs.
 3. **Dependency Integrity**: every `depends_on` reference resolves and has no cycles, and every dependency is a real execution-order dependency — reject fabricated or narrative-only dependencies that needlessly serialize the computed waves.
 4. **Key Links**: each task names concrete `target_files` for the files or evidence targets it changes or verifies.
-5. **Scope Control**: task targets stay inside declared scope.
+5. **Scope Control**: task targets stay inside declared scope, and the plan's `target_files` cover the full edit set the tasks' own objectives force — not just the definition sites. When a `task_kind=code` task changes a shared or widely-referenced type or contract (adding a case to a non-exhaustive/non-sealed enum, reshaping a widely-constructed struct/record, or changing a shared signature), the consumer edits it forces — the exhaustive-match or construction sites that will otherwise stop compiling — must be owned by some task's `target_files` (this task or a dependent one). If no task claims that blast radius, S2 cannot satisfy both the post-wave integration gate and keeping `changed_files` covered by `target_files`, so the conflict only surfaces mid-implementation as a compile failure plus a latent scope escape. Size the blast radius from the codebase map and flag the under-scoped task here.
 6. **Context Compliance**: task metadata supports context-safe execution (`task_kind` where present).
 7. **Test Coverage Mapping**: acceptance criteria map to automated checks; new scaffolding is an explicit dependency.
 8. **Alternatives Considered**: required/present `decision.md` names at least 2 approaches, tradeoffs, and the selected approach.

--- a/internal/tmpl/templates/skills/plan-audit/references/audit-smells.md
+++ b/internal/tmpl/templates/skills/plan-audit/references/audit-smells.md
@@ -9,6 +9,7 @@
 | "Tasks are clear enough" | Each task must have explicit acceptance criteria. |
 | "Verification will happen during implementation" | Plan audit still requires testable acceptance criteria and evidence paths before execution. |
 | "The task is self-evident" | Self-evident tasks still need observable verification. Implicit means unverifiable. |
+| "This code task only edits the file that defines the type" | A change to a shared or widely-referenced type/contract (new enum case, struct/record field, changed signature) forces every consumer to update too. Some task's `target_files` must own those call sites, or S2's integration gate and keeping `changed_files` covered by `target_files` become mutually unsatisfiable. |
 
 ## Failure Handling Patterns
 - If artifacts are missing or stale, set verdict to `fail` with specific blockers.

--- a/internal/tmpl/templates_test.go
+++ b/internal/tmpl/templates_test.go
@@ -952,6 +952,22 @@ func TestPlanAuditBlocksFutureLifecycleAcceptanceCriteria(t *testing.T) {
 	assert.NotContains(t, content, "S3 closeout")
 }
 
+func TestPlanAuditScopeControlFlagsSharedTypeBlastRadius(t *testing.T) {
+	t.Parallel()
+
+	content, err := Content("skills/plan-audit/SKILL.md")
+	require.NoError(t, err)
+	flat := strings.Join(strings.Fields(content), " ")
+
+	// Scope Control must catch a code task that changes a shared/widely-referenced
+	// type whose forced consumer edits no task's target_files own — the plan that
+	// passes plan-audit but the S2 integration gate later rejects (issue #277).
+	assert.Contains(t, flat, "cover the full edit set the tasks' own objectives force")
+	assert.Contains(t, flat, "shared or widely-referenced type or contract")
+	assert.Contains(t, flat, "non-exhaustive/non-sealed enum")
+	assert.Contains(t, flat, "owned by some task's `target_files`")
+}
+
 func TestNextCommandDocumentsWorktreeSkillCatalogFallback(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

Closes #277. `plan-audit` returned PASS for a `task_kind=code` task that declared a single-file `target_files` while its work was to add variants to *shared* enums / a field to a *shared* struct — a change that structurally forces edits across consumer crates. The conflict (`cargo check --workspace` failures + `task_changed_file_scope_escape`) only surfaced mid-S2, where the post-wave integration gate and `changed_files ⊆ target_files` became mutually unsatisfiable until `target_files` was amended in flight.

## Root cause

The 8D **Scope Control** dimension only checked that task targets stayed *inside* declared scope (over-broad). It said nothing about *under-scoped* targets, so a definition-only `target_files` on a shared-type change passed.

## Why the fix is in the skill, not the engine

The engine's `plan_dimension_scope_*` checks (`internal/engine/progression/validation.go`) are structural and language-agnostic (valid path / inside repo). Deciding whether a type change *ripples* across consumers (is this enum non-exhaustive? who matches it exhaustively?) is a language-level semantic judgment the language-agnostic engine must not make. So this lands in the plan-audit skill — the auditor's semantic layer — consistent with Slipway's "engine owns structure, skill owns judgment" boundary.

## Change

- **Scope Control** now also requires the plan's `target_files` to cover the full edit set the tasks' objectives force, naming shared-type blast radius explicitly (enum case / struct-record field / shared signature). It allows the consumer edits to be owned by a **dependent task** rather than the originating one — only a blast radius *no task claims* is flagged, which is exactly the S2-unsatisfiable case.
- `references/audit-smells.md` gains the matching "only edits the defining file" rationalization red flag.
- A template test (`TestPlanAuditScopeControlFlagsSharedTypeBlastRadius`) pins the new contract.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` — all green (incl. toolgen contract suite).
- `gofmt -s` clean; `golangci-lint run ./internal/tmpl/...` — 0 issues.

Distinct from #249 (a different S2 gate/cause), as the issue notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)