### PR TITLE
fix(runtime): prefer local archived change for unscoped status/validate in its worktree (#283)

### DIFF
--- a/cmd/active_change_resolution_test.go
+++ b/cmd/active_change_resolution_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -92,4 +93,204 @@ func TestRunFromRootReportsBoundElsewhere(t *testing.T) {
 		assert.Contains(t, cliErr.Remediation, "--change run-bound-change")
 		assert.Contains(t, cliErr.Remediation, normalizedWorktreePath)
 	})
+}
+
+func TestResolveActiveChangeRefPrefersArchivedWorktreeOverUnboundActive(t *testing.T) {
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		initGitRepoForWorktreeTests(t, root)
+
+		archivedSlug := "archived-review-worktree"
+		worktreePath := setupArchivedWorktreeForResolution(t, root, archivedSlug)
+
+		unbound := model.NewChange("unbound-active-change")
+		unbound.CurrentState = model.StateS2Implement
+		unbound.PlanSubStep = model.PlanSubStepNone
+		require.NoError(t, state.SaveChange(root, unbound))
+
+		withNestedWorkingDirectory(t, worktreePath, func() {
+			ref, err := resolveActiveChangeRef(root, "")
+			assert.Empty(t, ref.Slug)
+			cliErr := asCLIError(err)
+			require.NotNil(t, cliErr)
+			assert.Equal(t, "archived_change_not_validatable", cliErr.ErrorCode)
+			assert.Equal(t, archivedSlug, cliErr.Slug)
+			assert.Equal(t, true, cliErr.Details["archived"])
+		})
+	})
+}
+
+func TestResolveActiveChangeRefKeepsRootActiveOnArchivedBranch(t *testing.T) {
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		initGitRepoForWorktreeTests(t, root)
+
+		archivedSlug := "archived-root-branch-resolution"
+		worktreePath := setupArchivedWorktreeForResolution(t, root, archivedSlug)
+		runGit(t, worktreePath, "checkout", "--detach")
+		runGit(t, root, "checkout", state.DefaultWorktreeBranch(archivedSlug))
+
+		active := model.NewChange("root-active-change")
+		active.CurrentState = model.StateS2Implement
+		active.PlanSubStep = model.PlanSubStepNone
+		require.NoError(t, state.SaveChange(root, active))
+
+		withNestedWorkingDirectory(t, root, func() {
+			ref, err := resolveActiveChangeRef(root, "")
+			require.NoError(t, err)
+			assert.Equal(t, active.Slug, ref.Slug)
+		})
+	})
+}
+
+func TestStatusKeepsRootActiveOnArchivedBranch(t *testing.T) {
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		initGitRepoForWorktreeTests(t, root)
+
+		archivedSlug := "archived-root-branch-status"
+		worktreePath := setupArchivedWorktreeForResolution(t, root, archivedSlug)
+		runGit(t, worktreePath, "checkout", "--detach")
+		runGit(t, root, "checkout", state.DefaultWorktreeBranch(archivedSlug))
+
+		active := model.NewChange("root-active-status")
+		active.CurrentState = model.StateS2Implement
+		active.PlanSubStep = model.PlanSubStepNone
+		require.NoError(t, state.SaveChange(root, active))
+
+		var out bytes.Buffer
+		cmd := commandForRoot(t, root, makeStatusCmd())
+		cmd.SetArgs([]string{"--json"})
+		cmd.SetOut(&out)
+		require.NoError(t, cmd.Execute())
+
+		var view statusView
+		require.NoError(t, json.Unmarshal(out.Bytes(), &view))
+		assert.Equal(t, active.Slug, view.Slug)
+		assert.False(t, view.Archived)
+		assert.NotEqual(t, "archived", view.ExecutionMode)
+	})
+}
+
+func TestResolveActiveChangeRefKeepsBoundActiveBeforeArchivedCandidate(t *testing.T) {
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		initGitRepoForWorktreeTests(t, root)
+
+		archivedSlug := "archived-candidate-with-active-binding"
+		worktreePath := setupArchivedWorktreeForResolution(t, root, archivedSlug)
+
+		active := model.NewChange("active-bound-to-archived-worktree")
+		active.CurrentState = model.StateS2Implement
+		active.PlanSubStep = model.PlanSubStepNone
+		active.WorktreePath = worktreePath
+		active.WorktreeBranch = state.DefaultWorktreeBranch(archivedSlug)
+		require.NoError(t, state.SaveChange(root, active))
+
+		withNestedWorkingDirectory(t, worktreePath, func() {
+			ref, err := resolveActiveChangeRef(root, "")
+			require.NoError(t, err)
+			assert.Equal(t, active.Slug, ref.Slug)
+		})
+	})
+}
+
+func TestResolveActiveChangeRefPreservesMultipleActiveMatchesBeforeArchivedFallback(t *testing.T) {
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		initGitRepoForWorktreeTests(t, root)
+
+		archivedSlug := "archived-multiple-active-resolution"
+		worktreePath := setupArchivedWorktreeForResolution(t, root, archivedSlug)
+
+		activeA := model.NewChange("active-bound-duplicate-a")
+		activeA.CurrentState = model.StateS2Implement
+		activeA.PlanSubStep = model.PlanSubStepNone
+		activeA.WorktreePath = worktreePath
+		activeA.WorktreeBranch = state.DefaultWorktreeBranch(archivedSlug)
+		require.NoError(t, state.SaveChange(root, activeA))
+
+		activeB := model.NewChange("active-bound-duplicate-b")
+		activeB.CurrentState = model.StateS2Implement
+		activeB.PlanSubStep = model.PlanSubStepNone
+		activeB.WorktreePath = worktreePath
+		activeB.WorktreeBranch = state.DefaultWorktreeBranch(archivedSlug)
+		require.NoError(t, state.SaveChange(root, activeB))
+
+		withNestedWorkingDirectory(t, worktreePath, func() {
+			ref, err := resolveActiveChangeRef(root, "")
+			assert.Empty(t, ref.Slug)
+			cliErr := asCLIError(err)
+			require.NotNil(t, cliErr)
+			assert.Equal(t, "active_context_ambiguous", cliErr.ErrorCode)
+		})
+	})
+}
+
+func TestResolveActiveChangeRefFailsClosedOnCorruptLocalArchive(t *testing.T) {
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		initGitRepoForWorktreeTests(t, root)
+
+		archivedSlug := "archived-corrupt-resolution"
+		worktreePath := setupArchivedWorktreeForResolution(t, root, archivedSlug)
+		archivePath, err := state.ArchivedChangeFilePathForRead(root, archivedSlug)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(archivePath, []byte("slug: ["), 0o644))
+
+		unbound := model.NewChange("unbound-active-corrupt-fallback")
+		unbound.CurrentState = model.StateS2Implement
+		unbound.PlanSubStep = model.PlanSubStepNone
+		require.NoError(t, state.SaveChange(root, unbound))
+
+		withNestedWorkingDirectory(t, worktreePath, func() {
+			ref, err := resolveActiveChangeRef(root, "")
+			assert.Empty(t, ref.Slug)
+			cliErr := asCLIError(err)
+			require.NotNil(t, cliErr)
+			assert.Equal(t, categoryStateIntegrity, cliErr.Category)
+			assert.Equal(t, "change_state_load_failed", cliErr.ErrorCode)
+			assert.Equal(t, archivedSlug, cliErr.Slug)
+			assert.Equal(t, filepath.Join("artifacts", "changes", "archived", archivedSlug, "change.yaml"), cliErr.Details["path"])
+		})
+	})
+}
+
+func setupArchivedWorktreeForResolution(t *testing.T, root, slug string) string {
+	t.Helper()
+
+	branch := state.DefaultWorktreeBranch(slug)
+	worktreePath := state.DefaultWorktreePath(root, slug)
+	runGit(t, root, "branch", branch)
+	runGit(t, root, "worktree", "add", worktreePath, branch)
+
+	change := model.NewChange(slug)
+	change.CurrentState = model.StateS2Implement
+	change.PlanSubStep = model.PlanSubStepNone
+	change.WorktreePath = worktreePath
+	change.WorktreeBranch = branch
+	require.NoError(t, state.SaveChange(root, change))
+
+	_, err := state.ArchiveChange(root, change, model.ChangeStatusDone)
+	require.NoError(t, err)
+	return worktreePath
+}
+
+func withNestedWorkingDirectory(t *testing.T, dir string, fn func()) {
+	t.Helper()
+
+	previousWD, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	defer func() {
+		require.NoError(t, os.Chdir(previousWD))
+	}()
+
+	fn()
 }

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -323,6 +323,14 @@ func resolveActiveChangeRef(root string, explicitSlug string) (changeRef, error)
 	if worktreePath != "" {
 		change, err := state.FindActiveChangeForWorktree(root, worktreePath)
 		if err != nil {
+			// Before surfacing "no active change here" or "bound to another
+			// worktree", prefer this worktree's own archived change when it hosts
+			// one, so an archived-change worktree reports its own terminal state
+			// (archived_change_not_validatable) instead of an unrelated active
+			// change bound to a different worktree (#283).
+			if archived, ok, archErr := state.FindArchivedChangeForWorktree(root, worktreePath); archErr == nil && ok {
+				return resolveExplicitChange(root, archived.Slug)
+			}
 			if recoveryErr := deleteRecoveryError(root, ""); recoveryErr != nil {
 				return changeRef{}, recoveryErr
 			}

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -328,13 +328,27 @@ func resolveActiveChangeRef(root string, explicitSlug string) (changeRef, error)
 			// one, so an archived-change worktree reports its own terminal state
 			// (archived_change_not_validatable) instead of an unrelated active
 			// change bound to a different worktree (#283).
-			if archived, ok, archErr := state.FindArchivedChangeForWorktree(root, worktreePath); archErr == nil && ok {
-				return resolveExplicitChange(root, archived.Slug)
+			if shouldTryArchivedWorktreeFallback(err) {
+				if archived, ok, archErr := state.FindArchivedChangeForWorktree(root, worktreePath); archErr != nil {
+					return changeRef{}, wrapArchivedWorktreeResolutionError(archErr)
+				} else if ok {
+					return resolveExplicitChange(root, archived.Slug)
+				}
 			}
 			if recoveryErr := deleteRecoveryError(root, ""); recoveryErr != nil {
 				return changeRef{}, recoveryErr
 			}
 			return changeRef{}, wrapResolutionError(err)
+		}
+		if strings.TrimSpace(change.WorktreePath) == "" {
+			// A single unbound active change is only a fallback. In an archived
+			// review worktree, local archived authority is more specific and must
+			// fail closed before commands operate on the unrelated unbound change.
+			if archived, ok, archErr := state.FindArchivedChangeForWorktree(root, worktreePath); archErr != nil {
+				return changeRef{}, wrapArchivedWorktreeResolutionError(archErr)
+			} else if ok {
+				return resolveExplicitChange(root, archived.Slug)
+			}
 		}
 		return changeRef{Slug: change.Slug}, nil
 	}
@@ -347,6 +361,14 @@ func resolveActiveChangeRef(root string, explicitSlug string) (changeRef, error)
 		return changeRef{}, wrapResolutionError(err)
 	}
 	return changeRef{Slug: change.Slug}, nil
+}
+
+func shouldTryArchivedWorktreeFallback(err error) bool {
+	if errors.Is(err, state.ErrNoActiveChange) {
+		return true
+	}
+	var boundElsewhere *state.ChangeBoundElsewhereError
+	return errors.As(err, &boundElsewhere)
 }
 
 func addChangeSelectorFlags(cmd *cobra.Command, target *string, usage string) {
@@ -552,15 +574,35 @@ func staleRuntimeBindingReasons(slugs []string) []model.ReasonCode {
 // change's change.yaml cannot be loaded. All change-state loaders share it so
 // the error code, remediation, and metadata stay identical.
 func newChangeStateLoadFailedError(slug string, err error) *CLIError {
+	return newChangeStateLoadFailedErrorForPath(
+		slug,
+		filepath.Join("artifacts", "changes", slug, "change.yaml"),
+		err,
+	)
+}
+
+func newChangeStateLoadFailedErrorForPath(slug, path string, err error) *CLIError {
 	return newStateIntegrityError(
 		"change_state_load_failed",
 		fmt.Sprintf("failed to load change state for %q: %v", slug, err),
 		"Run `slipway repair` to inspect or repair change state files.",
 		slug,
 		map[string]any{
-			"path": filepath.Join("artifacts", "changes", slug, "change.yaml"),
+			"path": path,
 		},
 	)
+}
+
+func wrapArchivedWorktreeResolutionError(err error) error {
+	var archivedLoad *state.ArchivedChangeLoadError
+	if errors.As(err, &archivedLoad) {
+		return newChangeStateLoadFailedErrorForPath(
+			archivedLoad.Slug,
+			filepath.Join("artifacts", "changes", "archived", archivedLoad.Slug, "change.yaml"),
+			err,
+		)
+	}
+	return wrapResolutionError(err)
 }
 
 func wrapResolutionError(err error) error {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -254,6 +254,25 @@ func makeStatusCmd() *cobra.Command {
 				return showStatusForChange(cmd, root, change, outputFormat, effectiveView, hydrateKeys, hydrate)
 			}
 
+			// When the invocation worktree hosts a local archived change, prefer it
+			// over a global active change bound to a different worktree. Otherwise
+			// unscoped status silently reports that unrelated active change as if it
+			// were local, switching the review context out from under an
+			// archived-change review (#283).
+			if change, ok, err := statusArchivedChangeForCurrentWorktree(root); err != nil {
+				return err
+			} else if ok {
+				effectiveView := resolveEffectiveFocus("status", explicitFocus)
+				hydrateKeys := normalizeHydrateKeys(resolveEffectiveFocusHydrate("status", explicitFocus))
+				if hydrate {
+					hydrateKeys, err = selectHydrateKeys(hydrateKeys, hydrateRefs)
+					if err != nil {
+						return err
+					}
+				}
+				return showArchivedStatusForChange(cmd, root, change, outputFormat, effectiveView, hydrateKeys, hydrate)
+			}
+
 			changes, err := state.ListChanges(root)
 			if err != nil {
 				// A partially-deleted change (a governed bundle directory that
@@ -373,6 +392,21 @@ func statusChangeFromCurrentWorktreeBinding(root string) (model.Change, bool, er
 		return model.Change{}, false, nil
 	}
 	return model.Change{}, false, wrapResolutionError(err)
+}
+
+// statusArchivedChangeForCurrentWorktree resolves the archived change whose
+// dedicated worktree is the current invocation worktree, so unscoped status in
+// an archived-change worktree reports that local archived change instead of an
+// unrelated global active change bound elsewhere (#283).
+func statusArchivedChangeForCurrentWorktree(root string) (model.Change, bool, error) {
+	worktreePath, err := currentWorktreeRoot()
+	if err != nil {
+		return model.Change{}, false, wrapResolutionError(err)
+	}
+	if strings.TrimSpace(worktreePath) == "" {
+		return model.Change{}, false, nil
+	}
+	return state.FindArchivedChangeForWorktree(root, worktreePath)
 }
 
 func shouldFallbackStatusMultiSummary(err error) bool {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -406,7 +406,11 @@ func statusArchivedChangeForCurrentWorktree(root string) (model.Change, bool, er
 	if strings.TrimSpace(worktreePath) == "" {
 		return model.Change{}, false, nil
 	}
-	return state.FindArchivedChangeForWorktree(root, worktreePath)
+	change, ok, err := state.FindArchivedChangeForWorktree(root, worktreePath)
+	if err != nil {
+		return model.Change{}, false, wrapArchivedWorktreeResolutionError(err)
+	}
+	return change, ok, nil
 }
 
 func shouldFallbackStatusMultiSummary(err error) bool {

--- a/internal/state/find_archived_change_for_worktree_test.go
+++ b/internal/state/find_archived_change_for_worktree_test.go
@@ -75,3 +75,34 @@ func TestFindArchivedChangeForWorktreeIgnoresProjectRoot(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, ok, "the project root must not match any archived change's dedicated worktree")
 }
+
+func TestFindArchivedChangeForWorktreeIgnoresProjectRootOnArchivedBranch(t *testing.T) {
+	t.Parallel()
+	slug := "archived-root-on-feature-branch"
+	root, worktreePath := setupArchivedChangeWorktree(t, slug)
+	runGit(t, worktreePath, "checkout", "--detach")
+	runGit(t, root, "checkout", DefaultWorktreeBranch(slug))
+
+	_, ok, err := FindArchivedChangeForWorktree(root, root)
+	require.NoError(t, err)
+	assert.False(t, ok, "the project root must not match by archived branch alone")
+}
+
+func TestFindArchivedChangeForWorktreeFailsClosedOnCorruptLocalArchive(t *testing.T) {
+	t.Parallel()
+	slug := "archived-corrupt-local"
+	root, worktreePath := setupArchivedChangeWorktree(t, slug)
+
+	archivePath, err := ArchivedChangeFilePathForRead(root, slug)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(archivePath, []byte("slug: ["), 0o644))
+
+	_, ok, err := FindArchivedChangeForWorktree(root, worktreePath)
+	require.Error(t, err)
+	assert.False(t, ok)
+
+	var loadErr *ArchivedChangeLoadError
+	require.ErrorAs(t, err, &loadErr)
+	assert.Equal(t, slug, loadErr.Slug)
+	assert.Contains(t, loadErr.WorktreePath, filepath.Join(".worktrees", slug))
+}

--- a/internal/state/find_archived_change_for_worktree_test.go
+++ b/internal/state/find_archived_change_for_worktree_test.go
@@ -1,0 +1,77 @@
+package state
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/signalridge/slipway/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupArchivedChangeWorktree builds a repo with a Slipway-convention dedicated
+// worktree (`.worktrees/<slug>` on `feat/<slug>`) for slug, saves a change bound
+// to it, then archives it as done. It returns the repo root and the worktree
+// path so callers can assert how the archived change resolves from each.
+func setupArchivedChangeWorktree(t *testing.T, slug string) (repoRoot, worktreePath string) {
+	t.Helper()
+	repoRoot = t.TempDir()
+	runGit(t, repoRoot, "init", "--initial-branch=main")
+	runGit(t, repoRoot, "config", "user.email", "test@example.com")
+	runGit(t, repoRoot, "config", "user.name", "Test User")
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "README.md"), []byte("hello"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, ".slipway.yaml"), []byte("defaults:\n  artifact_schema: expanded\n"), 0o644))
+	runGit(t, repoRoot, "add", ".")
+	runGit(t, repoRoot, "commit", "-m", "init")
+
+	branch := DefaultWorktreeBranch(slug)
+	worktreePath = DefaultWorktreePath(repoRoot, slug)
+	runGit(t, repoRoot, "branch", branch)
+	runGit(t, repoRoot, "worktree", "add", worktreePath, branch)
+
+	change := model.NewChange(slug)
+	change.CurrentState = model.StateS2Implement
+	change.PlanSubStep = model.PlanSubStepNone
+	change.WorktreePath = worktreePath
+	change.WorktreeBranch = branch
+	require.NoError(t, SaveChange(repoRoot, change))
+
+	_, err := ArchiveChange(repoRoot, change, model.ChangeStatusDone)
+	require.NoError(t, err)
+	return repoRoot, worktreePath
+}
+
+// TestFindArchivedChangeForWorktreePrefersLocalArchivedChange proves the #283
+// fix: from inside an archived change's dedicated worktree, the local archived
+// change is recovered even though the git-local binding was removed at archive
+// time. This is what lets unscoped status/validate report the local archived
+// change instead of an unrelated active change bound to a different worktree.
+func TestFindArchivedChangeForWorktreePrefersLocalArchivedChange(t *testing.T) {
+	t.Parallel()
+	slug := "archived-review-worktree"
+	root, worktreePath := setupArchivedChangeWorktree(t, slug)
+
+	// Archive removed the runtime binding; resolution must reconstruct it.
+	_, statErr := os.Stat(WorktreeBindingPath(root, slug))
+	require.True(t, os.IsNotExist(statErr), "archive should have removed the runtime worktree binding")
+
+	resolved, ok, err := FindArchivedChangeForWorktree(root, worktreePath)
+	require.NoError(t, err)
+	require.True(t, ok, "archived change owning the invocation worktree must be found")
+	assert.Equal(t, slug, resolved.Slug)
+	assert.Equal(t, model.ChangeStatusDone, resolved.Status)
+}
+
+// TestFindArchivedChangeForWorktreeIgnoresProjectRoot proves the project root is
+// never treated as a dedicated change worktree, so unscoped resolution invoked
+// from the repo root still falls through to active-change resolution (status
+// from the repo root keeps reporting the global active change unchanged).
+func TestFindArchivedChangeForWorktreeIgnoresProjectRoot(t *testing.T) {
+	t.Parallel()
+	root, _ := setupArchivedChangeWorktree(t, "archived-not-at-root")
+
+	_, ok, err := FindArchivedChangeForWorktree(root, root)
+	require.NoError(t, err)
+	assert.False(t, ok, "the project root must not match any archived change's dedicated worktree")
+}

--- a/internal/state/worktree_binding.go
+++ b/internal/state/worktree_binding.go
@@ -32,6 +32,28 @@ type worktreeBinding struct {
 	GitCommonDir string `yaml:"git_common_dir,omitempty"`
 }
 
+// ArchivedChangeLoadError reports a candidate archived change that should have
+// been local to the invocation worktree but could not be loaded.
+type ArchivedChangeLoadError struct {
+	Slug         string
+	WorktreePath string
+	Err          error
+}
+
+func (err *ArchivedChangeLoadError) Error() string {
+	if err == nil {
+		return ""
+	}
+	return fmt.Sprintf("load archived change %q for worktree %q: %v", err.Slug, err.WorktreePath, err.Err)
+}
+
+func (err *ArchivedChangeLoadError) Unwrap() error {
+	if err == nil {
+		return nil
+	}
+	return err.Err
+}
+
 // WorktreeBindingPath returns the git-local worktree-binding record path for slug.
 func WorktreeBindingPath(root, slug string) string {
 	return filepath.Join(ChangeDir(root, slug), worktreeBindingFileName)
@@ -166,7 +188,14 @@ func FindArchivedChangeForWorktree(root, worktreePath string) (model.Change, boo
 	for _, slug := range archivedWorktreeSlugCandidates(normalizedWorktree, branch) {
 		change, err := LoadArchivedChange(root, slug)
 		if err != nil {
-			continue
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return model.Change{}, false, &ArchivedChangeLoadError{
+				Slug:         slug,
+				WorktreePath: normalizedWorktree,
+				Err:          err,
+			}
 		}
 		if archivedChangeBoundToWorktree(root, change, normalizedWorktree, branch) {
 			return change, true, nil
@@ -204,13 +233,17 @@ func archivedWorktreeSlugCandidates(worktreePath, branch string) []string {
 
 // archivedChangeBoundToWorktree confirms a candidate archived change actually
 // owns the invocation worktree via authority that survives archival: either the
-// default dedicated worktree path matches, or the archived bundle's recorded
-// worktree_branch matches the worktree's current branch. The project root never
-// matches (its path is not `.worktrees/<slug>` and no archived change records a
-// `feat/<slug>` branch for it).
+// default dedicated worktree path matches, or a non-root worktree's branch
+// matches the archived bundle's recorded worktree_branch. The project root never
+// matches by branch alone; root invocations must fall through to active/global
+// resolution.
 func archivedChangeBoundToWorktree(root string, change model.Change, worktreePath, branch string) bool {
 	if defaultPath, err := NormalizePath(DefaultWorktreePath(root, change.Slug)); err == nil && defaultPath == worktreePath {
 		return true
+	}
+	normalizedRoot, err := NormalizePath(root)
+	if err != nil || normalizedRoot == worktreePath {
+		return false
 	}
 	recordedBranch := strings.TrimSpace(change.WorktreeBranch)
 	return recordedBranch != "" && branch != "" && recordedBranch == branch

--- a/internal/state/worktree_binding.go
+++ b/internal/state/worktree_binding.go
@@ -146,6 +146,76 @@ func FindActiveChangeByWorktreeBinding(root, currentWorktreePath string) (model.
 	return matches[0], nil
 }
 
+// FindArchivedChangeForWorktree resolves the archived change whose dedicated
+// worktree is the given invocation worktree. The git-local worktree-binding
+// record is removed at archive time, so the runtime-binding lookups used for
+// active changes cannot recover this association; instead it is reconstructed
+// from the portable archived bundle using the worktree authority that survives
+// archival: the default `.worktrees/<slug>` path convention and the bundle's
+// recorded worktree_branch.
+//
+// It returns (_, false, nil) when the invocation worktree hosts no local
+// archived change (the common case, including the project root and any active
+// worktree), so callers fall through to active-change resolution unchanged.
+func FindArchivedChangeForWorktree(root, worktreePath string) (model.Change, bool, error) {
+	normalizedWorktree, err := NormalizePath(worktreePath)
+	if err != nil {
+		return model.Change{}, false, fmt.Errorf("normalize worktree path: %w", err)
+	}
+	branch, _ := resolveWorktreeActualBranch(normalizedWorktree)
+	for _, slug := range archivedWorktreeSlugCandidates(normalizedWorktree, branch) {
+		change, err := LoadArchivedChange(root, slug)
+		if err != nil {
+			continue
+		}
+		if archivedChangeBoundToWorktree(root, change, normalizedWorktree, branch) {
+			return change, true, nil
+		}
+	}
+	return model.Change{}, false, nil
+}
+
+// archivedWorktreeSlugCandidates derives the archived slugs that could own the
+// invocation worktree from the worktree directory name and its git branch,
+// following Slipway's `.worktrees/<slug>` + `feat/<slug>` creation convention.
+// Deriving candidates (instead of enumerating every archived bundle) keeps
+// resolution delegated to LoadArchivedChange's own path authority.
+func archivedWorktreeSlugCandidates(worktreePath, branch string) []string {
+	seen := map[string]struct{}{}
+	candidates := make([]string, 0, 2)
+	add := func(slug string) {
+		slug = strings.TrimSpace(slug)
+		if slug == "" {
+			return
+		}
+		if err := ValidateChangeSlug(slug); err != nil {
+			return
+		}
+		if _, ok := seen[slug]; ok {
+			return
+		}
+		seen[slug] = struct{}{}
+		candidates = append(candidates, slug)
+	}
+	add(filepath.Base(worktreePath))
+	add(strings.TrimPrefix(strings.TrimSpace(branch), "feat/"))
+	return candidates
+}
+
+// archivedChangeBoundToWorktree confirms a candidate archived change actually
+// owns the invocation worktree via authority that survives archival: either the
+// default dedicated worktree path matches, or the archived bundle's recorded
+// worktree_branch matches the worktree's current branch. The project root never
+// matches (its path is not `.worktrees/<slug>` and no archived change records a
+// `feat/<slug>` branch for it).
+func archivedChangeBoundToWorktree(root string, change model.Change, worktreePath, branch string) bool {
+	if defaultPath, err := NormalizePath(DefaultWorktreePath(root, change.Slug)); err == nil && defaultPath == worktreePath {
+		return true
+	}
+	recordedBranch := strings.TrimSpace(change.WorktreeBranch)
+	return recordedBranch != "" && branch != "" && recordedBranch == branch
+}
+
 func gitCommonDirIdentity(root string) string {
 	normalized, err := NormalizePath(GitCommonDir(root))
 	if err != nil {


### PR DESCRIPTION
## Problem (#283)

From an archived change's dedicated worktree, the unscoped Slipway surfaces silently switched the governance context to an unrelated change bound to a *different* worktree:

- `slipway status --json` exited **0** but reported a different global active change (`S3_REVIEW`), with the binding mismatch only buried in `freshness_diagnostics.path_authority` (`invocation_workspace_path` ≠ `bound_workspace_path`) — no surfaced warning.
- `slipway validate --json` exited **3** with `change_bound_to_other_worktree` pointing at that unrelated change.

A reviewer auditing the archived change could collect or report governance evidence for the wrong change without realizing the context had switched.

## Fix

Make the **invocation worktree authoritative**. When it hosts a local archived change:

- **status** reports that local archived change (`DONE` / `execution_mode: archived`), the same as `status --change <slug>`.
- **validate** (and the other commands sharing `resolveActiveChangeRef`: next/run/review/fix) returns `archived_change_not_validatable` for it — clear and expected — instead of `change_bound_to_other_worktree` for an unrelated change.

Resolution from the **project root** or an **active worktree** is unchanged (status from root still reports the global active change; active worktrees resolve normally).

## How

The git-local worktree binding is removed at archive time, so the association is reconstructed from the portable archived bundle via the authority that survives archival — the `.worktrees/<slug>` default path and the recorded `worktree_branch`:

- `internal/state/worktree_binding.go`: new `FindArchivedChangeForWorktree`.
- `cmd/status.go`: prefer the local archived change before the global fallthrough.
- `cmd/common.go` (`resolveActiveChangeRef`): prefer the local archived change over the bound-elsewhere error.

## Verification

Reproduced and verified against the real `signalridge/lattice` F7 (archived) / F0 (active) worktrees:

| invocation | before | after |
|---|---|---|
| `status` @ F7 | F0 `S3_REVIEW` (exit 0) | **F7 `DONE`/archived** (exit 0) |
| `validate` @ F7 | `change_bound_to_other_worktree` | **`archived_change_not_validatable`** |
| `status`/`validate` @ root | F0 / bound-elsewhere | unchanged |
| `status`/`validate` @ F0 | F0 normal | unchanged |
| `--change F7` | archived DONE | unchanged |

New behavior-based tests in `internal/state/find_archived_change_for_worktree_test.go`; `go test ./...` green; `gofmt -s` + `go vet` clean.

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)