### PR TITLE
fix(status): non-destructive recovery for orphan bundle whose slug names an unmanaged worktree (#285)

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -468,45 +468,95 @@ func deleteRecoveryError(root, slug string) *CLIError {
 	return staleRuntimeBindingError(root, slug)
 }
 
+// unmanagedOrphan pairs an orphan-bundle slug with the live, externally-managed
+// worktree match that makes its recovery non-destructive (issue #285).
+type unmanagedOrphan struct {
+	Slug  string
+	Match state.SlugWorktreeMatch
+}
+
+// orphanClassification splits orphan-bundle slugs into the unmanaged-worktree
+// case (preserve-first, never discard) and the plain discardable residue.
+type orphanClassification struct {
+	Unmanaged []unmanagedOrphan
+	Plain     []string
+}
+
+// classifyOrphanBundles cross-checks each orphan slug against git
+// worktrees/branches so the destructive-discard decision is made per orphan, not
+// just for the first. A slug naming a live worktree Slipway does not manage maps
+// to externally-managed, possibly-unmerged work and is classified Unmanaged; a
+// slug with no live worktree (or one Slipway itself provisioned, which the
+// discard path already owns safely) is Plain. It is the single classifier shared
+// by the CLI error and status recovery surfaces so they never diverge (#285).
+func classifyOrphanBundles(root string, orphans []string) orphanClassification {
+	var class orphanClassification
+	for _, slug := range orphans {
+		if match, ok, err := state.FindSlugWorktreeMatch(root, slug); err == nil && ok && !match.SlipwayManaged {
+			class.Unmanaged = append(class.Unmanaged, unmanagedOrphan{Slug: slug, Match: match})
+			continue
+		}
+		class.Plain = append(class.Plain, slug)
+	}
+	return class
+}
+
+func unmanagedOrphanSlugs(orphans []unmanagedOrphan) []string {
+	slugs := make([]string, 0, len(orphans))
+	for _, o := range orphans {
+		slugs = append(slugs, o.Slug)
+	}
+	return slugs
+}
+
 func orphanedChangeBundleError(root, slug string) *CLIError {
 	orphans, err := orphanedChangeBundleSlugs(root, slug)
 	if err != nil || len(orphans) == 0 {
 		return nil
 	}
-	primarySlug := orphans[0]
-	// Before routing to a destructive discard, cross-check git worktrees/branches:
-	// if a slug names a live worktree Slipway does not manage, the residue maps to
-	// externally-managed, possibly-unmerged work — recover non-destructively instead
-	// of recommending deletion of a worktree Slipway never provisioned (issue #285).
-	//
 	// orphans carries a single slug when called for a specific change, but several
-	// when called with an empty slug (the no-target delete-recovery path), so scan
-	// every orphan and route whichever one names an unmanaged worktree to the
-	// non-destructive recovery for that exact slug before any orphan is folded into
-	// the plural discard guidance below.
-	for _, candidate := range orphans {
-		match, ok, mErr := state.FindSlugWorktreeMatch(root, candidate)
-		if mErr != nil || !ok || match.SlipwayManaged {
-			continue
+	// when called with an empty slug (the no-target delete-recovery path). Classify
+	// EVERY orphan so a mixed no-target recovery preserves a blocker for each one,
+	// instead of returning only the first unmanaged match and dropping the rest.
+	class := classifyOrphanBundles(root, orphans)
+
+	reasons := make([]model.ReasonCode, 0, len(orphans))
+	for _, u := range class.Unmanaged {
+		reasons = append(reasons, model.NewReasonCode("orphaned_bundle_unmanaged_worktree", u.Slug))
+	}
+	reasons = append(reasons, orphanedChangeBundleReasons(class.Plain)...)
+
+	// An unmanaged orphan is the dangerous case, so it leads the error: its
+	// preserve-first remediation and non-destructive recovery class reach the
+	// operator before any discardable residue is folded in.
+	if len(class.Unmanaged) > 0 {
+		primary := class.Unmanaged[0]
+		details := map[string]any{
+			"unmanaged_worktree_path":    primary.Match.WorktreePath,
+			"unmanaged_worktree_branch":  primary.Match.Branch,
+			"unmanaged_worktree_orphans": unmanagedOrphanSlugs(class.Unmanaged),
+		}
+		remediation := unmanagedWorktreeOrphanRemediation(primary.Slug, primary.Match)
+		if len(class.Plain) > 0 {
+			details["orphaned_change_bundles"] = class.Plain
+			remediation += fmt.Sprintf(" Separately, the abandoned residue with no live worktree can be discarded with `slipway delete --change <slug>` for: %s.", strings.Join(class.Plain, ", "))
 		}
 		return newCLIErrorWithReasons(
 			categoryPrecondition,
 			"orphaned_bundle_unmanaged_worktree",
-			fmt.Sprintf("governed bundle %q lost its change.yaml authority, but a live git worktree Slipway does not manage still holds work for this slug", candidate),
-			unmanagedWorktreeOrphanRemediation(candidate, match),
-			candidate,
-			[]model.ReasonCode{model.NewReasonCode("orphaned_bundle_unmanaged_worktree", candidate)},
-			map[string]any{
-				"unmanaged_worktree_path":   match.WorktreePath,
-				"unmanaged_worktree_branch": match.Branch,
-			},
+			fmt.Sprintf("governed bundle %q lost its change.yaml authority, but a live git worktree Slipway does not manage still holds work for this slug", primary.Slug),
+			remediation,
+			primary.Slug,
+			reasons,
+			details,
 		)
 	}
-	reasons := orphanedChangeBundleReasons(orphans)
+
+	primarySlug := class.Plain[0]
 	message := fmt.Sprintf("governed bundle %q is missing its change.yaml authority", primarySlug)
 	remediation := fmt.Sprintf("Discard it with `slipway delete --change %s` (add --worktree to also remove its worktree).", primarySlug)
-	if len(orphans) > 1 {
-		message = "governed bundles are missing their change.yaml authority: " + strings.Join(orphans, ", ")
+	if len(class.Plain) > 1 {
+		message = "governed bundles are missing their change.yaml authority: " + strings.Join(class.Plain, ", ")
 		remediation = fmt.Sprintf("Discard each abandoned change with `slipway delete --change <slug>`; first suggested command: `slipway delete --change %s`.", primarySlug)
 	}
 	return newCLIErrorWithReasons(
@@ -517,7 +567,7 @@ func orphanedChangeBundleError(root, slug string) *CLIError {
 		primarySlug,
 		reasons,
 		map[string]any{
-			"orphaned_change_bundles": orphans,
+			"orphaned_change_bundles": class.Plain,
 		},
 	)
 }

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -475,17 +475,27 @@ func orphanedChangeBundleError(root, slug string) *CLIError {
 	}
 	primarySlug := orphans[0]
 	// Before routing to a destructive discard, cross-check git worktrees/branches:
-	// if the slug names a live worktree Slipway does not manage, the residue maps to
+	// if a slug names a live worktree Slipway does not manage, the residue maps to
 	// externally-managed, possibly-unmerged work — recover non-destructively instead
 	// of recommending deletion of a worktree Slipway never provisioned (issue #285).
-	if match, ok, mErr := state.FindSlugWorktreeMatch(root, primarySlug); mErr == nil && ok && !match.SlipwayManaged {
+	//
+	// orphans carries a single slug when called for a specific change, but several
+	// when called with an empty slug (the no-target delete-recovery path), so scan
+	// every orphan and route whichever one names an unmanaged worktree to the
+	// non-destructive recovery for that exact slug before any orphan is folded into
+	// the plural discard guidance below.
+	for _, candidate := range orphans {
+		match, ok, mErr := state.FindSlugWorktreeMatch(root, candidate)
+		if mErr != nil || !ok || match.SlipwayManaged {
+			continue
+		}
 		return newCLIErrorWithReasons(
 			categoryPrecondition,
 			"orphaned_bundle_unmanaged_worktree",
-			fmt.Sprintf("governed bundle %q lost its change.yaml authority, but a live git worktree Slipway does not manage still holds work for this slug", primarySlug),
-			unmanagedWorktreeOrphanRemediation(primarySlug, match),
-			primarySlug,
-			[]model.ReasonCode{model.NewReasonCode("orphaned_bundle_unmanaged_worktree", primarySlug)},
+			fmt.Sprintf("governed bundle %q lost its change.yaml authority, but a live git worktree Slipway does not manage still holds work for this slug", candidate),
+			unmanagedWorktreeOrphanRemediation(candidate, match),
+			candidate,
+			[]model.ReasonCode{model.NewReasonCode("orphaned_bundle_unmanaged_worktree", candidate)},
 			map[string]any{
 				"unmanaged_worktree_path":   match.WorktreePath,
 				"unmanaged_worktree_branch": match.Branch,

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -473,8 +473,26 @@ func orphanedChangeBundleError(root, slug string) *CLIError {
 	if err != nil || len(orphans) == 0 {
 		return nil
 	}
-	reasons := orphanedChangeBundleReasons(orphans)
 	primarySlug := orphans[0]
+	// Before routing to a destructive discard, cross-check git worktrees/branches:
+	// if the slug names a live worktree Slipway does not manage, the residue maps to
+	// externally-managed, possibly-unmerged work — recover non-destructively instead
+	// of recommending deletion of a worktree Slipway never provisioned (issue #285).
+	if match, ok, mErr := state.FindSlugWorktreeMatch(root, primarySlug); mErr == nil && ok && !match.SlipwayManaged {
+		return newCLIErrorWithReasons(
+			categoryPrecondition,
+			"orphaned_bundle_unmanaged_worktree",
+			fmt.Sprintf("governed bundle %q lost its change.yaml authority, but a live git worktree Slipway does not manage still holds work for this slug", primarySlug),
+			unmanagedWorktreeOrphanRemediation(primarySlug, match),
+			primarySlug,
+			[]model.ReasonCode{model.NewReasonCode("orphaned_bundle_unmanaged_worktree", primarySlug)},
+			map[string]any{
+				"unmanaged_worktree_path":   match.WorktreePath,
+				"unmanaged_worktree_branch": match.Branch,
+			},
+		)
+	}
+	reasons := orphanedChangeBundleReasons(orphans)
 	message := fmt.Sprintf("governed bundle %q is missing its change.yaml authority", primarySlug)
 	remediation := fmt.Sprintf("Discard it with `slipway delete --change %s` (add --worktree to also remove its worktree).", primarySlug)
 	if len(orphans) > 1 {
@@ -491,6 +509,20 @@ func orphanedChangeBundleError(root, slug string) *CLIError {
 		map[string]any{
 			"orphaned_change_bundles": orphans,
 		},
+	)
+}
+
+// unmanagedWorktreeOrphanRemediation renders non-destructive recovery prose for
+// an orphan bundle whose slug names a live worktree Slipway does not manage. It
+// leads with inspect/preserve and never recommends removing that worktree.
+func unmanagedWorktreeOrphanRemediation(slug string, match state.SlugWorktreeMatch) string {
+	location := match.WorktreePath
+	if strings.TrimSpace(match.Branch) != "" {
+		location = fmt.Sprintf("%s (branch %s)", match.WorktreePath, match.Branch)
+	}
+	return fmt.Sprintf(
+		"A live git worktree Slipway does not manage holds work for %q at %s. Inspect and preserve that worktree and its branch first — Slipway never removes a worktree it did not provision. Once its work is merged or saved, discard only the stale bundle residue with `slipway delete --change %s` (never pass --worktree).",
+		slug, location, slug,
 	)
 }
 

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -475,10 +475,22 @@ type unmanagedOrphan struct {
 	Match state.SlugWorktreeMatch
 }
 
+// unknownOrphan pairs an orphan-bundle slug with the git cross-check error that
+// prevented classifying whether a live worktree holds its work. Recovery must
+// fail closed: work whose ownership could not be verified is never routed to the
+// destructive discard path (issue #285).
+type unknownOrphan struct {
+	Slug string
+	Err  error
+}
+
 // orphanClassification splits orphan-bundle slugs into the unmanaged-worktree
-// case (preserve-first, never discard) and the plain discardable residue.
+// case (preserve-first, never discard), the ownership-unknown case (the git
+// cross-check failed, so fail closed to preserve-first), and the plain
+// discardable residue.
 type orphanClassification struct {
 	Unmanaged []unmanagedOrphan
+	Unknown   []unknownOrphan
 	Plain     []string
 }
 
@@ -486,14 +498,30 @@ type orphanClassification struct {
 // worktrees/branches so the destructive-discard decision is made per orphan, not
 // just for the first. A slug naming a live worktree Slipway does not manage maps
 // to externally-managed, possibly-unmerged work and is classified Unmanaged; a
-// slug with no live worktree (or one Slipway itself provisioned, which the
-// discard path already owns safely) is Plain. It is the single classifier shared
-// by the CLI error and status recovery surfaces so they never diverge (#285).
+// slug whose git cross-check FAILS is classified Unknown and fails closed to
+// preserve-first (never the destructive discard path); a slug with no live
+// worktree (or one Slipway itself provisioned, which the discard path already
+// owns safely) is Plain. It is the single classifier shared by the CLI error and
+// status recovery surfaces so they never diverge (#285).
+type slugWorktreeMatcher func(root, slug string) (state.SlugWorktreeMatch, bool, error)
+
 func classifyOrphanBundles(root string, orphans []string) orphanClassification {
+	return classifyOrphanBundlesWith(root, orphans, state.FindSlugWorktreeMatch)
+}
+
+func classifyOrphanBundlesWith(root string, orphans []string, match slugWorktreeMatcher) orphanClassification {
 	var class orphanClassification
 	for _, slug := range orphans {
-		if match, ok, err := state.FindSlugWorktreeMatch(root, slug); err == nil && ok && !match.SlipwayManaged {
-			class.Unmanaged = append(class.Unmanaged, unmanagedOrphan{Slug: slug, Match: match})
+		m, ok, err := match(root, slug)
+		if err != nil {
+			// Fail closed: a git worktree/branch cross-check failure means we cannot
+			// prove the slug's work is safe to discard, so it never enters the
+			// destructive discard path (#285).
+			class.Unknown = append(class.Unknown, unknownOrphan{Slug: slug, Err: err})
+			continue
+		}
+		if ok && !m.SlipwayManaged {
+			class.Unmanaged = append(class.Unmanaged, unmanagedOrphan{Slug: slug, Match: m})
 			continue
 		}
 		class.Plain = append(class.Plain, slug)
@@ -502,6 +530,14 @@ func classifyOrphanBundles(root string, orphans []string) orphanClassification {
 }
 
 func unmanagedOrphanSlugs(orphans []unmanagedOrphan) []string {
+	slugs := make([]string, 0, len(orphans))
+	for _, o := range orphans {
+		slugs = append(slugs, o.Slug)
+	}
+	return slugs
+}
+
+func unknownOrphanSlugs(orphans []unknownOrphan) []string {
 	slugs := make([]string, 0, len(orphans))
 	for _, o := range orphans {
 		slugs = append(slugs, o.Slug)
@@ -524,29 +560,56 @@ func orphanedChangeBundleError(root, slug string) *CLIError {
 	for _, u := range class.Unmanaged {
 		reasons = append(reasons, model.NewReasonCode("orphaned_bundle_unmanaged_worktree", u.Slug))
 	}
+	for _, u := range class.Unknown {
+		reasons = append(reasons, model.NewReasonCode("orphaned_bundle_ownership_unknown", u.Slug))
+	}
 	reasons = append(reasons, orphanedChangeBundleReasons(class.Plain)...)
 
-	// An unmanaged orphan is the dangerous case, so it leads the error: its
-	// preserve-first remediation and non-destructive recovery class reach the
-	// operator before any discardable residue is folded in.
-	if len(class.Unmanaged) > 0 {
-		primary := class.Unmanaged[0]
-		details := map[string]any{
-			"unmanaged_worktree_path":    primary.Match.WorktreePath,
-			"unmanaged_worktree_branch":  primary.Match.Branch,
-			"unmanaged_worktree_orphans": unmanagedOrphanSlugs(class.Unmanaged),
+	// A non-destructive case (a live worktree Slipway does not manage, or one whose
+	// ownership could not be verified) is the dangerous one: it leads the error so
+	// its preserve-first remediation reaches the operator before any discardable
+	// residue is folded in. Unmanaged leads when present (it carries a concrete
+	// path/branch); otherwise the ownership-unknown case leads.
+	if len(class.Unmanaged) > 0 || len(class.Unknown) > 0 {
+		var (
+			errorCode   string
+			primarySlug string
+			message     string
+			remediation string
+		)
+		details := map[string]any{}
+		if len(class.Unmanaged) > 0 {
+			primary := class.Unmanaged[0]
+			errorCode = "orphaned_bundle_unmanaged_worktree"
+			primarySlug = primary.Slug
+			message = fmt.Sprintf("governed bundle %q lost its change.yaml authority, but a live git worktree Slipway does not manage still holds work for this slug", primary.Slug)
+			remediation = unmanagedWorktreeOrphanRemediation(primary.Slug, primary.Match)
+			details["unmanaged_worktree_path"] = primary.Match.WorktreePath
+			details["unmanaged_worktree_branch"] = primary.Match.Branch
+			details["unmanaged_worktree_orphans"] = unmanagedOrphanSlugs(class.Unmanaged)
+			if len(class.Unknown) > 0 {
+				unknown := unknownOrphanSlugs(class.Unknown)
+				details["ownership_unknown_orphans"] = unknown
+				remediation += fmt.Sprintf(" Ownership could not be verified for: %s (git worktree cross-check failed); inspect those for live worktrees and preserve any unmerged work before discarding anything.", strings.Join(unknown, ", "))
+			}
+		} else {
+			primary := class.Unknown[0]
+			errorCode = "orphaned_bundle_ownership_unknown"
+			primarySlug = primary.Slug
+			message = fmt.Sprintf("governed bundle %q lost its change.yaml authority and its git worktree ownership could not be verified", primary.Slug)
+			remediation = ownershipUnknownOrphanRemediation(primary.Slug, primary.Err)
+			details["ownership_unknown_orphans"] = unknownOrphanSlugs(class.Unknown)
 		}
-		remediation := unmanagedWorktreeOrphanRemediation(primary.Slug, primary.Match)
 		if len(class.Plain) > 0 {
 			details["orphaned_change_bundles"] = class.Plain
-			remediation += fmt.Sprintf(" Separately, the abandoned residue with no live worktree can be discarded with `slipway delete --change <slug>` for: %s.", strings.Join(class.Plain, ", "))
+			remediation += fmt.Sprintf(" Separately, the abandoned residue with no live worktree can be discarded with `slipway delete --change %s` for: %s.", class.Plain[0], strings.Join(class.Plain, ", "))
 		}
 		return newCLIErrorWithReasons(
 			categoryPrecondition,
-			"orphaned_bundle_unmanaged_worktree",
-			fmt.Sprintf("governed bundle %q lost its change.yaml authority, but a live git worktree Slipway does not manage still holds work for this slug", primary.Slug),
+			errorCode,
+			message,
 			remediation,
-			primary.Slug,
+			primarySlug,
 			reasons,
 			details,
 		)
@@ -583,6 +646,20 @@ func unmanagedWorktreeOrphanRemediation(slug string, match state.SlugWorktreeMat
 	return fmt.Sprintf(
 		"A live git worktree Slipway does not manage holds work for %q at %s. Inspect and preserve that worktree and its branch first — Slipway never removes a worktree it did not provision. Once its work is merged or saved, discard only the stale bundle residue with `slipway delete --change %s` (never pass --worktree).",
 		slug, location, slug,
+	)
+}
+
+// ownershipUnknownOrphanRemediation renders preserve-first prose for an orphan
+// bundle whose git worktree ownership could not be verified (the cross-check
+// failed). It must never recommend `--worktree` and must lead with inspect/preserve.
+func ownershipUnknownOrphanRemediation(slug string, cause error) string {
+	detail := ""
+	if cause != nil {
+		detail = fmt.Sprintf(" (%v)", cause)
+	}
+	return fmt.Sprintf(
+		"A live git worktree may hold work for %q, but Slipway could not verify its ownership because the git worktree/branch cross-check failed%s. Do not discard this bundle yet: inspect for a live worktree or branch named after %q and preserve any unmerged work first. Once you have confirmed no unmerged work remains, discard only the stale bundle residue with `slipway delete --change %s` (never pass --worktree).",
+		slug, detail, slug, slug,
 	)
 }
 

--- a/cmd/orphaned_bundle_unmanaged_worktree_test.go
+++ b/cmd/orphaned_bundle_unmanaged_worktree_test.go
@@ -1,0 +1,151 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/signalridge/slipway/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// orphanRecoveryWorkspace creates a real git repo (so git worktree records are
+// queryable by FindSlugWorktreeMatch), initializes the Slipway workspace, and
+// chdirs into the root so cwd-based resolution matches production. Tests using it
+// must not run in parallel because they chdir.
+func orphanRecoveryWorkspace(t *testing.T) (root string) {
+	t.Helper()
+	root = t.TempDir()
+	runGit(t, root, "init")
+	runGit(t, root, "config", "user.email", "test@example.com")
+	runGit(t, root, "config", "user.name", "Test")
+	runGit(t, root, "commit", "--allow-empty", "-m", "init")
+
+	previousWD, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(root))
+	t.Cleanup(func() { _ = os.Chdir(previousWD) })
+
+	_, _, err = runRootCommandIn(root, []string{"init", "--tools", "none"})
+	require.NoError(t, err)
+	return root
+}
+
+// writeOrphanBundle materializes an orphan governed bundle for slug at
+// artifacts/changes/<slug>: a directory that holds residue files but has lost its
+// change.yaml authority. This is exactly what state.OrphanBundleSlugs detects.
+func writeOrphanBundle(t *testing.T, root, slug string) {
+	t.Helper()
+	bundleDir := filepath.Join(state.ActiveBundlesDir(root), slug)
+	require.NoError(t, os.MkdirAll(bundleDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "intent.md"), []byte("orphaned residue\n"), 0o644))
+	// No change.yaml is written: this is what makes the bundle an orphan.
+	require.NoFileExists(t, filepath.Join(bundleDir, "change.yaml"))
+
+	orphans, err := state.OrphanBundleSlugs(root)
+	require.NoError(t, err)
+	require.Contains(t, orphans, slug, "fixture must register %q as an orphan bundle", slug)
+}
+
+// addWorktreeOnBranch adds a real git worktree at path on a freshly-created
+// branch, so FindSlugWorktreeMatch can read its (path, branch) record.
+func addWorktreeOnBranch(t *testing.T, root, path, branch string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	runGit(t, root, "worktree", "add", "-b", branch, path)
+}
+
+// TestOrphanedChangeBundleErrorUnmanagedWorktreeRoute is the #285 core case: an
+// orphan bundle whose slug also names a live worktree Slipway did NOT provision
+// (default .worktrees/<slug> path but a hand-named branch, NOT feat/<slug>) must
+// route to the non-destructive recovery, never to the destructive discard.
+func TestOrphanedChangeBundleErrorUnmanagedWorktreeRoute(t *testing.T) {
+	root := orphanRecoveryWorkspace(t)
+	slug := "fix-283"
+	externalBranch := "fix/issue-283-archived-worktree-resolution"
+
+	writeOrphanBundle(t, root, slug)
+	// Place an external worktree at the default convention path but on a branch
+	// that is not feat/<slug>: SlipwayManaged must be false (path matches, branch
+	// does not), so recovery must not recommend removing it.
+	addWorktreeOnBranch(t, root, state.DefaultWorktreePath(root, slug), externalBranch)
+
+	// Sanity: the match resolves as external (not managed) — the property the
+	// #285 fix guarantees and this routing test depends on.
+	match, ok, err := state.FindSlugWorktreeMatch(root, slug)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.False(t, match.SlipwayManaged, "external worktree on a hand-named branch must not be SlipwayManaged")
+
+	cliErr := orphanedChangeBundleError(root, slug)
+	require.NotNil(t, cliErr, "orphan bundle + unmanaged worktree must produce a recovery error")
+
+	assert.Equal(t, "orphaned_bundle_unmanaged_worktree", cliErr.ErrorCode)
+	assert.Equal(t, categoryPrecondition, cliErr.Category)
+	assert.Equal(t, slug, cliErr.Slug)
+
+	// Reason code carries the same code, scoped to the slug.
+	require.NotEmpty(t, cliErr.Reasons)
+	assert.Equal(t, "orphaned_bundle_unmanaged_worktree", string(cliErr.Reasons[0].Code))
+
+	// Non-destructive remediation: it tells the operator to never pass --worktree
+	// and must NOT suggest "add --worktree" (the destructive discard prose).
+	assert.Contains(t, cliErr.Remediation, "never pass --worktree")
+	assert.NotContains(t, cliErr.Remediation, "add --worktree")
+	assert.NotContains(t, cliErr.Message, "add --worktree")
+
+	// The unmanaged worktree path and branch are surfaced in details for triage.
+	require.NotNil(t, cliErr.Details)
+	assert.Equal(t, match.WorktreePath, cliErr.Details["unmanaged_worktree_path"])
+	assert.Equal(t, externalBranch, cliErr.Details["unmanaged_worktree_branch"])
+}
+
+// TestOrphanedChangeBundleErrorManagedWorktreeRoute confirms a worktree Slipway
+// DID provision (default path AND feat/<slug> branch) keeps the existing
+// destructive-discard recovery: the discard path already owns it safely.
+func TestOrphanedChangeBundleErrorManagedWorktreeRoute(t *testing.T) {
+	root := orphanRecoveryWorkspace(t)
+	slug := "managed-slug"
+
+	writeOrphanBundle(t, root, slug)
+	addWorktreeOnBranch(t, root, state.DefaultWorktreePath(root, slug), state.DefaultWorktreeBranch(slug))
+
+	match, ok, err := state.FindSlugWorktreeMatch(root, slug)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.True(t, match.SlipwayManaged, "default path + feat/<slug> branch must be SlipwayManaged")
+
+	cliErr := orphanedChangeBundleError(root, slug)
+	require.NotNil(t, cliErr)
+
+	assert.Equal(t, "orphaned_change_bundle", cliErr.ErrorCode)
+	assert.Equal(t, categoryPrecondition, cliErr.Category)
+	// The existing discard remediation MAY offer --worktree removal here because
+	// Slipway owns this worktree.
+	assert.Contains(t, cliErr.Remediation, "slipway delete --change "+slug)
+	assert.Contains(t, cliErr.Remediation, "add --worktree")
+}
+
+// TestOrphanedChangeBundleErrorNoWorktreeRoute confirms an orphan bundle with no
+// corresponding live worktree keeps the plain discard recovery.
+func TestOrphanedChangeBundleErrorNoWorktreeRoute(t *testing.T) {
+	root := orphanRecoveryWorkspace(t)
+	slug := "lonely-slug"
+
+	writeOrphanBundle(t, root, slug)
+
+	// No worktree corresponds to the slug.
+	_, ok, err := state.FindSlugWorktreeMatch(root, slug)
+	require.NoError(t, err)
+	require.False(t, ok, "no worktree should correspond to the slug in this case")
+
+	cliErr := orphanedChangeBundleError(root, slug)
+	require.NotNil(t, cliErr)
+
+	assert.Equal(t, "orphaned_change_bundle", cliErr.ErrorCode)
+	assert.Equal(t, categoryPrecondition, cliErr.Category)
+	require.NotNil(t, cliErr.Details)
+	assert.Contains(t, cliErr.Details["orphaned_change_bundles"], slug)
+	assert.Contains(t, cliErr.Remediation, "slipway delete --change "+slug)
+}

--- a/cmd/orphaned_bundle_unmanaged_worktree_test.go
+++ b/cmd/orphaned_bundle_unmanaged_worktree_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -9,6 +10,20 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestClassifyOrphanBundlesFailsClosedOnMatcherError proves the injectable
+// classifier never lands a cross-check failure in the discardable Plain bucket:
+// ownership it cannot verify must fail closed into Unknown (#285).
+func TestClassifyOrphanBundlesFailsClosedOnMatcherError(t *testing.T) {
+	failing := func(_, slug string) (state.SlugWorktreeMatch, bool, error) {
+		return state.SlugWorktreeMatch{}, false, errors.New("git worktree list failed")
+	}
+	class := classifyOrphanBundlesWith("/does/not/matter", []string{"mystery-slug"}, failing)
+	require.Empty(t, class.Plain, "a cross-check error must NOT land in the discardable Plain bucket")
+	require.Empty(t, class.Unmanaged)
+	require.Len(t, class.Unknown, 1)
+	assert.Equal(t, "mystery-slug", class.Unknown[0].Slug)
+}
 
 // orphanRecoveryWorkspace creates a real git repo (so git worktree records are
 // queryable by FindSlugWorktreeMatch), initializes the Slipway workspace, and
@@ -99,6 +114,15 @@ func TestOrphanedChangeBundleErrorUnmanagedWorktreeRoute(t *testing.T) {
 	require.NotNil(t, cliErr.Details)
 	assert.Equal(t, match.WorktreePath, cliErr.Details["unmanaged_worktree_path"])
 	assert.Equal(t, externalBranch, cliErr.Details["unmanaged_worktree_branch"])
+
+	// A single-unmanaged case must NOT also fold in the plain discard reason or
+	// details: there is no discardable residue here, only the preserved worktree.
+	for _, r := range cliErr.Reasons {
+		assert.NotEqual(t, "orphaned_change_bundle", string(r.Code),
+			"a single unmanaged orphan must not carry the plain discard reason")
+	}
+	assert.Nil(t, cliErr.Details["orphaned_change_bundles"],
+		"a single unmanaged orphan must not carry plain discard details")
 }
 
 // TestOrphanedChangeBundleErrorManagedWorktreeRoute confirms a worktree Slipway
@@ -182,6 +206,23 @@ func assertNonDestructiveUnmanagedRecovery(t *testing.T, payload map[string]any,
 
 	assert.NotContains(t, stdout, "add --worktree", "must never suggest the destructive --worktree escalation")
 	assert.Contains(t, stdout, "never pass --worktree")
+
+	// The single-unmanaged status case carries no plain discard blocker, and no
+	// recovery step may route to the destructive discard.
+	assert.False(t, statusBlockerHasCode(t, payload, "orphaned_change_bundle"),
+		"a single unmanaged orphan must not surface the plain discard blocker")
+	steps, _ := recovery["steps"].([]any)
+	for _, s := range steps {
+		sm, ok := s.(map[string]any)
+		if !ok {
+			continue
+		}
+		assert.NotEqual(t, "discard_change", sm["recovery_class"],
+			"no recovery step may be classed discard_change for a preserved worktree")
+		cmd, _ := sm["command"].(string)
+		assert.NotContains(t, cmd, "slipway delete",
+			"no recovery step command may route to the destructive discard")
+	}
 }
 
 // TestStatusJSONUnmanagedWorktreeOrphanIsNonDestructive is the #285 status --json
@@ -221,4 +262,38 @@ func TestStatusJSONUnmanagedWorktreeOrphanIsNonDestructive(t *testing.T) {
 	assert.True(t, statusBlockerHasCode(t, payload, "orphaned_bundle_unmanaged_worktree"),
 		"explicit blockers must include the orphaned_bundle_unmanaged_worktree reason")
 	assertNonDestructiveUnmanagedRecovery(t, payload, stdout)
+}
+
+// TestOrphanedChangeBundleErrorMixedOrphansClassifyEach is the #285 no-target
+// path: an unmanaged-worktree orphan AND a plain discardable orphan together.
+// The error must LEAD with the non-destructive unmanaged case, keep a reason for
+// EACH orphan, and name the CONCRETE plain slug in the residue prose (never a
+// literal "<slug>").
+func TestOrphanedChangeBundleErrorMixedOrphansClassifyEach(t *testing.T) {
+	root := orphanRecoveryWorkspace(t)
+	const unmanaged = "fix-283"
+	const plain = "lonely-slug"
+	writeOrphanBundle(t, root, unmanaged)
+	writeOrphanBundle(t, root, plain)
+	addWorktreeOnBranch(t, root, state.DefaultWorktreePath(root, unmanaged), "fix/issue-283-archived-worktree-resolution")
+
+	cliErr := orphanedChangeBundleError(root, "") // empty slug -> all orphans
+	require.NotNil(t, cliErr)
+	assert.Equal(t, "orphaned_bundle_unmanaged_worktree", cliErr.ErrorCode, "the non-destructive case must lead")
+
+	codes := map[string]bool{}
+	for _, r := range cliErr.Reasons {
+		codes[string(r.Code)] = true
+	}
+	assert.True(t, codes["orphaned_bundle_unmanaged_worktree"], "unmanaged orphan keeps its reason")
+	assert.True(t, codes["orphaned_change_bundle"], "plain orphan must not be dropped")
+
+	require.NotNil(t, cliErr.Details)
+	assert.Contains(t, cliErr.Details["unmanaged_worktree_orphans"], unmanaged)
+	assert.Contains(t, cliErr.Details["orphaned_change_bundles"], plain)
+
+	// F5: residue prose names the concrete plain slug, never a literal placeholder.
+	assert.Contains(t, cliErr.Remediation, "slipway delete --change "+plain)
+	assert.NotContains(t, cliErr.Remediation, "--change <slug>")
+	assert.Contains(t, cliErr.Remediation, "never pass --worktree")
 }

--- a/cmd/orphaned_bundle_unmanaged_worktree_test.go
+++ b/cmd/orphaned_bundle_unmanaged_worktree_test.go
@@ -149,3 +149,76 @@ func TestOrphanedChangeBundleErrorNoWorktreeRoute(t *testing.T) {
 	assert.Contains(t, cliErr.Details["orphaned_change_bundles"], slug)
 	assert.Contains(t, cliErr.Remediation, "slipway delete --change "+slug)
 }
+
+// statusBlockerHasCode reports whether the status --json blockers list carries a
+// reason with the given code. Blockers are encoded as model.ReasonCode objects,
+// so each entry is a map with a "code" field.
+func statusBlockerHasCode(t *testing.T, payload map[string]any, code string) bool {
+	t.Helper()
+	blockers, _ := payload["blockers"].([]any)
+	for _, b := range blockers {
+		if bm, ok := b.(map[string]any); ok && bm["code"] == code {
+			return true
+		}
+	}
+	return false
+}
+
+// assertNonDestructiveUnmanagedRecovery checks the status --json recovery object
+// and full stdout for the #285 preserve-first contract: preserve_work class, no
+// destructive `slipway delete` primary command, no "add --worktree" escalation,
+// and the inspect/preserve prose present.
+func assertNonDestructiveUnmanagedRecovery(t *testing.T, payload map[string]any, stdout string) {
+	t.Helper()
+	recovery, ok := payload["recovery"].(map[string]any)
+	require.True(t, ok, "status must surface a recovery object")
+	assert.Equal(t, "preserve_work", recovery["recovery_class"])
+
+	// primary_command is omitempty, so it is absent (or empty) for preserve_work —
+	// it must never route to the destructive discard command.
+	primary, _ := recovery["primary_command"].(string)
+	assert.Empty(t, primary, "preserve_work recovery must carry no primary_command")
+	assert.NotContains(t, primary, "slipway delete")
+
+	assert.NotContains(t, stdout, "add --worktree", "must never suggest the destructive --worktree escalation")
+	assert.Contains(t, stdout, "never pass --worktree")
+}
+
+// TestStatusJSONUnmanagedWorktreeOrphanIsNonDestructive is the #285 status --json
+// contract: an orphan bundle whose slug names a live worktree Slipway does NOT
+// manage must surface a non-destructive preserve_work recovery, both unscoped and
+// with an explicit --change selector. NOT parallel: the workspace helper chdirs.
+func TestStatusJSONUnmanagedWorktreeOrphanIsNonDestructive(t *testing.T) {
+	root := orphanRecoveryWorkspace(t)
+	slug := "fix-283"
+	externalBranch := "fix/issue-283-archived-worktree-resolution"
+
+	writeOrphanBundle(t, root, slug)
+	addWorktreeOnBranch(t, root, state.DefaultWorktreePath(root, slug), externalBranch)
+
+	// Sanity: the match resolves as external (not managed).
+	match, ok, err := state.FindSlugWorktreeMatch(root, slug)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.False(t, match.SlipwayManaged)
+
+	// Unscoped status routes through the orphan diagnostics view.
+	stdout, stderr, err := runRootCommandIn(root, []string{"status", "--json"})
+	require.NoError(t, err, "status must not dead-end on an orphan bundle with a live unmanaged worktree")
+	require.Empty(t, stderr)
+	payload := decodeJSONMap(t, stdout)
+	assert.Equal(t, "diagnostics", payload["execution_mode"])
+	assert.True(t, statusBlockerHasCode(t, payload, "orphaned_bundle_unmanaged_worktree"),
+		"blockers must include the orphaned_bundle_unmanaged_worktree reason")
+	assertNonDestructiveUnmanagedRecovery(t, payload, stdout)
+
+	// The same non-destructive recovery must hold with an explicit --change selector.
+	stdout, stderr, err = runRootCommandIn(root, []string{"status", "--json", "--change", slug})
+	require.NoError(t, err, "explicit status must not dead-end on the unmanaged-worktree orphan")
+	require.Empty(t, stderr)
+	payload = decodeJSONMap(t, stdout)
+	assert.Equal(t, "diagnostics", payload["execution_mode"])
+	assert.True(t, statusBlockerHasCode(t, payload, "orphaned_bundle_unmanaged_worktree"),
+		"explicit blockers must include the orphaned_bundle_unmanaged_worktree reason")
+	assertNonDestructiveUnmanagedRecovery(t, payload, stdout)
+}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -453,11 +453,21 @@ func deleteRecoveryStatusViewForSlug(root, slug string) *statusView {
 		ExecutionMode:     "diagnostics",
 		EvidenceFreshness: "unknown",
 	}
+	var plainOrphans []string
 	for _, slug := range orphans {
+		// Cross-check git worktrees/branches before recommending discard: a slug
+		// whose live worktree Slipway does not manage maps to externally-managed,
+		// possibly-unmerged work, so it must recover non-destructively (issue #285).
+		if match, ok, mErr := state.FindSlugWorktreeMatch(root, slug); mErr == nil && ok && !match.SlipwayManaged {
+			view.Diagnostics = append(view.Diagnostics, unmanagedWorktreeOrphanRemediation(slug, match))
+			view.Blockers = append(view.Blockers, model.NewReasonCode("orphaned_bundle_unmanaged_worktree", slug))
+			continue
+		}
 		view.Diagnostics = append(view.Diagnostics, fmt.Sprintf(
 			"governed bundle %q is missing its change.yaml authority; discard it with `slipway delete --change %s`",
 			slug, slug,
 		))
+		plainOrphans = append(plainOrphans, slug)
 	}
 	for _, slug := range stale {
 		view.Diagnostics = append(view.Diagnostics, fmt.Sprintf(
@@ -465,7 +475,7 @@ func deleteRecoveryStatusViewForSlug(root, slug string) *statusView {
 			slug, slug,
 		))
 	}
-	view.Blockers = append(view.Blockers, orphanedChangeBundleReasons(orphans)...)
+	view.Blockers = append(view.Blockers, orphanedChangeBundleReasons(plainOrphans)...)
 	view.Blockers = append(view.Blockers, staleRuntimeBindingReasons(stale)...)
 	view.Recovery = model.BuildRecovery(view.Blockers)
 	return view

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -453,21 +453,20 @@ func deleteRecoveryStatusViewForSlug(root, slug string) *statusView {
 		ExecutionMode:     "diagnostics",
 		EvidenceFreshness: "unknown",
 	}
-	var plainOrphans []string
-	for _, slug := range orphans {
-		// Cross-check git worktrees/branches before recommending discard: a slug
-		// whose live worktree Slipway does not manage maps to externally-managed,
-		// possibly-unmerged work, so it must recover non-destructively (issue #285).
-		if match, ok, mErr := state.FindSlugWorktreeMatch(root, slug); mErr == nil && ok && !match.SlipwayManaged {
-			view.Diagnostics = append(view.Diagnostics, unmanagedWorktreeOrphanRemediation(slug, match))
-			view.Blockers = append(view.Blockers, model.NewReasonCode("orphaned_bundle_unmanaged_worktree", slug))
-			continue
-		}
+	// Cross-check git worktrees/branches before recommending discard: a slug whose
+	// live worktree Slipway does not manage maps to externally-managed,
+	// possibly-unmerged work, so it must recover non-destructively (issue #285).
+	// The same classifier backs the CLI error surface so the two never diverge.
+	class := classifyOrphanBundles(root, orphans)
+	for _, u := range class.Unmanaged {
+		view.Diagnostics = append(view.Diagnostics, unmanagedWorktreeOrphanRemediation(u.Slug, u.Match))
+		view.Blockers = append(view.Blockers, model.NewReasonCode("orphaned_bundle_unmanaged_worktree", u.Slug))
+	}
+	for _, slug := range class.Plain {
 		view.Diagnostics = append(view.Diagnostics, fmt.Sprintf(
 			"governed bundle %q is missing its change.yaml authority; discard it with `slipway delete --change %s`",
 			slug, slug,
 		))
-		plainOrphans = append(plainOrphans, slug)
 	}
 	for _, slug := range stale {
 		view.Diagnostics = append(view.Diagnostics, fmt.Sprintf(
@@ -475,7 +474,7 @@ func deleteRecoveryStatusViewForSlug(root, slug string) *statusView {
 			slug, slug,
 		))
 	}
-	view.Blockers = append(view.Blockers, orphanedChangeBundleReasons(plainOrphans)...)
+	view.Blockers = append(view.Blockers, orphanedChangeBundleReasons(class.Plain)...)
 	view.Blockers = append(view.Blockers, staleRuntimeBindingReasons(stale)...)
 	view.Recovery = model.BuildRecovery(view.Blockers)
 	return view

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -462,6 +462,10 @@ func deleteRecoveryStatusViewForSlug(root, slug string) *statusView {
 		view.Diagnostics = append(view.Diagnostics, unmanagedWorktreeOrphanRemediation(u.Slug, u.Match))
 		view.Blockers = append(view.Blockers, model.NewReasonCode("orphaned_bundle_unmanaged_worktree", u.Slug))
 	}
+	for _, u := range class.Unknown {
+		view.Diagnostics = append(view.Diagnostics, ownershipUnknownOrphanRemediation(u.Slug, u.Err))
+		view.Blockers = append(view.Blockers, model.NewReasonCode("orphaned_bundle_ownership_unknown", u.Slug))
+	}
 	for _, slug := range class.Plain {
 		view.Diagnostics = append(view.Diagnostics, fmt.Sprintf(
 			"governed bundle %q is missing its change.yaml authority; discard it with `slipway delete --change %s`",

--- a/internal/model/reason_code.go
+++ b/internal/model/reason_code.go
@@ -338,6 +338,10 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 		Severity: ReasonSeverityError,
 		Message:  "The governed change is not ready for finalization",
 	},
+	"orphaned_bundle_unmanaged_worktree": {
+		Severity: ReasonSeverityError,
+		Message:  "A governed bundle lost its change.yaml authority but a live worktree Slipway does not manage holds work for its slug",
+	},
 	"orphaned_change_bundle": {
 		Severity: ReasonSeverityError,
 		Message:  "A governed bundle directory is missing its change.yaml authority",

--- a/internal/model/reason_code.go
+++ b/internal/model/reason_code.go
@@ -338,6 +338,10 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 		Severity: ReasonSeverityError,
 		Message:  "The governed change is not ready for finalization",
 	},
+	"orphaned_bundle_ownership_unknown": {
+		Severity: ReasonSeverityError,
+		Message:  "A governed bundle lost its change.yaml authority and its live-worktree ownership could not be verified",
+	},
 	"orphaned_bundle_unmanaged_worktree": {
 		Severity: ReasonSeverityError,
 		Message:  "A governed bundle lost its change.yaml authority but a live worktree Slipway does not manage holds work for its slug",

--- a/internal/model/reason_code_contract_test.go
+++ b/internal/model/reason_code_contract_test.go
@@ -119,6 +119,7 @@ func canonicalReasonCodeSnapshot() []string {
 		"not_done_ready",
 		"orphan_bundle_directory",
 		"orphan_task_evidence",
+		"orphaned_bundle_ownership_unknown",
 		"orphaned_bundle_unmanaged_worktree",
 		"orphaned_change_bundle",
 		"parallel_wave_changed_file_overlap",

--- a/internal/model/reason_code_contract_test.go
+++ b/internal/model/reason_code_contract_test.go
@@ -119,6 +119,7 @@ func canonicalReasonCodeSnapshot() []string {
 		"not_done_ready",
 		"orphan_bundle_directory",
 		"orphan_task_evidence",
+		"orphaned_bundle_unmanaged_worktree",
 		"orphaned_change_bundle",
 		"parallel_wave_changed_file_overlap",
 		"plan_audit_budget_exhausted",

--- a/internal/model/recovery.go
+++ b/internal/model/recovery.go
@@ -314,6 +314,15 @@ var blockerRemediations = map[string]blockerRemediation{
 		CommandTemplate: "slipway next",
 		Class:           RecoveryClassRerunSkill,
 	},
+	"orphaned_bundle_unmanaged_worktree": {
+		// Emitted as orphaned_bundle_unmanaged_worktree:<slug>. The bundle lost its
+		// change.yaml, but a live git worktree Slipway never provisioned still holds
+		// work for the slug. Lead with inspect/preserve and NEVER suggest --worktree:
+		// recovery must not endanger externally-managed, possibly-unmerged work.
+		Remediation:     "Governed bundle {subject} lost its change.yaml, but a live git worktree Slipway does not manage still holds work for this slug. Inspect and preserve that worktree and its branch first — Slipway never removes a worktree it did not provision. Once its work is merged or saved, discard only the stale bundle residue with `slipway delete --change {subject}` (never pass --worktree).",
+		CommandTemplate: "slipway delete --change {subject}",
+		Class:           RecoveryClassDiscardChange,
+	},
 	"orphaned_change_bundle": {
 		// Emitted as orphaned_change_bundle:<slug>. The governed bundle directory
 		// survived without its change.yaml authority (a partially-deleted change),

--- a/internal/model/recovery.go
+++ b/internal/model/recovery.go
@@ -54,6 +54,7 @@ type RecoveryClass string
 
 const (
 	RecoveryClassConfirmPreset   RecoveryClass = "confirm_preset"
+	RecoveryClassPreserveWork    RecoveryClass = "preserve_work"
 	RecoveryClassDiscardChange   RecoveryClass = "discard_change"
 	RecoveryClassNewChange       RecoveryClass = "new_change"
 	RecoveryClassSatisfyControl  RecoveryClass = "satisfy_control"
@@ -71,6 +72,10 @@ const (
 // higher priority for selecting the single primary command.
 var recoveryClassPriority = []RecoveryClass{
 	RecoveryClassConfirmPreset,
+	// PreserveWork outranks DiscardChange so that when a no-target recovery
+	// surfaces both an unmanaged-worktree orphan and a plain discardable orphan,
+	// the non-destructive preserve-first action is chosen as primary (#285).
+	RecoveryClassPreserveWork,
 	RecoveryClassNewChange,
 	RecoveryClassDiscardChange,
 	RecoveryClassSatisfyControl,
@@ -317,11 +322,16 @@ var blockerRemediations = map[string]blockerRemediation{
 	"orphaned_bundle_unmanaged_worktree": {
 		// Emitted as orphaned_bundle_unmanaged_worktree:<slug>. The bundle lost its
 		// change.yaml, but a live git worktree Slipway never provisioned still holds
-		// work for the slug. Lead with inspect/preserve and NEVER suggest --worktree:
-		// recovery must not endanger externally-managed, possibly-unmerged work.
+		// work for the slug. This is a PRESERVE-first recovery, not a discard: the
+		// structured surface must NOT route to `slipway delete` as the primary
+		// command and must NOT carry the discard_change class (#285). The CommandTemplate
+		// is deliberately empty — preservation is a manual, multi-step judgment with no
+		// single safe automated command — so primary_command is omitted and the prose
+		// carries the action. `slipway delete --change <slug>` survives only in prose as
+		// the FINAL residue cleanup after the work is saved, and never with --worktree.
 		Remediation:     "Governed bundle {subject} lost its change.yaml, but a live git worktree Slipway does not manage still holds work for this slug. Inspect and preserve that worktree and its branch first — Slipway never removes a worktree it did not provision. Once its work is merged or saved, discard only the stale bundle residue with `slipway delete --change {subject}` (never pass --worktree).",
-		CommandTemplate: "slipway delete --change {subject}",
-		Class:           RecoveryClassDiscardChange,
+		CommandTemplate: "",
+		Class:           RecoveryClassPreserveWork,
 	},
 	"orphaned_change_bundle": {
 		// Emitted as orphaned_change_bundle:<slug>. The governed bundle directory

--- a/internal/model/recovery.go
+++ b/internal/model/recovery.go
@@ -319,6 +319,17 @@ var blockerRemediations = map[string]blockerRemediation{
 		CommandTemplate: "slipway next",
 		Class:           RecoveryClassRerunSkill,
 	},
+	"orphaned_bundle_ownership_unknown": {
+		// Emitted as orphaned_bundle_ownership_unknown:<slug>. The bundle lost its
+		// change.yaml and the git worktree/branch cross-check that proves ownership
+		// FAILED, so we cannot show it is safe to discard. Fail closed: this is a
+		// PRESERVE-first recovery, never a discard. CommandTemplate is empty so no
+		// primary_command routes to `slipway delete`; the prose carries the action and
+		// never recommends --worktree.
+		Remediation:     "Governed bundle {subject} lost its change.yaml, and Slipway could not verify whether a live git worktree holds its work (the worktree cross-check failed). Do not discard it yet: inspect for a live worktree or branch named after {subject} and preserve any unmerged work first. Only after confirming no unmerged work remains, discard the stale residue with `slipway delete --change {subject}` (never pass --worktree).",
+		CommandTemplate: "",
+		Class:           RecoveryClassPreserveWork,
+	},
 	"orphaned_bundle_unmanaged_worktree": {
 		// Emitted as orphaned_bundle_unmanaged_worktree:<slug>. The bundle lost its
 		// change.yaml, but a live git worktree Slipway never provisioned still holds

--- a/internal/model/recovery_test.go
+++ b/internal/model/recovery_test.go
@@ -484,6 +484,24 @@ func TestBuildRecoveryUnmanagedWorktreeOrphanIsNonDestructive(t *testing.T) {
 	assert.Equal(t, RecoveryClassPreserveWork, got.Steps[0].RecoveryClass)
 }
 
+func TestBuildRecoveryOwnershipUnknownOrphanIsNonDestructive(t *testing.T) {
+	t.Parallel()
+	got := BuildRecovery([]ReasonCode{
+		NewReasonCode("orphaned_bundle_ownership_unknown", "mystery-change"),
+	})
+	require.NotNil(t, got)
+	require.Len(t, got.Steps, 1)
+	assert.Equal(t, RecoveryClassPreserveWork, got.RecoveryClass)
+	assert.Empty(t, got.PrimaryCommand)
+	assert.NotContains(t, got.PrimaryCommand, "slipway delete")
+	assert.Empty(t, got.Steps[0].Command)
+	// The prose must forbid the destructive escalation, never recommend it: it says
+	// "never pass --worktree" and must NOT carry the "add --worktree" escalation.
+	assert.NotContains(t, got.PrimaryAction, "add --worktree")
+	assert.Contains(t, got.PrimaryAction, "never pass --worktree")
+	assert.Contains(t, got.PrimaryAction, "mystery-change")
+}
+
 func TestBuildRecoveryUnmanagedOrphanOutranksPlainDiscard(t *testing.T) {
 	t.Parallel()
 

--- a/internal/model/recovery_test.go
+++ b/internal/model/recovery_test.go
@@ -472,6 +472,49 @@ func TestBuildRecoveryUnmanagedWorktreeOrphanIsNonDestructive(t *testing.T) {
 	assert.Contains(t, got.PrimaryAction, "Inspect and preserve")
 	assert.Contains(t, got.PrimaryAction, "never pass --worktree")
 	assert.NotContains(t, got.PrimaryAction, "add --worktree")
+
+	// The recovery must be classed preserve_work, never discard_change, and must
+	// carry NO primary command — preservation is a manual, multi-step judgment, so
+	// the prose carries the action instead of routing to `slipway delete`.
+	assert.Equal(t, RecoveryClassPreserveWork, got.RecoveryClass)
+	assert.NotEqual(t, RecoveryClassDiscardChange, got.RecoveryClass)
+	assert.Empty(t, got.PrimaryCommand)
+	assert.NotContains(t, got.PrimaryCommand, "slipway delete")
+	assert.Empty(t, got.Steps[0].Command)
+	assert.Equal(t, RecoveryClassPreserveWork, got.Steps[0].RecoveryClass)
+}
+
+func TestBuildRecoveryUnmanagedOrphanOutranksPlainDiscard(t *testing.T) {
+	t.Parallel()
+
+	// #285: when a no-target recovery surfaces BOTH an unmanaged-worktree orphan
+	// (preserve_work) and a plain discardable orphan (discard_change), the
+	// non-destructive preserve-first action must win the primary slot, and no
+	// orphan may be dropped — the plain one still keeps its own discard step.
+	got := BuildRecovery([]ReasonCode{
+		NewReasonCode("orphaned_bundle_unmanaged_worktree", "live-wt"),
+		NewReasonCode("orphaned_change_bundle", "dead-residue"),
+	})
+	require.NotNil(t, got)
+	assert.Equal(t, RecoveryClassPreserveWork, got.RecoveryClass)
+	assert.Empty(t, got.PrimaryCommand)
+	assert.NotContains(t, got.PrimaryCommand, "slipway delete")
+	require.Len(t, got.Steps, 2)
+
+	var live, dead *RecoveryStep
+	for i := range got.Steps {
+		switch got.Steps[i].Subject {
+		case "live-wt":
+			live = &got.Steps[i]
+		case "dead-residue":
+			dead = &got.Steps[i]
+		}
+	}
+	require.NotNil(t, live, "the unmanaged-worktree orphan must keep its own step")
+	require.NotNil(t, dead, "the plain discardable orphan must not be dropped")
+	assert.Empty(t, live.Command, "the preserved worktree step must carry no destructive command")
+	assert.Equal(t, "slipway delete --change dead-residue", dead.Command,
+		"the plain orphan still routes to discard")
 }
 
 func TestBuildRecoveryStaleRuntimeBindingRoutesToDelete(t *testing.T) {

--- a/internal/model/recovery_test.go
+++ b/internal/model/recovery_test.go
@@ -458,6 +458,22 @@ func TestBuildRecoveryOrphanedChangeBundleRoutesToDelete(t *testing.T) {
 	assert.Contains(t, got.Steps[0].Remediation, "slipway delete --change abandoned-change")
 }
 
+func TestBuildRecoveryUnmanagedWorktreeOrphanIsNonDestructive(t *testing.T) {
+	t.Parallel()
+
+	// #285: when an orphan bundle's slug names a live worktree Slipway does not
+	// manage, recovery must lead with inspect/preserve and must never recommend
+	// removing that worktree (no --worktree escalation).
+	got := BuildRecovery([]ReasonCode{
+		NewReasonCode("orphaned_bundle_unmanaged_worktree", "abandoned-change"),
+	})
+	require.NotNil(t, got)
+	require.Len(t, got.Steps, 1)
+	assert.Contains(t, got.PrimaryAction, "Inspect and preserve")
+	assert.Contains(t, got.PrimaryAction, "never pass --worktree")
+	assert.NotContains(t, got.PrimaryAction, "add --worktree")
+}
+
 func TestBuildRecoveryStaleRuntimeBindingRoutesToDelete(t *testing.T) {
 	t.Parallel()
 

--- a/internal/state/delete.go
+++ b/internal/state/delete.go
@@ -270,6 +270,17 @@ func planWorktreeTargetWithResolver(root, slug string, opts DeleteOptions, resol
 		target.Reason = "bound worktree directory is already missing; git worktree metadata will be removed"
 		return target
 	}
+	provisioned, perr := worktreeIsSlipwayProvisioned(root, slug, worktreePath)
+	if perr != nil {
+		target.Action = DeleteActionRefused
+		target.Reason = fmt.Sprintf("cannot verify whether Slipway provisioned this worktree: %v", perr)
+		return target
+	}
+	if !provisioned {
+		target.Action = DeleteActionRefused
+		target.Reason = "refusing to remove a worktree Slipway did not provision (not .worktrees/<slug> on feat/<slug>); preserve it or remove it yourself — Slipway never removes a worktree it did not provision"
+		return target
+	}
 	refusal, derr := worktreeRemovalRefusalReason(worktreePath, slug, opts.Force)
 	if derr != nil {
 		target.Action = DeleteActionRefused
@@ -373,6 +384,37 @@ func RemoveChangeWorktree(root, slug, worktreePath string, force bool) error {
 	_ = exec.Command("git", "-C", repoRoot, "worktree", "prune").Run() // #nosec G204 -- command and arguments are constructed by Slipway helpers and executed without shell interpolation.
 	invalidateWorktreeListCache(repoRoot)
 	return nil
+}
+
+// worktreeIsSlipwayProvisioned reports whether the worktree at worktreePath is one
+// Slipway itself provisioned for slug: positive proof is BOTH its default
+// .worktrees/<slug> path AND its feat/<slug> branch. Anything else is treated as
+// externally managed and must never be removed by `slipway delete --worktree`,
+// even with --force (issue #285). A non-git context yields (false, nil).
+func worktreeIsSlipwayProvisioned(root, slug, worktreePath string) (bool, error) {
+	repoRoot, err := gitWorkspaceRoot(root)
+	if err != nil {
+		if gitCommandReportsNotRepository(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	defaultPath, err := NormalizePath(DefaultWorktreePath(repoRoot, slug))
+	if err != nil {
+		return false, err
+	}
+	normalized, err := NormalizePath(worktreePath)
+	if err != nil {
+		normalized = filepath.Clean(worktreePath)
+	}
+	if normalized != defaultPath {
+		return false, nil
+	}
+	branch, err := resolveWorktreeActualBranch(worktreePath)
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(branch) == DefaultWorktreeBranch(slug), nil
 }
 
 // resolveChangeWorktreePath returns the bound worktree path for slug, reading

--- a/internal/state/delete_test.go
+++ b/internal/state/delete_test.go
@@ -2,10 +2,42 @@ package state
 
 import (
 	"errors"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+// TestPlanWorktreeTargetRefusesUnmanagedWorktreeEvenWithForce proves the
+// execution-surface gate: a worktree at the default path but on a hand-named
+// branch (NOT feat/<slug>) was not provisioned by Slipway, so --worktree must be
+// refused even with --force (issue #285).
+func TestPlanWorktreeTargetRefusesUnmanagedWorktreeEvenWithForce(t *testing.T) {
+	root := t.TempDir()
+	initGitRepoAt(t, root)
+	const slug = "fix-283"
+	// External worktree at the DEFAULT path but on a hand-named branch: not provisioned by Slipway.
+	path := filepath.Join(root, ".worktrees", slug)
+	runGit(t, root, "worktree", "add", "-b", "hand/local-work", path)
+
+	target := planWorktreeTarget(root, slug, DeleteOptions{RemoveWorktree: true, Force: true})
+	assert.Equal(t, DeleteTargetWorktree, target.Kind)
+	assert.Equal(t, DeleteActionRefused, target.Action)
+	assert.Contains(t, target.Reason, "did not provision")
+}
+
+// TestPlanWorktreeTargetAllowsManagedWorktree confirms a worktree Slipway DID
+// provision (default path + feat/<slug> branch) stays removable.
+func TestPlanWorktreeTargetAllowsManagedWorktree(t *testing.T) {
+	root := t.TempDir()
+	initGitRepoAt(t, root)
+	const slug = "demo"
+	path := filepath.Join(root, ".worktrees", slug)
+	runGit(t, root, "worktree", "add", "-b", DefaultWorktreeBranch(slug), path)
+
+	target := planWorktreeTarget(root, slug, DeleteOptions{RemoveWorktree: true})
+	assert.Equal(t, DeleteActionDelete, target.Action, "a Slipway-provisioned worktree (default path + feat/<slug>) must be removable")
+}
 
 func TestPlanWorktreeTargetRefusesResolverErrorWhenWorktreeRequested(t *testing.T) {
 	t.Parallel()

--- a/internal/state/find_slug_worktree_match_test.go
+++ b/internal/state/find_slug_worktree_match_test.go
@@ -17,6 +17,9 @@ func TestFindSlugWorktreeMatch_SlugifyBranchAssumptions(t *testing.T) {
 	t.Parallel()
 	assert.Equal(t, "demo", model.SlugifyTitle("demo"))
 	assert.Equal(t, "my-feature", model.SlugifyTitle("my-feature"))
+	assert.Equal(t, "fix-issue-283-archived-worktree-resolution",
+		model.SlugifyTitle("fix/issue-283-archived-worktree-resolution"),
+		"a slash-bearing branch slugifies to the dashed slug the custom-path case relies on")
 	assert.Equal(t, "change", model.SlugifyTitle(""),
 		"empty branch slugifies to \"change\" — the collision a detached HEAD must avoid")
 }
@@ -157,21 +160,61 @@ func TestFindSlugWorktreeMatch_DetachedHeadDoesNotCollideWithChangeSlug(t *testi
 
 // TestFindSlugWorktreeMatch_ExternalSlugifiedBranchCustomPath covers an external
 // worktree at a custom (non-default) path whose branch slugifies to the slug:
-// it corresponds (ok==true) but is not managed (no default path proof).
+// it corresponds (ok==true) but is not managed (no default path proof). The
+// branch carries a "/" so the raw branch != slug, and the worktree sits on a
+// custom path != .worktrees/<slug> — so the ONLY thing that can make it
+// correspond is the slugified-branch == slug rule (model.SlugifyTitle(branch)).
 func TestFindSlugWorktreeMatch_ExternalSlugifiedBranchCustomPath(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
 	initGitRepoAt(t, root)
 
-	const slug = "my-feature"
-	customPath := addCustomWorktree(t, root, "elsewhere", "my-feature")
+	const slug = "fix-issue-283-archived-worktree-resolution"
+	const branch = "fix/issue-283-archived-worktree-resolution"
+	require.NotEqual(t, slug, branch, "branch must differ from slug so raw equality cannot match")
+	require.Equal(t, slug, model.SlugifyTitle(branch), "only slugified-branch correspondence can match")
+
+	customPath := addCustomWorktree(t, root, "elsewhere", branch)
 
 	match, ok, err := FindSlugWorktreeMatch(root, slug)
 	require.NoError(t, err)
 	require.True(t, ok, "a custom-path worktree whose branch slugifies to the slug must correspond")
 	assert.False(t, match.SlipwayManaged, "a custom path is no proof Slipway provisioned the worktree")
-	assert.Equal(t, "my-feature", match.Branch)
+	assert.Equal(t, branch, match.Branch)
 	assert.Equal(t, normalize(t, customPath), match.WorktreePath)
+}
+
+// TestFindSlugWorktreeMatch_BranchSwitchInvalidatesCache is the regression for
+// the worktree-list cache probe: an in-place branch switch (no worktree
+// add/remove) rewrites .git/worktrees/<entry>/HEAD but leaves the entry set and
+// the parent dir's mtime untouched. Before the probe fingerprinted each linked
+// worktree's HEAD, a warm cache returned the STALE feat/<slug> branch, so the
+// switched-away worktree still read SlipwayManaged==true. The match must instead
+// drop SlipwayManaged and report the hand-named branch even with a warm cache.
+func TestFindSlugWorktreeMatch_BranchSwitchInvalidatesCache(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	initGitRepoAt(t, root)
+
+	const slug = "cache-slug"
+	path := addDefaultConventionWorktree(t, root, slug, DefaultWorktreeBranch(slug))
+
+	// Warm the cache on the genuine managed worktree.
+	m1, ok1, err1 := FindSlugWorktreeMatch(root, slug)
+	require.NoError(t, err1)
+	require.True(t, ok1)
+	require.True(t, m1.SlipwayManaged, "default path + feat/<slug> branch must be managed before the switch")
+
+	// Switch the SAME worktree to a hand-named branch in place: no worktree entry
+	// is added or removed, only HEAD is rewritten.
+	runGit(t, path, "checkout", "-b", "hand/local-work")
+
+	m2, ok2, err2 := FindSlugWorktreeMatch(root, slug)
+	require.NoError(t, err2)
+	require.True(t, ok2, "the worktree still sits at the default path, so it still corresponds")
+	assert.False(t, m2.SlipwayManaged,
+		"an in-place branch switch off feat/<slug> must drop SlipwayManaged even with a warm cache")
+	assert.Equal(t, "hand/local-work", m2.Branch)
 }
 
 // TestFindSlugWorktreeMatch_NoMatch confirms a slug with no corresponding live

--- a/internal/state/find_slug_worktree_match_test.go
+++ b/internal/state/find_slug_worktree_match_test.go
@@ -1,0 +1,191 @@
+package state
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/signalridge/slipway/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Sanity-anchor the slug correspondence the external-branch cases rely on:
+// SlugifyTitle is the same transform FindSlugWorktreeMatch applies to a branch.
+func TestFindSlugWorktreeMatch_SlugifyBranchAssumptions(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "demo", model.SlugifyTitle("demo"))
+	assert.Equal(t, "my-feature", model.SlugifyTitle("my-feature"))
+	assert.Equal(t, "change", model.SlugifyTitle(""),
+		"empty branch slugifies to \"change\" — the collision a detached HEAD must avoid")
+}
+
+// normalize resolves a path the same way FindSlugWorktreeMatch does, so
+// expected paths survive macOS's /var -> /private/var symlink resolution.
+func normalize(t *testing.T, path string) string {
+	t.Helper()
+	out, err := NormalizePath(path)
+	require.NoError(t, err)
+	return out
+}
+
+// addDefaultConventionWorktree adds a git worktree at <root>/.worktrees/<slug>
+// on a new branch, mirroring the path convention DefaultWorktreePath uses. The
+// branch is supplied explicitly so callers can exercise both the genuine
+// feat/<slug> convention and an external hand-named branch at the same path.
+func addDefaultConventionWorktree(t *testing.T, root, slug, branch string) string {
+	t.Helper()
+	path := filepath.Join(root, ".worktrees", slug)
+	runGit(t, root, "worktree", "add", "-b", branch, path)
+	return path
+}
+
+// addCustomWorktree adds a git worktree at a custom (non-.worktrees) path on a
+// new branch, so the match can only come from branch/slug correspondence, never
+// from the default path convention.
+func addCustomWorktree(t *testing.T, root, dirName, branch string) string {
+	t.Helper()
+	path := filepath.Join(root, dirName)
+	runGit(t, root, "worktree", "add", "-b", branch, path)
+	return path
+}
+
+// addDetachedWorktree adds a detached-HEAD git worktree at a custom path. A
+// detached worktree carries no branch, so it must never be matched via
+// SlugifyTitle's empty-string "change" fallback.
+func addDetachedWorktree(t *testing.T, root, dirName string) string {
+	t.Helper()
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = root
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "git rev-parse HEAD failed: %s", string(out))
+	sha := strings.TrimSpace(string(out))
+	path := filepath.Join(root, dirName)
+	runGit(t, root, "worktree", "add", "--detach", path, sha)
+	return path
+}
+
+// TestFindSlugWorktreeMatch_Issue285ExternalWorktreeNotManaged is the headline
+// regression for issue #285: an external worktree a user placed at the default
+// .worktrees/<slug> path but on a hand-named branch (NOT feat/<slug>) must be
+// reported as a real, corresponding match yet SlipwayManaged==false, so
+// orphan-bundle recovery never recommends destroying the user's live work.
+//
+// Pre-fix, managed was pathMatches || branchMatches, so the default-path-only
+// match was wrongly classed SlipwayManaged==true.
+func TestFindSlugWorktreeMatch_Issue285ExternalWorktreeNotManaged(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	initGitRepoAt(t, root)
+
+	const slug = "fix-283"
+	const branch = "fix/issue-283-archived-worktree-resolution"
+	addDefaultConventionWorktree(t, root, slug, branch)
+
+	match, ok, err := FindSlugWorktreeMatch(root, slug)
+	require.NoError(t, err)
+	require.True(t, ok, "an external worktree at the default path must still correspond to the slug")
+	assert.False(t, match.SlipwayManaged,
+		"#285: default path alone (hand-named branch) is NOT positive proof Slipway provisioned it")
+	assert.Equal(t, branch, match.Branch)
+	assert.True(t, strings.HasSuffix(filepath.ToSlash(match.WorktreePath), ".worktrees/fix-283"),
+		"match must point at the external worktree path, got %q", match.WorktreePath)
+}
+
+// TestFindSlugWorktreeMatch_GenuineManaged covers a worktree carrying BOTH the
+// default .worktrees/<slug> path AND the feat/<slug> branch: positive proof
+// Slipway provisioned it, so SlipwayManaged==true.
+func TestFindSlugWorktreeMatch_GenuineManaged(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	initGitRepoAt(t, root)
+
+	const slug = "demo"
+	addDefaultConventionWorktree(t, root, slug, DefaultWorktreeBranch(slug))
+
+	match, ok, err := FindSlugWorktreeMatch(root, slug)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.True(t, match.SlipwayManaged,
+		"default path + feat/<slug> branch is positive proof Slipway provisioned the worktree")
+	assert.Equal(t, DefaultWorktreeBranch(slug), match.Branch)
+	// FindSlugWorktreeMatch returns NormalizePath-normalized paths (symlinks
+	// resolved), so compare against the normalized default path.
+	assert.Equal(t, normalize(t, DefaultWorktreePath(root, slug)), match.WorktreePath)
+}
+
+// TestFindSlugWorktreeMatch_ManagedPreferredOverExternal verifies that when both
+// a Slipway-managed worktree and a coincidentally-corresponding external
+// worktree exist for the same slug, the managed one is returned.
+func TestFindSlugWorktreeMatch_ManagedPreferredOverExternal(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	initGitRepoAt(t, root)
+
+	const slug = "demo"
+	// External worktree first: custom path on a branch whose SlugifyTitle == slug.
+	addCustomWorktree(t, root, "external-demo", "demo")
+	// Genuine managed worktree: default path + feat/<slug> branch.
+	managedPath := addDefaultConventionWorktree(t, root, slug, DefaultWorktreeBranch(slug))
+
+	match, ok, err := FindSlugWorktreeMatch(root, slug)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.True(t, match.SlipwayManaged, "the Slipway-managed worktree must win over an external match")
+	assert.Equal(t, DefaultWorktreeBranch(slug), match.Branch)
+	assert.Equal(t, normalize(t, managedPath), match.WorktreePath)
+}
+
+// TestFindSlugWorktreeMatch_DetachedHeadDoesNotCollideWithChangeSlug guards the
+// "change" slug edge: model.SlugifyTitle("") == "change", so before the fix a
+// detached-HEAD worktree (empty branch) could be matched as the literal "change"
+// slug. A detached worktree carries no branch and must never correspond.
+func TestFindSlugWorktreeMatch_DetachedHeadDoesNotCollideWithChangeSlug(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	initGitRepoAt(t, root)
+
+	detachedPath := addDetachedWorktree(t, root, "detached-wt")
+
+	match, ok, err := FindSlugWorktreeMatch(root, "change")
+	require.NoError(t, err)
+	assert.False(t, ok, "a detached-HEAD worktree must not match the literal \"change\" slug")
+	assert.NotEqual(t, detachedPath, match.WorktreePath,
+		"the detached worktree must never be returned for the \"change\" slug")
+}
+
+// TestFindSlugWorktreeMatch_ExternalSlugifiedBranchCustomPath covers an external
+// worktree at a custom (non-default) path whose branch slugifies to the slug:
+// it corresponds (ok==true) but is not managed (no default path proof).
+func TestFindSlugWorktreeMatch_ExternalSlugifiedBranchCustomPath(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	initGitRepoAt(t, root)
+
+	const slug = "my-feature"
+	customPath := addCustomWorktree(t, root, "elsewhere", "my-feature")
+
+	match, ok, err := FindSlugWorktreeMatch(root, slug)
+	require.NoError(t, err)
+	require.True(t, ok, "a custom-path worktree whose branch slugifies to the slug must correspond")
+	assert.False(t, match.SlipwayManaged, "a custom path is no proof Slipway provisioned the worktree")
+	assert.Equal(t, "my-feature", match.Branch)
+	assert.Equal(t, normalize(t, customPath), match.WorktreePath)
+}
+
+// TestFindSlugWorktreeMatch_NoMatch confirms a slug with no corresponding live
+// worktree returns ok==false and a nil error.
+func TestFindSlugWorktreeMatch_NoMatch(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	initGitRepoAt(t, root)
+
+	// Add an unrelated worktree so the listing is non-empty but non-matching.
+	addCustomWorktree(t, root, "unrelated", "unrelated-branch")
+
+	match, ok, err := FindSlugWorktreeMatch(root, "does-not-exist")
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Equal(t, SlugWorktreeMatch{}, match)
+}

--- a/internal/state/find_slug_worktree_match_test.go
+++ b/internal/state/find_slug_worktree_match_test.go
@@ -184,6 +184,30 @@ func TestFindSlugWorktreeMatch_ExternalSlugifiedBranchCustomPath(t *testing.T) {
 	assert.Equal(t, normalize(t, customPath), match.WorktreePath)
 }
 
+// TestFindSlugWorktreeMatch_ExternalFeatBranchCustomPath covers branchMatches &&
+// !pathMatches: a worktree on the EXACT feat/<slug> branch but at a CUSTOM path.
+// SlugifyTitle("feat/<slug>") != slug, so ONLY the exact-branch rule makes it
+// correspond; a custom path is no proof Slipway provisioned it -> not managed.
+func TestFindSlugWorktreeMatch_ExternalFeatBranchCustomPath(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	initGitRepoAt(t, root)
+
+	const slug = "demo"
+	branch := DefaultWorktreeBranch(slug) // feat/demo
+	require.NotEqual(t, slug, model.SlugifyTitle(branch),
+		"feat/<slug> must NOT slugify back to slug, so only branchMatches can match")
+
+	customPath := addCustomWorktree(t, root, "feat-elsewhere", branch)
+
+	match, ok, err := FindSlugWorktreeMatch(root, slug)
+	require.NoError(t, err)
+	require.True(t, ok, "a custom-path worktree on the exact feat/<slug> branch must correspond")
+	assert.False(t, match.SlipwayManaged, "a custom path is no proof Slipway provisioned the worktree")
+	assert.Equal(t, branch, match.Branch)
+	assert.Equal(t, normalize(t, customPath), match.WorktreePath)
+}
+
 // TestFindSlugWorktreeMatch_BranchSwitchInvalidatesCache is the regression for
 // the worktree-list cache probe: an in-place branch switch (no worktree
 // add/remove) rewrites .git/worktrees/<entry>/HEAD but leaves the entry set and

--- a/internal/state/health.go
+++ b/internal/state/health.go
@@ -60,7 +60,7 @@ func CollectHealthReport(root string, activeSlugOpt ...string) (HealthReport, er
 		return HealthReport{}, err
 	}
 	for _, slug := range orphanSlugs {
-		findings = append(findings, HealthFinding{
+		finding := HealthFinding{
 			Severity:   model.ReasonSeverityWarning,
 			Category:   "bundle_integrity",
 			Slug:       slug,
@@ -68,7 +68,19 @@ func CollectHealthReport(root string, activeSlugOpt ...string) (HealthReport, er
 			Repairable: false,
 			RepairHint: "Inspect the orphan bundle directory and remove it manually if it contains no useful state.",
 			Reasons:    []model.ReasonCode{model.NewReasonCode("orphan_bundle_directory", slug)},
-		})
+		}
+		// Cross-check git worktrees/branches before suggesting manual removal: a slug
+		// whose live worktree Slipway does not manage (or whose ownership cannot be
+		// verified) must fail closed to preserve-first guidance, never "remove it
+		// manually" (issue #285). The status/CLI recovery surfaces use the same check.
+		if match, ok, err := FindSlugWorktreeMatch(root, slug); err != nil {
+			finding.Message = "Bundle directory exists without change.yaml and its worktree ownership could not be verified: " + slug
+			finding.RepairHint = "Could not verify whether a live git worktree holds this slug's work; inspect for a live worktree or branch named after the slug and preserve any unmerged work before removing anything."
+		} else if ok && !match.SlipwayManaged {
+			finding.Message = "Bundle directory exists without change.yaml, but a live git worktree Slipway does not manage holds work for it: " + slug
+			finding.RepairHint = "A live git worktree Slipway did not provision holds work for this slug; inspect and preserve that worktree and its branch first — never remove a worktree Slipway did not provision. Discard only the stale bundle residue once its work is saved."
+		}
+		findings = append(findings, finding)
 	}
 
 	changes, issues, err := ListChangesBestEffortWithIssues(root)

--- a/internal/state/worktree.go
+++ b/internal/state/worktree.go
@@ -36,8 +36,8 @@ type worktreeListProbe struct {
 }
 
 type worktreeListCacheEntry struct {
-	Probe     worktreeListProbe
-	Worktrees map[string]struct{}
+	Probe   worktreeListProbe
+	Records []gitWorktreeRecord
 }
 
 var worktreeListCache = struct {
@@ -465,11 +465,30 @@ func ParseWorktreePreflightReferences(references []string) (path string, branch 
 	return path, branch, baselineVerifyCmd, stringutil.UniqueSorted(reasons)
 }
 
+// listGitWorktrees returns the set of normalized worktree paths registered in
+// the repository. It projects the cached path+branch records to a path set so a
+// single porcelain listing serves both path and branch lookups per repo probe.
 func listGitWorktrees(repoRoot string) (map[string]struct{}, error) {
-	return listGitWorktreesCachedWithLister(repoRoot, listGitWorktreesUncached)
+	records, err := listGitWorktreeRecords(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	return worktreeRecordPathSet(records)
 }
 
-func listGitWorktreesCachedWithLister(repoRoot string, lister func(string) (map[string]struct{}, error)) (map[string]struct{}, error) {
+func worktreeRecordPathSet(records []gitWorktreeRecord) (map[string]struct{}, error) {
+	set := make(map[string]struct{}, len(records))
+	for _, rec := range records {
+		normalized, err := NormalizePath(rec.Path)
+		if err != nil {
+			return nil, err
+		}
+		set[normalized] = struct{}{}
+	}
+	return set, nil
+}
+
+func listGitWorktreeRecordsCachedWithLister(repoRoot string, lister func(string) ([]gitWorktreeRecord, error)) ([]gitWorktreeRecord, error) {
 	normalizedRoot, err := NormalizePath(repoRoot)
 	if err != nil {
 		normalizedRoot = filepath.Clean(repoRoot)
@@ -480,11 +499,11 @@ func listGitWorktreesCachedWithLister(repoRoot string, lister func(string) (map[
 	entry, ok := worktreeListCache.entries[normalizedRoot]
 	if ok && worktreeListProbeMatches(entry.Probe, probeBefore) {
 		worktreeListCache.mu.Unlock()
-		return cloneWorktreeSet(entry.Worktrees), nil
+		return cloneWorktreeRecords(entry.Records), nil
 	}
 	worktreeListCache.mu.Unlock()
 
-	worktrees, err := lister(normalizedRoot)
+	records, err := lister(normalizedRoot)
 	if err != nil {
 		return nil, err
 	}
@@ -493,16 +512,16 @@ func listGitWorktreesCachedWithLister(repoRoot string, lister func(string) (map[
 	worktreeListCache.mu.Lock()
 	if entry, ok := worktreeListCache.entries[normalizedRoot]; ok && worktreeListProbeMatches(entry.Probe, probeAfter) {
 		worktreeListCache.mu.Unlock()
-		return cloneWorktreeSet(entry.Worktrees), nil
+		return cloneWorktreeRecords(entry.Records), nil
 	}
 	if worktreeListProbeMatches(probeBefore, probeAfter) {
 		worktreeListCache.entries[normalizedRoot] = worktreeListCacheEntry{
-			Probe:     probeAfter,
-			Worktrees: cloneWorktreeSet(worktrees),
+			Probe:   probeAfter,
+			Records: cloneWorktreeRecords(records),
 		}
 	}
 	worktreeListCache.mu.Unlock()
-	return cloneWorktreeSet(worktrees), nil
+	return cloneWorktreeRecords(records), nil
 }
 
 func invalidateWorktreeListCache(repoRoot string) {
@@ -515,30 +534,13 @@ func invalidateWorktreeListCache(repoRoot string) {
 	worktreeListCache.mu.Unlock()
 }
 
-func listGitWorktreesUncached(repoRoot string) (map[string]struct{}, error) {
+func listGitWorktreeRecordsUncached(repoRoot string) ([]gitWorktreeRecord, error) {
 	cmd := exec.Command("git", "-C", repoRoot, "worktree", "list", "--porcelain") // #nosec G204 -- command and arguments are constructed by Slipway helpers and executed without shell interpolation.
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("list git worktrees: %w (%s)", err, strings.TrimSpace(string(out)))
 	}
-
-	worktrees := map[string]struct{}{}
-	lines := bytes.Split(out, []byte("\n"))
-	for _, line := range lines {
-		if len(line) == 0 {
-			continue
-		}
-		if !bytes.HasPrefix(line, []byte("worktree ")) {
-			continue
-		}
-		path := strings.TrimSpace(strings.TrimPrefix(string(line), "worktree "))
-		normalized, err := NormalizePath(path)
-		if err != nil {
-			return nil, err
-		}
-		worktrees[normalized] = struct{}{}
-	}
-	return worktrees, nil
+	return parseGitWorktreePorcelain(out), nil
 }
 
 // SlugWorktreeMatch describes a live git worktree (and its branch) whose
@@ -550,10 +552,11 @@ type SlugWorktreeMatch struct {
 	WorktreePath string
 	// Branch is the worktree's checked-out branch (empty for a detached HEAD).
 	Branch string
-	// SlipwayManaged is true only when the match follows Slipway's own
-	// .worktrees/<slug> path or feat/<slug> branch convention, i.e. a worktree
-	// Slipway itself provisioned. False marks an externally-managed worktree that
-	// recovery must never recommend removing.
+	// SlipwayManaged is true only when the match carries positive proof Slipway
+	// itself provisioned the worktree: BOTH its default .worktrees/<slug> path and
+	// its feat/<slug> branch. False marks an externally-managed worktree (e.g. one
+	// a user placed at .worktrees/<slug> on a hand-named branch) that recovery must
+	// never recommend removing.
 	SlipwayManaged bool
 }
 
@@ -594,14 +597,29 @@ func FindSlugWorktreeMatch(root, slug string) (match SlugWorktreeMatch, ok bool,
 		if nerr != nil {
 			normPath = filepath.Clean(rec.Path)
 		}
-		// The main checkout is never the slug's dedicated worktree.
+		// Skip the checkout we resolved from: the workspace root is never the
+		// slug's own dedicated worktree.
 		if normPath == normalizedRepoRoot {
 			continue
 		}
-		managed := normPath == defaultPath || rec.Branch == defaultBranch
-		if !managed && model.SlugifyTitle(rec.Branch) != slug {
+		branch := strings.TrimSpace(rec.Branch)
+		pathMatches := normPath == defaultPath
+		branchMatches := branch == defaultBranch
+		// A branch whose slugified identity equals slug also corresponds to the
+		// slug, but only when the worktree actually carries a branch: a detached
+		// HEAD has no branch and must not borrow SlugifyTitle's "change" fallback
+		// to collide with a literal "change" slug.
+		slugMatches := branch != "" && model.SlugifyTitle(branch) == slug
+		if !pathMatches && !branchMatches && !slugMatches {
 			continue
 		}
+		// Slipway-managed requires positive proof Slipway itself provisioned the
+		// worktree: BOTH its default .worktrees/<slug> path AND its feat/<slug>
+		// branch. A path or branch that merely coincides with the slug — e.g. an
+		// external worktree a user placed at .worktrees/<slug> on a hand-named
+		// branch (issue #285) — is NOT managed, and recovery must never recommend
+		// removing it.
+		managed := pathMatches && branchMatches
 		candidate := SlugWorktreeMatch{WorktreePath: normPath, Branch: rec.Branch, SlipwayManaged: managed}
 		if managed {
 			// A Slipway-managed worktree is the authoritative match; existing
@@ -624,15 +642,17 @@ type gitWorktreeRecord struct {
 	Branch string
 }
 
-// listGitWorktreeRecords parses `git worktree list --porcelain` into path+branch
-// records. Unlike listGitWorktrees it preserves each worktree's checked-out
-// branch so callers can map a worktree back to a change slug.
+// listGitWorktreeRecords returns each registered worktree's path and checked-out
+// branch (empty for a detached HEAD), cached behind the same repo probe as the
+// rest of the worktree listing so callers can map a worktree back to a change
+// slug without re-forking git.
 func listGitWorktreeRecords(repoRoot string) ([]gitWorktreeRecord, error) {
-	cmd := exec.Command("git", "-C", repoRoot, "worktree", "list", "--porcelain") // #nosec G204 -- command and arguments are constructed by Slipway helpers and executed without shell interpolation.
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return nil, fmt.Errorf("list git worktrees: %w (%s)", err, strings.TrimSpace(string(out)))
-	}
+	return listGitWorktreeRecordsCachedWithLister(repoRoot, listGitWorktreeRecordsUncached)
+}
+
+// parseGitWorktreePorcelain parses `git worktree list --porcelain` output into
+// path+branch records. Paths are left as reported by git; callers normalize.
+func parseGitWorktreePorcelain(out []byte) []gitWorktreeRecord {
 	var records []gitWorktreeRecord
 	var current *gitWorktreeRecord
 	for _, raw := range bytes.Split(out, []byte("\n")) {
@@ -651,7 +671,7 @@ func listGitWorktreeRecords(repoRoot string) ([]gitWorktreeRecord, error) {
 	if current != nil {
 		records = append(records, *current)
 	}
-	return records, nil
+	return records
 }
 
 // ResolveGitWorkspaceRoot returns the git worktree root for root.
@@ -724,11 +744,12 @@ func worktreeListProbeMatches(a, b worktreeListProbe) bool {
 	return a.ModTime.Equal(b.ModTime) && slices.Equal(a.EntryNames, b.EntryNames)
 }
 
-func cloneWorktreeSet(in map[string]struct{}) map[string]struct{} {
-	out := make(map[string]struct{}, len(in))
-	for path := range in {
-		out[path] = struct{}{}
+func cloneWorktreeRecords(in []gitWorktreeRecord) []gitWorktreeRecord {
+	if in == nil {
+		return nil
 	}
+	out := make([]gitWorktreeRecord, len(in))
+	copy(out, in)
 	return out
 }
 

--- a/internal/state/worktree.go
+++ b/internal/state/worktree.go
@@ -541,6 +541,119 @@ func listGitWorktreesUncached(repoRoot string) (map[string]struct{}, error) {
 	return worktrees, nil
 }
 
+// SlugWorktreeMatch describes a live git worktree (and its branch) whose
+// identity corresponds to a change slug. It lets orphan-bundle recovery avoid
+// recommending destructive cleanup of a slug whose live, possibly-unmerged work
+// lives in a worktree Slipway does not manage.
+type SlugWorktreeMatch struct {
+	// WorktreePath is the normalized path of the matching live worktree.
+	WorktreePath string
+	// Branch is the worktree's checked-out branch (empty for a detached HEAD).
+	Branch string
+	// SlipwayManaged is true only when the match follows Slipway's own
+	// .worktrees/<slug> path or feat/<slug> branch convention, i.e. a worktree
+	// Slipway itself provisioned. False marks an externally-managed worktree that
+	// recovery must never recommend removing.
+	SlipwayManaged bool
+}
+
+// FindSlugWorktreeMatch reports whether any live git worktree corresponds to
+// slug, matched either by Slipway's own worktree/branch convention or by a
+// branch whose slugified identity equals slug. It returns the strongest match,
+// preferring a Slipway-managed worktree when one exists. ok is false when no
+// live worktree matches, or root is not a git repository.
+func FindSlugWorktreeMatch(root, slug string) (match SlugWorktreeMatch, ok bool, err error) {
+	slug = strings.TrimSpace(slug)
+	if slug == "" {
+		return SlugWorktreeMatch{}, false, nil
+	}
+	repoRoot, err := gitWorkspaceRoot(root)
+	if err != nil {
+		if gitCommandReportsNotRepository(err) {
+			return SlugWorktreeMatch{}, false, nil
+		}
+		return SlugWorktreeMatch{}, false, err
+	}
+	records, err := listGitWorktreeRecords(repoRoot)
+	if err != nil {
+		return SlugWorktreeMatch{}, false, err
+	}
+	defaultPath, perr := NormalizePath(DefaultWorktreePath(repoRoot, slug))
+	if perr != nil {
+		defaultPath = filepath.Clean(DefaultWorktreePath(repoRoot, slug))
+	}
+	defaultBranch := DefaultWorktreeBranch(slug)
+	normalizedRepoRoot, perr := NormalizePath(repoRoot)
+	if perr != nil {
+		normalizedRepoRoot = filepath.Clean(repoRoot)
+	}
+
+	var external *SlugWorktreeMatch
+	for _, rec := range records {
+		normPath, nerr := NormalizePath(rec.Path)
+		if nerr != nil {
+			normPath = filepath.Clean(rec.Path)
+		}
+		// The main checkout is never the slug's dedicated worktree.
+		if normPath == normalizedRepoRoot {
+			continue
+		}
+		managed := normPath == defaultPath || rec.Branch == defaultBranch
+		if !managed && model.SlugifyTitle(rec.Branch) != slug {
+			continue
+		}
+		candidate := SlugWorktreeMatch{WorktreePath: normPath, Branch: rec.Branch, SlipwayManaged: managed}
+		if managed {
+			// A Slipway-managed worktree is the authoritative match; existing
+			// discard recovery already owns this case safely.
+			return candidate, true, nil
+		}
+		if external == nil {
+			c := candidate
+			external = &c
+		}
+	}
+	if external != nil {
+		return *external, true, nil
+	}
+	return SlugWorktreeMatch{}, false, nil
+}
+
+type gitWorktreeRecord struct {
+	Path   string
+	Branch string
+}
+
+// listGitWorktreeRecords parses `git worktree list --porcelain` into path+branch
+// records. Unlike listGitWorktrees it preserves each worktree's checked-out
+// branch so callers can map a worktree back to a change slug.
+func listGitWorktreeRecords(repoRoot string) ([]gitWorktreeRecord, error) {
+	cmd := exec.Command("git", "-C", repoRoot, "worktree", "list", "--porcelain") // #nosec G204 -- command and arguments are constructed by Slipway helpers and executed without shell interpolation.
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("list git worktrees: %w (%s)", err, strings.TrimSpace(string(out)))
+	}
+	var records []gitWorktreeRecord
+	var current *gitWorktreeRecord
+	for _, raw := range bytes.Split(out, []byte("\n")) {
+		line := string(raw)
+		switch {
+		case strings.HasPrefix(line, "worktree "):
+			if current != nil {
+				records = append(records, *current)
+			}
+			current = &gitWorktreeRecord{Path: strings.TrimSpace(strings.TrimPrefix(line, "worktree "))}
+		case strings.HasPrefix(line, "branch ") && current != nil:
+			ref := strings.TrimSpace(strings.TrimPrefix(line, "branch "))
+			current.Branch = strings.TrimPrefix(ref, "refs/heads/")
+		}
+	}
+	if current != nil {
+		records = append(records, *current)
+	}
+	return records, nil
+}
+
 // ResolveGitWorkspaceRoot returns the git worktree root for root.
 func ResolveGitWorkspaceRoot(root string) (string, error) {
 	return gitWorkspaceRoot(root)

--- a/internal/state/worktree.go
+++ b/internal/state/worktree.go
@@ -33,6 +33,12 @@ type worktreeListProbe struct {
 	Exists     bool
 	ModTime    time.Time
 	EntryNames []string
+	// Heads fingerprints each linked worktree's HEAD ("<entry>\x00<head>", sorted).
+	// The cached records carry each worktree's Branch, but a branch switch rewrites
+	// .git/worktrees/<entry>/HEAD WITHOUT changing the parent dir's mtime or entry
+	// set — so without this, branch-sensitive matching (FindSlugWorktreeMatch, #285)
+	// could read a stale branch from the cache and misjudge SlipwayManaged.
+	Heads []string
 }
 
 type worktreeListCacheEntry struct {
@@ -727,10 +733,19 @@ func worktreeListProbeForRepo(repoRoot string) worktreeListProbe {
 		return probe
 	}
 	probe.EntryNames = make([]string, 0, len(entries))
+	probe.Heads = make([]string, 0, len(entries))
 	for _, entry := range entries {
-		probe.EntryNames = append(probe.EntryNames, entry.Name())
+		name := entry.Name()
+		probe.EntryNames = append(probe.EntryNames, name)
+		// Read each linked worktree's HEAD so an in-place branch switch (which
+		// rewrites HEAD but leaves the entry set and parent mtime untouched)
+		// invalidates the cache. A missing/unreadable HEAD contributes empty
+		// content; if it later appears the fingerprint changes and re-invalidates.
+		head, _ := os.ReadFile(filepath.Join(path, name, "HEAD")) // #nosec G304 -- path is derived from the repo's own git metadata dir, not user input.
+		probe.Heads = append(probe.Heads, name+"\x00"+strings.TrimSpace(string(head)))
 	}
 	slices.Sort(probe.EntryNames)
+	slices.Sort(probe.Heads)
 	return probe
 }
 
@@ -741,7 +756,7 @@ func worktreeListProbeMatches(a, b worktreeListProbe) bool {
 	if !a.Exists {
 		return true
 	}
-	return a.ModTime.Equal(b.ModTime) && slices.Equal(a.EntryNames, b.EntryNames)
+	return a.ModTime.Equal(b.ModTime) && slices.Equal(a.EntryNames, b.EntryNames) && slices.Equal(a.Heads, b.Heads)
 }
 
 func cloneWorktreeRecords(in []gitWorktreeRecord) []gitWorktreeRecord {

--- a/internal/state/worktree_test.go
+++ b/internal/state/worktree_test.go
@@ -21,6 +21,15 @@ func hasReasonCode(reasons []model.ReasonCode, code string) bool {
 	return false
 }
 
+func recordsContainPath(records []gitWorktreeRecord, path string) bool {
+	for _, rec := range records {
+		if rec.Path == path {
+			return true
+		}
+	}
+	return false
+}
+
 func TestPersistScopeWorktreeMetadata(t *testing.T) {
 	t.Parallel()
 	change := model.NewChange("slug")
@@ -99,36 +108,28 @@ func TestListGitWorktreesCachedWithListerReusesCacheUntilProbeChanges(t *testing
 	worktreeA := filepath.Join(repoRoot, "wt-a")
 	worktreeB := filepath.Join(repoRoot, "wt-b")
 	calls := 0
-	current := map[string]struct{}{
-		worktreeA: {},
-	}
-	lister := func(string) (map[string]struct{}, error) {
+	current := []gitWorktreeRecord{{Path: worktreeA}}
+	lister := func(string) ([]gitWorktreeRecord, error) {
 		calls++
-		out := make(map[string]struct{}, len(current))
-		for path := range current {
-			out[path] = struct{}{}
-		}
-		return out, nil
+		return cloneWorktreeRecords(current), nil
 	}
 
-	first, err := listGitWorktreesCachedWithLister(repoRoot, lister)
+	first, err := listGitWorktreeRecordsCachedWithLister(repoRoot, lister)
 	require.NoError(t, err)
-	require.Contains(t, first, worktreeA)
+	require.True(t, recordsContainPath(first, worktreeA))
 
-	second, err := listGitWorktreesCachedWithLister(repoRoot, lister)
+	second, err := listGitWorktreeRecordsCachedWithLister(repoRoot, lister)
 	require.NoError(t, err)
-	require.Contains(t, second, worktreeA)
+	require.True(t, recordsContainPath(second, worktreeA))
 	assert.Equal(t, 1, calls, "unchanged worktree probe should reuse cached listing")
 
-	current = map[string]struct{}{
-		worktreeB: {},
-	}
+	current = []gitWorktreeRecord{{Path: worktreeB}}
 	later := time.Now().Add(2 * time.Second)
 	require.NoError(t, os.Chtimes(worktreesDir, later, later))
 
-	third, err := listGitWorktreesCachedWithLister(repoRoot, lister)
+	third, err := listGitWorktreeRecordsCachedWithLister(repoRoot, lister)
 	require.NoError(t, err)
-	require.Contains(t, third, worktreeB)
+	require.True(t, recordsContainPath(third, worktreeB))
 	assert.Equal(t, 2, calls, "worktree probe changes must invalidate the cache")
 }
 
@@ -143,38 +144,30 @@ func TestListGitWorktreesCachedWithListerInvalidatesWhenEntryFingerprintChanges(
 	worktreeA := filepath.Join(repoRoot, "wt-a")
 	worktreeB := filepath.Join(repoRoot, "wt-b")
 	calls := 0
-	current := map[string]struct{}{
-		worktreeA: {},
-	}
-	lister := func(string) (map[string]struct{}, error) {
+	current := []gitWorktreeRecord{{Path: worktreeA}}
+	lister := func(string) ([]gitWorktreeRecord, error) {
 		calls++
-		out := make(map[string]struct{}, len(current))
-		for path := range current {
-			out[path] = struct{}{}
-		}
-		return out, nil
+		return cloneWorktreeRecords(current), nil
 	}
 
 	fixed := time.Unix(1_700_000_000, 0).UTC()
 	require.NoError(t, os.Chtimes(worktreesDir, fixed, fixed))
 
-	first, err := listGitWorktreesCachedWithLister(repoRoot, lister)
+	first, err := listGitWorktreeRecordsCachedWithLister(repoRoot, lister)
 	require.NoError(t, err)
-	require.Contains(t, first, worktreeA)
+	require.True(t, recordsContainPath(first, worktreeA))
 	assert.Equal(t, 1, calls)
 
 	require.NoError(t, os.RemoveAll(initialEntry))
 	require.NoError(t, os.MkdirAll(filepath.Join(worktreesDir, "entry-b"), 0o755))
 	require.NoError(t, os.Chtimes(worktreesDir, fixed, fixed))
 
-	current = map[string]struct{}{
-		worktreeB: {},
-	}
+	current = []gitWorktreeRecord{{Path: worktreeB}}
 
-	second, err := listGitWorktreesCachedWithLister(repoRoot, lister)
+	second, err := listGitWorktreeRecordsCachedWithLister(repoRoot, lister)
 	require.NoError(t, err)
-	require.Contains(t, second, worktreeB)
-	assert.NotContains(t, second, worktreeA)
+	require.True(t, recordsContainPath(second, worktreeB))
+	assert.False(t, recordsContainPath(second, worktreeA))
 	assert.Equal(t, 2, calls, "entry-name changes must invalidate the cache even when directory modtime is restored")
 }
 
@@ -189,24 +182,24 @@ func TestListGitWorktreesCachedWithListerDoesNotCacheStaleResultWhenProbeChanges
 	worktreeA := filepath.Join(repoRoot, "wt-a")
 	worktreeB := filepath.Join(repoRoot, "wt-b")
 	calls := 0
-	lister := func(string) (map[string]struct{}, error) {
+	lister := func(string) ([]gitWorktreeRecord, error) {
 		calls++
 		if calls == 1 {
 			require.NoError(t, os.RemoveAll(initialEntry))
 			require.NoError(t, os.MkdirAll(filepath.Join(worktreesDir, "entry-b"), 0o755))
-			return map[string]struct{}{worktreeA: {}}, nil
+			return []gitWorktreeRecord{{Path: worktreeA}}, nil
 		}
-		return map[string]struct{}{worktreeB: {}}, nil
+		return []gitWorktreeRecord{{Path: worktreeB}}, nil
 	}
 
-	first, err := listGitWorktreesCachedWithLister(repoRoot, lister)
+	first, err := listGitWorktreeRecordsCachedWithLister(repoRoot, lister)
 	require.NoError(t, err)
-	require.Contains(t, first, worktreeA)
+	require.True(t, recordsContainPath(first, worktreeA))
 
-	second, err := listGitWorktreesCachedWithLister(repoRoot, lister)
+	second, err := listGitWorktreeRecordsCachedWithLister(repoRoot, lister)
 	require.NoError(t, err)
-	require.Contains(t, second, worktreeB)
-	assert.NotContains(t, second, worktreeA)
+	require.True(t, recordsContainPath(second, worktreeB))
+	assert.False(t, recordsContainPath(second, worktreeA))
 	assert.Equal(t, 2, calls, "probe changes during listing must prevent caching stale worktree sets")
 }
 


### PR DESCRIPTION
Closes #285.

Non-destructive recovery for an orphan bundle whose slug names a live worktree Slipway did not provision — now closed at **every** surface, not just the recommendation prose. The unifying invariant: *a live git worktree Slipway did not provision must never be discarded/removed; when ownership cannot be verified, fail closed (preserve-first), never route to destructive discard.*

## What changed

- **Fail-closed classifier (cmd):** a git worktree/branch cross-check error now lands in a new `Unknown` bucket (preserve-first), never the discardable `Plain` bucket. `classifyOrphanBundles` is injectable for regression testing.
- **New reason code `orphaned_bundle_ownership_unknown`:** `preserve_work` class, empty command, never recommends `--worktree`.
- **status:** surfaces the `Unknown` bucket as a non-destructive blocker + diagnostic; shares one classifier with the CLI error so the two never diverge.
- **Concrete-slug prose:** mixed-residue remediation names a concrete slug instead of a literal `<slug>`.
- **Delete execution face:** `slipway delete --worktree` refuses to remove a worktree Slipway did not provision (not `.worktrees/<slug>` on `feat/<slug>`) — a refusal `--force` cannot bypass.
- **health/doctor:** git cross-checks orphans; the destructive "remove it manually" hint is suppressed for unmanaged/unknown cases.

## Verified findings closed

| # | Finding | Severity |
|---|---------|----------|
| F1 | classifier failed open on git cross-check error → destructive discard | Major |
| F2 | single-unmanaged tests didn't assert absence of the discard step | Minor |
| F3 | `branchMatches && !pathMatches` (feat-branch at custom path) untested | Minor |
| F4 | mixed multi-orphan no-target path had no e2e | Minor |
| F5 | literal `<slug>` placeholder in mixed remediation | Minor |
| F6 | health/doctor not aligned with the cross-check | Minor |
| — | delete execution face could remove an unmanaged worktree with `--force` | (pre-existing) |

## Tests

Fail-closed classifier bucketing (injected failing matcher), ownership-unknown `preserve_work` recovery, strengthened single-unmanaged assertions (no `orphaned_change_bundle`, no discard step/command), branchMatches-only custom-path match, mixed multi-orphan e2e, and delete refuse-unmanaged-even-with-`--force` + allow-managed.

`gofmt -s` / `go build ./...` / `go vet` clean; `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)