### PR TITLE
fix(execution): harden auto mode governance

### DIFF
--- a/artifacts/changes/archived/harden-execution-auto-mode/assurance.md
+++ b/artifacts/changes/archived/harden-execution-auto-mode/assurance.md
@@ -1,0 +1,138 @@
+# Assurance
+
+## Scope Summary
+
+This change hardens the existing `execution.auto` behavior without expanding the
+public run or next JSON API surface. It addresses the confirmed audit,
+fail-closed, regression-pin, and blocker-precedence gaps for auto mode:
+
+- auto-resolved eligible `human_verify` checkpoints now carry an explicit
+  `auto_checkpoint_acknowledged` lifecycle side effect that is derived from a
+  non-user-controlled auto signal, not from response text alone
+- `slipway learn` separates manual and auto checkpoint-resolution counts so
+  auto acknowledgments no longer inflate the manual human-verification signal
+- skill handoff auto-softening is now an explicit pure-pacing allowlist, with
+  `security-review`, `worktree-preflight`, and unknown or unlisted skills
+  remaining hard stops
+- README, generated run-command, and run prompt safety redlines are pinned by
+  tests
+- auto-off non-pacing governance blockers are pinned to outrank review-batch and
+  skill-handoff pacing prompts
+
+No guardrail domain is active for this change, and no schema migration or data
+backfill is required.
+
+## Verification Verdict
+
+Verdict: pass, pending final-closeout recording.
+
+Fresh verification for run summary version 1 passed:
+
+- `go test ./...`
+- `go build ./...`
+- `git diff --check`
+- target-file placeholder scan, with only intentional template-test fixture
+  markers found
+- `go run . validate --json`, reporting fresh evidence and
+  `scope_contract.status: pass`
+
+S3 reviewer evidence is recorded and stamped for:
+
+- `spec-compliance-review`: pass, `layer:R0=pass`
+- `code-quality-review`: pass, `layer:IR1=pass`
+- `independent-review`: pass
+- `goal-verification`: pass, with
+  `fresh:command_ref=artifacts/changes/harden-execution-auto-mode/verification/full-suite-proof.md`
+
+## Evidence Index
+
+- Full suite proof:
+  `artifacts/changes/harden-execution-auto-mode/verification/full-suite-proof.md`
+- Suite keystone:
+  `artifacts/changes/harden-execution-auto-mode/verification/suite-result.yaml`
+  with full suite digest
+  `sha256:51b21885ae1d883786ed7807742a9f98dc91545a7b3a029962a77e3df5c46671`
+- Spec compliance:
+  `artifacts/changes/harden-execution-auto-mode/verification/spec-compliance-review.yaml`
+  and
+  `artifacts/changes/harden-execution-auto-mode/verification/spec-compliance-review-notes.md`
+- Code quality:
+  `artifacts/changes/harden-execution-auto-mode/verification/code-quality-review.yaml`
+  and
+  `artifacts/changes/harden-execution-auto-mode/verification/code-quality-review-notes.md`
+- Independent review:
+  `artifacts/changes/harden-execution-auto-mode/verification/independent-review.yaml`
+  and
+  `artifacts/changes/harden-execution-auto-mode/verification/independent-review-notes.md`
+- Goal verification:
+  `artifacts/changes/harden-execution-auto-mode/verification/goal-verification.yaml`
+  and
+  `artifacts/changes/harden-execution-auto-mode/verification/goal-verification-notes.md`
+- Wave execution evidence:
+  `artifacts/changes/harden-execution-auto-mode/verification/wave-orchestration.yaml`
+  plus task evidence for `t-01` through `t-05`
+
+## Requirement Coverage
+
+- REQ-001, Auditable Auto Checkpoint Resolution: covered by
+  `cmd/run.go`, `cmd/stage.go`, `cmd/next_context_build.go`, `cmd/next.go`, and
+  `cmd/auto_mode_test.go`. The real `run --auto` path emits
+  `auto_checkpoint_acknowledged`; manual response text equal to
+  `auto-acknowledged` remains manual.
+- REQ-002, Learn Separates Manual And Auto Checkpoints: covered by
+  `cmd/learn.go` and `cmd/learn_test.go`. `checkpoint_resolved_manual` and
+  `checkpoint_resolved_auto` are separate, while `checkpoint_resolved` remains
+  the total.
+- REQ-003, Skill Auto Softening Is Explicitly Allowlisted: covered by
+  `internal/engine/progression/confirmation_boundaries.go`, `cmd/next.go`, and
+  `cmd/auto_mode_test.go`. All current pure-pacing skills still soften under
+  auto; `security-review`, `worktree-preflight`, and unlisted skills hard-stop.
+- REQ-004, Auto Mode Safety Text Is Regression Pinned: covered by
+  `internal/toolgen/toolgen_test.go` and `internal/tmpl/templates_test.go`.
+  README, run registry, and generated run prompt surfaces are checked for the
+  safety redlines around guardrail/sensitive confirmations, `security-review`,
+  decision and human-action checkpoints, stale or unknown freshness, and
+  evidence gates.
+- REQ-005, Governance Blockers Precede Handoff Pacing: covered by
+  `cmd/next.go` and `cmd/auto_mode_test.go`. Auto-off views with non-pacing
+  blockers now assert `blocked_by_governance` ahead of skill-handoff and
+  review-batch pacing prompts.
+
+## Residual Risks and Exceptions
+
+- Historical lifecycle events are not backfilled with the new auto side effect.
+  The change is intentionally forward-only; old events remain readable and are
+  still counted as they were recorded.
+- Unknown future skills now hard-stop under auto until added to the pure-pacing
+  allowlist. This is an intentional fail-closed behavior change for pacing, not
+  an evidence-gate change.
+- README text did not require an edit. It is included in scope because the new
+  tests pin its existing redline semantics.
+- No guardrail domain is active, so no SAST safety-baseline token is required.
+
+## Rollback Readiness
+
+Rollback is straightforward: revert the implementation, test, and governed
+artifact changes from this branch, then rerun:
+
+- `go test ./cmd ./internal/toolgen ./internal/tmpl`
+- `go build ./...`
+
+The lifecycle side effect is optional metadata on new events. Removing the code
+does not require migration and does not make existing lifecycle logs
+unreadable. The learn signal additions are additive JSON fields; rollback
+returns the prior aggregation behavior.
+
+## Archive Decision
+
+Archive readiness decision: ready after final-closeout passes and the active
+change gate reports no blockers.
+
+Active `validate --json` proof was captured in S3 before final-closeout. At the
+time this assurance was authored, it reported fresh evidence, valid
+requirements/tasks/decision contracts, and `scope_contract.status: pass`; the
+remaining blockers were the expected final-closeout and assurance attestations.
+Final-closeout must refresh `validate --json` before `done` and record
+`closeout:assurance_complete=pass` and
+`closeout:reviewer_independence=pass`. Archived bundles should be treated as
+frozen records after `done`, not as active validation inputs.

--- a/artifacts/changes/archived/harden-execution-auto-mode/change.yaml
+++ b/artifacts/changes/archived/harden-execution-auto-mode/change.yaml
@@ -1,0 +1,61 @@
+version: 1
+slug: harden-execution-auto-mode
+description: harden execution auto mode
+status: done
+current_state: DONE
+needs_discovery: true
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-06-20T15:07:47.980576Z
+quality_mode: standard
+workflow_profile: code
+workflow_preset: standard
+worktree_branch: feat/harden-execution-auto-mode
+artifact_schema: expanded
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: fe8597b39f1e940bab006ff6eb1533ac14d4bbaa04b7be152ccf1df265413dd7
+        updated_at: 2026-06-20T16:34:12.709513725Z
+    decision:
+        id: decision
+        path: decision.md
+        state: frozen
+        content_hash: 0ffe51eccfe88a113e791f3efbe1a07c1945ea2d82db41fe045936aa3c941354
+        updated_at: 2026-06-20T15:27:41.410006941Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: 619343152e5529dc39a43b7f6ca8db7e2753e2092d5378b1d6748063f537631a
+        updated_at: 2026-06-20T15:09:10.706640293Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: fad32fc672cd8c825b97465f97872dddd578b6a6f94c62f866ed91d38f6a21f0
+        updated_at: 2026-06-20T15:27:41.40964415Z
+    research:
+        id: research
+        path: research.md
+        state: frozen
+        content_hash: c878afed62be90a938f90a3bd343a469b0c69adc234c785766b368ad2ec961e6
+        updated_at: 2026-06-20T15:11:08.260001717Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: 19d427cee72b0b22a106954546e0e1e7ec63bc48778e2ea7092881f8e1742227
+        updated_at: 2026-06-20T16:10:22.116341749Z
+evidence_refs:
+    code-quality-review: .worktrees/harden-execution-auto-mode/artifacts/changes/harden-execution-auto-mode/verification/code-quality-review.yaml
+    final-closeout: .worktrees/harden-execution-auto-mode/artifacts/changes/harden-execution-auto-mode/verification/final-closeout.yaml
+    goal-verification: .worktrees/harden-execution-auto-mode/artifacts/changes/harden-execution-auto-mode/verification/goal-verification.yaml
+    independent-review: .worktrees/harden-execution-auto-mode/artifacts/changes/harden-execution-auto-mode/verification/independent-review.yaml
+    intake-clarification: .worktrees/harden-execution-auto-mode/artifacts/changes/harden-execution-auto-mode/verification/intake-clarification.yaml
+    plan-audit: .worktrees/harden-execution-auto-mode/artifacts/changes/harden-execution-auto-mode/verification/plan-audit.yaml
+    research-orchestration: .worktrees/harden-execution-auto-mode/artifacts/changes/harden-execution-auto-mode/verification/research-orchestration.yaml
+    spec-compliance-review: .worktrees/harden-execution-auto-mode/artifacts/changes/harden-execution-auto-mode/verification/spec-compliance-review.yaml
+    wave-orchestration: .worktrees/harden-execution-auto-mode/artifacts/changes/harden-execution-auto-mode/verification/wave-orchestration.yaml

--- a/artifacts/changes/archived/harden-execution-auto-mode/decision.md
+++ b/artifacts/changes/archived/harden-execution-auto-mode/decision.md
@@ -1,0 +1,83 @@
+# Decision
+
+## Alternatives Considered
+
+### Option 1: Add only an auto checkpoint event marker
+This would repair the highest-confidence audit gap by adding an
+`auto_checkpoint_acknowledged` side effect to auto-resolved `human_verify`
+checkpoint events. It is the smallest code change, but leaves skill softening
+with default-permissive polarity and leaves redline/C1 regression gaps.
+
+### Option 2: Focused hardening of existing auto-mode seams
+This adds an auto-specific checkpoint event marker, separates learn signals for
+manual and auto checkpoint resolution, converts skill auto-softening to an
+explicit pure-pacing allowlist, and adds targeted regression tests for redline
+surfaces and blocker precedence. It changes only existing auto-mode seams and
+tests, while preserving evidence gates and security-review hard stops.
+
+### Option 3: Broaden auto-mode observability API
+This includes Option 2 and additionally adds top-level JSON fields for effective
+auto mode and extra session-start audit events. It may be useful later, but it
+creates a wider public surface than the confirmed findings require.
+
+## Selected Approach
+Select Option 2.
+
+The confirmed issues are localized to current auto-mode seams: checkpoint event
+metadata, skill boundary polarity, documentation/test pins, and one precedence
+test. Option 2 fixes all confirmed issues without expanding public JSON APIs or
+touching unrelated lifecycle gates. `security-review` remains a hard stop both
+inside and outside guardrail domains.
+
+## Interfaces and Data Flow
+- `cmd/run.go` continues to inject `autoAcknowledgedResponse` only for eligible
+  fresh non-guardrail `human_verify` checkpoints, and also threads a
+  non-user-controlled auto-acknowledgment signal for that injected response.
+- `cmd/next_context_build.go` continues to carry the response in
+  `resumeCheckpoint.UserResponsePayload` and exposes the explicit auto signal
+  to the checkpoint consumption path.
+- `cmd/next.go` consumes active checkpoints and will mark
+  `checkpoint.resolved` events as auto acknowledged only when the explicit auto
+  signal is set for the consumed checkpoint. Manual `--resume-response` text,
+  including the literal sentinel string, remains manual.
+- `cmd/learn.go` will expose separate lifecycle signal counts for manual
+  checkpoint resolutions and auto-acknowledged checkpoint resolutions.
+- `internal/engine/progression/confirmation_boundaries.go` will expose an
+  explicit pure-pacing allowlist used by `cmd/next.go` to decide whether a skill
+  handoff may soften under auto. The allowlist preserves current auto-softened
+  non-sensitive host handoffs for `intake-clarification`,
+  `research-orchestration`, `plan-audit`, `wave-orchestration`,
+  `spec-compliance-review`, `code-quality-review`, `independent-review`,
+  `goal-verification`, and `final-closeout`; `security-review`,
+  `worktree-preflight`, and unknown skills remain hard stops.
+- `README.md`, `internal/toolgen/toolgen.go`, and
+  `internal/tmpl/templates/_partials/command-run-body.tmpl` keep their public
+  text semantics; tests pin their redline phrases. `README.md` is a verification
+  target for these assertions, not an expected edit unless the existing text must
+  be minimally clarified for testability.
+
+No file format migration is needed because lifecycle events already support
+side effects and diagnostics.
+
+## Rollout and Rollback
+Rollout is the normal Slipway source release path after tests pass.
+
+Rollback path:
+- Revert the code and test changes in this change.
+- Verify with `go test ./cmd ./internal/toolgen ./internal/tmpl` and
+  `go build ./...`.
+
+Because the event marker uses existing optional event fields, rollback does not
+require data migration. Older events without the marker remain readable.
+
+## Risk
+- Changing skill auto-softening to an allowlist can make future or unclassified
+  handoffs require manual confirmation under auto. This is intentional
+  fail-closed behavior and only affects pacing, not evidence gates. To prevent a
+  current-behavior regression, tests must also prove every listed current
+  pure-pacing skill still softens under auto.
+- Auto checkpoint event attribution must not rely on the internal sentinel value
+  alone because `--resume-response` is user-controlled. Tests must prove manual
+  response text equal to the sentinel is not marked as auto.
+- Redline tests should assert stable phrases, not full paragraphs, to avoid
+  brittle copy-edit failures while still preventing safety text removal.

--- a/artifacts/changes/archived/harden-execution-auto-mode/intent.md
+++ b/artifacts/changes/archived/harden-execution-auto-mode/intent.md
@@ -1,0 +1,66 @@
+# Intent
+
+## Summary
+harden execution auto mode
+
+## Complexity Assessment
+complex
+
+This touches Slipway's governed execution auto-mode boundary, lifecycle audit
+events, generated command surfaces, README safety text, and confirmation
+requirement tests. The change is not a current vulnerability fix, but it hardens
+auditing, future skill-boundary defaults, and regression coverage around safety
+red lines.
+
+## Guardrail Domains
+None.
+
+## In Scope
+- Distinguish auto-acknowledged non-guardrail `human_verify` checkpoint
+  resolution events from operator-provided `--resume-response` events.
+- Keep `slipway learn` from treating auto-acknowledged checkpoint resolutions as
+  indistinguishable human verification signals.
+- Replace skill auto-softening's single-skill blocklist with an explicit
+  allowlist of pure-pacing skills that are safe for `execution.auto`.
+- Add regression tests for README and run command auto-mode safety red lines.
+- Add a regression test for auto-off plus non-pacing blocker precedence over a
+  handoff boundary.
+
+## Out of Scope
+- Do not weaken or rewrite the existing `security-review` hard-stop behavior;
+  C2 is correct fail-closed behavior and remains unchanged.
+- Do not add broad new lifecycle UX fields unless they are required to make the
+  audited auto-acknowledgment distinguishable.
+- Do not refactor unrelated lifecycle, review, or evidence gates.
+
+## Constraints
+- Preserve existing manual `--resume-response` behavior and event shape except
+  where auto acknowledgments need an explicit marker.
+- Preserve evidence gates: auto mode may only soften pacing, never required
+  evidence or guardrail boundaries.
+- Keep the implementation small and test-driven around the reported gaps.
+
+## Acceptance Signals
+- `go test ./cmd` covers auto-ack audit event distinction and C1 blocker
+  precedence.
+- `go test ./internal/toolgen` covers run command registry redline text.
+- `go test ./internal/tmpl` covers run prompt redline text.
+- `go test ./...` and `go build ./...` pass, or any unrelated known slow test is
+  identified precisely.
+
+## Open Questions
+None.
+
+## Deferred Ideas
+- Broader observability fields for effective auto mode in top-level JSON can be
+  considered separately if operators still need it after auto checkpoint events
+  become auditable.
+
+## Approved Summary
+The user explicitly requested a new change to repair all confirmed issues from
+the combined review: M1, M2, M3, and C1. This change hardens execution auto mode
+by making auto `human_verify` checkpoint acknowledgments auditable, switching
+skill auto-softening to an explicit safe allowlist, and adding regression pins
+for README/run redlines plus auto-off blocker precedence. C2 is excluded because
+the existing `security-review` hard-stop behavior is correct and should remain
+unchanged.

--- a/artifacts/changes/archived/harden-execution-auto-mode/requirements.md
+++ b/artifacts/changes/archived/harden-execution-auto-mode/requirements.md
@@ -1,0 +1,88 @@
+# Requirements
+
+## Requirements
+
+### Requirement: Auditable Auto Checkpoint Resolution
+REQ-001: The system MUST emit a distinguishable lifecycle event marker when
+`execution.auto` auto-acknowledges an eligible non-guardrail `human_verify`
+checkpoint, and MUST derive that marker from an explicit auto-acknowledgment
+signal rather than from user-controlled response text alone.
+
+#### Scenario: auto checkpoint resolution is distinguishable
+GIVEN a governed change with a fresh non-guardrail `human_verify` checkpoint
+WHEN `slipway run --auto` consumes that checkpoint
+THEN the lifecycle event for `checkpoint.resolved` includes an auto-specific
+reason or side effect that manual `--resume-response` events do not include.
+
+#### Scenario: manual checkpoint resolution remains manual
+GIVEN a governed change with a fresh non-guardrail `human_verify` checkpoint
+WHEN `slipway run --resume-response "<text>"` consumes that checkpoint
+THEN the lifecycle event remains attributable to manual response recording and
+does not include the auto-specific checkpoint marker.
+
+#### Scenario: manual sentinel text is not treated as auto
+GIVEN a governed change with a fresh non-guardrail `human_verify` checkpoint
+WHEN `slipway run --resume-response "auto-acknowledged"` consumes that checkpoint
+THEN the lifecycle event remains manual because the auto-acknowledgment signal
+was not set by the run entry path.
+
+### Requirement: Learn Separates Manual And Auto Checkpoints
+REQ-002: The system MUST keep `slipway learn` checkpoint resolution signals from
+collapsing auto-acknowledged checkpoint resolutions into the same human
+verification count as manual responses.
+
+#### Scenario: learn counts auto checkpoint acknowledgments separately
+GIVEN lifecycle events containing manual and auto checkpoint resolutions
+WHEN `slipway learn --json` aggregates lifecycle signals
+THEN manual checkpoint resolutions and auto-acknowledged checkpoint resolutions
+are observable as separate signal counts.
+
+### Requirement: Skill Auto Softening Is Explicitly Allowlisted
+REQ-003: The system MUST only soften skill handoff boundaries under
+`execution.auto` for skills explicitly classified as pure-pacing auto-safe.
+The allowlist MUST preserve the current non-sensitive pacing behavior for these
+known skills:
+`intake-clarification`, `research-orchestration`, `plan-audit`,
+`wave-orchestration`, `spec-compliance-review`, `code-quality-review`,
+`independent-review`, `goal-verification`, and `final-closeout`.
+`security-review`, `worktree-preflight`, and any unlisted or unknown skill MUST
+remain hard stops under auto.
+
+#### Scenario: pure pacing skill softens under auto
+GIVEN a non-guardrail change whose next skill is one of the explicitly
+allowlisted pure-pacing skills
+WHEN the confirmation requirement is derived with auto enabled
+THEN the boundary is an evidence continuation with prior authorization
+sufficient.
+
+#### Scenario: every current pure pacing skill remains softened
+GIVEN a non-guardrail change for each currently allowlisted pure-pacing skill
+WHEN the confirmation requirement is derived with auto enabled
+THEN each listed skill handoff softens to an evidence continuation.
+
+#### Scenario: unknown skill hard-stops under auto
+GIVEN a non-guardrail change whose next skill is not in the pure-pacing allowlist
+WHEN the confirmation requirement is derived with auto enabled
+THEN the boundary remains a hard stop requiring fresh confirmation.
+
+### Requirement: Auto Mode Safety Text Is Regression Pinned
+REQ-004: The system MUST keep README, run command registry, and run prompt
+surfaces pinned to the auto-mode red lines that auto never crosses sensitive or
+guardrail confirmations, `security-review`, decision or human-action
+checkpoints, stale checkpoints, or evidence gates.
+
+#### Scenario: safety instruction surfaces retain red lines
+GIVEN generated command surfaces and README are checked by tests
+WHEN safety redline text for run auto mode is removed or weakened
+THEN the relevant toolgen, template, or README regression test fails.
+
+### Requirement: Governance Blockers Precede Handoff Pacing
+REQ-005: The system MUST preserve blocker precedence so non-pacing governance
+blockers outrank review-batch or skill-handoff pacing prompts even when auto is
+disabled.
+
+#### Scenario: auto-off non-pacing blocker wins over handoff
+GIVEN a view with auto disabled, a non-pacing blocker, and a skill or review
+handoff
+WHEN the confirmation requirement is derived
+THEN the result is `blocked_by_governance` rather than a handoff reason.

--- a/artifacts/changes/archived/harden-execution-auto-mode/research.md
+++ b/artifacts/changes/archived/harden-execution-auto-mode/research.md
@@ -1,0 +1,154 @@
+# Research
+
+## Alternatives Considered
+
+### Architecture
+- Affected modules:
+  - `cmd/run.go` resolves effective auto mode and injects the
+    `autoAcknowledgedResponse` sentinel for eligible checkpoints.
+  - `cmd/next_context_build.go` carries `resumeResponse` into
+    `resumeCheckpoint.UserResponsePayload` and marks active checkpoints for
+    consumption.
+  - `cmd/next.go` consumes active checkpoints and emits `checkpoint.resolved`
+    lifecycle events; it also derives auto-softened confirmation requirements.
+  - `cmd/learn.go` aggregates lifecycle `checkpoint.resolved` events into
+    checkpoint resolution signals.
+  - `internal/engine/progression/confirmation_boundaries.go` owns the current
+    skill boundary helper used by `cmd/next.go`.
+  - `internal/toolgen/toolgen.go`, `internal/tmpl/templates/_partials`, and
+    `README.md` own the safety instruction surfaces that need regression pins.
+- Dependency chains:
+  - `run` -> `autoAckResumeResponse` -> `buildNextViewForCommand` ->
+    `buildResumeCheckpoint` -> `consumeNextCheckpoint` -> lifecycle event log.
+  - `next` / stage commands -> `deriveConfirmationRequirement` ->
+    progression skill boundary helpers.
+  - `learn` -> `state.ReadLifecycleEvents` -> aggregate signals from event
+    fields and side effects.
+- Blast radius:
+  - Runtime behavior is limited to auto-mode checkpoint event metadata and
+    skill handoff confirmation softening.
+  - Manual `--resume-response` behavior must remain unchanged.
+  - Evidence gates and guardrail hard stops must remain independent of auto mode.
+- Constraints:
+  - The lifecycle event log is append-only and already supports
+    `ActorKind`, `Reason`, `Diagnostics`, and `SideEffects`, so no schema
+    migration is needed.
+  - The skill boundary helper already centralizes related logic and can expose a
+    safe allowlist without changing `cmd/next.go`'s public JSON contract.
+
+### Patterns
+- Existing conventions:
+  - Auto preset confirmation records a distinguishable lifecycle reason and
+    side effect: `auto_preset_confirmed`.
+  - Review companion handoff helpers use explicit allowlists rather than default
+    permissive matching.
+  - Tests in `cmd/auto_mode_test.go` use direct `nextView` fixtures for
+    confirmation boundary decisions and command fixtures for real `run` paths.
+  - Toolgen/template tests assert safety text with `assert.Contains` on rendered
+    command entries and generated prompt content.
+- Reusable abstractions:
+  - Reuse lifecycle `SideEffects` for an `auto_checkpoint_acknowledged` marker.
+  - Add a helper that detects auto checkpoint acknowledgments from the
+    `resumeCheckpoint.UserResponsePayload`; this keeps event attribution close
+    to the consumption path without widening public structs.
+  - Replace `SkillRequiresManualAutoBoundary` with a pure-pacing allowlist
+    helper and make manual-boundary semantics the negation of the allowlist.
+- Convention deviations:
+  - `ActorKind` should stay `cli` to preserve command attribution; the
+    distinguishable audit surface can live in `Reason` and `SideEffects`.
+
+### Risks
+- Technical risks:
+  - Medium: changing skill auto-softening polarity can make currently softened
+    non-allowlisted skills hard-stop. This is intended fail-closed behavior, but
+    tests must pin the expected allowlist.
+  - Low: adding an event side effect could affect timeline consumers that compare
+    exact event JSON. Existing event consumers should ignore unknown side effect
+    kinds or benefit from the marker.
+  - Low: README/run surface tests can become brittle if they assert paragraphs
+    instead of stable redline phrases.
+- Guardrail domains:
+  - No domain such as auth, credentials, schema migration, or irreversible ops is
+    modified. This is a governance-control hardening change.
+- Reversibility:
+  - Changes are local and reversible by removing helper changes and tests.
+    Event schema remains compatible because it uses existing fields.
+
+### Test Strategy
+- Existing coverage:
+  - `cmd/auto_mode_test.go` already covers auto flag resolution, guardrail
+    hard stops, security-review hard stops, and the real auto checkpoint run
+    path.
+  - `internal/toolgen/toolgen_test.go` and `internal/tmpl/templates_test.go`
+    cover parts of generated safety text, but not the run/README redlines now in
+    scope.
+- Infrastructure needs:
+  - Use existing temp workspace and command fixtures from `cmd/auto_mode_test.go`.
+  - Use existing rendered command and prompt helpers for toolgen/template checks.
+  - No external services, mocks, or new test framework needed.
+- Verification approach:
+  - Add a command-path test that auto-acknowledged checkpoints emit an
+    auto-specific lifecycle side effect/reason and that manual responses do not.
+  - Add confirmation-boundary tests showing pure-pacing allowlisted skills soften
+    under auto and unknown skills hard-stop.
+  - Add C1 regression coverage for auto-off plus non-pacing blocker over a
+    skill/review handoff.
+  - Add README/run redline text assertions using stable phrases.
+
+### Options
+- Option 1: Minimal metadata marker only.
+  - Add `auto_checkpoint_acknowledged` side effect to checkpoint resolution
+    events and leave skill-boundary polarity unchanged.
+  - Tradeoff: fixes M1 only and leaves the future fail-open skill concern.
+- Option 2: Focused hardening of existing seams.
+  - Add auto checkpoint audit markers, make `learn` distinguish manual from
+    auto checkpoint resolutions, replace skill softening with an explicit
+    pure-pacing allowlist, and add redline/blocker tests.
+  - Tradeoff: slightly changes future default behavior for unlisted skills, but
+    that is the intended fail-closed posture.
+- Option 3: Broader auto-mode observability expansion.
+  - Add top-level JSON effective-auto fields and session-start audit events in
+    addition to Option 2.
+  - Tradeoff: larger public API surface and broader compatibility concerns than
+    needed for the confirmed findings.
+- Selected: Option 2. It repairs M1, M2, M3, and C1 directly while preserving
+  C2 and avoiding speculative JSON/API expansion.
+
+## Unknowns
+- Resolved: whether `artifacts/codebase` is relevant to this change -> it is
+  populated but stale for this scope; it describes an adapter/toolgen change, so
+  current-source citations are used instead.
+- Resolved: whether C2 requires changes -> no; existing `security-review`
+  hard-stop behavior is correct and remains out of scope.
+- Remaining: None.
+
+## Assumptions
+- Existing lifecycle event fields are sufficient for audit distinction.
+  Evidence: `cmd/next.go` already emits `SideEffects` for checkpoint clearing,
+  and `advance_governed.go` uses side effects for auto preset confirmation.
+- Manual checkpoint resolution should keep the current event shape except for
+  unaffected existing fields. Evidence: manual and auto paths both flow through
+  `consumeNextCheckpoint`; the fix can branch only when the payload equals the
+  internal auto sentinel.
+- Unknown or unclassified skills should hard-stop under auto until explicitly
+  allowlisted as pure pacing. Evidence: other auto-mode boundaries fail closed
+  for guardrail domains, stale checkpoints, decision/human_action checkpoints,
+  and evidence gates.
+
+## Canonical References
+- `cmd/run.go:137-189`
+- `cmd/next_context_build.go:320-329`
+- `cmd/next.go:506-535`
+- `cmd/next.go:690-735`
+- `cmd/next.go:784-804`
+- `cmd/learn.go:27-56`
+- `cmd/learn.go:204-208`
+- `cmd/learn.go:382-388`
+- `internal/engine/progression/confirmation_boundaries.go:47-67`
+- `internal/toolgen/toolgen.go:48-52`
+- `internal/toolgen/toolgen.go:295-300`
+- `README.md:111-131`
+- `cmd/auto_mode_test.go:266-445`
+- `cmd/auto_mode_test.go:635-657`
+- `internal/toolgen/toolgen_test.go:1714-1768`
+- `internal/tmpl/templates_test.go:1182-1237`

--- a/artifacts/changes/archived/harden-execution-auto-mode/tasks.md
+++ b/artifacts/changes/archived/harden-execution-auto-mode/tasks.md
@@ -1,0 +1,33 @@
+# Tasks
+
+## Task List
+
+- [x] `t-01` Mark auto-acknowledged checkpoint resolution events and split learn signals
+  - depends_on: []
+  - target_files: [cmd/run.go, cmd/stage.go, cmd/next_context_build.go, cmd/next.go, cmd/learn.go, cmd/auto_mode_test.go, cmd/learn_test.go]
+  - task_kind: code
+  - covers: [REQ-001, REQ-002]
+
+- [x] `t-02` Replace skill auto-softening blocklist with explicit pure-pacing allowlist
+  - depends_on: [t-01]
+  - target_files: [internal/engine/progression/confirmation_boundaries.go, cmd/next.go, cmd/auto_mode_test.go]
+  - task_kind: code
+  - covers: [REQ-003]
+
+- [x] `t-03` Pin existing run and README auto-mode redline surfaces
+  - depends_on: []
+  - target_files: [README.md, internal/toolgen/toolgen_test.go, internal/tmpl/templates_test.go]
+  - task_kind: test
+  - covers: [REQ-004]
+
+- [x] `t-04` Pin auto-off non-pacing blocker precedence over handoff pacing
+  - depends_on: [t-02]
+  - target_files: [cmd/auto_mode_test.go]
+  - task_kind: test
+  - covers: [REQ-005]
+
+- [x] `t-05` Run focused and full verification
+  - depends_on: [t-01, t-02, t-03, t-04]
+  - target_files: [artifacts/changes/harden-execution-auto-mode/verification]
+  - task_kind: verification
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004, REQ-005]

--- a/cmd/auto_mode_test.go
+++ b/cmd/auto_mode_test.go
@@ -859,7 +859,11 @@ func TestNextPreviewUnderAutoHasNoSideEffect(t *testing.T) {
 	advPath := state.BundleChangeFilePath(root, advSlug)
 	advBefore, err := os.ReadFile(advPath)
 	require.NoError(t, err)
-	_, err = buildNextViewForCommand(root, changeRef{Slug: advSlug}, "", false, true, false, "run", true, false)
+	_, err = buildNextViewForCommand(root, changeRef{Slug: advSlug}, nextViewOptions{
+		AutoSkipEvidence: true,
+		Command:          "run",
+		Auto:             true,
+	})
 	require.NoError(t, err)
 	advAfter, err := os.ReadFile(advPath)
 	require.NoError(t, err)
@@ -880,7 +884,12 @@ func TestNextPreviewUnderAutoHasNoSideEffect(t *testing.T) {
 
 	// preview=true is the `next` query path; auto is threaded for the displayed
 	// requirement but must never advance/mutate.
-	_, err = buildNextViewForCommand(root, changeRef{Slug: slug}, "", true, true, false, "next", true, false)
+	_, err = buildNextViewForCommand(root, changeRef{Slug: slug}, nextViewOptions{
+		Preview:          true,
+		AutoSkipEvidence: true,
+		Command:          "next",
+		Auto:             true,
+	})
 	require.NoError(t, err)
 
 	after, err := state.LoadChange(root, slug)
@@ -920,7 +929,11 @@ func TestAutoDoesNotAutoWriteIntakeApprovedSummary(t *testing.T) {
 	require.NoError(t, os.WriteFile(intentPath, []byte(intentBody), 0o644))
 
 	// Advancing path with auto on at the Approved-Summary confirm boundary.
-	view, err := buildNextViewForCommand(root, changeRef{Slug: slug}, "", false, true, false, "run", true, false)
+	view, err := buildNextViewForCommand(root, changeRef{Slug: slug}, nextViewOptions{
+		AutoSkipEvidence: true,
+		Command:          "run",
+		Auto:             true,
+	})
 	require.NoError(t, err)
 
 	after, err := state.LoadChange(root, slug)
@@ -1062,7 +1075,11 @@ func TestLightAutoPassEligibilityUnchangedUnderAuto(t *testing.T) {
 		writePassingGoalVerificationEvidence(t, root, slug, 1)
 
 		// skipAutoPass=true surfaces AutoPassEligible instead of auto-passing.
-		view, err := buildNextViewForCommand(root, changeRef{Slug: slug}, "", false, false, true, "run", auto, false)
+		view, err := buildNextViewForCommand(root, changeRef{Slug: slug}, nextViewOptions{
+			SkipAutoPass: true,
+			Command:      "run",
+			Auto:         auto,
+		})
 		require.NoError(t, err)
 		return view
 	}

--- a/cmd/auto_mode_test.go
+++ b/cmd/auto_mode_test.go
@@ -186,7 +186,7 @@ func TestDeriveConfirmationRequirementAutoSoftensNonGuardrail(t *testing.T) {
 			},
 		}
 		req := deriveConfirmationRequirement(view)
-		assert.NotEqual(t, "hard_stop", req.Boundary)
+		assert.Equal(t, "evidence_continuation", req.Boundary)
 		assert.True(t, req.PriorAuthorizationSufficient)
 		assert.False(t, req.FreshConfirmationRequired)
 		assert.Equal(t, "review_batch", req.Reason)
@@ -201,12 +201,65 @@ func TestDeriveConfirmationRequirementAutoSoftensNonGuardrail(t *testing.T) {
 			NextSkill:       &nextSkillView{Name: "wave-orchestration"},
 		}
 		req := deriveConfirmationRequirement(view)
-		assert.NotEqual(t, "hard_stop", req.Boundary)
+		assert.Equal(t, "evidence_continuation", req.Boundary)
 		assert.True(t, req.PriorAuthorizationSufficient)
 		assert.False(t, req.FreshConfirmationRequired)
 		assert.Contains(t, req.Reason, "skill_handoff")
 		assert.NotEmpty(t, req.NextAction)
 	})
+}
+
+func TestDeriveConfirmationRequirementAutoSoftensOnlyPurePacingAllowlist(t *testing.T) {
+	t.Parallel()
+
+	for _, skillName := range []string{
+		progression.SkillIntakeClarification,
+		progression.SkillResearchOrchestration,
+		progression.SkillPlanAudit,
+		progression.SkillWaveOrchestration,
+		progression.SkillSpecComplianceReview,
+		progression.SkillCodeQualityReview,
+		progression.SkillIndependentReview,
+		progression.SkillGoalVerification,
+		progression.SkillFinalCloseout,
+	} {
+		skillName := skillName
+		t.Run("allowlisted_"+skillName, func(t *testing.T) {
+			t.Parallel()
+			view := nextView{
+				auto:            true,
+				GuardrailDomain: "",
+				NextSkill:       &nextSkillView{Name: skillName},
+			}
+
+			req := deriveConfirmationRequirement(view)
+			assert.Equal(t, "evidence_continuation", req.Boundary)
+			assert.True(t, req.PriorAuthorizationSufficient)
+			assert.False(t, req.FreshConfirmationRequired)
+			assert.Equal(t, "skill_handoff:"+skillName, req.Reason)
+		})
+	}
+
+	for _, skillName := range []string{
+		progression.SkillWorktreePreflight,
+		"future-sensitive-review",
+	} {
+		skillName := skillName
+		t.Run("unlisted_"+skillName, func(t *testing.T) {
+			t.Parallel()
+			view := nextView{
+				auto:            true,
+				GuardrailDomain: "",
+				NextSkill:       &nextSkillView{Name: skillName},
+			}
+
+			req := deriveConfirmationRequirement(view)
+			assert.Equal(t, "hard_stop", req.Boundary)
+			assert.False(t, req.PriorAuthorizationSufficient)
+			assert.True(t, req.FreshConfirmationRequired)
+			assert.Equal(t, "skill_handoff:"+skillName, req.Reason)
+		})
+	}
 }
 
 func TestDeriveConfirmationRequirementAutoKeepsSecurityReviewHardStop(t *testing.T) {
@@ -443,6 +496,50 @@ func TestDeriveConfirmationRequirementAutoOffUnchanged(t *testing.T) {
 	assert.Equal(t, confirmationHardStop("skill_handoff:wave-orchestration"), deriveConfirmationRequirement(skillView))
 }
 
+func TestDeriveConfirmationRequirementAutoOffNonPacingBlockerPrecedesHandoff(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name string
+		view nextView
+	}{
+		{
+			name: "skill_handoff",
+			view: nextView{
+				auto:      false,
+				NextSkill: &nextSkillView{Name: progression.SkillWaveOrchestration},
+				Blockers: []model.ReasonCode{
+					model.NewReasonCode("scope_contract_drift", "cmd/next.go"),
+				},
+			},
+		},
+		{
+			name: "review_batch",
+			view: nextView{
+				auto: false,
+				ReviewBatch: &reviewBatchView{
+					Skills: []reviewBatchSkillView{{Name: progression.SkillSpecComplianceReview}},
+				},
+				Blockers: []model.ReasonCode{
+					model.NewReasonCode("scope_contract_drift", "cmd/next.go"),
+				},
+			},
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := deriveConfirmationRequirement(tt.view)
+			assert.Equal(t, "hard_stop", req.Boundary)
+			assert.False(t, req.PriorAuthorizationSufficient)
+			assert.True(t, req.FreshConfirmationRequired)
+			assert.Equal(t, "blocked_by_governance", req.Reason)
+			assert.Equal(t, "blocker_resolution", req.NextActionKind)
+		})
+	}
+}
+
 // TASK D (findings #1, #2): the resume_checkpoint confirmation contract under
 // auto. Only a FRESH, non-guardrail human_verify checkpoint softens to an
 // evidence_continuation; every other kind, a guardrail domain, or stale
@@ -541,6 +638,17 @@ func setupAutoModeCheckpoint(t *testing.T, guardrail, checkpointType string, fre
 	return root, slug, changeRef{Slug: slug}
 }
 
+func requireCheckpointResolvedEvent(t *testing.T, events []state.LifecycleEvent) state.LifecycleEvent {
+	t.Helper()
+	for _, event := range events {
+		if event.EventType == "checkpoint.resolved" {
+			return event
+		}
+	}
+	require.FailNow(t, "expected checkpoint.resolved lifecycle event", "events=%+v", events)
+	return state.LifecycleEvent{}
+}
+
 // (d) ENTRY-LEVEL: auto-ack injects a response only for a non-guardrail
 // human_verify checkpoint; decision/human_action/guardrail stay manual.
 func TestAutoAckResumeResponseEntryLevel(t *testing.T) {
@@ -551,9 +659,10 @@ func TestAutoAckResumeResponseEntryLevel(t *testing.T) {
 		root, _, ref := setupAutoModeCheckpoint(t, "", string(model.CheckpointHumanVerify), true)
 
 		// auto-ack injects a standing response so entry validation passes.
-		effective, err := autoAckResumeResponse(root, ref, true, false, "")
+		effective, autoAcknowledged, err := autoAckResumeResponse(root, ref, true, false, "")
 		require.NoError(t, err)
 		assert.Equal(t, autoAcknowledgedResponse, effective)
+		assert.True(t, autoAcknowledged)
 		require.NoError(t, validateRunEntry(root, ref, false, effective))
 	})
 
@@ -561,9 +670,10 @@ func TestAutoAckResumeResponseEntryLevel(t *testing.T) {
 		t.Parallel()
 		root, _, ref := setupAutoModeCheckpoint(t, "", string(model.CheckpointDecision), false)
 
-		effective, err := autoAckResumeResponse(root, ref, true, false, "")
+		effective, autoAcknowledged, err := autoAckResumeResponse(root, ref, true, false, "")
 		require.NoError(t, err)
 		assert.Equal(t, "", effective, "decision checkpoint must not be auto-acknowledged")
+		assert.False(t, autoAcknowledged)
 		err = validateRunEntry(root, ref, false, effective)
 		cliErr := asCLIError(err)
 		require.NotNil(t, cliErr)
@@ -574,9 +684,10 @@ func TestAutoAckResumeResponseEntryLevel(t *testing.T) {
 		t.Parallel()
 		root, _, ref := setupAutoModeCheckpoint(t, "", string(model.CheckpointHumanAction), false)
 
-		effective, err := autoAckResumeResponse(root, ref, true, false, "")
+		effective, autoAcknowledged, err := autoAckResumeResponse(root, ref, true, false, "")
 		require.NoError(t, err)
 		assert.Equal(t, "", effective, "human_action checkpoint must not be auto-acknowledged")
+		assert.False(t, autoAcknowledged)
 		err = validateRunEntry(root, ref, false, effective)
 		cliErr := asCLIError(err)
 		require.NotNil(t, cliErr)
@@ -587,9 +698,10 @@ func TestAutoAckResumeResponseEntryLevel(t *testing.T) {
 		t.Parallel()
 		root, _, ref := setupAutoModeCheckpoint(t, model.GuardrailDomainAuthAuthZ, string(model.CheckpointHumanVerify), false)
 
-		effective, err := autoAckResumeResponse(root, ref, true, false, "")
+		effective, autoAcknowledged, err := autoAckResumeResponse(root, ref, true, false, "")
 		require.NoError(t, err)
 		assert.Equal(t, "", effective, "guardrail human_verify must not be auto-acknowledged")
+		assert.False(t, autoAcknowledged)
 		err = validateRunEntry(root, ref, false, effective)
 		cliErr := asCLIError(err)
 		require.NotNil(t, cliErr)
@@ -600,18 +712,20 @@ func TestAutoAckResumeResponseEntryLevel(t *testing.T) {
 		t.Parallel()
 		root, _, ref := setupAutoModeCheckpoint(t, "", string(model.CheckpointHumanVerify), false)
 
-		effective, err := autoAckResumeResponse(root, ref, true, false, "operator says ok")
+		effective, autoAcknowledged, err := autoAckResumeResponse(root, ref, true, false, "operator says ok")
 		require.NoError(t, err)
 		assert.Equal(t, "operator says ok", effective)
+		assert.False(t, autoAcknowledged)
 	})
 
 	t.Run("auto off never auto-acks", func(t *testing.T) {
 		t.Parallel()
 		root, _, ref := setupAutoModeCheckpoint(t, "", string(model.CheckpointHumanVerify), false)
 
-		effective, err := autoAckResumeResponse(root, ref, false, false, "")
+		effective, autoAcknowledged, err := autoAckResumeResponse(root, ref, false, false, "")
 		require.NoError(t, err)
 		assert.Equal(t, "", effective)
+		assert.False(t, autoAcknowledged)
 	})
 
 	// TASK B: a fresh human_verify checkpoint auto-acks; a stale/unknown one must
@@ -621,9 +735,10 @@ func TestAutoAckResumeResponseEntryLevel(t *testing.T) {
 		t.Parallel()
 		root, _, ref := setupAutoModeCheckpoint(t, "", string(model.CheckpointHumanVerify), false)
 
-		effective, err := autoAckResumeResponse(root, ref, true, false, "")
+		effective, autoAcknowledged, err := autoAckResumeResponse(root, ref, true, false, "")
 		require.NoError(t, err)
 		assert.Equal(t, "", effective, "stale/unknown freshness must not be auto-acknowledged")
+		assert.False(t, autoAcknowledged)
 
 		err = validateRunEntry(root, ref, false, effective)
 		cliErr := asCLIError(err)
@@ -654,6 +769,39 @@ func TestRunCommandAutoFlagsExerciseRealEntryPath(t *testing.T) {
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		assert.Nil(t, change.ActiveCheckpoint, "run --auto must consume the eligible checkpoint through the real command path")
+
+		events, err := state.ReadLifecycleEvents(root, change)
+		require.NoError(t, err)
+		event := requireCheckpointResolvedEvent(t, events)
+		assert.True(t, lifecycleEventHasSideEffect(event, "active_checkpoint_cleared"))
+		assert.True(t, lifecycleEventHasSideEffect(event, autoCheckpointAcknowledgedSideEffect))
+	})
+
+	t.Run("manual literal auto-acknowledged response stays manual", func(t *testing.T) {
+		t.Parallel()
+		root, slug, _ := setupAutoModeCheckpoint(t, "", string(model.CheckpointHumanVerify), true)
+
+		cmd := commandForRoot(t, root, makeRunCmd())
+		cmd.SetArgs([]string{"--json", "--diagnostics", "--auto", "--resume-response", autoAcknowledgedResponse})
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		cmd.SetErr(&buf)
+		require.NoError(t, cmd.Execute(), buf.String())
+
+		var view nextView
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &view))
+		require.NotNil(t, view.InputContext.ResumeCheckpoint)
+		assert.Equal(t, autoAcknowledgedResponse, view.InputContext.ResumeCheckpoint.UserResponsePayload)
+
+		change, err := state.LoadChange(root, slug)
+		require.NoError(t, err)
+		assert.Nil(t, change.ActiveCheckpoint, "manual resume response must still consume the checkpoint")
+
+		events, err := state.ReadLifecycleEvents(root, change)
+		require.NoError(t, err)
+		event := requireCheckpointResolvedEvent(t, events)
+		assert.True(t, lifecycleEventHasSideEffect(event, "active_checkpoint_cleared"))
+		assert.False(t, lifecycleEventHasSideEffect(event, autoCheckpointAcknowledgedSideEffect))
 	})
 
 	t.Run("--no-auto overrides config auto and keeps checkpoint manual", func(t *testing.T) {
@@ -711,7 +859,7 @@ func TestNextPreviewUnderAutoHasNoSideEffect(t *testing.T) {
 	advPath := state.BundleChangeFilePath(root, advSlug)
 	advBefore, err := os.ReadFile(advPath)
 	require.NoError(t, err)
-	_, err = buildNextViewForCommand(root, changeRef{Slug: advSlug}, "", false, true, false, "run", true)
+	_, err = buildNextViewForCommand(root, changeRef{Slug: advSlug}, "", false, true, false, "run", true, false)
 	require.NoError(t, err)
 	advAfter, err := os.ReadFile(advPath)
 	require.NoError(t, err)
@@ -732,7 +880,7 @@ func TestNextPreviewUnderAutoHasNoSideEffect(t *testing.T) {
 
 	// preview=true is the `next` query path; auto is threaded for the displayed
 	// requirement but must never advance/mutate.
-	_, err = buildNextViewForCommand(root, changeRef{Slug: slug}, "", true, true, false, "next", true)
+	_, err = buildNextViewForCommand(root, changeRef{Slug: slug}, "", true, true, false, "next", true, false)
 	require.NoError(t, err)
 
 	after, err := state.LoadChange(root, slug)
@@ -772,7 +920,7 @@ func TestAutoDoesNotAutoWriteIntakeApprovedSummary(t *testing.T) {
 	require.NoError(t, os.WriteFile(intentPath, []byte(intentBody), 0o644))
 
 	// Advancing path with auto on at the Approved-Summary confirm boundary.
-	view, err := buildNextViewForCommand(root, changeRef{Slug: slug}, "", false, true, false, "run", true)
+	view, err := buildNextViewForCommand(root, changeRef{Slug: slug}, "", false, true, false, "run", true, false)
 	require.NoError(t, err)
 
 	after, err := state.LoadChange(root, slug)
@@ -914,7 +1062,7 @@ func TestLightAutoPassEligibilityUnchangedUnderAuto(t *testing.T) {
 		writePassingGoalVerificationEvidence(t, root, slug, 1)
 
 		// skipAutoPass=true surfaces AutoPassEligible instead of auto-passing.
-		view, err := buildNextViewForCommand(root, changeRef{Slug: slug}, "", false, false, true, "run", auto)
+		view, err := buildNextViewForCommand(root, changeRef{Slug: slug}, "", false, false, true, "run", auto, false)
 		require.NoError(t, err)
 		return view
 	}

--- a/cmd/codebase_map_context_test.go
+++ b/cmd/codebase_map_context_test.go
@@ -127,7 +127,7 @@ func TestBuildNextContextFallsBackToProjectRootWithoutWorktreeBinding(t *testing
 	require.NoError(t, state.SaveChange(root, change))
 
 	var view nextView
-	loaded, _, err := buildNextContextByMode(root, &view, changeRef{Slug: change.Slug}, "", true)
+	loaded, _, err := buildNextContextByMode(root, &view, changeRef{Slug: change.Slug}, "", true, false)
 	require.NoError(t, err)
 	require.NotNil(t, loaded)
 
@@ -154,7 +154,7 @@ func TestBuildNextContextIncludesBoundedHandoffContext(t *testing.T) {
 	require.NoError(t, state.SaveChange(root, change))
 
 	var view nextView
-	loaded, _, err := buildNextContextByMode(root, &view, changeRef{Slug: change.Slug}, "", true)
+	loaded, _, err := buildNextContextByMode(root, &view, changeRef{Slug: change.Slug}, "", true, false)
 	require.NoError(t, err)
 	require.NotNil(t, loaded)
 
@@ -202,7 +202,7 @@ terminology:
 	require.NoError(t, state.SaveChange(root, change))
 
 	var view nextView
-	loaded, _, err := buildNextContextByMode(root, &view, changeRef{Slug: change.Slug}, "", true)
+	loaded, _, err := buildNextContextByMode(root, &view, changeRef{Slug: change.Slug}, "", true, false)
 	require.NoError(t, err)
 	require.NotNil(t, loaded)
 
@@ -241,7 +241,7 @@ func TestBuildNextContextLeavesGateStatusToReadinessEvaluation(t *testing.T) {
 	require.NoError(t, os.WriteFile(verificationPath, []byte("verdict: ["), 0o644))
 
 	var view nextView
-	loaded, _, err := buildNextContextByMode(root, &view, changeRef{Slug: slug}, "", true)
+	loaded, _, err := buildNextContextByMode(root, &view, changeRef{Slug: slug}, "", true, false)
 	require.NoError(t, err)
 	require.NotNil(t, loaded)
 	assert.Nil(t, view.InputContext.GateStatus)
@@ -316,7 +316,7 @@ func TestBuildNextContextIncludesSelectedArchivedDependencyContext(t *testing.T)
 	require.NoError(t, state.SaveChange(root, change))
 
 	var view nextView
-	loaded, _, err := buildNextContextByMode(root, &view, changeRef{Slug: change.Slug}, "", true)
+	loaded, _, err := buildNextContextByMode(root, &view, changeRef{Slug: change.Slug}, "", true, false)
 	require.NoError(t, err)
 	require.NotNil(t, loaded)
 

--- a/cmd/learn.go
+++ b/cmd/learn.go
@@ -52,6 +52,8 @@ type learnSignals struct {
 	CheckpointResolvedManual       int            `json:"checkpoint_resolved_manual"`
 	CheckpointResolvedAuto         int            `json:"checkpoint_resolved_auto"`
 	CheckpointResolutionRate       float64        `json:"checkpoint_resolution_rate"`
+	CheckpointManualResolutionRate float64        `json:"checkpoint_manual_resolution_rate"`
+	CheckpointAutoResolutionRate   float64        `json:"checkpoint_auto_resolution_rate"`
 	InterruptionCount              int            `json:"interruption_count"`
 	InterruptionResumeSuccesses    int            `json:"interruption_resume_successes"`
 	InterruptionResumeSuccessRate  float64        `json:"interruption_resume_success_rate"`
@@ -391,7 +393,14 @@ func computeLearnDerivedSignals(view *learnView) {
 	view.Signals.ClarificationBlockRate = learnRate(view.Signals.RequiredSkillMissing["intake-clarification"], analyzed)
 	view.Signals.PlanAuditStallRate = learnRate(view.Signals.PlanAuditStalled, analyzed)
 	view.Signals.ReviewIntentDriftFailureRate = learnRate(view.Signals.ReviewIntentDrift, analyzed)
-	view.Signals.CheckpointResolutionRate = learnRate(view.Signals.CheckpointResolvedManual, view.Signals.CheckpointOpened)
+	// checkpoint_resolution_rate stays the TOTAL resolved/opened rate it has always
+	// been; the manual/auto split is exposed as the two attribution rates below so
+	// the existing public metric keeps its meaning. CheckpointResolved equals
+	// CheckpointResolvedManual + CheckpointResolvedAuto, so manual_rate + auto_rate
+	// equals checkpoint_resolution_rate.
+	view.Signals.CheckpointResolutionRate = learnRate(view.Signals.CheckpointResolved, view.Signals.CheckpointOpened)
+	view.Signals.CheckpointManualResolutionRate = learnRate(view.Signals.CheckpointResolvedManual, view.Signals.CheckpointOpened)
+	view.Signals.CheckpointAutoResolutionRate = learnRate(view.Signals.CheckpointResolvedAuto, view.Signals.CheckpointOpened)
 	view.Signals.InterruptionResumeSuccessRate = learnRate(view.Signals.InterruptionResumeSuccesses, view.Signals.InterruptionCount)
 }
 

--- a/cmd/learn.go
+++ b/cmd/learn.go
@@ -49,6 +49,8 @@ type learnSignals struct {
 	ReviewIntentDriftChanges       []string       `json:"review_intent_drift_changes,omitempty"`
 	CheckpointOpened               int            `json:"checkpoint_opened"`
 	CheckpointResolved             int            `json:"checkpoint_resolved"`
+	CheckpointResolvedManual       int            `json:"checkpoint_resolved_manual"`
+	CheckpointResolvedAuto         int            `json:"checkpoint_resolved_auto"`
 	CheckpointResolutionRate       float64        `json:"checkpoint_resolution_rate"`
 	InterruptionCount              int            `json:"interruption_count"`
 	InterruptionResumeSuccesses    int            `json:"interruption_resume_successes"`
@@ -206,6 +208,11 @@ func analyzeChangeForLearning(root string, change model.Change, view *learnView)
 			view.Signals.CheckpointOpened++
 		case "checkpoint.resolved":
 			view.Signals.CheckpointResolved++
+			if lifecycleEventHasSideEffect(event, autoCheckpointAcknowledgedSideEffect) {
+				view.Signals.CheckpointResolvedAuto++
+			} else {
+				view.Signals.CheckpointResolvedManual++
+			}
 		case "abort.marked":
 			if event.Result == "interrupted" || event.Action == "execution_interrupted" {
 				interrupted = true
@@ -384,7 +391,7 @@ func computeLearnDerivedSignals(view *learnView) {
 	view.Signals.ClarificationBlockRate = learnRate(view.Signals.RequiredSkillMissing["intake-clarification"], analyzed)
 	view.Signals.PlanAuditStallRate = learnRate(view.Signals.PlanAuditStalled, analyzed)
 	view.Signals.ReviewIntentDriftFailureRate = learnRate(view.Signals.ReviewIntentDrift, analyzed)
-	view.Signals.CheckpointResolutionRate = learnRate(view.Signals.CheckpointResolved, view.Signals.CheckpointOpened)
+	view.Signals.CheckpointResolutionRate = learnRate(view.Signals.CheckpointResolvedManual, view.Signals.CheckpointOpened)
 	view.Signals.InterruptionResumeSuccessRate = learnRate(view.Signals.InterruptionResumeSuccesses, view.Signals.InterruptionCount)
 }
 
@@ -437,6 +444,19 @@ func learnRate(numerator, denominator int) float64 {
 		return 0
 	}
 	return float64(numerator) / float64(denominator)
+}
+
+func lifecycleEventHasSideEffect(event state.LifecycleEvent, kind string) bool {
+	kind = strings.TrimSpace(kind)
+	if kind == "" {
+		return false
+	}
+	for _, effect := range event.SideEffects {
+		if strings.TrimSpace(effect.Kind) == kind {
+			return true
+		}
+	}
+	return false
 }
 
 func governanceActionControlFromLearnBlocker(blocker model.ReasonCode) string {

--- a/cmd/learn_test.go
+++ b/cmd/learn_test.go
@@ -73,6 +73,48 @@ func TestBuildLearnViewAggregatesLifecycleSignalsIntoPreviewProposals(t *testing
 	assert.NotEmpty(t, view.Proposals[0].Risk)
 }
 
+func TestBuildLearnViewSplitsManualAndAutoCheckpointResolutionSignals(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	change := model.NewChange("learn-checkpoint-resolution-signals")
+	require.NoError(t, state.SaveChange(root, change))
+	for range 2 {
+		_, err := state.AppendLifecycleEvent(root, change, state.LifecycleEvent{
+			EventType: "checkpoint.opened",
+			Action:    "opened",
+		})
+		require.NoError(t, err)
+	}
+	_, err := state.AppendLifecycleEvent(root, change, state.LifecycleEvent{
+		EventType: "checkpoint.resolved",
+		Action:    "resolved",
+		SideEffects: []state.LifecycleSideEffect{
+			{Kind: "active_checkpoint_cleared"},
+		},
+	})
+	require.NoError(t, err)
+	_, err = state.AppendLifecycleEvent(root, change, state.LifecycleEvent{
+		EventType: "checkpoint.resolved",
+		Action:    "resolved",
+		SideEffects: []state.LifecycleSideEffect{
+			{Kind: "active_checkpoint_cleared"},
+			{Kind: autoCheckpointAcknowledgedSideEffect},
+		},
+	})
+	require.NoError(t, err)
+
+	view, err := buildLearnView(root, time.Date(2026, 5, 24, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+
+	assert.Equal(t, 4, view.Signals.LifecycleEventCount)
+	assert.Equal(t, 2, view.Signals.CheckpointOpened)
+	assert.Equal(t, 2, view.Signals.CheckpointResolved)
+	assert.Equal(t, 1, view.Signals.CheckpointResolvedManual)
+	assert.Equal(t, 1, view.Signals.CheckpointResolvedAuto)
+	assert.Equal(t, 0.5, view.Signals.CheckpointResolutionRate)
+}
+
 func TestBuildLearnViewToleratesArchivedChangeWithoutLifecycleEvents(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/learn_test.go
+++ b/cmd/learn_test.go
@@ -112,7 +112,14 @@ func TestBuildLearnViewSplitsManualAndAutoCheckpointResolutionSignals(t *testing
 	assert.Equal(t, 2, view.Signals.CheckpointResolved)
 	assert.Equal(t, 1, view.Signals.CheckpointResolvedManual)
 	assert.Equal(t, 1, view.Signals.CheckpointResolvedAuto)
-	assert.Equal(t, 0.5, view.Signals.CheckpointResolutionRate)
+	// The manual/auto counts must partition the total resolved count exactly.
+	assert.Equal(t, view.Signals.CheckpointResolved,
+		view.Signals.CheckpointResolvedManual+view.Signals.CheckpointResolvedAuto)
+	// checkpoint_resolution_rate keeps its historical TOTAL meaning (resolved/opened);
+	// the manual/auto rates break that total down by attribution.
+	assert.Equal(t, 1.0, view.Signals.CheckpointResolutionRate)
+	assert.Equal(t, 0.5, view.Signals.CheckpointManualResolutionRate)
+	assert.Equal(t, 0.5, view.Signals.CheckpointAutoResolutionRate)
 }
 
 func TestBuildLearnViewToleratesArchivedChangeWithoutLifecycleEvents(t *testing.T) {

--- a/cmd/next.go
+++ b/cmd/next.go
@@ -449,7 +449,7 @@ func buildNextViewForCommand(root string, ref changeRef, opts nextViewOptions) (
 		return view, nil
 	}
 
-	governedChange, execCtx, err := buildNextContextByModeWithCheckpointAck(root, &view, ref, resumeResponse, preview, autoCheckpointAcknowledged)
+	governedChange, execCtx, err := buildNextContextByMode(root, &view, ref, resumeResponse, preview, autoCheckpointAcknowledged)
 	if err != nil {
 		return nextView{}, err
 	}

--- a/cmd/next.go
+++ b/cmd/next.go
@@ -337,7 +337,13 @@ func makeNextCmd() *cobra.Command {
 				}
 
 				// next is always query-only; state advancement is owned by `run`.
-				view, err := buildNextViewForCommand(root, ref, "", true, !jsonOutput, noAutoPass, "next", auto, false)
+				view, err := buildNextViewForCommand(root, ref, nextViewOptions{
+					Preview:          true,
+					AutoSkipEvidence: !jsonOutput,
+					SkipAutoPass:     noAutoPass,
+					Command:          "next",
+					Auto:             auto,
+				})
 				if err != nil {
 					return err
 				}
@@ -370,20 +376,44 @@ func makeNextCmd() *cobra.Command {
 }
 
 func buildNextView(root string, ref changeRef, resumeResponse string, preview bool, autoSkipEvidence bool, skipAutoPass bool) (nextView, error) {
-	return buildNextViewForCommand(root, ref, resumeResponse, preview, autoSkipEvidence, skipAutoPass, "run", false, false)
+	return buildNextViewForCommand(root, ref, nextViewOptions{
+		ResumeResponse:   resumeResponse,
+		Preview:          preview,
+		AutoSkipEvidence: autoSkipEvidence,
+		SkipAutoPass:     skipAutoPass,
+		Command:          "run",
+	})
 }
 
-func buildNextViewForCommand(
-	root string,
-	ref changeRef,
-	resumeResponse string,
-	preview bool,
-	autoSkipEvidence bool,
-	skipAutoPass bool,
-	command string,
-	auto bool,
-	autoCheckpointAcknowledged bool,
-) (nextView, error) {
+// nextViewOptions carries the per-command knobs for buildNextViewForCommand.
+// Grouping them in a named struct keeps the call sites self-documenting instead
+// of relying on a long tail of positional booleans.
+type nextViewOptions struct {
+	// ResumeResponse is the operator (or auto-injected) checkpoint response.
+	ResumeResponse string
+	// Preview makes the build read-only: no advancement side effects.
+	Preview bool
+	// AutoSkipEvidence advances but defers evidence prompts the caller surfaces.
+	AutoSkipEvidence bool
+	// SkipAutoPass advances state but suppresses auto-pass so the caller decides.
+	SkipAutoPass bool
+	// Command is the owning command name (e.g. "next", "run", a stage name).
+	Command string
+	// Auto carries execution.auto into advancement and confirmation softening.
+	Auto bool
+	// AutoCheckpointAcknowledged marks the consumed checkpoint as auto-resolved.
+	// Only the first iteration of an auto run sets it; later iterations pass false.
+	AutoCheckpointAcknowledged bool
+}
+
+func buildNextViewForCommand(root string, ref changeRef, opts nextViewOptions) (nextView, error) {
+	resumeResponse := opts.ResumeResponse
+	preview := opts.Preview
+	autoSkipEvidence := opts.AutoSkipEvidence
+	skipAutoPass := opts.SkipAutoPass
+	command := opts.Command
+	auto := opts.Auto
+	autoCheckpointAcknowledged := opts.AutoCheckpointAcknowledged
 	// READ-ONLY PREVIEW INVARIANT: only the advancing path (run/stage) carries
 	// auto into advancement so the engine preset auto-confirm can fire. A preview
 	// query (`slipway next`) must never trigger an auto-confirm side effect, so

--- a/cmd/next.go
+++ b/cmd/next.go
@@ -13,6 +13,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const autoCheckpointAcknowledgedSideEffect = "auto_checkpoint_acknowledged"
+
 type nextView struct {
 	Command                   string                               `json:"command,omitempty"`
 	DelegatedTo               string                               `json:"delegated_to,omitempty"`
@@ -54,7 +56,8 @@ type nextView struct {
 	Recovery                  *model.RecoverySummary               `json:"recovery,omitempty"`
 	ConfirmationRequirement   confirmationRequirement              `json:"confirmation_requirement"`
 
-	consumeActiveCheckpoint bool
+	consumeActiveCheckpoint                 bool
+	consumeActiveCheckpointAutoAcknowledged bool
 	// planLocked records whether the lifecycle G_plan gate has approved the plan.
 	// It is unexported (never serialized) and drives whether a parsed decision.md
 	// selection is reported as a locked or pending skill_constraint (issue #140).
@@ -334,7 +337,7 @@ func makeNextCmd() *cobra.Command {
 				}
 
 				// next is always query-only; state advancement is owned by `run`.
-				view, err := buildNextViewForCommand(root, ref, "", true, !jsonOutput, noAutoPass, "next", auto)
+				view, err := buildNextViewForCommand(root, ref, "", true, !jsonOutput, noAutoPass, "next", auto, false)
 				if err != nil {
 					return err
 				}
@@ -367,10 +370,20 @@ func makeNextCmd() *cobra.Command {
 }
 
 func buildNextView(root string, ref changeRef, resumeResponse string, preview bool, autoSkipEvidence bool, skipAutoPass bool) (nextView, error) {
-	return buildNextViewForCommand(root, ref, resumeResponse, preview, autoSkipEvidence, skipAutoPass, "run", false)
+	return buildNextViewForCommand(root, ref, resumeResponse, preview, autoSkipEvidence, skipAutoPass, "run", false, false)
 }
 
-func buildNextViewForCommand(root string, ref changeRef, resumeResponse string, preview bool, autoSkipEvidence bool, skipAutoPass bool, command string, auto bool) (nextView, error) {
+func buildNextViewForCommand(
+	root string,
+	ref changeRef,
+	resumeResponse string,
+	preview bool,
+	autoSkipEvidence bool,
+	skipAutoPass bool,
+	command string,
+	auto bool,
+	autoCheckpointAcknowledged bool,
+) (nextView, error) {
 	// READ-ONLY PREVIEW INVARIANT: only the advancing path (run/stage) carries
 	// auto into advancement so the engine preset auto-confirm can fire. A preview
 	// query (`slipway next`) must never trigger an auto-confirm side effect, so
@@ -406,7 +419,7 @@ func buildNextViewForCommand(root string, ref changeRef, resumeResponse string, 
 		return view, nil
 	}
 
-	governedChange, execCtx, err := buildNextContextByMode(root, &view, ref, resumeResponse, preview)
+	governedChange, execCtx, err := buildNextContextByModeWithCheckpointAck(root, &view, ref, resumeResponse, preview, autoCheckpointAcknowledged)
 	if err != nil {
 		return nextView{}, err
 	}
@@ -509,11 +522,16 @@ func consumeNextCheckpoint(root string, change *model.Change, view *nextView) er
 	}
 	if change == nil || change.ActiveCheckpoint == nil {
 		view.consumeActiveCheckpoint = false
+		view.consumeActiveCheckpointAutoAcknowledged = false
 		return nil
 	}
 
 	beforeChange := *change
 	checkpoint := *change.ActiveCheckpoint
+	sideEffects := []state.LifecycleSideEffect{{Kind: "active_checkpoint_cleared"}}
+	if view.consumeActiveCheckpointAutoAcknowledged {
+		sideEffects = append(sideEffects, state.LifecycleSideEffect{Kind: autoCheckpointAcknowledgedSideEffect})
+	}
 	change.ActiveCheckpoint = nil
 	if err := state.SaveChange(root, *change); err != nil {
 		return err
@@ -527,12 +545,13 @@ func consumeNextCheckpoint(root string, change *model.Change, view *nextView) er
 		BeforeState:   beforeChange.CurrentState,
 		AfterState:    change.CurrentState,
 		Diagnostics:   []string{"task_id=" + checkpoint.PausedTaskID},
-		SideEffects:   []state.LifecycleSideEffect{{Kind: "active_checkpoint_cleared"}},
+		SideEffects:   sideEffects,
 		ClearedFields: []string{"active_checkpoint"},
 	}); err != nil {
 		return err
 	}
 	view.consumeActiveCheckpoint = false
+	view.consumeActiveCheckpointAutoAcknowledged = false
 	return nil
 }
 
@@ -688,11 +707,11 @@ func checkPresetPendingEarlyReturn(root string, ref changeRef, view *nextView) (
 }
 
 func deriveConfirmationRequirement(view nextView) confirmationRequirement {
-	// Auto softens pure-pacing confirmation boundaries into a
-	// standing-authorization continuation, but only when the change is NOT in a
-	// guardrail/sensitive domain and the surfaced handoff is not a selected
-	// security review. Preset, decision, human_action, stale-checkpoint, and
-	// evidence-gate boundaries keep their hard_stop even under auto.
+	// Auto softens explicitly allowlisted pure-pacing confirmation boundaries into
+	// a standing-authorization continuation, but only when the change is NOT in a
+	// guardrail/sensitive domain. Preset, decision, human_action,
+	// stale-checkpoint, unclassified skill, and evidence-gate boundaries keep
+	// their hard_stop even under auto.
 	autoSoftens := view.auto &&
 		!isGuardrailSensitive(view.GuardrailDomain) &&
 		!viewRequiresManualAutoBoundary(view)

--- a/cmd/next_context_build.go
+++ b/cmd/next_context_build.go
@@ -51,11 +51,7 @@ func missingCodebaseMapDocStates(docs map[string]string) map[string]string {
 // (state, lifecycle, artifacts, checkpoints).
 // Returns the loaded Change plus its execution context so downstream next-path
 // consumers can reuse the same execution-summary read.
-func buildNextContextByMode(root string, view *nextView, ref changeRef, resumeResponse string, preview bool) (*model.Change, *executionContext, error) {
-	return buildNextContextByModeWithCheckpointAck(root, view, ref, resumeResponse, preview, false)
-}
-
-func buildNextContextByModeWithCheckpointAck(
+func buildNextContextByMode(
 	root string,
 	view *nextView,
 	ref changeRef,
@@ -104,7 +100,7 @@ func buildNextContextByModeWithCheckpointAck(
 	if err != nil {
 		return nil, nil, err
 	}
-	if err := buildResumeCheckpointWithCheckpointAck(root, &change, execCtx, view, resumeResponse, preview, autoCheckpointAcknowledged); err != nil {
+	if err := buildResumeCheckpoint(root, &change, execCtx, view, resumeResponse, preview, autoCheckpointAcknowledged); err != nil {
 		return nil, nil, err
 	}
 	return &change, &execCtx, nil
@@ -308,11 +304,7 @@ func buildHandoffRiskForReadiness(existing *handoffRiskView, controls []model.Co
 
 // buildResumeCheckpoint handles active checkpoint validation and wave execution
 // resume checkpoint construction for governed changes.
-func buildResumeCheckpoint(root string, change *model.Change, execCtx executionContext, view *nextView, resumeResponse string, preview bool) error {
-	return buildResumeCheckpointWithCheckpointAck(root, change, execCtx, view, resumeResponse, preview, false)
-}
-
-func buildResumeCheckpointWithCheckpointAck(
+func buildResumeCheckpoint(
 	root string,
 	change *model.Change,
 	execCtx executionContext,

--- a/cmd/next_context_build.go
+++ b/cmd/next_context_build.go
@@ -52,6 +52,17 @@ func missingCodebaseMapDocStates(docs map[string]string) map[string]string {
 // Returns the loaded Change plus its execution context so downstream next-path
 // consumers can reuse the same execution-summary read.
 func buildNextContextByMode(root string, view *nextView, ref changeRef, resumeResponse string, preview bool) (*model.Change, *executionContext, error) {
+	return buildNextContextByModeWithCheckpointAck(root, view, ref, resumeResponse, preview, false)
+}
+
+func buildNextContextByModeWithCheckpointAck(
+	root string,
+	view *nextView,
+	ref changeRef,
+	resumeResponse string,
+	preview bool,
+	autoCheckpointAcknowledged bool,
+) (*model.Change, *executionContext, error) {
 	change, err := state.LoadChange(root, ref.Slug)
 	if err != nil {
 		return nil, nil, err
@@ -93,7 +104,7 @@ func buildNextContextByMode(root string, view *nextView, ref changeRef, resumeRe
 	if err != nil {
 		return nil, nil, err
 	}
-	if err := buildResumeCheckpoint(root, &change, execCtx, view, resumeResponse, preview); err != nil {
+	if err := buildResumeCheckpointWithCheckpointAck(root, &change, execCtx, view, resumeResponse, preview, autoCheckpointAcknowledged); err != nil {
 		return nil, nil, err
 	}
 	return &change, &execCtx, nil
@@ -298,6 +309,18 @@ func buildHandoffRiskForReadiness(existing *handoffRiskView, controls []model.Co
 // buildResumeCheckpoint handles active checkpoint validation and wave execution
 // resume checkpoint construction for governed changes.
 func buildResumeCheckpoint(root string, change *model.Change, execCtx executionContext, view *nextView, resumeResponse string, preview bool) error {
+	return buildResumeCheckpointWithCheckpointAck(root, change, execCtx, view, resumeResponse, preview, false)
+}
+
+func buildResumeCheckpointWithCheckpointAck(
+	root string,
+	change *model.Change,
+	execCtx executionContext,
+	view *nextView,
+	resumeResponse string,
+	preview bool,
+	autoCheckpointAcknowledged bool,
+) error {
 	if err := validateActiveCheckpointAuthority(root, *change, execCtx, "next"); err != nil {
 		return err
 	}
@@ -327,6 +350,7 @@ func buildResumeCheckpoint(root string, change *model.Change, execCtx executionC
 				// so failed readiness/projection passes preserve the pending resume
 				// contract.
 				view.consumeActiveCheckpoint = true
+				view.consumeActiveCheckpointAutoAcknowledged = autoCheckpointAcknowledged
 			}
 		}
 		view.InputContext.ResumeCheckpoint = checkpoint

--- a/cmd/next_eval_fixture_test.go
+++ b/cmd/next_eval_fixture_test.go
@@ -77,7 +77,7 @@ Docs render.
 				return slug
 			},
 			execute: func(t *testing.T, root, slug string) nextView {
-				view, err := runGovernedLoop(root, changeRef{Slug: slug}, "", false)
+				view, err := runGovernedLoop(root, changeRef{Slug: slug}, "", false, false)
 				require.NoError(t, err)
 				return view
 			},

--- a/cmd/next_handoff.go
+++ b/cmd/next_handoff.go
@@ -203,7 +203,7 @@ func buildNextHandoffContextByMode(root string, view *nextView, ref changeRef, r
 	if err != nil {
 		return nil, nil, err
 	}
-	if err := buildResumeCheckpoint(root, &change, execCtx, view, resumeResponse, preview); err != nil {
+	if err := buildResumeCheckpoint(root, &change, execCtx, view, resumeResponse, preview, false); err != nil {
 		return nil, nil, err
 	}
 	return &change, &execCtx, nil

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -190,6 +190,11 @@ const autoAcknowledgedResponse = "auto-acknowledged"
 
 // isGuardrailSensitive reports whether a change's guardrail domain marks it as a
 // sensitive domain that must keep failing closed to manual review under auto.
+//
+// An empty domain reports non-sensitive on the authority of upstream intake
+// classification: a sensitive change carries a non-empty GuardrailDomain set by
+// the governed intake/plan stages, so a blank domain here means the classifier
+// found no sensitive domain rather than that classification was skipped.
 func isGuardrailSensitive(guardrailDomain string) bool {
 	return strings.TrimSpace(guardrailDomain) != ""
 }
@@ -308,7 +313,12 @@ func resumableWavePlanHasStructuralDrift(root string, change model.Change) bool 
 
 func runGovernedLoop(root string, ref changeRef, resumeResponse string, auto bool) (nextView, error) {
 	buildNext := func(nextResumeResponse string) (nextView, error) {
-		return buildNextViewForCommand(root, ref, nextResumeResponse, false, true, false, "run", auto, false)
+		return buildNextViewForCommand(root, ref, nextViewOptions{
+			ResumeResponse:   nextResumeResponse,
+			AutoSkipEvidence: true,
+			Command:          "run",
+			Auto:             auto,
+		})
 	}
 	return runGovernedLoopWithBuilder(root, ref, resumeResponse, buildNext)
 }
@@ -322,7 +332,13 @@ func runGovernedLoopWithCheckpointAck(
 ) (nextView, error) {
 	nextAutoCheckpointAcknowledged := autoCheckpointAcknowledged
 	buildNext := func(nextResumeResponse string) (nextView, error) {
-		view, err := buildNextViewForCommand(root, ref, nextResumeResponse, false, true, false, "run", auto, nextAutoCheckpointAcknowledged)
+		view, err := buildNextViewForCommand(root, ref, nextViewOptions{
+			ResumeResponse:             nextResumeResponse,
+			AutoSkipEvidence:           true,
+			Command:                    "run",
+			Auto:                       auto,
+			AutoCheckpointAcknowledged: nextAutoCheckpointAcknowledged,
+		})
 		nextAutoCheckpointAcknowledged = false
 		return view, err
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -59,7 +59,7 @@ func makeRunCmd() *cobra.Command {
 				if err := validateRunEntry(root, ref, resume, effectiveResumeResponse); err != nil {
 					return err
 				}
-				view, err := runGovernedLoopWithCheckpointAck(root, ref, effectiveResumeResponse, effectiveAuto, autoCheckpointAcknowledged)
+				view, err := runGovernedLoop(root, ref, effectiveResumeResponse, effectiveAuto, autoCheckpointAcknowledged)
 				if err != nil {
 					return err
 				}
@@ -311,19 +311,7 @@ func resumableWavePlanHasStructuralDrift(root string, change model.Change) bool 
 	return planHash != "" && currentHash != "" && planHash != currentHash
 }
 
-func runGovernedLoop(root string, ref changeRef, resumeResponse string, auto bool) (nextView, error) {
-	buildNext := func(nextResumeResponse string) (nextView, error) {
-		return buildNextViewForCommand(root, ref, nextViewOptions{
-			ResumeResponse:   nextResumeResponse,
-			AutoSkipEvidence: true,
-			Command:          "run",
-			Auto:             auto,
-		})
-	}
-	return runGovernedLoopWithBuilder(root, ref, resumeResponse, buildNext)
-}
-
-func runGovernedLoopWithCheckpointAck(
+func runGovernedLoop(
 	root string,
 	ref changeRef,
 	resumeResponse string,

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -52,14 +52,14 @@ func makeRunCmd() *cobra.Command {
 				// the loop, so the checkpoint is consumed exactly as an operator
 				// --resume-response would. Decision/human_action/guardrail checkpoints
 				// are deliberately left untouched and still fail closed.
-				effectiveResumeResponse, err := autoAckResumeResponse(root, ref, effectiveAuto, resume, resumeResponse)
+				effectiveResumeResponse, autoCheckpointAcknowledged, err := autoAckResumeResponse(root, ref, effectiveAuto, resume, resumeResponse)
 				if err != nil {
 					return err
 				}
 				if err := validateRunEntry(root, ref, resume, effectiveResumeResponse); err != nil {
 					return err
 				}
-				view, err := runGovernedLoop(root, ref, effectiveResumeResponse, effectiveAuto)
+				view, err := runGovernedLoopWithCheckpointAck(root, ref, effectiveResumeResponse, effectiveAuto, autoCheckpointAcknowledged)
 				if err != nil {
 					return err
 				}
@@ -141,22 +141,22 @@ func resolveEffectiveAuto(root string, cmd *cobra.Command, auto, noAuto bool) (b
 // the loop consumes the checkpoint. Decision and human_action checkpoints, and
 // any checkpoint in a guardrail/sensitive domain, are never auto-acknowledged —
 // they keep failing closed exactly as in the non-auto path.
-func autoAckResumeResponse(root string, ref changeRef, auto, resume bool, resumeResponse string) (string, error) {
+func autoAckResumeResponse(root string, ref changeRef, auto, resume bool, resumeResponse string) (string, bool, error) {
 	if !auto || resume || strings.TrimSpace(resumeResponse) != "" {
-		return resumeResponse, nil
+		return resumeResponse, false, nil
 	}
 	change, err := state.LoadChange(root, ref.Slug)
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 	eligible, err := autoAckEligibleCheckpoint(root, change)
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 	if !eligible {
-		return resumeResponse, nil
+		return resumeResponse, false, nil
 	}
-	return autoAcknowledgedResponse, nil
+	return autoAcknowledgedResponse, true, nil
 }
 
 // autoAckEligibleCheckpoint reports whether the change has an active checkpoint
@@ -307,6 +307,34 @@ func resumableWavePlanHasStructuralDrift(root string, change model.Change) bool 
 }
 
 func runGovernedLoop(root string, ref changeRef, resumeResponse string, auto bool) (nextView, error) {
+	buildNext := func(nextResumeResponse string) (nextView, error) {
+		return buildNextViewForCommand(root, ref, nextResumeResponse, false, true, false, "run", auto, false)
+	}
+	return runGovernedLoopWithBuilder(root, ref, resumeResponse, buildNext)
+}
+
+func runGovernedLoopWithCheckpointAck(
+	root string,
+	ref changeRef,
+	resumeResponse string,
+	auto bool,
+	autoCheckpointAcknowledged bool,
+) (nextView, error) {
+	nextAutoCheckpointAcknowledged := autoCheckpointAcknowledged
+	buildNext := func(nextResumeResponse string) (nextView, error) {
+		view, err := buildNextViewForCommand(root, ref, nextResumeResponse, false, true, false, "run", auto, nextAutoCheckpointAcknowledged)
+		nextAutoCheckpointAcknowledged = false
+		return view, err
+	}
+	return runGovernedLoopWithBuilder(root, ref, resumeResponse, buildNext)
+}
+
+func runGovernedLoopWithBuilder(
+	root string,
+	ref changeRef,
+	resumeResponse string,
+	buildNext func(string) (nextView, error),
+) (nextView, error) {
 	const maxIterations = maxAutoNextIterations
 
 	var lastView nextView
@@ -317,7 +345,7 @@ func runGovernedLoop(root string, ref changeRef, resumeResponse string, auto boo
 		delegatedTo = primaryCommandForState(change.CurrentState)
 	}
 	for i := 0; i < maxIterations; i++ {
-		view, err := buildNextViewForCommand(root, ref, nextResumeResponse, false, true, false, "run", auto)
+		view, err := buildNext(nextResumeResponse)
 		if err != nil {
 			return nextView{}, err
 		}

--- a/cmd/stage.go
+++ b/cmd/stage.go
@@ -149,7 +149,13 @@ func runStageLoop(root string, ref changeRef, spec stageCommandSpec, resumeRespo
 	nextResumeResponse := resumeResponse
 	nextAutoCheckpointAcknowledged := autoCheckpointAcknowledged
 	for i := 0; i < maxIterations; i++ {
-		view, err := buildNextViewForCommand(root, ref, nextResumeResponse, false, true, false, spec.Name, auto, nextAutoCheckpointAcknowledged)
+		view, err := buildNextViewForCommand(root, ref, nextViewOptions{
+			ResumeResponse:             nextResumeResponse,
+			AutoSkipEvidence:           true,
+			Command:                    spec.Name,
+			Auto:                       auto,
+			AutoCheckpointAcknowledged: nextAutoCheckpointAcknowledged,
+		})
 		if err != nil {
 			return nextView{}, err
 		}

--- a/cmd/stage.go
+++ b/cmd/stage.go
@@ -79,9 +79,10 @@ func makeStageCmd(spec stageCommandSpec) *cobra.Command {
 					return err
 				}
 				effectiveResumeResponse := resumeResponse
+				autoCheckpointAcknowledged := false
 				if spec.SupportsResume {
 					var err error
-					effectiveResumeResponse, err = autoAckResumeResponse(root, ref, auto, resume, resumeResponse)
+					effectiveResumeResponse, autoCheckpointAcknowledged, err = autoAckResumeResponse(root, ref, auto, resume, resumeResponse)
 					if err != nil {
 						return err
 					}
@@ -89,7 +90,7 @@ func makeStageCmd(spec stageCommandSpec) *cobra.Command {
 						return err
 					}
 				}
-				view, err := runStageLoop(root, ref, spec, effectiveResumeResponse, auto)
+				view, err := runStageLoop(root, ref, spec, effectiveResumeResponse, auto, autoCheckpointAcknowledged)
 				if err != nil {
 					return err
 				}
@@ -140,20 +141,22 @@ func validateStageCommandEntry(root string, ref changeRef, spec stageCommandSpec
 	)
 }
 
-func runStageLoop(root string, ref changeRef, spec stageCommandSpec, resumeResponse string, auto bool) (nextView, error) {
+func runStageLoop(root string, ref changeRef, spec stageCommandSpec, resumeResponse string, auto bool, autoCheckpointAcknowledged bool) (nextView, error) {
 	const maxIterations = maxAutoNextIterations
 
 	var lastView nextView
 	transitions := make([]progression.AdvanceSummary, 0, maxIterations)
 	nextResumeResponse := resumeResponse
+	nextAutoCheckpointAcknowledged := autoCheckpointAcknowledged
 	for i := 0; i < maxIterations; i++ {
-		view, err := buildNextViewForCommand(root, ref, nextResumeResponse, false, true, false, spec.Name, auto)
+		view, err := buildNextViewForCommand(root, ref, nextResumeResponse, false, true, false, spec.Name, auto, nextAutoCheckpointAcknowledged)
 		if err != nil {
 			return nextView{}, err
 		}
 		view.Command = spec.Name
 		view.DelegatedTo = spec.Name
 		nextResumeResponse = ""
+		nextAutoCheckpointAcknowledged = false
 		lastView = view
 		if view.Advanced != nil && (view.Advanced.Action == "advanced" || view.Advanced.Action == "done_ready") {
 			transitions = append(transitions, *view.Advanced)

--- a/internal/engine/progression/confirmation_boundaries.go
+++ b/internal/engine/progression/confirmation_boundaries.go
@@ -46,6 +46,12 @@ func ReviewCompanionBlockerCanRide(reason model.ReasonCode) bool {
 
 // ReviewCompanionSkillCanCarryBlockers reports skills whose handoff may carry
 // review/closeout companion blockers without turning them into a separate stop.
+//
+// SkillSecurityReview is intentionally listed here but is deliberately ABSENT
+// from SkillIsPurePacingAutoSafe: a security review may carry companion blockers
+// on its handoff, yet it must always hard-stop under execution.auto. Keep that
+// divergence intact when editing either list; it is pinned by
+// TestSecurityReviewDivergesAcrossAutoBoundaries.
 func ReviewCompanionSkillCanCarryBlockers(skillName string) bool {
 	switch strings.TrimSpace(skillName) {
 	case SkillSpecComplianceReview,
@@ -62,6 +68,11 @@ func ReviewCompanionSkillCanCarryBlockers(skillName string) bool {
 
 // SkillIsPurePacingAutoSafe reports skills whose handoff is only a pacing
 // boundary and may be softened by execution.auto for non-guardrail changes.
+//
+// SkillSecurityReview is deliberately omitted: even outside a guardrail domain a
+// security review must hard-stop under auto, so it must never appear here even
+// though ReviewCompanionSkillCanCarryBlockers does list it. This divergence is
+// pinned by TestSecurityReviewDivergesAcrossAutoBoundaries.
 func SkillIsPurePacingAutoSafe(skillName string) bool {
 	switch strings.TrimSpace(skillName) {
 	case SkillIntakeClarification,

--- a/internal/engine/progression/confirmation_boundaries.go
+++ b/internal/engine/progression/confirmation_boundaries.go
@@ -60,8 +60,29 @@ func ReviewCompanionSkillCanCarryBlockers(skillName string) bool {
 	}
 }
 
-// SkillRequiresManualAutoBoundary reports selected skills that must not be
-// softened by execution.auto even when the change has no guardrail domain.
+// SkillIsPurePacingAutoSafe reports skills whose handoff is only a pacing
+// boundary and may be softened by execution.auto for non-guardrail changes.
+func SkillIsPurePacingAutoSafe(skillName string) bool {
+	switch strings.TrimSpace(skillName) {
+	case SkillIntakeClarification,
+		SkillResearchOrchestration,
+		SkillPlanAudit,
+		SkillWaveOrchestration,
+		SkillSpecComplianceReview,
+		SkillCodeQualityReview,
+		SkillIndependentReview,
+		SkillGoalVerification,
+		SkillFinalCloseout:
+		return true
+	default:
+		return false
+	}
+}
+
+// SkillRequiresManualAutoBoundary reports skills that must not be softened by
+// execution.auto even when the change has no guardrail domain. Unknown non-empty
+// skill names fail closed until explicitly classified as pure-pacing auto-safe.
 func SkillRequiresManualAutoBoundary(skillName string) bool {
-	return strings.TrimSpace(skillName) == SkillSecurityReview
+	name := strings.TrimSpace(skillName)
+	return name != "" && !SkillIsPurePacingAutoSafe(name)
 }

--- a/internal/engine/progression/confirmation_boundaries.go
+++ b/internal/engine/progression/confirmation_boundaries.go
@@ -82,6 +82,13 @@ func SkillIsPurePacingAutoSafe(skillName string) bool {
 // SkillRequiresManualAutoBoundary reports skills that must not be softened by
 // execution.auto even when the change has no guardrail domain. Unknown non-empty
 // skill names fail closed until explicitly classified as pure-pacing auto-safe.
+//
+// A blank name reports false by design, not as a fail-open gap: an empty skill
+// name means there is no skill handoff to gate, so there is nothing for auto to
+// soften. ReviewBatch skill names and NextSkill.Name are always populated, so
+// they never reach the blank case. NextSkill.BlockingName may be blank, but when
+// it is, nextSkillRequiresManualAutoBoundary still also checks the always-populated
+// Name, so a blank name never opens a softening path.
 func SkillRequiresManualAutoBoundary(skillName string) bool {
 	name := strings.TrimSpace(skillName)
 	return name != "" && !SkillIsPurePacingAutoSafe(name)

--- a/internal/engine/progression/confirmation_boundaries_test.go
+++ b/internal/engine/progression/confirmation_boundaries_test.go
@@ -1,0 +1,74 @@
+package progression
+
+import "testing"
+
+// TestSecurityReviewDivergesAcrossAutoBoundaries pins the deliberate divergence
+// between ReviewCompanionSkillCanCarryBlockers (lists security-review) and
+// SkillIsPurePacingAutoSafe (must NOT list it): a security review may carry
+// review/closeout companion blockers, but it must always hard-stop under
+// execution.auto. A future edit that adds a review skill to one list must not
+// silently add security-review to the auto-safe list.
+func TestSecurityReviewDivergesAcrossAutoBoundaries(t *testing.T) {
+	t.Parallel()
+
+	if !ReviewCompanionSkillCanCarryBlockers(SkillSecurityReview) {
+		t.Fatal("security-review must be allowed to carry review/closeout companion blockers")
+	}
+	if SkillIsPurePacingAutoSafe(SkillSecurityReview) {
+		t.Fatal("security-review must never be pure-pacing auto-safe; it must hard-stop under execution.auto")
+	}
+	if !SkillRequiresManualAutoBoundary(SkillSecurityReview) {
+		t.Fatal("security-review must require a manual auto boundary")
+	}
+}
+
+// TestSkillRequiresManualAutoBoundaryFailsClosed pins the fail-closed contract:
+// an unknown non-empty skill requires a manual auto boundary, while a blank or
+// whitespace-only name reports false by design (there is no handoff to gate).
+func TestSkillRequiresManualAutoBoundaryFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	if !SkillRequiresManualAutoBoundary("totally-unknown-future-skill") {
+		t.Fatal("unknown non-empty skill must fail closed to a manual auto boundary")
+	}
+	if SkillRequiresManualAutoBoundary("") {
+		t.Fatal("blank skill name must report false (no handoff to gate), not fail closed")
+	}
+	if SkillRequiresManualAutoBoundary("   ") {
+		t.Fatal("whitespace-only skill name must be treated as blank")
+	}
+}
+
+// TestPurePacingAutoSafeAllowlistMembership pins the current pure-pacing
+// allowlist so a silent add or removal is caught. worktree-preflight and
+// security-review are intentionally excluded and must keep hard-stopping.
+func TestPurePacingAutoSafeAllowlistMembership(t *testing.T) {
+	t.Parallel()
+
+	autoSafe := []string{
+		SkillIntakeClarification,
+		SkillResearchOrchestration,
+		SkillPlanAudit,
+		SkillWaveOrchestration,
+		SkillSpecComplianceReview,
+		SkillCodeQualityReview,
+		SkillIndependentReview,
+		SkillGoalVerification,
+		SkillFinalCloseout,
+	}
+	for _, name := range autoSafe {
+		if !SkillIsPurePacingAutoSafe(name) {
+			t.Errorf("skill %q must be pure-pacing auto-safe", name)
+		}
+	}
+
+	mustHardStop := []string{
+		SkillWorktreePreflight,
+		SkillSecurityReview,
+	}
+	for _, name := range mustHardStop {
+		if SkillIsPurePacingAutoSafe(name) {
+			t.Errorf("skill %q must NOT be pure-pacing auto-safe", name)
+		}
+	}
+}

--- a/internal/tmpl/templates_test.go
+++ b/internal/tmpl/templates_test.go
@@ -1257,6 +1257,7 @@ func TestRunCommandEntryContainsLoopBehavioralBlocks(t *testing.T) {
 		"`--auto`/`--no-auto`: override `execution.auto` for this run",
 		"Auto never crosses sensitive/guardrail confirmations",
 		"`security-review` boundaries",
+		"the intake Approved Summary",
 		"decision/human_action checkpoints",
 		"stale or unknown-freshness checkpoints",
 		"evidence gates",

--- a/internal/tmpl/templates_test.go
+++ b/internal/tmpl/templates_test.go
@@ -1250,6 +1250,20 @@ func TestRunCommandEntryContainsLoopBehavioralBlocks(t *testing.T) {
 	assert.Contains(t, content, "auto mode auto-acknowledges",
 		"run command must describe auto-ack without duplicated wording")
 	assert.NotContains(t, content, "auto auto-acknowledges")
+
+	normalized := strings.Join(strings.Fields(content), " ")
+	for _, phrase := range []string{
+		"Under auto (`execution.auto` or `slipway run --auto`)",
+		"`--auto`/`--no-auto`: override `execution.auto` for this run",
+		"Auto never crosses sensitive/guardrail confirmations",
+		"`security-review` boundaries",
+		"decision/human_action checkpoints",
+		"stale or unknown-freshness checkpoints",
+		"evidence gates",
+	} {
+		assert.Contains(t, normalized, phrase,
+			"run command auto-mode redline phrase missing")
+	}
 }
 
 func TestStatusCommandEntryUsesGovernanceSummaryContract(t *testing.T) {

--- a/internal/toolgen/toolgen_test.go
+++ b/internal/toolgen/toolgen_test.go
@@ -1725,10 +1725,26 @@ func TestCommandEntriesLockNextAndRunExecutionContracts(t *testing.T) {
 
 	runEntry, err := renderCommandEntry(toolRegistry["claude"], "run")
 	require.NoError(t, err)
+	normalizedRunEntry := strings.Join(strings.Fields(runEntry), " ")
+	runArguments := CommandArguments("run")
+	assert.Contains(t, runArguments, "[--auto|--no-auto]",
+		"run registry arguments must expose per-run auto overrides")
 	assert.Contains(t, runEntry, "Shortcut driver for the current lifecycle stage")
 	assert.Contains(t, runEntry, "`run` is an auto-driver shortcut")
 	assert.Contains(t, runEntry, "JSON output includes `delegated_to`")
 	assert.Contains(t, runEntry, "`run` reuses the same `next --json` contract")
+	assert.Contains(t, normalizedRunEntry, "`--auto`/`--no-auto`: override `execution.auto` for this run",
+		"run command entry must document the override behavior")
+	for _, phrase := range []string{
+		"`security-review` boundaries",
+		"sensitive/guardrail confirmations",
+		"decision/human_action checkpoints",
+		"stale or unknown-freshness checkpoints",
+		"evidence gates",
+	} {
+		assert.Contains(t, normalizedRunEntry, phrase,
+			"run command entry missing auto-mode redline phrase")
+	}
 
 	for _, commandID := range []string{"intake", "plan", "implement"} {
 		commandID := commandID
@@ -1758,6 +1774,21 @@ func TestReadmeAndCommandDescriptionsReflectCurrentEntrySurface(t *testing.T) {
 	assert.Contains(t, readme, "`slipway run`")
 	assert.Contains(t, readme, "`artifacts/changes/`")
 	assert.Contains(t, readme, "`artifacts/codebase/`")
+	normalizedReadme := strings.Join(strings.Fields(readme), " ")
+	for _, phrase := range []string{
+		"overridden per run with `slipway run --auto`",
+		"`slipway run --no-auto` forces a single run back to manual pacing",
+		"the per-run `--auto` / `--no-auto` overrides live only on `slipway run`",
+		"Auto mode never relaxes governance.",
+		"`security-review` boundaries",
+		"sensitive/guardrail confirmations",
+		"decision and human_action checkpoints",
+		"stale or unknown-freshness checkpoints",
+		"every evidence gate",
+	} {
+		assert.Contains(t, normalizedReadme, phrase,
+			"README auto-mode safety phrase missing")
+	}
 	assert.NotContains(t, readme, "request intake")
 	assert.NotContains(t, readme, "active request resolution")
 	assert.NotContains(t, readme, "`openspec/`")

--- a/internal/toolgen/toolgen_test.go
+++ b/internal/toolgen/toolgen_test.go
@@ -1738,6 +1738,7 @@ func TestCommandEntriesLockNextAndRunExecutionContracts(t *testing.T) {
 	for _, phrase := range []string{
 		"`security-review` boundaries",
 		"sensitive/guardrail confirmations",
+		"the intake Approved Summary",
 		"decision/human_action checkpoints",
 		"stale or unknown-freshness checkpoints",
 		"evidence gates",
@@ -1782,6 +1783,7 @@ func TestReadmeAndCommandDescriptionsReflectCurrentEntrySurface(t *testing.T) {
 		"Auto mode never relaxes governance.",
 		"`security-review` boundaries",
 		"sensitive/guardrail confirmations",
+		"the intake Approved Summary",
 		"decision and human_action checkpoints",
 		"stale or unknown-freshness checkpoints",
 		"every evidence gate",


### PR DESCRIPTION
## Summary

Harden `execution.auto` after the follow-up review of #280:

- mark auto-resolved eligible `human_verify` checkpoints with an explicit lifecycle side effect instead of inferring auto from the user-controllable response string
- split `slipway learn` checkpoint resolution signals into manual and auto counts so auto acknowledgments do not pollute the manual human-verification signal
- invert skill handoff auto-softening to an explicit pure-pacing allowlist while keeping `security-review`, `worktree-preflight`, and unknown skills as hard stops
- pin run/README auto-mode safety redlines in regression tests
- pin auto-off blocker precedence so non-pacing governance blockers outrank handoff/review pacing
- archive the governed change `harden-execution-auto-mode`

## Why

The original auto-mode implementation preserved core evidence-gate safety, but review found quality and audit gaps around checkpoint provenance, learn signal semantics, future skill defaults, documentation regression coverage, and blocker-precedence testing. This patch keeps the behavior scoped to existing auto-mode seams and does not add a new public run/next JSON API surface.

## Validation

- `go test ./...`
- `go build ./...`
- `git diff --check HEAD~1..HEAD`
- Governed review passed before archive:
  - `spec-compliance-review`
  - `code-quality-review`
  - `independent-review`
  - `goal-verification`
  - `final-closeout`
- `go run . done --json` completed and archived `harden-execution-auto-mode`

## Notes

The archived change is committed under `artifacts/changes/archived/harden-execution-auto-mode/`. The repository ignore rules intentionally exclude archived `verification/` and `events/` contents from git, matching the existing archive pattern.
