### PR TITLE
refactor: remove verified dead code, retire unwired gate, drop legacy compat

### DIFF
--- a/cmd/abort_test.go
+++ b/cmd/abort_test.go
@@ -19,7 +19,7 @@ func TestAbortRequiresExecuteState(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		_ = createGovernedRequest(t, root, "L2", "abort wrong state")
+		_ = createGovernedRequest(t, root, levelNonDiscovery, "abort wrong state")
 
 		cmd := makeAbortCmd()
 		cmd.SetArgs([]string{"--json"})
@@ -41,7 +41,7 @@ func TestAbortRejectsUnexpectedArgs(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		_ = createGovernedRequest(t, root, "L2", "abort rejects unexpected args")
+		_ = createGovernedRequest(t, root, levelNonDiscovery, "abort rejects unexpected args")
 
 		cmd := makeAbortCmd()
 		cmd.SetArgs([]string{"unexpected"})
@@ -61,7 +61,7 @@ func TestAbortOutsideExecuteDoesNotPreemptTrackedProcesses(t *testing.T) {
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "abort should not preempt outside execute")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "abort should not preempt outside execute")
 
 		cfg := model.DefaultConfig()
 		cfg.Execution.CancelGracePeriodSeconds = 0
@@ -105,7 +105,7 @@ func TestAbortClearsCheckpointAndPreservesActiveChange(t *testing.T) {
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "abort preserve change")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "abort preserve change")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -150,7 +150,7 @@ func TestAbortRepairBranchGuidanceNamesRun(t *testing.T) {
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "abort repair branch names run")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "abort repair branch names run")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS2Implement
@@ -182,7 +182,7 @@ func TestAbortTextUsesRunWhenNoResumableWaveStateExists(t *testing.T) {
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "abort text should suggest fresh run")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "abort text should suggest fresh run")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS2Implement
@@ -206,7 +206,7 @@ func TestAbortTextUsesRunResumeWhenResumableWaveStateExists(t *testing.T) {
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "abort text should suggest resume")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "abort text should suggest resume")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS2Implement

--- a/cmd/auto_mode_test.go
+++ b/cmd/auto_mode_test.go
@@ -608,7 +608,7 @@ func setupAutoModeCheckpoint(t *testing.T, guardrail, checkpointType string, fre
 	root := t.TempDir()
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
-	slug := createGovernedRequest(t, root, "L2", "auto ack entry "+checkpointType+" "+guardrail)
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "auto ack entry "+checkpointType+" "+guardrail)
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = model.StateS2Implement
@@ -1061,7 +1061,7 @@ func TestLightAutoPassEligibilityUnchangedUnderAuto(t *testing.T) {
 		ensureTestGitRepo(t, root)
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "light autopass unchanged under auto")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "light autopass unchanged under auto")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.WorkflowPreset = model.WorkflowPresetLight

--- a/cmd/checkpoint_test.go
+++ b/cmd/checkpoint_test.go
@@ -16,7 +16,7 @@ func TestCheckpointSetsActiveCheckpoint(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "test checkpoint")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "test checkpoint")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -51,7 +51,7 @@ func TestCheckpointDecisionWithAllowedResponses(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "test decision checkpoint")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "test decision checkpoint")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -84,7 +84,7 @@ func TestCheckpointRejectsWrongState(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		_ = createGovernedRequest(t, root, "L2", "test wrong state")
+		_ = createGovernedRequest(t, root, levelNonDiscovery, "test wrong state")
 
 		cmd := makeCheckpointCmd()
 		cmd.SetArgs([]string{"--task-id", "task-01"})
@@ -98,7 +98,7 @@ func TestCheckpointRejectsDuplicate(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "test duplicate checkpoint")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "test duplicate checkpoint")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -122,7 +122,7 @@ func TestCheckpointRequiresTaskID(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "test missing task id")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "test missing task id")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -147,7 +147,7 @@ func TestCheckpointDecisionRequiresAllowedResponses(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "test decision no responses")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "test decision no responses")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -168,7 +168,7 @@ func TestCheckpointRejectsTaskOutsideCurrentWave(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "test checkpoint current wave enforcement")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "test checkpoint current wave enforcement")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -206,7 +206,7 @@ func TestCheckpointRejectsWhenWaveRunsAreMissing(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "checkpoint should fail closed when wave runs are missing")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "checkpoint should fail closed when wave runs are missing")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -292,7 +292,7 @@ func TestCheckpointSettableAtWaveBoundaryBeforeSkillEvidence(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "checkpoint wave boundary")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "checkpoint wave boundary")
 		seedTwoWaveExecution(t, root, slug)
 
 		change, err := state.LoadChange(root, slug)
@@ -350,7 +350,7 @@ func TestCheckpointWaveOneDefaultWithoutTaskEvidence(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "checkpoint wave one default")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "checkpoint wave one default")
 		seedTwoWaveExecution(t, root, slug)
 
 		// wave-2 task rejected: wave 1 is still the current incomplete wave.

--- a/cmd/cli_e2e_test.go
+++ b/cmd/cli_e2e_test.go
@@ -155,7 +155,7 @@ func TestCLIEndToEndRunBlocksOnNextGovernanceSkill(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L3", "run should stop at research orchestration")
+		slug := createGovernedRequest(t, root, levelDiscovery, "run should stop at research orchestration")
 
 		stdout, stderr, err := runRootCommandIn(root, []string{"run", "--json", "--change", slug})
 		require.NoError(t, err)
@@ -179,7 +179,7 @@ func TestCLIEndToEndRunResumeResponseFlow(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "run resume-response e2e")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "run resume-response e2e")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -233,7 +233,7 @@ func TestCLIEndToEndAbortThenRunResumeFlow(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "abort then resume e2e")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "abort then resume e2e")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS2Implement
@@ -316,7 +316,7 @@ func TestCLIEndToEndValidateIncludesRequirementsContract(t *testing.T) {
 	root := t.TempDir()
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "sync e2e positive path")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "sync e2e positive path")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -351,17 +351,17 @@ func TestCLIEndToEndValidateIncludesRequirementsContract(t *testing.T) {
 	})
 }
 
-func TestCLIEndToEndSuccessfulCheckpointAtS5(t *testing.T) {
+func TestCLIEndToEndSuccessfulCheckpointDuringImplementation(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "checkpoint e2e positive path")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "checkpoint e2e positive path")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
-		// Advance to S5_RUN_WAVES.
+		// Advance to S2_IMPLEMENT.
 		change.CurrentState = model.StateS2Implement
 		change.PlanSubStep = model.PlanSubStepNone
 		require.NoError(t, state.SaveChange(root, change))
@@ -398,7 +398,7 @@ func TestCLIEndToEndSuccessfulReviewPassAtS3(t *testing.T) {
 	root := t.TempDir()
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "review e2e positive path")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "review e2e positive path")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -447,7 +447,7 @@ func TestCLIEndToEndSuccessfulDoneArchive(t *testing.T) {
 	root := t.TempDir()
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "done e2e positive path")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "done e2e positive path")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -498,7 +498,7 @@ func TestCLIEndToEndValidateRequirementsContractAfterRequestNext(t *testing.T) {
 		initTestWorkspace(t, root)
 
 		// Create governed change via helper (request + scaffold + advance to S1).
-		slug := createGovernedRequest(t, root, "L2", "implement token rotation")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "implement token rotation")
 
 		// Write requirements in the change bundle (flat).
 		change, err := state.LoadChange(root, slug)

--- a/cmd/codebase_map_context_test.go
+++ b/cmd/codebase_map_context_test.go
@@ -46,7 +46,7 @@ func TestNextSurfacesScaffoldCodebaseMapStatusOnBothSurfaces(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {
 		require.NoError(t, bootstrap.InitWorkspace(root, []string{"codex"}, false))
-		slug := createGovernedRequest(t, root, "L2", "surface scaffold codebase map status")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "surface scaffold codebase map status")
 		writeScaffoldCodebaseMapDocs(t, root)
 
 		// Standard next view (diagnostics) carries the freshness status field.
@@ -71,7 +71,7 @@ func TestNextReportsMissingCodebaseMapStatusNotOmitted(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {
 		require.NoError(t, bootstrap.InitWorkspace(root, []string{"codex"}, false))
-		createGovernedRequest(t, root, "L2", "missing codebase map status")
+		createGovernedRequest(t, root, levelNonDiscovery, "missing codebase map status")
 		require.NoError(t, os.RemoveAll(state.CodebaseMapDir(root)))
 
 		// No map present: the field must report the valid "missing" assessment
@@ -94,7 +94,7 @@ func TestNextIncludesDurableCodebaseMapPathsForGovernedRequests(t *testing.T) {
 	withWorkspace(t, root, func() {
 		require.NoError(t, bootstrap.InitWorkspace(root, []string{"codex"}, false))
 
-		slug := createGovernedRequest(t, root, "L2", "durable codebase mapping paths")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "durable codebase mapping paths")
 
 		var out bytes.Buffer
 		cmd := makeNextCmd()
@@ -235,7 +235,7 @@ func TestBuildNextContextLeavesGateStatusToReadinessEvaluation(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "gate status warning on malformed verification")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "gate status warning on malformed verification")
 	verificationPath := state.VerificationFilePath(root, slug, "plan-audit")
 	require.NoError(t, os.MkdirAll(filepath.Dir(verificationPath), 0o755))
 	require.NoError(t, os.WriteFile(verificationPath, []byte("verdict: ["), 0o644))
@@ -254,7 +254,7 @@ func TestNextUsesWorktreeScopedCodebaseMapPathsForDedicatedWorktree(t *testing.T
 		initTestWorkspace(t, root)
 		initGitRepoForWorktreeTests(t, root)
 
-		slug := createGovernedRequest(t, root, "L3", "worktree-scoped codebase map in worktree")
+		slug := createGovernedRequest(t, root, levelDiscovery, "worktree-scoped codebase map in worktree")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -83,7 +83,7 @@ func TestResolveExplicitChangeRejectsInactiveSlug(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "inactive explicit request")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "inactive explicit request")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.Status = model.ChangeStatusCancelled
@@ -142,7 +142,7 @@ func TestResolveExplicitChangeRejectsArchivedSlugWithConcreteDiagnostic(t *testi
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "archived explicit request")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "archived explicit request")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	_, err = state.ArchiveChange(root, change, model.ChangeStatusDone)
@@ -167,7 +167,7 @@ func TestValidateChangeFlagRejectsArchivedSlugWithConcreteDiagnostic(t *testing.
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "validate archived explicit request")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "validate archived explicit request")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	_, err = state.ArchiveChange(root, change, model.ChangeStatusDone)
@@ -194,7 +194,7 @@ func TestResolveExplicitChangeSurfacesCorruptState(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "corrupt explicit governed request")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "corrupt explicit governed request")
 	require.NoError(t, os.WriteFile(
 		state.BundleChangeFilePath(root, slug),
 		[]byte("slug: ["),
@@ -214,7 +214,7 @@ func TestLoadActiveChangeRejectsInactiveStatus(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "inactive change helper")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "inactive change helper")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.Status = model.ChangeStatusDone
@@ -239,7 +239,7 @@ func TestLoadActiveChangeSurfacesCorruptStateIntegrity(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "corrupt change helper")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "corrupt change helper")
 	require.NoError(t, os.WriteFile(
 		state.BundleChangeFilePath(root, slug),
 		[]byte("slug: ["),
@@ -264,7 +264,7 @@ func TestLoadExecutionContextWrapsCorruptExecutionSummaryIntegrity(t *testing.T)
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "corrupt execution summary helper")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "corrupt execution summary helper")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 
@@ -359,7 +359,7 @@ func TestLoadExecutionContextUsesAuthoritativeWorktreeSummaryForHiddenBoundChang
 		runGit(t, root, "commit", "-m", "init")
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L3", "hidden worktree summary path should stay authoritative")
+		slug := createGovernedRequest(t, root, levelDiscovery, "hidden worktree summary path should stay authoritative")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS2Implement
@@ -404,7 +404,7 @@ func TestProjectFreshnessIgnoresDerivedTaskCheckboxSync(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "freshness should ignore derived task checkbox sync")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "freshness should ignore derived task checkbox sync")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = model.StateS2Implement
@@ -469,7 +469,7 @@ func TestProjectFreshnessTracksTasksPlanHash(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "freshness tracks tasks plan hash")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "freshness tracks tasks plan hash")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = model.StateS2Implement
@@ -556,7 +556,7 @@ func TestProjectFreshnessFailsClosedWhenFreshnessArtifactIsUnreadable(t *testing
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "freshness fails closed on unreadable artifact")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "freshness fails closed on unreadable artifact")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = model.StateS2Implement
@@ -631,7 +631,7 @@ func TestStatusCommandFromBoundWorktreeUsesBoundScopeConfigCopy(t *testing.T) {
 		runGit(t, root, "commit", "-m", "init")
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L3", "bound worktree should read main-scope config")
+		slug := createGovernedRequest(t, root, levelDiscovery, "bound worktree should read main-scope config")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS2Implement
@@ -694,7 +694,7 @@ func TestResolveActiveChangeRefFromNestedBoundWorktreeCWD(t *testing.T) {
 		runGit(t, root, "commit", "-m", "init")
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L3", "nested bound worktree active change resolution")
+		slug := createGovernedRequest(t, root, levelDiscovery, "nested bound worktree active change resolution")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS2Implement

--- a/cmd/error_contract_test.go
+++ b/cmd/error_contract_test.go
@@ -73,7 +73,7 @@ func TestExecuteFailureEnvelopeStateIntegrityForMalformedGovernanceSkill(t *test
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "review malformed governance skill")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "review malformed governance skill")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS3Review
@@ -105,7 +105,7 @@ func assertMalformedGovernanceSkillCommandFailsStateIntegrity(t *testing.T, comm
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", description)
+		slug := createGovernedRequest(t, root, levelNonDiscovery, description)
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS3Review

--- a/cmd/evidence_skill_test.go
+++ b/cmd/evidence_skill_test.go
@@ -21,7 +21,7 @@ func TestEvidenceSkillRecordsPlanAuditVerification(t *testing.T) {
 	root := t.TempDir()
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "evidence skill records plan audit")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "evidence skill records plan audit")
 		change := setEvidenceSkillChangeState(t, root, slug, model.StateS1Plan, model.PlanSubStepAudit)
 
 		notesRel := filepath.ToSlash(filepath.Join("artifacts", "changes", slug, "verification", "plan-audit-notes.md"))
@@ -89,7 +89,7 @@ func TestEvidenceSkillAllowsStaleResearchRestampFromAuditSubstep(t *testing.T) {
 	root := t.TempDir()
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L3", "evidence skill restamps stale research")
+		slug := createGovernedRequest(t, root, levelDiscovery, "evidence skill restamps stale research")
 		change := setEvidenceSkillChangeState(t, root, slug, model.StateS1Plan, model.PlanSubStepAudit)
 		writeMinimalGovernedBundle(t, root, change)
 		writeSkillVerification(t, root, slug, progression.SkillResearchOrchestration, model.VerificationRecord{
@@ -157,7 +157,7 @@ func TestEvidenceSkillRejectsNonStaleResearchRestampFromAuditSubstep(t *testing.
 	root := t.TempDir()
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L3", "evidence skill rejects non-stale research restamp")
+		slug := createGovernedRequest(t, root, levelDiscovery, "evidence skill rejects non-stale research restamp")
 		change := setEvidenceSkillChangeState(t, root, slug, model.StateS1Plan, model.PlanSubStepAudit)
 		writeMinimalGovernedBundle(t, root, change)
 		writeSkillVerification(t, root, slug, progression.SkillResearchOrchestration, model.VerificationRecord{
@@ -197,7 +197,7 @@ func TestEvidenceSkillNotesFileUsesBoundWorktreeWorkspace(t *testing.T) {
 		runGit(t, root, "commit", "-m", "init")
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "evidence skill bound notes file")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "evidence skill bound notes file")
 		change := setEvidenceSkillChangeState(t, root, slug, model.StateS1Plan, model.PlanSubStepAudit)
 
 		worktreeRoot := filepath.Join(t.TempDir(), slug)
@@ -248,7 +248,7 @@ func TestEvidenceSkillFailOverwritesPlanAuditAndPrunesDigest(t *testing.T) {
 	root := t.TempDir()
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "evidence skill fail prunes digest")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "evidence skill fail prunes digest")
 		change := setEvidenceSkillChangeState(t, root, slug, model.StateS1Plan, model.PlanSubStepAudit)
 
 		passCmd := commandForRoot(t, root, makeEvidenceCmd())
@@ -293,7 +293,7 @@ func TestEvidenceSkillRecordsSelectedReviewPeerWithoutSpecPredecessor(t *testing
 	root := t.TempDir()
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "evidence skill records unordered review peer")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "evidence skill records unordered review peer")
 		setEvidenceSkillChangeState(t, root, slug, model.StateS3Review, model.PlanSubStepNone)
 		writePassingExecutionSummary(t, root, slug, 1, "t-01")
 
@@ -334,7 +334,7 @@ func TestEvidenceSkillAllowsSelectedReviewerRestampForInvalidContextOrigin(t *te
 	root := t.TempDir()
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "evidence skill restamps invalid review origin")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "evidence skill restamps invalid review origin")
 		setEvidenceSkillChangeState(t, root, slug, model.StateS3Review, model.PlanSubStepNone)
 		writePassingExecutionSummary(t, root, slug, 1, "t-01")
 		writePassingReviewEvidencePack(t, root, slug, 1)
@@ -386,7 +386,7 @@ func TestEvidenceSkillRejectsSelectedReviewerRestampWithValidContextOrigin(t *te
 	root := t.TempDir()
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "evidence skill rejects valid review origin overwrite")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "evidence skill rejects valid review origin overwrite")
 		setEvidenceSkillChangeState(t, root, slug, model.StateS3Review, model.PlanSubStepNone)
 		writePassingExecutionSummary(t, root, slug, 1, "t-01")
 		writePassingReviewEvidencePack(t, root, slug, 1)
@@ -422,7 +422,7 @@ func TestEvidenceSkillRejectsUnselectedSecurityReview(t *testing.T) {
 	root := t.TempDir()
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "evidence skill rejects unselected security")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "evidence skill rejects unselected security")
 		setEvidenceSkillChangeState(t, root, slug, model.StateS3Review, model.PlanSubStepNone)
 		writePassingExecutionSummary(t, root, slug, 1, "t-01")
 
@@ -452,7 +452,7 @@ func TestEvidenceSkillRejectsFinalCloseoutBeforeGoalVerification(t *testing.T) {
 	root := t.TempDir()
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "evidence skill rejects closeout ordering")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "evidence skill rejects closeout ordering")
 		setEvidenceSkillChangeState(t, root, slug, model.StateS3Review, model.PlanSubStepNone)
 		writePassingExecutionSummary(t, root, slug, 1, "t-01")
 		writePassingWaveEvidence(t, root, slug, 1)
@@ -486,7 +486,7 @@ func TestEvidenceSkillRejectsRunSummaryBoundWithoutExecutionSummary(t *testing.T
 	root := t.TempDir()
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "evidence skill requires execution summary")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "evidence skill requires execution summary")
 		setEvidenceSkillChangeState(t, root, slug, model.StateS3Review, model.PlanSubStepNone)
 
 		cmd := commandForRoot(t, root, makeEvidenceCmd())
@@ -584,7 +584,7 @@ func TestEvidenceSkillRejectsWrongState(t *testing.T) {
 	root := t.TempDir()
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "evidence skill wrong state")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "evidence skill wrong state")
 		setEvidenceSkillChangeState(t, root, slug, model.StateS1Plan, model.PlanSubStepAudit)
 
 		cmd := commandForRoot(t, root, makeEvidenceCmd())
@@ -609,7 +609,7 @@ func TestEvidenceSkillWrongStateForWaveOrchestrationInS3RoutesToReviewAndVerific
 	root := t.TempDir()
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "evidence skill wave wrong state in review")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "evidence skill wave wrong state in review")
 		setEvidenceSkillChangeState(t, root, slug, model.StateS3Review, model.PlanSubStepNone)
 
 		cmd := commandForRoot(t, root, makeEvidenceCmd())
@@ -636,7 +636,7 @@ func TestEvidenceSkillWrongStateForWaveEvidenceInS3RoutesToCloseoutEvidence(t *t
 	root := t.TempDir()
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "evidence skill wave wrong state in review")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "evidence skill wave wrong state in review")
 		setEvidenceSkillChangeState(t, root, slug, model.StateS3Review, model.PlanSubStepNone)
 
 		cmd := commandForRoot(t, root, makeEvidenceCmd())
@@ -660,7 +660,7 @@ func TestEvidenceSkillRejectsNotesConflict(t *testing.T) {
 	root := t.TempDir()
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "evidence skill notes conflict")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "evidence skill notes conflict")
 		setEvidenceSkillChangeState(t, root, slug, model.StateS1Plan, model.PlanSubStepAudit)
 
 		notesPath := filepath.Join(root, "notes.md")

--- a/cmd/evidence_task_test.go
+++ b/cmd/evidence_task_test.go
@@ -177,7 +177,7 @@ func TestEvidenceSkillRejectsRunSummaryBoundSkillWithoutExecutionSummary(t *test
 	root := t.TempDir()
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "skill evidence command")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "skill evidence command")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS3Review
@@ -477,7 +477,7 @@ func TestEvidenceTaskRejectsNonWorkspaceRelativePathsWithoutWritingEvidence(t *t
 func createEvidenceTaskFixture(t *testing.T, root string) (string, model.Change) {
 	t.Helper()
 
-	slug := createGovernedRequest(t, root, "L2", "evidence task command")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "evidence task command")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = model.StateS2Implement

--- a/cmd/fix_test.go
+++ b/cmd/fix_test.go
@@ -19,7 +19,7 @@ func TestFixJSONSurfacesReviewFindingRepairContract(t *testing.T) {
 	root := t.TempDir()
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "fix should surface review findings")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "fix should surface review findings")
 
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
@@ -62,7 +62,7 @@ func TestFixRejectsNonReviewState(t *testing.T) {
 	root := t.TempDir()
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "fix should reject non review state")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "fix should reject non review state")
 
 		cmd := commandForRoot(t, root, makeFixCmd())
 		cmd.SetArgs([]string{"--json", "--change", slug})

--- a/cmd/governance_gate_consistency_test.go
+++ b/cmd/governance_gate_consistency_test.go
@@ -23,7 +23,7 @@ func TestGateStatusUsesPlanningEvidenceAcrossStatusValidateAndNext(t *testing.T)
 	initTestWorkspace(t, root)
 	initGitRepoForWorktreeTests(t, root)
 
-	slug := createGovernedRequest(t, root, "L3", "gate status should stay stable outside planning")
+	slug := createGovernedRequest(t, root, levelDiscovery, "gate status should stay stable outside planning")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	worktreeRoot := filepath.Join(t.TempDir(), change.Slug)
@@ -133,7 +133,7 @@ func TestExecutionEvidenceBlockersStayConsistentAcrossStatusValidateAndNext(t *t
 		ensureTestGitRepo(t, root)
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "execution summary blockers should stay aligned")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "execution summary blockers should stay aligned")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS3Review
@@ -174,7 +174,7 @@ func TestExecutionEvidenceBlockersStayConsistentAcrossStatusValidateAndNext(t *t
 		ensureTestGitRepo(t, root)
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "stale execution evidence should stay aligned")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "stale execution evidence should stay aligned")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS3Review
@@ -207,7 +207,7 @@ func TestMissingReviewEvidenceBlockersIncludeSelectedReviewSetAcrossStatusValida
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "missing selected review evidence should stay aligned")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "missing selected review evidence should stay aligned")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = model.StateS3Review
@@ -244,7 +244,7 @@ func TestReviewLayerBlockersStayConsistentAcrossStatusValidateNextAndReview(t *t
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "review layer blockers should stay aligned")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "review layer blockers should stay aligned")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = model.StateS3Review
@@ -290,7 +290,7 @@ func TestSatisfiedDomainReviewAttributionStaysConsistentAcrossStatusValidateAndN
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "domain review attribution should stay aligned")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "domain review attribution should stay aligned")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = model.StateS3Review
@@ -323,7 +323,7 @@ func TestDoneShipGateReasonsStayConsistentWithSharedReadiness(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "done should reuse shared ship gate result")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "done should reuse shared ship gate result")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = model.StateS3Review
@@ -360,7 +360,7 @@ func TestShipOnlyBlockersStayConsistentAcrossStatusValidateAndNext(t *testing.T)
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "ship-only blockers should stay aligned")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "ship-only blockers should stay aligned")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = model.StateS3Review
@@ -402,7 +402,7 @@ func TestMissingArtifactBlockerStaysConsistentAcrossStatusValidateAndNextWithout
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "missing artifacts should block every read surface")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "missing artifacts should block every read surface")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = model.StateS1Plan
@@ -439,7 +439,7 @@ func TestWorktreeBindingBlockerStaysConsistentAcrossStatusValidateAndNext(t *tes
 	initTestWorkspace(t, root)
 	initGitRepoForWorktreeTests(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "invalid worktree binding should stay aligned")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "invalid worktree binding should stay aligned")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = model.StateS1Plan
@@ -469,7 +469,7 @@ func TestNextIncludesGovernanceActionBlockersFromReadiness(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "next should surface governance blockers")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "next should surface governance blockers")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = model.StateS3Review
@@ -488,7 +488,7 @@ func TestGovernanceSurfaceUsesReadinessSnapshotWithinInvocation(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "governance surface should reuse computed readiness snapshot")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "governance surface should reuse computed readiness snapshot")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = model.StateS1Plan

--- a/cmd/governance_readiness_error_test.go
+++ b/cmd/governance_readiness_error_test.go
@@ -20,7 +20,7 @@ func TestStatsDoesNotMislabelMalformedVerificationAsExecutionSummaryFailure(t *t
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "stats should classify readiness failures correctly")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "stats should classify readiness failures correctly")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = model.StateS3Review
@@ -46,7 +46,7 @@ func TestNextReadinessFailureUsesGovernanceReadinessEnvelope(t *testing.T) {
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "next should classify readiness failures correctly")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "next should classify readiness failures correctly")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS3Review
@@ -80,7 +80,7 @@ func TestNextReadinessFailureEnvelopeJSON(t *testing.T) {
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "next JSON envelope should classify readiness failures correctly")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "next JSON envelope should classify readiness failures correctly")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS3Review
@@ -109,7 +109,7 @@ func TestStatusReadinessFailureUsesGovernanceReadinessEnvelope(t *testing.T) {
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "status should classify readiness failures correctly")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "status should classify readiness failures correctly")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS3Review
@@ -141,7 +141,7 @@ func TestValidateReadinessFailureUsesGovernanceReadinessEnvelope(t *testing.T) {
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "validate should classify readiness failures correctly")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "validate should classify readiness failures correctly")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS3Review
@@ -173,7 +173,7 @@ func TestReviewReadinessFailureUsesGovernanceReadinessEnvelope(t *testing.T) {
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "review should classify readiness failures correctly")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "review should classify readiness failures correctly")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS3Review
@@ -208,7 +208,7 @@ func TestNextDiagnosticsProjectionFailureUsesGovernanceReadinessEnvelope(t *test
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "next should classify projection failures consistently")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "next should classify projection failures consistently")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS1Plan
@@ -243,7 +243,7 @@ func TestNextReadinessFailureDoesNotConsumeActiveCheckpoint(t *testing.T) {
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "next should not consume checkpoint on readiness failure")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "next should not consume checkpoint on readiness failure")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS1Plan

--- a/cmd/health_test.go
+++ b/cmd/health_test.go
@@ -152,7 +152,7 @@ func TestHealthCommandDoctorOutputsPrioritizedRepairActions(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "doctor should surface wave repair")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "doctor should surface wave repair")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS2Implement
@@ -225,7 +225,7 @@ func TestHealthCommandDoctorDoesNotSuggestResumeBeforeWaveRunsExist(t *testing.T
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "doctor should wait for wave runs before resume")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "doctor should wait for wave runs before resume")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS2Implement
@@ -281,7 +281,7 @@ func TestHealthCommandDoctorDoesNotSuggestResumeWhenWavePlanIsMissingBeforeExecu
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "doctor should not suggest resume before pre-summary wave plan repair")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "doctor should not suggest resume before pre-summary wave plan repair")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS2Implement
@@ -348,7 +348,7 @@ func TestHealthCommandDoctorExplainsInterruptedExecution(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "doctor should explain interrupted execution")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "doctor should explain interrupted execution")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS2Implement
@@ -403,7 +403,7 @@ func TestHealthCommandDoctorIgnoresMissingPersistedWavePlanDuringS2(t *testing.T
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "doctor should ignore missing persisted wave cache")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "doctor should ignore missing persisted wave cache")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS2Implement
@@ -461,7 +461,7 @@ func TestHealthCommandMarksUnreadableExecutionSummaryRepairableWhenWaveEvidenceE
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "health should promote repairable execution summary finding")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "health should promote repairable execution summary finding")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS2Implement
@@ -503,7 +503,7 @@ func TestHealthCommandDoctorIgnoresPersistedWavePlanDriftDuringS2(t *testing.T) 
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "doctor should ignore stale persisted wave cache")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "doctor should ignore stale persisted wave cache")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS2Implement
@@ -748,7 +748,7 @@ func TestHealthCommandDoesNotReportToolResolutionFailureForMultiAdapterWorkspace
 	withCommandWorkspace(t, root, func() {
 		require.NoError(t, bootstrap.InitWorkspace(root, []string{"codex", "claude"}, false))
 
-		slug := createGovernedRequest(t, root, "L2", "health should stay query-only in multi-adapter workspace")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "health should stay query-only in multi-adapter workspace")
 
 		var out bytes.Buffer
 		cmd := commandForRoot(t, root, makeHealthCmd())
@@ -838,7 +838,7 @@ func TestHealthCommandDoctorIncludesGovernanceFailuresWithoutExtraFlags(t *testi
 		initTestWorkspace(t, root)
 		initGitRepoForWorktreeTests(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "doctor should include governance failures")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "doctor should include governance failures")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS1Plan
@@ -891,7 +891,7 @@ func TestHealthCommandObservationsFlagIncludesSignalProvenance(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "health observations")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "health observations")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.GuardrailDomain = "auth_authz"
@@ -924,7 +924,7 @@ func TestHealthCommandGovernanceReportsUnreadableSnapshotInsteadOfFailing(t *tes
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "health unreadable snapshot")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "health unreadable snapshot")
 		snapshotPath := governance.SnapshotPath(root, slug)
 		require.NoError(t, os.MkdirAll(filepath.Dir(snapshotPath), 0o755))
 		require.NoError(t, os.WriteFile(
@@ -968,7 +968,7 @@ func TestHealthCommandDoctorSurfacesGaplessTraceabilityWarning(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "health doctor gapless traceability")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "health doctor gapless traceability")
 		snapshotPath := governance.SnapshotPath(root, slug)
 		require.NoError(t, os.MkdirAll(filepath.Dir(snapshotPath), 0o755))
 		require.NoError(t, os.WriteFile(snapshotPath, []byte("version: ["), 0o644))
@@ -1011,7 +1011,7 @@ func TestHealthCommandGovernanceObservationsStillRenderWhenSnapshotUnreadable(t 
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "health unreadable snapshot observations")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "health unreadable snapshot observations")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.GuardrailDomain = "auth_authz"
@@ -1047,7 +1047,7 @@ func TestHealthCommandGovernanceSkipsRecomputeWhenBoundWorktreeInvalid(t *testin
 		initTestWorkspace(t, root)
 		initGitRepoForWorktreeTests(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "health invalid bound worktree")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "health invalid bound worktree")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS1Plan
@@ -1108,7 +1108,7 @@ func TestHealthCommandGovernanceRecomputesCurrentArtifacts(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "health live recompute")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "health live recompute")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS1Plan
@@ -1219,7 +1219,7 @@ func TestHealthCommandGovernanceRecomputeDropsResolvedClarificationControl(t *te
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "health resolved clarification")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "health resolved clarification")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS1Plan
@@ -1307,7 +1307,7 @@ func TestHealthCommandGovernancePreservesPersistedFreshnessSignal(t *testing.T) 
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "health stale persisted snapshot")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "health stale persisted snapshot")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS1Plan
@@ -1408,7 +1408,7 @@ func TestHealthCommandGovernanceUsesFreshnessFromRecomputedSnapshotWhenMaterialS
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "health refreshed snapshot")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "health refreshed snapshot")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS1Plan
@@ -1517,7 +1517,7 @@ func TestHealthCommandGovernanceBlocksOnStateLock(t *testing.T) {
 		cfg.Execution.LockWaitTimeoutSeconds = 1
 		require.NoError(t, model.SaveConfig(state.ConfigPath(root), cfg))
 
-		slug := createGovernedRequest(t, root, "L2", "health lock")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "health lock")
 		lockPath := state.ChangeStateLockPath(root, slug)
 		stopLockHolder := startStateLockHolder(t, lockPath)
 		defer stopLockHolder()
@@ -1773,7 +1773,7 @@ REQ-001: verified via tests
 			withCommandWorkspace(t, root, func() {
 				initTestWorkspace(t, root)
 
-				slug := createGovernedRequest(t, root, "L2", "assurance stage-aware doctor")
+				slug := createGovernedRequest(t, root, levelNonDiscovery, "assurance stage-aware doctor")
 				change, err := state.LoadChange(root, slug)
 				require.NoError(t, err)
 				change.CurrentState = tc.state

--- a/cmd/instructions_test.go
+++ b/cmd/instructions_test.go
@@ -233,7 +233,7 @@ func TestInstructionsChangeAwareAuthoringPayload(t *testing.T) {
 	root := t.TempDir()
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "instructions change-aware payload")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "instructions change-aware payload")
 
 		// Exercise both done-status branches. decision.md depends on intent.md
 		// and requirements.md in the expanded schema. Author intent.md (present →
@@ -278,7 +278,7 @@ func TestInstructionsDependencyDoneRequiresValidUpstreamArtifact(t *testing.T) {
 	root := t.TempDir()
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "instructions dependency validity")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "instructions dependency validity")
 
 		bundlePath := filepath.Join(root, "artifacts", "changes", slug)
 		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "intent.md",

--- a/cmd/lifecycle_commands_test.go
+++ b/cmd/lifecycle_commands_test.go
@@ -30,7 +30,7 @@ func TestDoneArchivesGovernedExecution(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "refactor service modules")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "refactor service modules")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		markChangeReadyForDone(t, root, &change)
@@ -54,7 +54,7 @@ func TestDoneArchivesGovernedAsTerminalDoneState(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "archive terminal governed state")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "archive terminal governed state")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		markChangeReadyForDone(t, root, &change)
@@ -379,7 +379,7 @@ func TestDoneReportsAndPersistsRemediationSources(t *testing.T) {
 		_, err := state.ArchiveChange(root, source, model.ChangeStatusDone)
 		require.NoError(t, err)
 
-		slug := createGovernedRequest(t, root, "L2", "fix archived workflow feedback")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "fix archived workflow feedback")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		markChangeReadyForDone(t, root, &change)
@@ -426,7 +426,7 @@ func TestDoneRemediationSourceScanDoesNotFollowBundleSymlink(t *testing.T) {
 		_, err := state.ArchiveChange(root, source, model.ChangeStatusDone)
 		require.NoError(t, err)
 
-		slug := createGovernedRequest(t, root, "L2", "fix archived workflow feedback")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "fix archived workflow feedback")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		markChangeReadyForDone(t, root, &change)
@@ -462,7 +462,7 @@ func TestDoneGovernedEmptyAssuranceReturnsInvalid(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "refactor service modules")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "refactor service modules")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		markChangeReadyForDone(t, root, &change)
@@ -486,7 +486,7 @@ func TestDoneGovernedValidAssuranceSucceeds(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "refactor service modules")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "refactor service modules")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		markChangeReadyForDone(t, root, &change)
@@ -533,7 +533,7 @@ func TestDoneQuickFullRevalidatesShipGateBeforeArchive(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "quick full closeout must be fresh")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "quick full closeout must be fresh")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.QualityMode = model.QualityModeFull
@@ -565,7 +565,7 @@ func TestDoneShipGateBlockedSurfacesStaleEvidenceRepair(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "done surfaces stale repair")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "done surfaces stale repair")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		markChangeReadyForDone(t, root, &change)
@@ -602,7 +602,7 @@ func TestDoneRequiresReviewEvidenceBeforeArchive(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "review evidence must be fresh")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "review evidence must be fresh")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS3Review
@@ -637,7 +637,7 @@ func TestDoneRejectsReviewLayerBlockersBeforeArchive(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "review layer blockers must stop done")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "review layer blockers must stop done")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		markChangeReadyForDone(t, root, &change)
@@ -681,7 +681,7 @@ func TestDoneRejectsExecutionSummaryLevelBlockersBeforeArchive(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "summary blockers must stop done")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "summary blockers must stop done")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		markChangeReadyForDone(t, root, &change)
@@ -719,7 +719,7 @@ func TestDoneRejectsChecklistBlockersBeforeArchive(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "tasks checklist blockers must stop done")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "tasks checklist blockers must stop done")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		markChangeReadyForDone(t, root, &change)
@@ -751,7 +751,7 @@ func TestDoneRejectsPlanAuditChanges(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "plan audit change")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "plan audit change")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS1Plan
@@ -996,7 +996,7 @@ func TestCancelArchivesGovernedExecutionWithCancelledStatus(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "refactor service modules")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "refactor service modules")
 
 		cancelCmd := commandForRoot(t, root, makeCancelCmd())
 		require.NoError(t, cancelCmd.Execute())
@@ -1520,7 +1520,7 @@ func TestChangeYamlStableAfterSave(t *testing.T) {
 	root := t.TempDir()
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "refactor service modules")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "refactor service modules")
 
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
@@ -1572,7 +1572,7 @@ func TestArchiveMovesChangeDirAndArtifacts(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "archive migration test")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "archive migration test")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -1643,14 +1643,25 @@ func createGovernedChangeFixture(t *testing.T, root, description string, mutate 
 // createGovernedRequest creates and routes a governed (L2/L3) request.
 // Returns the slug. The change exists in artifacts/changes/<slug>/change.yaml after routing.
 // The change is advanced to S1_PLAN to simulate having passed intake.
-func createGovernedRequest(t *testing.T, root, level, description string) string {
+// governedRequestLevel selects the discovery posture of a governed fixture
+// created by createGovernedRequest.
+type governedRequestLevel string
+
+const (
+	// levelNonDiscovery is a non-discovery governed request.
+	levelNonDiscovery governedRequestLevel = "non-discovery"
+	// levelDiscovery is a discovery-scoped governed request.
+	levelDiscovery governedRequestLevel = "discovery"
+)
+
+func createGovernedRequest(t *testing.T, root string, level governedRequestLevel, description string) string {
 	t.Helper()
 	return createGovernedChangeFixture(t, root, description, func(change *model.Change) {
 		// Advance past S0 intake to S1_PLAN (simulating intake completion).
 		change.CurrentState = model.StateS1Plan
 		change.IntakeSubStep = ""
 		change.PlanSubStep = model.PlanSubStepResearch
-		change.NeedsDiscovery = level == "L3"
+		change.NeedsDiscovery = level == levelDiscovery
 	})
 }
 

--- a/cmd/new_test.go
+++ b/cmd/new_test.go
@@ -1322,7 +1322,7 @@ func TestNewCommandAllowsBoundSiblingWorktreeActiveChange(t *testing.T) {
 		runGit(t, root, "add", ".")
 		runGit(t, root, "commit", "-m", "init")
 
-		slug := createGovernedRequest(t, root, "L3", "existing hidden bound worktree change")
+		slug := createGovernedRequest(t, root, levelDiscovery, "existing hidden bound worktree change")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS2Implement
@@ -1369,7 +1369,7 @@ func TestNewCommandRejectsWhenActiveChangeIsBoundToCurrentWorktree(t *testing.T)
 		runGit(t, root, "add", ".")
 		runGit(t, root, "commit", "-m", "init")
 
-		slug := createGovernedRequest(t, root, "L3", "existing current bound worktree change")
+		slug := createGovernedRequest(t, root, levelDiscovery, "existing current bound worktree change")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS2Implement

--- a/cmd/next.go
+++ b/cmd/next.go
@@ -510,7 +510,7 @@ func buildNextViewForCommand(root string, ref changeRef, opts nextViewOptions) (
 
 	// Attach wave plan when at S2_IMPLEMENT for governed changes.
 	if view.CurrentState == model.StateS2Implement && governedChange != nil {
-		view.InputContext.WavePlan = buildWavePlan(root, governedChange, view.InputContext.ArtifactBundle)
+		view.InputContext.WavePlan = buildWavePlan(root, view.InputContext.ArtifactBundle)
 	}
 
 	if view.CurrentState == model.StateDone {

--- a/cmd/next_context_budget.go
+++ b/cmd/next_context_budget.go
@@ -79,9 +79,19 @@ func estimateContextBudget(root string, skill *nextSkillView, inputContext nextC
 	}
 
 	assumedContextWindow := defaultContextWindowTokens
-	if raw := strings.TrimSpace(os.Getenv("SPECLANE_CONTEXT_WINDOW_TOKENS")); raw != "" {
+	// Honor the first VALID override in priority order (SLIPWAY_ before the legacy
+	// SPECLANE_). A malformed or non-positive higher-priority value must not mask a
+	// valid lower-priority value or silently revert the guard to the default
+	// window, so only a successful parse stops the scan; anything else falls
+	// through. Mirrors contextPressureWindowTokens.
+	for _, key := range []string{"SLIPWAY_CONTEXT_WINDOW_TOKENS", "SPECLANE_CONTEXT_WINDOW_TOKENS"} {
+		raw := strings.TrimSpace(os.Getenv(key))
+		if raw == "" {
+			continue
+		}
 		if parsed, err := strconv.Atoi(raw); err == nil && parsed > 0 {
 			assumedContextWindow = parsed
+			break
 		}
 	}
 	utilization := (float64(total) / float64(assumedContextWindow)) * 100

--- a/cmd/next_context_budget_test.go
+++ b/cmd/next_context_budget_test.go
@@ -26,3 +26,43 @@ func TestEstimateContextBudgetFallsBackWhenMarshalFails(t *testing.T) {
 		t.Fatal("expected non-zero state context from fallback serialization")
 	}
 }
+
+// estimateContextBudget must honor the first VALID context-window override in
+// priority order. A malformed or non-positive higher-priority alias
+// (SLIPWAY_CONTEXT_WINDOW_TOKENS) must NOT mask a valid lower-priority alias
+// (SPECLANE_CONTEXT_WINDOW_TOKENS) or silently revert to the default window —
+// that would weaken the context hard-stop guard. Regression for the alias loop
+// that short-circuited on the first non-empty value regardless of validity.
+func TestEstimateContextBudgetEnvWindowPrecedence(t *testing.T) {
+	const defaultWindow = 200000
+	skill := &nextSkillView{Name: "plan-audit"}
+	ctx := nextContext{WorkspaceRoot: "/tmp/workspace", ArtifactBundle: "artifacts/changes/demo"}
+
+	cases := []struct {
+		name     string
+		slipway  string
+		speclane string
+		want     int
+	}{
+		{"valid new alias wins over legacy", "300000", "1", 300000},
+		{"invalid new alias must not mask valid legacy alias", "bad", "1", 1},
+		{"non-positive new alias falls through to legacy", "0", "1", 1},
+		{"legacy alias honored when new alias unset", "", "1", 1},
+		{"both invalid falls back to default", "bad", "nope", defaultWindow},
+		{"neither set falls back to default", "", "", defaultWindow},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("SLIPWAY_CONTEXT_WINDOW_TOKENS", tc.slipway)
+			t.Setenv("SPECLANE_CONTEXT_WINDOW_TOKENS", tc.speclane)
+
+			budget := estimateContextBudget(t.TempDir(), skill, ctx)
+			if budget == nil {
+				t.Fatal("expected a context budget")
+			}
+			if budget.AssumedContextWindow != tc.want {
+				t.Fatalf("AssumedContextWindow = %d, want %d", budget.AssumedContextWindow, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/next_eval_fixture_test.go
+++ b/cmd/next_eval_fixture_test.go
@@ -31,7 +31,7 @@ func TestGovernedAgentEvalFixtures(t *testing.T) {
 		{
 			name: "plan audit missing evidence surfaces deterministic next skill and gate blockers",
 			setup: func(t *testing.T, root string) string {
-				slug := createGovernedRequest(t, root, "L2", "eval fixture plan audit missing")
+				slug := createGovernedRequest(t, root, levelNonDiscovery, "eval fixture plan audit missing")
 				change, err := state.LoadChange(root, slug)
 				require.NoError(t, err)
 				change.PlanSubStep = model.PlanSubStepAudit

--- a/cmd/next_handoff.go
+++ b/cmd/next_handoff.go
@@ -133,7 +133,7 @@ func buildNextHandoffSourceView(root string, ref changeRef, resumeResponse strin
 		view.planLocked = planLockedFromGates(readiness)
 	}
 	if view.CurrentState == model.StateS2Implement && governedChange != nil {
-		view.InputContext.WavePlan = buildWavePlan(root, governedChange, view.InputContext.ArtifactBundle)
+		view.InputContext.WavePlan = buildWavePlan(root, view.InputContext.ArtifactBundle)
 	}
 
 	if view.CurrentState == model.StateDone {

--- a/cmd/next_plan_audit_handoff_test.go
+++ b/cmd/next_plan_audit_handoff_test.go
@@ -43,7 +43,7 @@ func TestNextBundleHandoffDoesNotAdvertiseEvidenceBeforeAudit(t *testing.T) {
 	root := t.TempDir()
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L3", "plan-audit bundle handoff")
+		slug := createGovernedRequest(t, root, levelDiscovery, "plan-audit bundle handoff")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.PlanSubStep = model.PlanSubStepBundle
@@ -81,7 +81,7 @@ func TestNextAuditHandoffStillAdvertisesEvidence(t *testing.T) {
 	root := t.TempDir()
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L3", "plan-audit audit handoff")
+		slug := createGovernedRequest(t, root, levelDiscovery, "plan-audit audit handoff")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.PlanSubStep = model.PlanSubStepAudit

--- a/cmd/next_skill_capability_hints_test.go
+++ b/cmd/next_skill_capability_hints_test.go
@@ -233,7 +233,7 @@ func TestNextChangeFromRootDerivesCodebaseMapStatusFromWorktree(t *testing.T) {
 		initTestWorkspace(t, root)
 		initGitRepoForWorktreeTests(t, root)
 
-		slug := createGovernedRequest(t, root, "L3", "workspace consistent codebase map status")
+		slug := createGovernedRequest(t, root, levelDiscovery, "workspace consistent codebase map status")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.PlanSubStep = model.PlanSubStepAudit
@@ -298,7 +298,7 @@ func TestNextSurfacesCodebaseMapAdvisoryWarningEndToEnd(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {
 		require.NoError(t, bootstrap.InitWorkspace(root, []string{"codex"}, false))
-		createGovernedRequest(t, root, "L2", "advisory warning surfaces end to end")
+		createGovernedRequest(t, root, levelNonDiscovery, "advisory warning surfaces end to end")
 		// createGovernedRequest lands at S1_PLAN/research, so research-orchestration
 		// is next; a scaffold_only map must trigger the consume-time advisory.
 		writeScaffoldCodebaseMapDocs(t, root)
@@ -327,7 +327,7 @@ func TestRunSurfacesBaselineCodebaseMapStatusAndAdvisory(t *testing.T) {
 	root := t.TempDir()
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "run surfaces baseline codebase map advisory")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "run surfaces baseline codebase map advisory")
 		writeBaselineCodebaseMapDocs(t, root)
 
 		var handoff nextHandoffView
@@ -354,7 +354,7 @@ func TestNextSurfacesCodebaseMapRelevanceAdvisoryForPopulatedMap(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {
 		require.NoError(t, bootstrap.InitWorkspace(root, []string{"codex"}, false))
-		createGovernedRequest(t, root, "L2", "relevance advisory for populated map")
+		createGovernedRequest(t, root, levelNonDiscovery, "relevance advisory for populated map")
 		writePopulatedCodebaseMapDocs(t, root)
 
 		var view nextView
@@ -390,7 +390,7 @@ func TestNextSurfacesCodebaseMapRelevanceAdvisoryForWaveOrchestration(t *testing
 	root := t.TempDir()
 	withWorkspace(t, root, func() {
 		require.NoError(t, bootstrap.InitWorkspace(root, []string{"codex"}, false))
-		slug := createGovernedRequest(t, root, "L2", "relevance advisory at wave-orchestration")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "relevance advisory at wave-orchestration")
 		writePopulatedCodebaseMapDocs(t, root)
 
 		change, err := state.LoadChange(root, slug)
@@ -428,7 +428,7 @@ func TestNextSurfacesCodebaseMapRelevanceAdvisoryForPartialMap(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {
 		require.NoError(t, bootstrap.InitWorkspace(root, []string{"codex"}, false))
-		createGovernedRequest(t, root, "L2", "relevance advisory for partial map")
+		createGovernedRequest(t, root, levelNonDiscovery, "relevance advisory for partial map")
 		writePartialCodebaseMapDocs(t, root)
 
 		var view nextView
@@ -467,7 +467,7 @@ func TestNextSurfacesMissingMapDiscoveryAdvisoryEndToEnd(t *testing.T) {
 	withWorkspace(t, root, func() {
 		require.NoError(t, bootstrap.InitWorkspace(root, []string{"codex"}, false))
 		// L3 => needs_discovery; lands at S1_PLAN/research with no map written.
-		createGovernedRequest(t, root, "L3", "missing map discovery advisory surfaces")
+		createGovernedRequest(t, root, levelDiscovery, "missing map discovery advisory surfaces")
 
 		var view nextView
 		decodeNextJSON(t, []string{"--json", "--diagnostics"}, &view)
@@ -504,7 +504,7 @@ func TestNextOmitsDiscoveryAdvisoryForNonDiscoveryChange(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {
 		require.NoError(t, bootstrap.InitWorkspace(root, []string{"codex"}, false))
-		createGovernedRequest(t, root, "L2", "non-discovery change omits discovery advisory")
+		createGovernedRequest(t, root, levelNonDiscovery, "non-discovery change omits discovery advisory")
 
 		var view nextView
 		decodeNextJSON(t, []string{"--json", "--diagnostics"}, &view)

--- a/cmd/next_skill_constraints_test.go
+++ b/cmd/next_skill_constraints_test.go
@@ -167,7 +167,7 @@ func TestSkillConstraintsPopulatedInNextOutput(t *testing.T) {
 	withWorkspace(t, root, func() {
 		require.NoError(t, bootstrap.InitWorkspace(root, []string{"claude"}, false))
 
-		slug := createGovernedRequest(t, root, "L2", "constraints test")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "constraints test")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -205,7 +205,7 @@ func TestSkillConstraintsPendingDecisionsBeforePlanLock(t *testing.T) {
 	withWorkspace(t, root, func() {
 		require.NoError(t, bootstrap.InitWorkspace(root, []string{"claude"}, false))
 
-		slug := createGovernedRequest(t, root, "L2", "pending decisions test")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "pending decisions test")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -276,7 +276,7 @@ func TestSkillConstraintsLockedDecisionsAfterPlanLock(t *testing.T) {
 	withWorkspace(t, root, func() {
 		require.NoError(t, bootstrap.InitWorkspace(root, []string{"claude"}, false))
 
-		slug := createGovernedRequest(t, root, "L2", "locked decisions test")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "locked decisions test")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -479,7 +479,7 @@ func TestSkillConstraintsGuardrailDomainFromAdmission(t *testing.T) {
 	withWorkspace(t, root, func() {
 		require.NoError(t, bootstrap.InitWorkspace(root, []string{"claude"}, false))
 
-		slug := createGovernedRequest(t, root, "L2", "guardrail domain test")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "guardrail domain test")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 

--- a/cmd/next_skill_handoff_test.go
+++ b/cmd/next_skill_handoff_test.go
@@ -16,7 +16,7 @@ func TestCLIEndToEndNextJSONHidesRetiredAgentFields(t *testing.T) {
 	withWorkspace(t, root, func() {
 		require.NoError(t, bootstrap.InitWorkspace(root, []string{"claude"}, false))
 
-		slug := createGovernedRequest(t, root, "L3", "next should expose skill handoff")
+		slug := createGovernedRequest(t, root, levelDiscovery, "next should expose skill handoff")
 
 		stdout, stderr, err := runRootCommand([]string{"next", "--json", "--change", slug})
 		require.NoError(t, err)
@@ -39,7 +39,7 @@ func TestCLIEndToEndNextJSONFromBoundWorktreeDoesNotLeakRetiredAgentFields(t *te
 		runGit(t, root, "commit", "-m", "init")
 		require.NoError(t, bootstrap.InitWorkspace(root, []string{"claude"}, false))
 
-		slug := createGovernedRequest(t, root, "L3", "next should expose skill handoff from bound worktree")
+		slug := createGovernedRequest(t, root, levelDiscovery, "next should expose skill handoff from bound worktree")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 

--- a/cmd/next_skill_view.go
+++ b/cmd/next_skill_view.go
@@ -340,7 +340,7 @@ func assembleSkillViewWithOptions(
 		}
 	}
 
-	// Auto capability resolver: attach B1 catalog-skill hints on top of the
+	// Auto capability resolver: attach catalog-skill hints on top of the
 	// kernel's host selection. Never changes the next skill chosen by
 	// ResolveNextSkill; only enriches TechniqueHints.
 	ns.TechniqueHints = appendCatalogHints(ns.TechniqueHints, nextSkillName, governedChange, view)

--- a/cmd/next_tool_path_test.go
+++ b/cmd/next_tool_path_test.go
@@ -17,7 +17,7 @@ func TestNextReturnsSkillNameWhenWorkspaceIsCodexOnly(t *testing.T) {
 	withWorkspace(t, root, func() {
 		require.NoError(t, bootstrap.InitWorkspace(root, []string{"codex"}, false))
 
-		slug := createGovernedRequest(t, root, "L2", "codex-only next skill handoff")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "codex-only next skill handoff")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -43,7 +43,7 @@ func TestNextSucceedsInMultiAdapterWorkspaceWithoutToolDisambiguation(t *testing
 	withWorkspace(t, root, func() {
 		require.NoError(t, bootstrap.InitWorkspace(root, []string{"claude", "codex"}, false))
 
-		slug := createGovernedRequest(t, root, "L2", "multi-adapter next handoff")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "multi-adapter next handoff")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 

--- a/cmd/next_wave_plan.go
+++ b/cmd/next_wave_plan.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
@@ -16,28 +15,8 @@ import (
 // buildWavePlan returns a live projection from the current tasks.md in S2.
 // The persisted wave-plan.yaml is an execution artifact/cache; it is not the
 // planning authority while implementation tasks are still being amended.
-func buildWavePlan(root string, change *model.Change, artifactBundle string) *wavePlanView {
-	if change != nil && change.CurrentState == model.StateS2Implement {
-		return derivedWavePlanView(root, artifactBundle)
-	}
+func buildWavePlan(root, artifactBundle string) *wavePlanView {
 	return derivedWavePlanView(root, artifactBundle)
-}
-
-func authoritativeWavePlanView(root string, change model.Change) *wavePlanView {
-	plan, err := state.LoadOptionalWavePlanForChange(root, change)
-	switch {
-	case err == nil && plan != nil:
-		return wavePlanViewFromModel(
-			root,
-			*plan,
-			state.EffectiveForcedParallel(root),
-			sourceTargetFilesByTaskForChange(root, change),
-		)
-	case err == nil:
-		return &wavePlanView{ParseError: "persisted wave-plan.yaml is missing; run `slipway repair`"}
-	default:
-		return &wavePlanView{ParseError: fmt.Sprintf("failed to load persisted wave-plan.yaml: %v", err)}
-	}
 }
 
 // derivedWavePlanView parses tasks.md and computes dependency-ordered waves.
@@ -108,60 +87,6 @@ func derivedWavePlanView(root, artifactBundle string) *wavePlanView {
 	return planView
 }
 
-func wavePlanViewFromModel(
-	root string,
-	plan model.WavePlan,
-	forcedParallel bool,
-	sourceTargetFilesByTask ...map[string][]string,
-) *wavePlanView {
-	plan = state.ApplyEffectiveParallel(plan, forcedParallel)
-	if len(plan.Waves) == 0 {
-		return nil
-	}
-
-	view := &wavePlanView{
-		TotalTasks: plan.TotalTasks,
-		WaveCount:  len(plan.Waves),
-		Waves:      make([]waveView, len(plan.Waves)),
-	}
-	// Rebuild planner nodes from the persisted plan so the view-only narrowing
-	// advisories (REQ-006) can be computed on the authoritative from-model path
-	// exactly as on the derived path.
-	analyzerNodes := make([]wave.Node, 0, plan.TotalTasks)
-	for i, plannedWave := range plan.Waves {
-		tasks := make([]waveTaskView, len(plannedWave.Tasks))
-		for j, task := range plannedWave.Tasks {
-			tasks[j] = waveTaskView{
-				TaskID:      task.TaskID,
-				Objective:   task.Objective,
-				DependsOn:   append([]string(nil), task.DependsOn...),
-				TargetFiles: append([]string(nil), task.TargetFiles...),
-				TaskKind:    string(task.TaskKind),
-			}
-			node := wave.Node{
-				TaskID:    task.TaskID,
-				Objective: task.Objective,
-				DependsOn: append([]string(nil), task.DependsOn...),
-				TargetFiles: analyzerTargetFilesForSource(
-					root,
-					task.TaskID,
-					task.TargetFiles,
-					sourceTargetFilesByTask...,
-				),
-				TaskKind: task.TaskKind,
-			}
-			analyzerNodes = append(analyzerNodes, node)
-		}
-		view.Waves[i] = waveView{
-			WaveIndex: plannedWave.WaveIndex,
-			Parallel:  plannedWave.Parallel,
-			Tasks:     tasks,
-		}
-	}
-	view.Advisories = wave.AnalyzeWaveNarrowingCauses(analyzerNodes)
-	return view
-}
-
 func analyzerNodesFromSourceTargets(
 	root string,
 	nodes []wave.Node,
@@ -219,18 +144,6 @@ func targetIsExistingDirectory(root, target string) bool {
 	}
 	info, err := os.Stat(filepath.Join(root, filepath.FromSlash(normalized)))
 	return err == nil && info.IsDir()
-}
-
-func sourceTargetFilesByTaskForChange(root string, change model.Change) map[string][]string {
-	bundleDir, err := state.GovernedBundleDir(root, change)
-	if err != nil {
-		return nil
-	}
-	raw, err := os.ReadFile(filepath.Join(bundleDir, "tasks.md")) // #nosec G304 -- path is resolved from governed change authority.
-	if err != nil {
-		return nil
-	}
-	return sourceTargetFilesByTask(string(raw))
 }
 
 func sourceTargetFilesByTask(content string) map[string][]string {

--- a/cmd/next_wave_plan_test.go
+++ b/cmd/next_wave_plan_test.go
@@ -6,100 +6,12 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/signalridge/slipway/internal/model"
 	"github.com/signalridge/slipway/internal/state"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestWavePlanViewFromModelSurfacesParallel(t *testing.T) {
-	t.Parallel()
-
-	root := t.TempDir()
-	plan := model.WavePlan{
-		Version:    model.WavePlanVersion,
-		TotalTasks: 3,
-		Waves: []model.WavePlanWave{
-			{WaveIndex: 1, Parallel: true, Tasks: []model.WavePlanTask{{TaskID: "t-01"}, {TaskID: "t-02"}}},
-			{WaveIndex: 2, Parallel: false, Tasks: []model.WavePlanTask{{TaskID: "t-03"}}},
-		},
-	}
-
-	view := wavePlanViewFromModel(root, plan, true)
-	require.NotNil(t, view)
-	require.Len(t, view.Waves, 2)
-	assert.True(t, view.Waves[0].Parallel, "multi-task wave is surfaced as parallel")
-	assert.False(t, view.Waves[1].Parallel, "single-task wave is not parallel")
-}
-
-func TestAuthoritativeWavePlanViewReDerivesParallelFromCurrentConfig(t *testing.T) {
-	t.Parallel()
-
-	t.Run("stale persisted false becomes parallel by default", func(t *testing.T) {
-		t.Parallel()
-
-		root := t.TempDir()
-		change := model.NewChange("stale-wave-plan-default")
-		change.CurrentState = model.StateS2Implement
-		require.NoError(t, state.SaveChange(root, change))
-		require.NoError(t, state.SaveWavePlan(root, change.Slug, model.WavePlan{
-			Version: model.WavePlanVersion,
-			GeneratedAt: time.Date(2026, 6, 9, 1, 0, 0, 0,
-				time.UTC),
-			TotalTasks: 2,
-			Waves: []model.WavePlanWave{{
-				WaveIndex: 1,
-				Parallel:  false,
-				Tasks: []model.WavePlanTask{
-					{TaskID: "t-01"},
-					{TaskID: "t-02"},
-				},
-			}},
-		}))
-
-		view := authoritativeWavePlanView(root, change)
-		require.NotNil(t, view)
-		require.Empty(t, view.ParseError)
-		require.Len(t, view.Waves, 1)
-		assert.True(t, view.Waves[0].Parallel)
-	})
-
-	t.Run("parallelization off suppresses stale persisted true", func(t *testing.T) {
-		t.Parallel()
-
-		root := t.TempDir()
-		change := model.NewChange("stale-wave-plan-off")
-		change.CurrentState = model.StateS2Implement
-		require.NoError(t, state.SaveChange(root, change))
-		require.NoError(t, os.WriteFile(
-			state.ConfigPath(root),
-			[]byte("execution:\n  parallelization: off\n"),
-			0o644,
-		))
-		require.NoError(t, state.SaveWavePlan(root, change.Slug, model.WavePlan{
-			Version: model.WavePlanVersion,
-			GeneratedAt: time.Date(2026, 6, 9, 1, 0, 0, 0,
-				time.UTC),
-			TotalTasks: 2,
-			Waves: []model.WavePlanWave{{
-				WaveIndex: 1,
-				Parallel:  true,
-				Tasks: []model.WavePlanTask{
-					{TaskID: "t-01"},
-					{TaskID: "t-02"},
-				},
-			}},
-		}))
-
-		view := authoritativeWavePlanView(root, change)
-		require.NotNil(t, view)
-		require.Empty(t, view.ParseError)
-		require.Len(t, view.Waves, 1)
-		assert.False(t, view.Waves[0].Parallel)
-	})
-}
 
 // wavelessDependencyTasksFixture is the retired-`wave:` contract: no task
 // declares a wave line; three dependency-free tasks with pairwise-disjoint
@@ -211,7 +123,7 @@ func TestMaterializeWavePlanComputesWavesFromDependencies(t *testing.T) {
 	change := model.NewChange("waveless-materialization")
 	change.CurrentState = model.StateS2Implement
 	require.NoError(t, state.SaveChange(root, change))
-	writeWavePlanTasksFixture(t, root, change.Slug, wavelessDependencyTasksFixture)
+	bundle := writeWavePlanTasksFixture(t, root, change.Slug, wavelessDependencyTasksFixture)
 
 	plan, err := state.MaterializeWavePlan(root, change)
 	require.NoError(t, err,
@@ -226,7 +138,7 @@ func TestMaterializeWavePlanComputesWavesFromDependencies(t *testing.T) {
 	assert.Equal(t, []string{"t-04"}, wavePlanModelTaskIDs(plan.Waves[1]))
 	assert.False(t, plan.Waves[1].Parallel, "single-task wave is not parallel")
 
-	view := authoritativeWavePlanView(root, change)
+	view := derivedWavePlanView(root, bundle)
 	require.NotNil(t, view)
 	require.Empty(t, view.ParseError)
 	assert.Equal(t, 2, view.WaveCount)
@@ -322,159 +234,6 @@ func TestDerivedWavePlanViewPreservesExplicitNestedDirectoryAdvisory(t *testing.
 		"derived advisory analysis must preserve explicit nested directory targets whose trailing slash would otherwise be normalized away")
 }
 
-func TestWavePlanViewFromModelSurfacesNarrowingAdvisories(t *testing.T) {
-	t.Parallel()
-
-	root := t.TempDir()
-	require.NoError(t, os.MkdirAll(filepath.Join(root, ".github"), 0o755))
-	plan := model.WavePlan{
-		Version:    model.WavePlanVersion,
-		TotalTasks: 3,
-		Waves: []model.WavePlanWave{
-			{WaveIndex: 1, Parallel: false, Tasks: []model.WavePlanTask{
-				// Persisted wave plans carry normalized public paths, so an
-				// explicit ".github/" directory target is read back as ".github".
-				{TaskID: "t-01", TargetFiles: []string{".github"}, TaskKind: model.TaskKindCode},
-			}},
-			{WaveIndex: 2, Parallel: false, Tasks: []model.WavePlanTask{
-				{TaskID: "t-02", DependsOn: []string{"t-01"}, TargetFiles: []string{"cmd/next.go"}, TaskKind: model.TaskKindCode},
-			}},
-			{WaveIndex: 3, Parallel: false, Tasks: []model.WavePlanTask{
-				{TaskID: "t-03", DependsOn: []string{"t-02"}, TargetFiles: []string{"cmd/run.go"}, TaskKind: model.TaskKindCode},
-			}},
-		},
-	}
-
-	view := wavePlanViewFromModel(root, plan, true)
-	require.NotNil(t, view)
-
-	assert.Contains(t, view.Advisories, "broad_target_files:t-01",
-		"from-model path must rebuild nodes and surface the directory-target cue")
-	assert.Contains(t, view.Advisories, "fully_serial_plan",
-		"from-model path must rebuild nodes and surface the linear-chain cue")
-}
-
-func TestWavePlanViewFromModelRestoresNestedDirectoryAdvisory(t *testing.T) {
-	t.Parallel()
-
-	root := t.TempDir()
-	require.NoError(t, os.MkdirAll(filepath.Join(root, "internal", "engine"), 0o755))
-	require.NoError(t, os.MkdirAll(filepath.Join(root, "scripts"), 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(root, "scripts", "deploy"), []byte("#!/bin/sh\n"), 0o755))
-
-	plan := model.WavePlan{
-		Version:    model.WavePlanVersion,
-		TotalTasks: 2,
-		Waves: []model.WavePlanWave{{
-			WaveIndex: 1,
-			Parallel:  true,
-			Tasks: []model.WavePlanTask{
-				{
-					TaskID:      "t-01",
-					TargetFiles: []string{"internal/engine"},
-					TaskKind:    model.TaskKindCode,
-				},
-				{
-					TaskID:      "t-02",
-					TargetFiles: []string{"scripts/deploy"},
-					TaskKind:    model.TaskKindCode,
-				},
-			},
-		}},
-	}
-
-	view := wavePlanViewFromModel(root, plan, true)
-	require.NotNil(t, view)
-
-	assert.Contains(t, view.Advisories, "broad_target_files:t-01",
-		"from-model advisory analysis must recover nested directory targets whose trailing slash was removed by path normalization")
-	assert.NotContains(t, view.Advisories, "broad_target_files:t-02",
-		"an existing extensionless file must not be misreported as a broad directory target")
-}
-
-func TestAuthoritativeWavePlanViewPreservesExplicitDirectoryAdvisory(t *testing.T) {
-	t.Parallel()
-
-	root := t.TempDir()
-	change := model.NewChange("explicit-directory-advisory")
-	change.CurrentState = model.StateS2Implement
-	require.NoError(t, state.SaveChange(root, change))
-	writeWavePlanTasksFixture(t, root, change.Slug, `# Tasks
-
-- [ ] `+"`t-01`"+` creates a new package directory
-  - target_files: ["internal/newpkg/"]
-  - task_kind: code
-`)
-
-	plan, err := state.MaterializeWavePlan(root, change)
-	require.NoError(t, err)
-	require.Equal(t, []string{"internal/newpkg"}, plan.Waves[0].Tasks[0].TargetFiles,
-		"materialized plans normalize away the explicit directory slash")
-
-	view := authoritativeWavePlanView(root, change)
-	require.NotNil(t, view)
-
-	assert.Contains(t, view.Advisories, "broad_target_files:t-01",
-		"authoritative view advisories must use tasks.md source targets, not only normalized wave-plan.yaml targets")
-}
-
-func TestWavePlanViewFromModelIgnoresNonEquivalentSourceTargets(t *testing.T) {
-	t.Parallel()
-
-	root := t.TempDir()
-	plan := model.WavePlan{
-		Version:    model.WavePlanVersion,
-		TotalTasks: 1,
-		Waves: []model.WavePlanWave{{
-			WaveIndex: 1,
-			Tasks: []model.WavePlanTask{{
-				TaskID:      "t-01",
-				TargetFiles: []string{"cmd/next.go"},
-				TaskKind:    model.TaskKindCode,
-			}},
-		}},
-	}
-	sourceTargets := map[string][]string{
-		"t-01": {"internal/newpkg/"},
-	}
-
-	view := wavePlanViewFromModel(root, plan, true, sourceTargets)
-	require.NotNil(t, view)
-
-	assert.NotContains(t, view.Advisories, "broad_target_files:t-01",
-		"source targets that do not normalize to the materialized plan must not influence authoritative advisories")
-}
-
-func TestWavePlanViewFromModelRestoresExistingDirectoryAdvisoryWithSourceTargets(t *testing.T) {
-	t.Parallel()
-
-	root := t.TempDir()
-	require.NoError(t, os.MkdirAll(filepath.Join(root, "internal", "engine"), 0o755))
-
-	plan := model.WavePlan{
-		Version:    model.WavePlanVersion,
-		TotalTasks: 1,
-		Waves: []model.WavePlanWave{{
-			WaveIndex: 1,
-			Parallel:  true,
-			Tasks: []model.WavePlanTask{{
-				TaskID:      "t-01",
-				TargetFiles: []string{"internal/engine"},
-				TaskKind:    model.TaskKindCode,
-			}},
-		}},
-	}
-	sourceTargets := map[string][]string{
-		"t-01": {"internal/engine"},
-	}
-
-	view := wavePlanViewFromModel(root, plan, true, sourceTargets)
-	require.NotNil(t, view)
-
-	assert.Contains(t, view.Advisories, "broad_target_files:t-01",
-		"equivalent source targets must preserve existing-directory recovery on the authoritative from-model path")
-}
-
 func TestCleanParallelPlanEmitsNoNarrowingAdvisories(t *testing.T) {
 	t.Parallel()
 
@@ -497,7 +256,7 @@ func TestNarrowingAdvisoriesAreViewOnlyAndExcludedFromPersistedPlan(t *testing.T
 	change := model.NewChange("advisories-view-only")
 	change.CurrentState = model.StateS2Implement
 	require.NoError(t, state.SaveChange(root, change))
-	writeWavePlanTasksFixture(t, root, change.Slug, narrowingTasksFixture)
+	bundle := writeWavePlanTasksFixture(t, root, change.Slug, narrowingTasksFixture)
 
 	plan, err := state.MaterializeWavePlan(root, change)
 	require.NoError(t, err)
@@ -520,7 +279,7 @@ func TestNarrowingAdvisoriesAreViewOnlyAndExcludedFromPersistedPlan(t *testing.T
 	assert.NotContains(t, plan.TasksPlanScopeHash, "broad_target_files")
 
 	// The same plan, surfaced through the view, DOES carry the advisories.
-	view := wavePlanViewFromModel(root, plan, state.EffectiveForcedParallel(root))
+	view := derivedWavePlanView(root, bundle)
 	require.NotNil(t, view)
 	assert.Contains(t, view.Advisories, "broad_target_files:t-01")
 	assert.Contains(t, view.Advisories, "fully_serial_plan")

--- a/cmd/progression_next_test.go
+++ b/cmd/progression_next_test.go
@@ -64,7 +64,7 @@ func TestNextReturnsNextSkillForGovernedState(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "add caching layer")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "add caching layer")
 
 		cmd := commandForRoot(t, root, makeNextCmd())
 		cmd.SetArgs([]string{"--json"})
@@ -131,7 +131,7 @@ func TestNextS3ReviewWithPassingPeerEvidenceReportsGoalVerificationHandoff(t *te
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "s3 run guidance")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "s3 run guidance")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = model.StateS3Review
@@ -242,7 +242,7 @@ func TestNextS1BundleSurfacesPlanAuditHandoff(t *testing.T) {
 	root := t.TempDir()
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L3", "audit bundle handoff")
+		slug := createGovernedRequest(t, root, levelDiscovery, "audit bundle handoff")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.PlanSubStep = model.PlanSubStepBundle
@@ -270,7 +270,7 @@ func TestNextPreviewIncludesGovernanceSurfaceAndActionBlockers(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "governance blocker preview")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "governance blocker preview")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS1Plan
@@ -332,7 +332,7 @@ func TestNextPreviewIgnoresUnreadableGovernanceSnapshot(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "recover from corrupt governance snapshot")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "recover from corrupt governance snapshot")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS1Plan
@@ -373,7 +373,7 @@ func TestNextPreviewExposesPlanningRecoveryState(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "preview should expose plan recovery state")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "preview should expose plan recovery state")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -400,7 +400,7 @@ func TestNextJSONAutoPassesByDefault(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "light preset json autopass advisory")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "light preset json autopass advisory")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.WorkflowPreset = model.WorkflowPresetLight
@@ -434,7 +434,7 @@ func TestNextJSONNoAutoPassReportsEligibilityFromCurrentStateOnly(t *testing.T) 
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "light preset explicit no-auto-pass advisory")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "light preset explicit no-auto-pass advisory")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.WorkflowPreset = model.WorkflowPresetLight
@@ -471,7 +471,7 @@ func TestNextDoesNotAutoPassLightPresetReviewWithoutExecutionSummary(t *testing.
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "light preset review still requires execution authority")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "light preset review still requires execution authority")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.WorkflowPreset = model.WorkflowPresetLight
@@ -503,7 +503,7 @@ func TestNextDoesNotReturnDoneReadyWithoutGoalVerification(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "done-ready still requires goal verification")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "done-ready still requires goal verification")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.WorkflowPreset = model.WorkflowPresetLight
@@ -548,7 +548,7 @@ func TestNextDoesNotAutoPassStrictPresetReview(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "strict preset review")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "strict preset review")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.WorkflowPreset = model.WorkflowPresetStrict
@@ -579,7 +579,7 @@ func TestNextJSONGoalVerificationHintsDropRetiredFreshEvidence(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "goal verification hint contract")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "goal verification hint contract")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS3Review
@@ -636,7 +636,7 @@ func TestRunJSONFinalCloseoutDropsRetiredFreshEvidenceHint(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "final closeout run hint contract")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "final closeout run hint contract")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.QualityMode = model.QualityModeFull
@@ -670,7 +670,7 @@ func TestAssembleSkillViewFinalCloseoutDropsRetiredFreshEvidenceHint(t *testing.
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "final closeout hint contract")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "final closeout hint contract")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = model.StateS3Review
@@ -780,7 +780,7 @@ func TestNextReturnsSkillNameWithoutToolSpecificRuntimeFields(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "test agent hint")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "test agent hint")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -810,7 +810,7 @@ func TestNextReturnsReviewContextForArtifactReview(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "refactor service module")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "refactor service module")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -918,7 +918,7 @@ func TestNextJSONReportsActionableRequiredSkillAfterPassingReviewEvidence(t *tes
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "json evidence status surface")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "json evidence status surface")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS3Review
@@ -996,7 +996,7 @@ func TestBuildRequiredSkillEvidenceMarksDigestDriftedSkillStale(t *testing.T) {
 	root := t.TempDir()
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "stale evidence status surface")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "stale evidence status surface")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS1Plan
@@ -1028,7 +1028,7 @@ func TestBuildRequiredSkillEvidenceNonPrecomputedMarksDigestDriftedSkillStale(t 
 	root := t.TempDir()
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "non-precomputed stale evidence status")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "non-precomputed stale evidence status")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS1Plan
@@ -1063,7 +1063,7 @@ func TestReviewStateActionableNextSkillConsistentAcrossCommandSurfaces(t *testin
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "consistent review next skill")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "consistent review next skill")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS3Review
@@ -1188,7 +1188,7 @@ func TestReviewStateDocsProfileSkipsCodeQualityAcrossCommandSurfaces(t *testing.
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "docs review next skill")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "docs review next skill")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS3Review
@@ -1317,7 +1317,7 @@ func TestDiagnosticCommandsExposePathAuthorityWhenFreshnessUnknown(t *testing.T)
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "path authority should not depend on execution freshness")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "path authority should not depend on execution freshness")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS1Plan
@@ -1369,7 +1369,7 @@ func TestNextNoReviewContextForNonReviewState(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "add pagination")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "add pagination")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -1399,7 +1399,7 @@ func TestAssembleSkillViewReusesPrecomputedEvidenceMap(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "reuse precomputed next evidence")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "reuse precomputed next evidence")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 
@@ -1447,7 +1447,7 @@ func TestNextBlocksWithoutPlanAuditEvidence(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "test gplan blocking")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "test gplan blocking")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 
@@ -1498,7 +1498,7 @@ func TestNextPreviewFailsWhenSkillEvidenceEvaluationFails(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "review malformed skill registry handling")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "review malformed skill registry handling")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -1538,7 +1538,7 @@ func TestNextAdvancesWithPlanAuditEvidence(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "test gplan passing")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "test gplan passing")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 
@@ -1595,7 +1595,7 @@ func TestNextReadOnlyReportsRunGuidanceAfterPassingPlanAudit(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "report S1 audit advance guidance")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "report S1 audit advance guidance")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 
@@ -1630,7 +1630,7 @@ func TestNextBlocksWhenBundleMissingArtifacts(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "test bundle missing")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "test bundle missing")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 
@@ -1675,7 +1675,7 @@ func TestNextBlocksOnInvalidBoundWorktreeBeforeBundleChecks(t *testing.T) {
 	initTestWorkspace(t, root)
 	initGitRepoForWorktreeTests(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "bundle invalid bound worktree")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "bundle invalid bound worktree")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 
@@ -1702,7 +1702,7 @@ func TestNextBlocksWhenTasksChecklistMissingTargetFiles(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "tasks checklist validation")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "tasks checklist validation")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -1750,7 +1750,7 @@ func TestNextBlocksWhenTasksChecklistHasDependencyCycle(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "tasks checklist dependency cycle")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "tasks checklist dependency cycle")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -1802,7 +1802,7 @@ func TestNextPreviewIncludesTaskChecklistBlockers(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "preview tasks checklist blockers")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "preview tasks checklist blockers")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -1845,7 +1845,7 @@ func TestNextPreviewIncludesAssuranceContractBlockersAtReview(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "preview assurance contract blocker")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "preview assurance contract blocker")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS3Review
@@ -1873,7 +1873,7 @@ func TestRunRejectsResumeResponseWithoutCheckpoint(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		_ = createGovernedRequest(t, root, "L2", "test no checkpoint")
+		_ = createGovernedRequest(t, root, levelNonDiscovery, "test no checkpoint")
 
 		cmd := commandForRoot(t, root, makeRunCmd())
 		cmd.SetArgs([]string{"--json", "--resume-response", "approved"})
@@ -1898,7 +1898,7 @@ func TestNextReturnsDoneReadyWithoutNextSkillAfterGovernedShipPasses(t *testing.
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "done ready contract")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "done ready contract")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 
@@ -1947,7 +1947,7 @@ func TestNextReturnsDoneReadyWithFinalCloseoutAttestationForStandardRequestPath(
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "standard request done ready contract")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "standard request done ready contract")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 
@@ -1986,7 +1986,7 @@ func TestNextDiagnosticsSkillEvidenceUsesStandardCloseoutRequirement(t *testing.
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "standard closeout diagnostics contract")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "standard closeout diagnostics contract")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -2039,7 +2039,7 @@ func TestNextJSONDefaultIsHandoffOnlyAndDiagnosticsKeepsFullSurface(t *testing.T
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "handoff-only done ready contract")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "handoff-only done ready contract")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -2109,7 +2109,7 @@ func TestNextJSONDefaultOmitsFreshnessDiagnosticsWhenDiagnosticsViewHasThem(t *t
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "handoff suppresses freshness diagnostics")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "handoff suppresses freshness diagnostics")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS3Review
@@ -2164,7 +2164,7 @@ func TestNextHandoffSourceViewDoesNotBuildDiagnosticSurfaces(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "handoff source stays narrow")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "handoff source stays narrow")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS3Review
@@ -2463,7 +2463,7 @@ func TestRunRequiresResumeResponseForActiveCheckpoint(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "test checkpoint requires response")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "test checkpoint requires response")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -2494,7 +2494,7 @@ func TestRunDoesNotRequireResumeAfterAbortWithoutWaveBackedState(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "abort without wave-backed state should not require resume")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "abort without wave-backed state should not require resume")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS2Implement
@@ -2527,7 +2527,7 @@ func TestRunRequiresExplicitResumeAfterAbortWithWaveBackedState(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "abort with wave-backed state should require resume")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "abort with wave-backed state should require resume")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS2Implement
@@ -2600,7 +2600,7 @@ func TestRunDoesNotRequireResumeWhenPlanningEvidenceIsStale(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "stale planning should not resume old wave")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "stale planning should not resume old wave")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS2Implement
@@ -2663,7 +2663,7 @@ func TestRunResumesCheckpointWithValidResponse(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "test checkpoint resume")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "test checkpoint resume")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -2720,7 +2720,7 @@ func TestRunRejectsResumeResponseWhenWaveArtifactsAreMissing(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "run resume-response should fail closed when wave artifacts are missing")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "run resume-response should fail closed when wave artifacts are missing")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -2771,7 +2771,7 @@ func TestRunRejectsResumeResponseWhenCheckpointTaskIsMissingFromCurrentTasks(t *
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "run resume-response should fail closed when checkpoint task is missing")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "run resume-response should fail closed when checkpoint task is missing")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -2811,7 +2811,7 @@ func TestNextRejectsCheckpointContextWhenWaveArtifactsAreMissing(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "next should fail closed when checkpoint wave artifacts are missing")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "next should fail closed when checkpoint wave artifacts are missing")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -2862,7 +2862,7 @@ func TestNextRejectsCheckpointContextWhenCheckpointTaskIsMissingFromCurrentTasks
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "next should fail closed when checkpoint task is missing")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "next should fail closed when checkpoint task is missing")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -2902,7 +2902,7 @@ func TestRunRejectsResumeWhenWaveRunsAreIncomplete(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "run resume should fail closed when wave evidence is incomplete")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "run resume should fail closed when wave evidence is incomplete")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -2955,7 +2955,7 @@ func TestRunResumeUnavailableExplainsLifecycleBoundary(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "resume boundary")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "resume boundary")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS3Review
@@ -2984,7 +2984,7 @@ func TestRunRejectsInvalidAllowedResponse(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "test allowed responses")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "test allowed responses")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -3151,7 +3151,7 @@ func TestNextIncludesFreshnessInResumeCheckpoint(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "test freshness in checkpoint")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "test freshness in checkpoint")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -3193,7 +3193,7 @@ func TestNextDoesNotBuildResumeCheckpointFromChecklistWithoutReadyExecutionSumma
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "bundle checklist resume")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "bundle checklist resume")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -3240,7 +3240,7 @@ func TestNextDoesNotRetainResumeCheckpointWhenOnlyChecklistMarksTasksComplete(t 
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "bundle checkpoint without skip-safe tasks")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "bundle checkpoint without skip-safe tasks")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -3286,7 +3286,7 @@ func TestNextPreviewIncludesWavePlanTaskShape(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "wave plan protocol version")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "wave plan protocol version")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -3369,7 +3369,7 @@ func TestNextHandoffJSONIncludesWavePlanParallelSignal(t *testing.T) {
 					require.NoError(t, os.WriteFile(state.ConfigPath(root), []byte(tt.config), 0o644))
 				}
 
-				slug := createGovernedRequest(t, root, "L2", tt.name)
+				slug := createGovernedRequest(t, root, levelNonDiscovery, tt.name)
 				change, err := state.LoadChange(root, slug)
 				require.NoError(t, err)
 
@@ -3425,7 +3425,7 @@ func TestNextPreviewUsesCurrentTasksDuringS2Implementation(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "current tasks should drive S2 wave preview")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "current tasks should drive S2 wave preview")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -3489,7 +3489,7 @@ func TestNextPreviewIncludesActiveCheckpointBundle(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "preview checkpoint bundle")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "preview checkpoint bundle")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -3560,7 +3560,7 @@ func TestNextIncludesActiveCheckpointWithoutRequiringResumeResponse(t *testing.T
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "next should inspect active checkpoint without resume response")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "next should inspect active checkpoint without resume response")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -3621,7 +3621,7 @@ func TestNextResumeCheckpointFreshnessTurnsStaleAfterInputUpdate(t *testing.T) {
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "freshness stale after input update")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "freshness stale after input update")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -3693,7 +3693,7 @@ func TestNextPreviewAdvancesAfterPassingResearchVerification(t *testing.T) {
 		initTestWorkspace(t, root)
 		initGitRepoForWorktreeTests(t, root)
 
-		slug := createGovernedRequest(t, root, "L3", "passing research verification should advance to next skill")
+		slug := createGovernedRequest(t, root, levelDiscovery, "passing research verification should advance to next skill")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -3851,7 +3851,7 @@ func TestNextPreviewDoesNotAdvanceState(t *testing.T) {
 	root := t.TempDir()
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "preview should be read-only")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "preview should be read-only")
 
 		changeBefore, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
@@ -3880,7 +3880,7 @@ func TestNextPreviewDoesNotAppendLifecycleEvents(t *testing.T) {
 	root := t.TempDir()
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "preview should not append lifecycle events")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "preview should not append lifecycle events")
 
 		changeBefore, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
@@ -3913,7 +3913,7 @@ func TestNextPreviewExposesArtifactAmendmentsWithoutPersistingReconcile(t *testi
 	root := t.TempDir()
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "preview should expose artifact amendments without persisting")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "preview should expose artifact amendments without persisting")
 
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
@@ -3963,7 +3963,7 @@ func TestRunIncludesTransitionTrace(t *testing.T) {
 	root := t.TempDir()
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "run transition trace")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "run transition trace")
 
 		// createGovernedRequest runs request + one next, leaving governed lane at S1.
 		changeBefore, err := state.LoadChange(root, slug)
@@ -3995,8 +3995,11 @@ func TestNextContextBudgetHardStopAddsWarning(t *testing.T) {
 	root := t.TempDir()
 	withCommandWorkspace(t, root, func() {
 		t.Setenv("SPECLANE_CONTEXT_WINDOW_TOKENS", "1")
+		// Pin the higher-priority alias empty so an ambient SLIPWAY_CONTEXT_WINDOW_TOKENS
+		// cannot mask the legacy value this hard-stop assertion relies on.
+		t.Setenv("SLIPWAY_CONTEXT_WINDOW_TOKENS", "")
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "context hard stop")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "context hard stop")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS1Plan
@@ -4030,7 +4033,7 @@ func TestNextBlocksWhenGovernedChangeHasNoFrozenSchema(t *testing.T) {
 	root := t.TempDir()
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "document diagnostics warning")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "document diagnostics warning")
 
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
@@ -4052,12 +4055,12 @@ func TestNextBlocksWhenGovernedChangeHasNoFrozenSchema(t *testing.T) {
 	})
 }
 
-func TestNextS6GovernedMaterializesExecutionSummaryAndRuntimeSummary(t *testing.T) {
+func TestNextGovernedMaterializesExecutionSummaryAndRuntimeSummaryDuringImplementation(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
-	slug := createGovernedRequest(t, root, "L2", "materialize run summary")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "materialize run summary")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = model.StateS2Implement
@@ -4102,7 +4105,7 @@ func TestNextS6GovernedMaterializesExecutionSummaryAndRuntimeSummary(t *testing.
 	assert.Equal(t, model.TaskVerdictPass, summary.Tasks[0].Verdict)
 }
 
-func TestNextS6GovernedBlocksWithoutTaskEvidenceForWaveRunSummary(t *testing.T) {
+func TestNextGovernedBlocksWithoutTaskEvidenceForWaveRunSummaryDuringImplementation(t *testing.T) {
 	t.Parallel()
 	root, slug := prepareMissingTaskEvidenceForWaveRunSummaryFixture(t)
 
@@ -4160,7 +4163,7 @@ func TestReadOnlyS2DiagnosticsUseTaskEvidenceDriftInsteadOfRunSummaryMissing(t *
 	root := t.TempDir()
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
-	slug := createGovernedRequest(t, root, "L2", "surface stale task evidence diagnostics")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "surface stale task evidence diagnostics")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = model.StateS2Implement
@@ -4258,7 +4261,7 @@ func prepareMissingTaskEvidenceForWaveRunSummaryFixture(t *testing.T) (string, s
 	root := t.TempDir()
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
-	slug := createGovernedRequest(t, root, "L2", "missing task evidence should block")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "missing task evidence should block")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = model.StateS2Implement
@@ -4299,7 +4302,7 @@ func prepareStalePlanningRecoveryBaseFixture(t *testing.T, root string, currentS
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "stale planning recovery")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "stale planning recovery")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = currentState

--- a/cmd/repair_test.go
+++ b/cmd/repair_test.go
@@ -70,7 +70,7 @@ func TestRepairRestoresMissingBoundWorktreeScopeMetadata(t *testing.T) {
 		runGit(t, root, "commit", "-m", "init")
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "repair restores missing bound worktree scope metadata")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "repair restores missing bound worktree scope metadata")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS2Implement
@@ -172,7 +172,7 @@ func TestRepairReportsLegacyRuntimeHandoffAndCleansSafeRuntimeArtifacts(t *testi
 			root := t.TempDir()
 			withWorkspace(t, root, func() {
 				initTestWorkspace(t, root)
-				slug := createGovernedRequest(t, root, "L2", "repair runtime hygiene")
+				slug := createGovernedRequest(t, root, levelNonDiscovery, "repair runtime hygiene")
 
 				legacyHandoffPath := filepath.Join(state.GitRuntimeDir(root), tt.filename)
 				require.NoError(t, os.MkdirAll(filepath.Dir(legacyHandoffPath), 0o755))
@@ -453,7 +453,7 @@ func TestRepairReportsHiddenUnreadableChangeAuthorityFinding(t *testing.T) {
 		runGit(t, root, "commit", "-m", "init")
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "repair reports hidden unreadable authority")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "repair reports hidden unreadable authority")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -496,7 +496,7 @@ func TestRepairReportsUnreadableExecutionSummaryFinding(t *testing.T) {
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "repair reports unreadable execution summary")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "repair reports unreadable execution summary")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS2Implement
@@ -533,7 +533,7 @@ func TestRepairRebuildsUnreadableExecutionSummaryWithoutResidualDrift(t *testing
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "repair should converge unreadable execution summary")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "repair should converge unreadable execution summary")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS2Implement
@@ -634,7 +634,7 @@ func TestRepairMaterializesWavePlanRecoversWaveRunsAndClearsStaleCheckpoint(t *t
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "repair should recover wave execution artifacts")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "repair should recover wave execution artifacts")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS2Implement
@@ -689,7 +689,7 @@ func TestRepairClearsStaleCheckpointWhenExecutionSummaryUnreadable(t *testing.T)
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "repair should clear stale checkpoint despite unreadable summary")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "repair should clear stale checkpoint despite unreadable summary")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS2Implement
@@ -750,7 +750,7 @@ func TestRepairRebuildsUnreadableWavePlanAndWaveRuns(t *testing.T) {
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "repair should rebuild unreadable wave artifacts")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "repair should rebuild unreadable wave artifacts")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS2Implement
@@ -800,7 +800,7 @@ func TestRepairReportsMalformedTaskEvidenceWithoutFailing(t *testing.T) {
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "repair reports malformed task evidence")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "repair reports malformed task evidence")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS2Implement
@@ -846,7 +846,7 @@ func TestRepairRebuildsWavePlanButPreservesHistoricalExecutionEvidenceWhenTasksD
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "repair should not rewrite drifted historical execution")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "repair should not rewrite drifted historical execution")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS2Implement
@@ -937,7 +937,7 @@ func TestRepairRebuildsReadyButStaleExecutionSummaryDrift(t *testing.T) {
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "repair reports stale ready execution summary")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "repair reports stale ready execution summary")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS3Review
@@ -1031,7 +1031,7 @@ func TestRepairDoesNotRewriteReadyButStaleExecutionSummaryWhenTaskEvidenceInvali
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "repair leaves invalid task evidence alone")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "repair leaves invalid task evidence alone")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS3Review
@@ -1119,7 +1119,7 @@ func TestRepairReportsMissingRuntimeTaskEvidenceWithCommandHint(t *testing.T) {
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "repair reports missing task evidence source")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "repair reports missing task evidence source")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS3Review
@@ -1156,7 +1156,7 @@ func TestRepairDoesNotRebuildWhenPlanningEvidenceIsStale(t *testing.T) {
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "repair leaves stale planning evidence alone")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "repair leaves stale planning evidence alone")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS3Review
@@ -1232,7 +1232,7 @@ func TestRepairRoutesStaleGovernanceDigestToSlipwayRun(t *testing.T) {
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "repair routes stale digest to run")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "repair routes stale digest to run")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS1Plan
@@ -1323,7 +1323,7 @@ func TestRepairPathAuthorityUsesLinkedWorktreeInvocationWorkspace(t *testing.T) 
 		runGit(t, root, "commit", "-m", "init")
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "repair path authority linked worktree")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "repair path authority linked worktree")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS3Review

--- a/cmd/resolve_explicit_change_authority_test.go
+++ b/cmd/resolve_explicit_change_authority_test.go
@@ -71,7 +71,7 @@ func TestResolveExplicitChangeMissingAuthorityWithoutArchiveFailsClosed(t *testi
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "orphaned active bundle")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "orphaned active bundle")
 	// Drop change.yaml but leave a stray file so the bundle directory survives;
 	// LoadChange then reports a missing-authority error with no archived record.
 	activePath := state.BundleChangeFilePath(root, slug)
@@ -105,7 +105,7 @@ func TestResolveExplicitChangeMalformedActiveAuthorityFailsClosed(t *testing.T) 
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "malformed active authority")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "malformed active authority")
 	require.NoError(t, os.WriteFile(state.BundleChangeFilePath(root, slug), []byte("slug: ["), 0o644))
 
 	_, resolveErr := resolveExplicitChange(root, slug)

--- a/cmd/review_test.go
+++ b/cmd/review_test.go
@@ -126,7 +126,7 @@ func TestReviewRejectsHydrateWithJSONWithoutMutatingState(t *testing.T) {
 	withWorkspace(t, root, func() {
 		require.NoError(t, bootstrap.InitWorkspace(root, []string{"codex"}, true))
 
-		slug := createGovernedRequest(t, root, "L2", "review hydrate/json rejection must be side-effect free")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "review hydrate/json rejection must be side-effect free")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS2Implement
@@ -231,7 +231,7 @@ func TestReviewExplicitRequestRejectsInactiveGovernedChange(t *testing.T) {
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "review inactive governed change")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "review inactive governed change")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.Status = model.ChangeStatusCancelled
@@ -253,7 +253,7 @@ func TestReviewRejectsS2ImplementWithoutMutatingState(t *testing.T) {
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "review should not advance S2")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "review should not advance S2")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS2Implement
@@ -282,7 +282,7 @@ func TestReviewDiagnosticsFlagEmitsJSON(t *testing.T) {
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "review diagnostics json")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "review diagnostics json")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS3Review
@@ -312,7 +312,7 @@ func TestReviewRequiresExecutionSummaryEvenWhenChecklistIsComplete(t *testing.T)
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "review requires frozen execution summary")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "review requires frozen execution summary")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS3Review
@@ -346,7 +346,7 @@ func TestReviewPassFromS3ReviewPreservesGovernedState(t *testing.T) {
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "review should preserve governed done-ready state")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "review should preserve governed done-ready state")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS3Review
@@ -458,7 +458,7 @@ func TestReviewRequiresStoredWaveRunsForExecutionSummary(t *testing.T) {
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "review should use execution summary")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "review should use execution summary")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS3Review
@@ -534,7 +534,7 @@ func TestReviewFailsClosedOnWaveRunsMissingEvenWhenReadinessIsAlreadyBlocked(t *
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "review should fail closed when wave runs are missing")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "review should fail closed when wave runs are missing")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS3Review
@@ -599,7 +599,7 @@ func TestReviewFailsWhenWaveTaskLinkageIsMismatched(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "review should reject mismatched wave linkage")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "review should reject mismatched wave linkage")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = model.StateS3Review
@@ -688,7 +688,7 @@ func TestReviewDoesNotPreGateOnStaleExecutionEvidence(t *testing.T) {
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "review should fail on stale evidence")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "review should fail on stale evidence")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS3Review
@@ -732,7 +732,7 @@ func TestReviewAllDoesNotTreatImplementationEvidenceAsArtifactEvidence(t *testin
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "review should keep review evidence roles named")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "review should keep review evidence roles named")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS3Review
@@ -771,7 +771,7 @@ func TestReviewChangedOnlyUsesInMemoryArtifactReconcile(t *testing.T) {
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "review changed-only should follow stale artifact projection")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "review changed-only should follow stale artifact projection")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS3Review
@@ -868,7 +868,7 @@ func TestReviewChangedOnlyIncludesNonRequiredRuntimeArtifacts(t *testing.T) {
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "review changed-only should include non-required runtime artifacts")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "review changed-only should include non-required runtime artifacts")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS3Review
@@ -967,7 +967,7 @@ func TestReviewFailsWhenTasksChecklistCoverageDrifts(t *testing.T) {
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "review should fail when requirement coverage drifts")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "review should fail when requirement coverage drifts")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS3Review

--- a/cmd/route_surface_command_test.go
+++ b/cmd/route_surface_command_test.go
@@ -67,7 +67,7 @@ func TestStatusExplicitViewEmitsPublicAliasAndHydrateReferences(t *testing.T) {
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "status route-surface command contract")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "status route-surface command contract")
 
 		var out bytes.Buffer
 		cmd := makeStatusCmd()
@@ -88,7 +88,7 @@ func TestReviewFocusCalibrationEmitsPublicAliasAndHydrateReferences(t *testing.T
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "review focus calibration route-surface contract")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "review focus calibration route-surface contract")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 

--- a/cmd/scope_contract_test.go
+++ b/cmd/scope_contract_test.go
@@ -205,7 +205,7 @@ func writeScopeContractDriftFixtureInState(t *testing.T, workflowState model.Wor
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "scope contract drift fixture")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "scope contract drift fixture")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = workflowState

--- a/cmd/session_start_hook_test.go
+++ b/cmd/session_start_hook_test.go
@@ -17,7 +17,7 @@ func TestSessionStartHookEmitsCompiledHandoff(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "session-start compiled handoff")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "session-start compiled handoff")
 
 		handoffPath := state.ChangeHandoffPath(root, slug)
 		require.NoError(t, os.MkdirAll(filepath.Dir(handoffPath), 0o755))
@@ -50,7 +50,7 @@ func TestSessionStartHookReportsOnlyCurrentChangeHandoffAcrossBoundWorktrees(t *
 		initTestWorkspace(t, root)
 		initGitRepoForWorktreeTests(t, root)
 
-		currentSlug := createGovernedRequest(t, root, "L2", "current worktree handoff")
+		currentSlug := createGovernedRequest(t, root, levelNonDiscovery, "current worktree handoff")
 		currentChange, err := state.LoadChange(root, currentSlug)
 		require.NoError(t, err)
 		currentChange.WorktreePath = root
@@ -91,7 +91,7 @@ func TestSessionStartHookBareCommandOmitsUnknownToolAttribute(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", "session-start bare command")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "session-start bare command")
 
 		cmd := makeHookCmd()
 		cmd.SetArgs([]string{"session-start"})
@@ -164,7 +164,7 @@ func TestSessionStartHookFailsSilentOnUnusableInput(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		createGovernedRequest(t, root, "L2", "session-start fail-silent input")
+		createGovernedRequest(t, root, levelNonDiscovery, "session-start fail-silent input")
 
 		tests := []struct {
 			name  string

--- a/cmd/stats_test.go
+++ b/cmd/stats_test.go
@@ -21,7 +21,7 @@ func TestStatsCommandSummarizesRepoWideSignals(t *testing.T) {
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "stats view should summarize workflow state")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "stats view should summarize workflow state")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.QualityMode = model.QualityModeFull
@@ -107,7 +107,7 @@ func TestStatsDoesNotTreatMissingReviewEvidenceAsStaleRunSummary(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "stats should separate stale execution evidence from missing review evidence")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "stats should separate stale execution evidence from missing review evidence")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = model.StateS3Review
@@ -131,7 +131,7 @@ func TestStatsMarksStaleRunSummaryWhenExecutionEvidenceDrifts(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "stats should still report stale execution evidence")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "stats should still report stale execution evidence")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = model.StateS3Review
@@ -157,7 +157,7 @@ func TestStatsIgnoresBrokenExecutionSummaryOutsideExecutionStates(t *testing.T) 
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "stats should ignore irrelevant broken summary")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "stats should ignore irrelevant broken summary")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = model.StateS1Plan
@@ -180,7 +180,7 @@ func TestStatsReportsBrokenExecutionSummaryInExecutionStatesWithoutFailing(t *te
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "stats should degrade when execution summary is corrupt")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "stats should degrade when execution summary is corrupt")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = model.StateS3Review
@@ -206,7 +206,7 @@ func TestStatsCountsArchivedOwnersAlongsideHiddenBoundWorktreeChanges(t *testing
 	initTestWorkspace(t, root)
 	initGitRepoForWorktreeTests(t, root)
 
-	slug := createGovernedRequest(t, root, "L3", "stats should still see hidden siblings and archived owners")
+	slug := createGovernedRequest(t, root, levelDiscovery, "stats should still see hidden siblings and archived owners")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 
@@ -248,7 +248,7 @@ func TestStatsUsesAuthoritativeVerificationForHiddenBoundWorktreeCloseoutFreshne
 	initTestWorkspace(t, root)
 	initGitRepoForWorktreeTests(t, root)
 
-	slug := createGovernedRequest(t, root, "L3", "stats should keep hidden worktree closeout freshness authoritative")
+	slug := createGovernedRequest(t, root, levelDiscovery, "stats should keep hidden worktree closeout freshness authoritative")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 
@@ -297,7 +297,7 @@ func TestStatsCountsMissingMandatoryIndependentReviewEvidence(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "stats should count missing independent review evidence")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "stats should count missing independent review evidence")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = model.StateS3Review
@@ -332,7 +332,7 @@ func TestStatsCountsMissingSelectedSecurityReviewEvidence(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "stats should count selected security review evidence")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "stats should count selected security review evidence")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = model.StateS3Review

--- a/cmd/status_context_repair_test.go
+++ b/cmd/status_context_repair_test.go
@@ -41,7 +41,7 @@ func TestStatusCommandDefaultsToBoundWorktreeChangeWhenMultipleActiveChanges(t *
 		runGit(t, root, "commit", "-m", "init")
 		initTestWorkspace(t, root)
 
-		boundSlug := createGovernedRequest(t, root, "L3", "bound worktree status default route")
+		boundSlug := createGovernedRequest(t, root, levelDiscovery, "bound worktree status default route")
 		boundChange, err := state.LoadChange(root, boundSlug)
 		require.NoError(t, err)
 		boundChange.CurrentState = model.StateS2Implement
@@ -204,7 +204,7 @@ func TestBuildGovernedStatusView(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "status governed builder")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "status governed builder")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 
@@ -225,7 +225,7 @@ func TestBuildGovernedStatusViewRecomputesGovernanceReadinessWithoutPersistingSn
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "status governance recompute")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "status governance recompute")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = model.StateS3Review
@@ -314,7 +314,7 @@ func TestBuildGovernedStatusViewChecksInvalidBoundWorktreeBeforeBundle(t *testin
 	initGitRepoForWorktreeTests(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "status invalid bound worktree")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "status invalid bound worktree")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 
@@ -336,7 +336,7 @@ func TestBuildMultiChangeSummaryView(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	governedSlug := createGovernedRequest(t, root, "L2", "status governed summary")
+	governedSlug := createGovernedRequest(t, root, levelNonDiscovery, "status governed summary")
 	createIntakeChangeFixture(t, root, "status admission summary")
 
 	changes, err := state.ListChanges(root)
@@ -361,7 +361,7 @@ func TestBuildGovernedStatusViewPlanAuditKeepsNextAction(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "status plan finalized")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "status plan finalized")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = model.StateS1Plan
@@ -406,7 +406,7 @@ func assertReadOnlyArtifactReconcileDoesNotPersist(
 	root := t.TempDir()
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L2", description)
+		slug := createGovernedRequest(t, root, levelNonDiscovery, description)
 
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
@@ -530,7 +530,7 @@ func TestResolveExplicitRequestInactiveRemediationDoesNotPointToUnsupportedStatu
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "inactive explicit request remediation")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "inactive explicit request remediation")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.Status = model.ChangeStatusDone

--- a/cmd/status_view_build_test.go
+++ b/cmd/status_view_build_test.go
@@ -116,7 +116,7 @@ func TestBuildGovernedStatusViewPreAuditOmitsShipGateDebt(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "status should omit ship gate debt before verify")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "status should omit ship gate debt before verify")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 
@@ -133,7 +133,7 @@ func TestBuildGovernedStatusViewExposesDoneReadyReadiness(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "done-ready status projection")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "done-ready status projection")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	markChangeReadyForDone(t, root, &change)
@@ -714,7 +714,7 @@ func TestBuildGovernedStatusViewUsesResumeResponseForActiveCheckpoint(t *testing
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "status should suggest checkpoint resume-response")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "status should suggest checkpoint resume-response")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = model.StateS2Implement
@@ -756,7 +756,7 @@ func TestBuildGovernedStatusViewUsesCurrentTasksForActiveCheckpointWhenWavePlanI
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "status should use current tasks for checkpoint resume")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "status should use current tasks for checkpoint resume")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = model.StateS2Implement
@@ -804,7 +804,7 @@ func TestBuildGovernedStatusViewSuggestsRepairForActiveCheckpointWhenWaveRunsAre
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "status should fail closed for checkpoint resume when wave runs are missing")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "status should fail closed for checkpoint resume when wave runs are missing")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = model.StateS2Implement
@@ -856,7 +856,7 @@ func TestBuildGovernedStatusViewUsesRunResumeForIncompleteWaveExecution(t *testi
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "status should suggest run resume")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "status should suggest run resume")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = model.StateS2Implement
@@ -892,7 +892,7 @@ func TestBuildGovernedStatusViewSurfacesInterruptedExecutionContext(t *testing.T
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "status should surface interrupted execution context")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "status should surface interrupted execution context")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = model.StateS2Implement
@@ -931,7 +931,7 @@ func TestBuildGovernedStatusViewSuggestsRepairWhenWaveRunsAreIncomplete(t *testi
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "status should fail closed for incomplete wave evidence")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "status should fail closed for incomplete wave evidence")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = model.StateS2Implement
@@ -984,7 +984,7 @@ func TestBuildGovernedStatusViewSuggestsRepairWhenWaveRunsAreMissingDuringReview
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "status should surface missing wave runs during verify")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "status should surface missing wave runs during verify")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	change.CurrentState = model.StateS3Review

--- a/cmd/tool_test.go
+++ b/cmd/tool_test.go
@@ -35,7 +35,7 @@ func TestToolMergeSARIFDeterministicAndSeparatedByTool(t *testing.T) {
 
 	first, err := os.ReadFile(outPath)
 	require.NoError(t, err)
-	stdout, stderr, err = runRootCommandWithInput([]string{"tool", "merge-sarif", raw, outPath}, "")
+	_, stderr, err = runRootCommandWithInput([]string{"tool", "merge-sarif", raw, outPath}, "")
 	require.NoError(t, err, stderr)
 	second, err := os.ReadFile(outPath)
 	require.NoError(t, err)

--- a/cmd/validate_artifact_gate_test.go
+++ b/cmd/validate_artifact_gate_test.go
@@ -21,7 +21,7 @@ func TestValidateBlocksWhenGovernedBundleIsIncompleteAtSpecBundle(t *testing.T) 
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "validate should gate incomplete bundle")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "validate should gate incomplete bundle")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -111,7 +111,7 @@ func TestValidatePreAuditDefaultViewOmitsShipGateDebt(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "validate should omit ship gate debt before verify")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "validate should omit ship gate debt before verify")
 
 	view, err := buildValidateViewForSlug(root, slug)
 	require.NoError(t, err)
@@ -125,7 +125,7 @@ func TestNextBlocksWhenGovernedBundleIsIncompleteAtSpecBundle(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "next should gate incomplete bundle")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "next should gate incomplete bundle")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 
@@ -153,7 +153,7 @@ func TestValidateBlocksPlanAuditAdvanceWhenArtifactsAreMissingEvenIfSkillIsReady
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "validate should gate missing artifacts at plan audit")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "validate should gate missing artifacts at plan audit")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -191,7 +191,7 @@ func TestValidateBlocksPlanAuditWhenDecisionIsTemplateOnly(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "validate should gate template decision at plan audit")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "validate should gate template decision at plan audit")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 
@@ -255,7 +255,7 @@ func TestValidateUsesFilesystemArtifactReadinessWithoutPersistingReconcile(t *te
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "validate should use filesystem artifact readiness")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "validate should use filesystem artifact readiness")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 
@@ -292,7 +292,7 @@ func TestValidateExposesArtifactAmendmentsWithoutPersistingReconcile(t *testing.
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "validate should expose artifact amendments")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "validate should expose artifact amendments")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 
@@ -334,7 +334,7 @@ func TestValidateOnlyRequiresActivePlanningSkillAtPlanAudit(t *testing.T) {
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "validate should scope skill blockers to the active plan sub-step")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "validate should scope skill blockers to the active plan sub-step")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -362,7 +362,7 @@ func TestValidateSkillsReadyScopesToActivePlanningSubStep(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L3", "validate should scope passing skills to the active plan sub-step")
+	slug := createGovernedRequest(t, root, levelDiscovery, "validate should scope passing skills to the active plan sub-step")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 
@@ -393,7 +393,7 @@ func TestValidateExposesPlanningRecoveryState(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "validate should expose plan recovery state")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "validate should expose plan recovery state")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 
@@ -413,7 +413,7 @@ func TestValidateDoesNotLeakBundleBlockersBeforeWorktreeBinding(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L3", "validate should not leak bundle blockers before worktree")
+	slug := createGovernedRequest(t, root, levelDiscovery, "validate should not leak bundle blockers before worktree")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 
@@ -436,7 +436,7 @@ func TestValidateIncludesGovernanceActionBlockersAtReviewState(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "validate governance action blockers")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "validate governance action blockers")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 
@@ -458,7 +458,7 @@ func TestValidateIncludesTaskChecklistAdvisories(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "validate task checklist advisories")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "validate task checklist advisories")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 
@@ -495,7 +495,7 @@ func TestValidateIncludesTaskChecklistBlockers(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "validate task checklist blockers")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "validate task checklist blockers")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 
@@ -532,7 +532,7 @@ func TestValidateAtShipGateRequiresReviewEvidence(t *testing.T) {
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "validate review evidence at ship gate")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "validate review evidence at ship gate")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS3Review
@@ -575,7 +575,7 @@ func TestValidateBlocksWhenExecutionEvidenceIsStale(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "validate should block stale evidence")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "validate should block stale evidence")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 

--- a/cmd/validate_readonly_test.go
+++ b/cmd/validate_readonly_test.go
@@ -75,7 +75,7 @@ func TestValidateArchivedExplicitSlugIsZeroWrite(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 
-	slug := createGovernedRequest(t, root, "L2", "validate archived zero write")
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "validate archived zero write")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 	_, err = state.ArchiveChange(root, change, model.ChangeStatusDone)

--- a/cmd/validate_requirements_contract_test.go
+++ b/cmd/validate_requirements_contract_test.go
@@ -21,7 +21,7 @@ func TestValidateIncludesRequirementsContractForGovernedChange(t *testing.T) {
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "validate requirements contract")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "validate requirements contract")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		bundleDir, err := state.GovernedBundleDir(root, change)
@@ -51,7 +51,7 @@ func TestValidateReportsMissingRequirementsContract(t *testing.T) {
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "validate missing requirements contract")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "validate missing requirements contract")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		bundleDir, err := state.GovernedBundleDir(root, change)
@@ -72,7 +72,7 @@ func TestValidateReportsInvalidRequirementsContract(t *testing.T) {
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "validate invalid requirements contract")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "validate invalid requirements contract")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		bundleDir, err := state.GovernedBundleDir(root, change)
@@ -95,7 +95,7 @@ func TestValidateOmitsRequirementsContractWhenPresetConfirmationPending(t *testi
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "validate preset confirmation pending")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "validate preset confirmation pending")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.WorkflowPreset = ""
@@ -134,7 +134,7 @@ func TestValidateUsesDedicatedWorktreePathInRequirementsContractSource(t *testin
 		initTestWorkspace(t, root)
 		initGitRepoForWorktreeTests(t, root)
 
-		slug := createGovernedRequest(t, root, "L3", "validate worktree requirements contract")
+		slug := createGovernedRequest(t, root, levelDiscovery, "validate worktree requirements contract")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -178,7 +178,7 @@ func TestValidateOmitsRequirementsContractWhenRequirementsFileIsUnreadable(t *te
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 
-		slug := createGovernedRequest(t, root, "L2", "validate unreadable requirements contract")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "validate unreadable requirements contract")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 		change.CurrentState = model.StateS1Plan

--- a/cmd/worktree_preflight_test.go
+++ b/cmd/worktree_preflight_test.go
@@ -21,7 +21,7 @@ func TestNextBlocksL3AdvanceWithoutWorktreePreflightEvidence(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, "L3", "l3 worktree gate")
+		slug := createGovernedRequest(t, root, levelDiscovery, "l3 worktree gate")
 
 		// Advance to S2_IMPLEMENT where the worktree gate is now checked.
 		change, err := state.LoadChange(root, slug)
@@ -80,7 +80,7 @@ func TestNextL3AdvancesAfterDedicatedWorktreePreflightEvidence(t *testing.T) {
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 		initGitRepoForWorktreeTests(t, root)
-		slug := createGovernedRequest(t, root, "L3", "l3 worktree advance")
+		slug := createGovernedRequest(t, root, levelDiscovery, "l3 worktree advance")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -162,7 +162,7 @@ func TestNextUsesDedicatedWorktreePathsAfterPreflight(t *testing.T) {
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 		initGitRepoForWorktreeTests(t, root)
-		slug := createGovernedRequest(t, root, "L3", "l3 worktree paths")
+		slug := createGovernedRequest(t, root, levelDiscovery, "l3 worktree paths")
 		change, err := state.LoadChange(root, slug)
 		require.NoError(t, err)
 
@@ -203,7 +203,7 @@ func TestNextMovesGovernedBundleIntoDedicatedWorktreeAfterPreflight(t *testing.T
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 	initGitRepoForWorktreeTests(t, root)
-	slug := createGovernedRequest(t, root, "L3", "l3 worktree bundle migration")
+	slug := createGovernedRequest(t, root, levelDiscovery, "l3 worktree bundle migration")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 
@@ -237,7 +237,7 @@ func TestValidateBlocksL3WorktreePreflightWhenEvidenceTargetsMainWorkspace(t *te
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 		initGitRepoForWorktreeTests(t, root)
-		slug := createGovernedRequest(t, root, "L3", "l3 invalid main worktree")
+		slug := createGovernedRequest(t, root, levelDiscovery, "l3 invalid main worktree")
 
 		// Advance to S2_IMPLEMENT where the worktree gate is now checked.
 		change, err := state.LoadChange(root, slug)
@@ -277,7 +277,7 @@ func TestNextL3WorktreePreflightEvidenceUnblocksS2Implement(t *testing.T) {
 	ensureTestGitRepo(t, root)
 	initTestWorkspace(t, root)
 	initGitRepoForWorktreeTests(t, root)
-	slug := createGovernedRequest(t, root, "L3", "l3 worktree deadlock regression")
+	slug := createGovernedRequest(t, root, levelDiscovery, "l3 worktree deadlock regression")
 	change, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
 

--- a/docs/ai-tools.md
+++ b/docs/ai-tools.md
@@ -188,7 +188,7 @@ Cursor follows the same pattern, shipping
 These launchers only delegate to `slipway hook ...`; hook behavior lives in the
 Slipway binary.
 
-## P1 Adapter Notes
+## Additional Adapter Notes
 
 Copilot stores command prompts in `.github/prompts/` with the
 `.prompt.md` extension and generated skills in `.github/skills/`. Its sentinel

--- a/internal/engine/artifact/manager.go
+++ b/internal/engine/artifact/manager.go
@@ -460,20 +460,6 @@ func artifactSectionBodyLooksPlaceholder(body string) bool {
 	return false
 }
 
-// ParseDecisionLockedDecisions extracts decision items from decision.md.
-// It reads "Selected Approach" as the primary decision, and "Alternatives Considered"
-// for the selected direction marker. Ignores template placeholder text,
-// including scaffolded seeded-draft defaults that have not been confirmed by
-// research or explicit user selection yet. Explicit rejected or unknown decision
-// statuses are not usable locked decisions.
-func ParseDecisionLockedDecisions(content string) []string {
-	parsed := ParseDecisionContract(content)
-	if len(parsed.StatusBlockers) > 0 || len(parsed.Decisions) == 0 {
-		return nil
-	}
-	return parsed.Decisions
-}
-
 // LooksLikeTemplatePlaceholder returns true if the text looks like unedited
 // scaffold content, including seeded draft prose that still needs explicit
 // confirmation before it should satisfy governance/runtime checks. It is the

--- a/internal/engine/artifact/manager_test.go
+++ b/internal/engine/artifact/manager_test.go
@@ -634,7 +634,7 @@ func TestScaffoldGovernedBundleMarkdownSizeBudget(t *testing.T) {
 	assert.LessOrEqual(t, total, 15000, "fresh artifact bundle scaffold must stay structural, not analytical")
 }
 
-func TestParseDecisionLockedDecisionsIgnoresUnconfirmedSeededTextWithoutDraftComment(t *testing.T) {
+func TestParseDecisionContractIgnoresUnconfirmedSeededTextWithoutDraftComment(t *testing.T) {
 	t.Parallel()
 
 	content := `# Decision
@@ -660,10 +660,10 @@ Start with the direct implementation path for update auth middleware timeout str
 Primary risk for update auth middleware timeout strategy is hidden coupling in the existing implementation. Mitigate with focused code inspection and regression coverage before broad structural changes. Confirm or replace this after risk review.
 `
 
-	assert.Nil(t, ParseDecisionLockedDecisions(content))
+	assert.Empty(t, ParseDecisionContract(content).Decisions)
 }
 
-func TestParseDecisionLockedDecisionsRejectsDeadStatus(t *testing.T) {
+func TestParseDecisionContractRejectsDeadStatus(t *testing.T) {
 	t.Parallel()
 
 	content := `# Decision
@@ -694,7 +694,7 @@ Revert this parser change if needed.
 Low risk.
 `
 
-	assert.Nil(t, ParseDecisionLockedDecisions(content))
+	assert.NotEmpty(t, ParseDecisionContract(content).StatusBlockers)
 }
 
 func TestStalePropagationOrderBFS(t *testing.T) {

--- a/internal/engine/capability/gates_test.go
+++ b/internal/engine/capability/gates_test.go
@@ -38,7 +38,7 @@ func loadFrontmatter(t *testing.T, templates fs.FS, name string) frontmatter {
 	return fm
 }
 
-// TestFrontmatterMirrorsRegistryBindings is the B1 binding-compare gate.
+// TestFrontmatterMirrorsRegistryBindings is the binding-compare gate.
 // It parses each SKILL.md's frontmatter and asserts the bindings[] list
 // matches the Go-owned Skill entry exactly.
 func TestFrontmatterMirrorsRegistryBindings(t *testing.T) {
@@ -55,7 +55,7 @@ func TestFrontmatterMirrorsRegistryBindings(t *testing.T) {
 	}
 }
 
-// TestFrontmatterMirrorsRegistryHydrateReferences is the PR-4a hydrate
+// TestFrontmatterMirrorsRegistryHydrateReferences is the hydrate
 // compare gate. Every catalog skill's SKILL.md frontmatter
 // `hydrate_references:` list must match the Go-owned Skill.HydrateReferences
 // record-for-record after sorting by name.
@@ -73,7 +73,7 @@ func TestFrontmatterMirrorsRegistryHydrateReferences(t *testing.T) {
 	}
 }
 
-// TestSizeBudgetsForRegisteredSkills enforces the B1 tier-aware size-lint
+// TestSizeBudgetsForRegisteredSkills enforces the tier-aware size-lint
 // gate. Sizes above target are warning-band; sizes above hard-max require
 // `size_rationale` in frontmatter.
 func TestSizeBudgetsForRegisteredSkills(t *testing.T) {
@@ -109,7 +109,7 @@ func TestTierSizeBudgetRequiresRationaleAboveHardMax(t *testing.T) {
 	require.NoError(t, checkTierSizeBudget(TierT3, 3*1024+1, "known false-positive due embedded table"))
 }
 
-// TestFrontmatterHasRequiredFields enforces the B1 schema-lint gate on
+// TestFrontmatterHasRequiredFields enforces the schema-lint gate on
 // required frontmatter keys. It does not re-run the full DSL validator
 // (that is covered by trigger_test.go); it pins the authoring contract.
 func TestFrontmatterHasRequiredFields(t *testing.T) {
@@ -241,9 +241,9 @@ func assertHydrateReferencesEqual(t *testing.T, sk Skill, frontRefs []frontHydra
 func tierSizeBudget(tier Tier) (target, hardMax int) {
 	switch tier {
 	case TierT1:
-		return 2560, 6 * 1024 // 2.5 KB target (PR-3 lift), hard-max 6 KB
+		return 2560, 6 * 1024 // 2.5 KB target, hard-max 6 KB
 	case TierT2:
-		return 3584, 8 * 1024 // 3.5 KB target (PR-3 lift), hard-max 8 KB
+		return 3584, 8 * 1024 // 3.5 KB target, hard-max 8 KB
 	case TierT3:
 		return 1536, 3 * 1024 // 1.5 KB target, rationale above 3 KB
 	default:
@@ -276,9 +276,9 @@ func TestSkillDirectoryNamesMatchRegistry(t *testing.T) {
 	}
 }
 
-// TestNoPrematureTiebreakPromises ensures llm_tiebreak (B7+) does not leak
-// into authoring metadata before B7 lands. hydrate_references may appear
-// from B2 onward (context-assembly owns the first real use).
+// TestNoPrematureTiebreakPromises ensures llm_tiebreak does not leak
+// into authoring metadata before it lands. hydrate_references may appear
+// for scale-foundation skills onward (context-assembly owns the first real use).
 func TestNoPrematureTiebreakPromises(t *testing.T) {
 	t.Parallel()
 	templates := skillsFS()
@@ -294,7 +294,7 @@ func TestNoPrematureTiebreakPromises(t *testing.T) {
 			return err
 		}
 		fm := extractFrontmatterBlock(t, string(raw))
-		assert.NotContains(t, fm, "llm_tiebreak", "%s: llm_tiebreak is a B7+ surface", name)
+		assert.NotContains(t, fm, "llm_tiebreak", "%s: llm_tiebreak is an unreleased surface", name)
 		return nil
 	})
 	require.NoError(t, err)

--- a/internal/engine/capability/registry_change_shape_verification.go
+++ b/internal/engine/capability/registry_change_shape_verification.go
@@ -1,6 +1,6 @@
 package capability
 
-// B4 change-shape + verification skills.
+// change-shape + verification skills.
 
 func multiReviewerCalibration() Skill {
 	return Skill{

--- a/internal/engine/capability/registry_default.go
+++ b/internal/engine/capability/registry_default.go
@@ -4,27 +4,27 @@ package capability
 // skills come first, followed by later domain batches.
 func defaultSkills() []Skill {
 	return []Skill{
-		// B1 foundation set
+		// foundation set
 		independentReview(),
-		// B2 scale foundation
+		// scale foundation
 		contextAssembly(),
 		rootCauseTracing(),
 		securityReview(),
 		specTrace(),
-		// B3 security cluster
+		// security cluster
 		threatModeling(),
 		sastOrchestration(),
 		ghaSecurityReview(),
 		supplyChainAudit(),
-		// B4 change-shape + verification
+		// change-shape + verification
 		multiReviewerCalibration(),
 		variantAnalysis(),
 		coverageAnalysis(),
 		propertyTesting(),
 		mutationTesting(),
-		// B6 test-design
+		// test-design
 		testDesign(),
-		// B5 repair/CI + ops
+		// repair/CI + ops
 		ciTriage(),
 		reviewCommentTriage(),
 		gitRecovery(),

--- a/internal/engine/capability/registry_repair_ci_ops.go
+++ b/internal/engine/capability/registry_repair_ci_ops.go
@@ -1,6 +1,6 @@
 package capability
 
-// B5 repair/CI + ops skills.
+// repair/CI + ops skills.
 
 func ciTriage() Skill {
 	return Skill{

--- a/internal/engine/capability/registry_scale_foundation.go
+++ b/internal/engine/capability/registry_scale_foundation.go
@@ -1,6 +1,6 @@
 package capability
 
-// B2 scale-foundation skills.
+// scale-foundation skills.
 
 func contextAssembly() Skill {
 	return Skill{

--- a/internal/engine/capability/registry_security.go
+++ b/internal/engine/capability/registry_security.go
@@ -1,6 +1,6 @@
 package capability
 
-// B3 security-cluster skills.
+// security-cluster skills.
 
 func threatModeling() Skill {
 	return Skill{

--- a/internal/engine/capability/registry_test_design.go
+++ b/internal/engine/capability/registry_test_design.go
@@ -1,6 +1,6 @@
 package capability
 
-// B6 test-design skills.
+// test-design skills.
 
 func testDesign() Skill {
 	return Skill{

--- a/internal/engine/capability/resolver_test.go
+++ b/internal/engine/capability/resolver_test.go
@@ -137,7 +137,7 @@ func TestResolveHydrateDedupesAndSortsAcrossRouteAndSupports(t *testing.T) {
 	}
 }
 
-func TestResolvePR4aPreservesRouteAndSupportsInvariant(t *testing.T) {
+func TestResolvePreservesRouteAndSupportsInvariant(t *testing.T) {
 	t.Parallel()
 	reg := DefaultRegistry()
 	type supportSnapshot struct {
@@ -266,7 +266,7 @@ func TestResolveRetiredTddProofHydrateDoesNotLeak(t *testing.T) {
 	}
 }
 
-// TestResolveCiTriageNeverSurfacesHydrate enforces the Wave-3 PR-3 negative
+// TestResolveCiTriageNeverSurfacesHydrate enforces the negative
 // invariant: ci-triage is a scripts-only suggested-only skill with no
 // HydrateReferences, so its hydrate footprint is empty on every selection
 // path it owns (suggested on fix, and also on arbitrary hosts).

--- a/internal/engine/context/context.go
+++ b/internal/engine/context/context.go
@@ -2,7 +2,6 @@ package enginecontext
 
 import (
 	"reflect"
-	"time"
 )
 
 type ExecutionMode string
@@ -22,11 +21,6 @@ const (
 type EvidenceFreshnessInput struct {
 	ExpectedStructuralInput map[string]string `json:"expected_structural_input,omitempty"`
 	CurrentStructuralInput  map[string]string `json:"current_structural_input,omitempty"`
-	// EvidenceTimestamp and LatestRelevantUpdateAt remain serialized legacy
-	// metadata, but freshness is evaluated only from structural inputs. Ordering
-	// checks that still need timestamps must live at their domain-specific gate.
-	EvidenceTimestamp      time.Time `json:"evidence_timestamp"`
-	LatestRelevantUpdateAt time.Time `json:"latest_relevant_update_at"`
 }
 
 func EvaluateEvidenceFreshness(

--- a/internal/engine/context/context_test.go
+++ b/internal/engine/context/context_test.go
@@ -2,7 +2,6 @@ package enginecontext
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -16,8 +15,6 @@ func TestEvaluateEvidenceFreshness(t *testing.T) {
 		{
 			ExpectedStructuralInput: map[string]string{"task_id": "task-a"},
 			CurrentStructuralInput:  map[string]string{"task_id": "task-a"},
-			EvidenceTimestamp:       time.Now().UTC(),
-			LatestRelevantUpdateAt:  time.Now().UTC().Add(-time.Second),
 		},
 	})
 	assert.Equal(t, EvidenceFreshnessFresh, fresh)
@@ -29,14 +26,6 @@ func TestEvaluateEvidenceFreshness(t *testing.T) {
 		},
 	})
 	assert.Equal(t, EvidenceFreshnessStale, staleByStructuralInput)
-
-	timestampOnly := EvaluateEvidenceFreshness(true, []EvidenceFreshnessInput{
-		{
-			EvidenceTimestamp:      time.Now().UTC().Add(-2 * time.Minute),
-			LatestRelevantUpdateAt: time.Now().UTC().Add(-time.Minute),
-		},
-	})
-	assert.Equal(t, EvidenceFreshnessUnknown, timestampOnly)
 
 	unknownInsufficient := EvaluateEvidenceFreshness(true, []EvidenceFreshnessInput{
 		{},

--- a/internal/engine/control/derive.go
+++ b/internal/engine/control/derive.go
@@ -28,7 +28,6 @@ type DeriveControlsResult struct {
 	Summary        model.SignalSummary
 	Observations   []model.SignalObservation
 	ActiveControls []model.ControlActivation
-	NewActivations []model.ControlActivation
 }
 
 // DeriveControls computes governance signals and controls directly from Change
@@ -197,7 +196,6 @@ func DeriveControls(input DeriveControlsInput) DeriveControlsResult {
 		Summary:        summary,
 		Observations:   observations,
 		ActiveControls: merged.ActiveControls,
-		NewActivations: merged.NewActivations,
 	}
 }
 

--- a/internal/engine/control/derive_test.go
+++ b/internal/engine/control/derive_test.go
@@ -21,7 +21,6 @@ func TestDeriveControls_NoDomainSmallChangeNoDiscovery(t *testing.T) {
 	})
 
 	assert.Empty(t, result.ActiveControls, "no-domain small change with no discovery should produce no controls")
-	assert.Empty(t, result.NewActivations)
 }
 
 func TestDeriveControls_NeedsDiscoveryFalseSkipsExploration(t *testing.T) {
@@ -365,14 +364,6 @@ func TestDeriveControls_DisabledControlOverrideWithMonotonicPreservation(t *test
 	// DisabledControls removes new candidate, but monotonic merge preserves existing.
 	assert.Contains(t, controlIDs, model.ControlDomainReview,
 		"existing active control persists due to monotonic rule even when disabled")
-
-	// domain-review should NOT appear in NewActivations (it was existing, not newly added).
-	var newIDs []model.ControlID
-	for _, c := range result.NewActivations {
-		newIDs = append(newIDs, c.ControlID)
-	}
-	assert.NotContains(t, newIDs, model.ControlDomainReview,
-		"domain-review should not be a new activation since it came from existing controls")
 }
 
 func TestDeriveControls_ModeOverrideAdvisory(t *testing.T) {

--- a/internal/engine/control/evaluate.go
+++ b/internal/engine/control/evaluate.go
@@ -7,7 +7,6 @@ import (
 // mergeResult holds the output of monotonic control merge.
 type mergeResult struct {
 	ActiveControls []model.ControlActivation
-	NewActivations []model.ControlActivation
 }
 
 // mergeMonotonic ensures controls are never silently removed.
@@ -29,7 +28,6 @@ func mergeMonotonic(existing, candidates []model.ControlActivation) mergeResult 
 	}
 
 	var active []model.ControlActivation
-	var newActivations []model.ControlActivation
 
 	// Keep all existing active controls, refreshing policy metadata from
 	// current candidates when available.
@@ -49,31 +47,12 @@ func mergeMonotonic(existing, candidates []model.ControlActivation) mergeResult 
 	for _, ctrl := range candidates {
 		if _, exists := existingSet[ctrl.ControlID]; !exists {
 			active = append(active, ctrl)
-			newActivations = append(newActivations, ctrl)
 		}
 	}
 
 	return mergeResult{
 		ActiveControls: active,
-		NewActivations: newActivations,
 	}
-}
-
-// DeactivateControl removes a specific control from the active list.
-func DeactivateControl(
-	existing []model.ControlActivation,
-	controlID model.ControlID,
-) []model.ControlActivation {
-	var updated []model.ControlActivation
-
-	for _, ctrl := range existing {
-		if ctrl.ControlID == controlID && ctrl.Active {
-			continue
-		}
-		updated = append(updated, ctrl)
-	}
-
-	return updated
 }
 
 // controlThresholds defines the trigger thresholds for each control.

--- a/internal/engine/control/evaluate_test.go
+++ b/internal/engine/control/evaluate_test.go
@@ -8,33 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDeactivateControl(t *testing.T) {
-	t.Parallel()
-	existing := []model.ControlActivation{
-		{
-			ControlID:    model.ControlDomainReview,
-			Mode:         model.ControlModeBlocking,
-			Scope:        model.ControlScopeReview,
-			Active:       true,
-			TriggeredBy:  []string{"auth_authz"},
-			PolicySource: model.BuiltinPolicySource,
-		},
-		{
-			ControlID:    model.ControlWorktreeIsolation,
-			Mode:         model.ControlModeBlocking,
-			Scope:        model.ControlScopeExecution,
-			Active:       true,
-			TriggeredBy:  []string{"domain_present"},
-			PolicySource: model.BuiltinPolicySource,
-		},
-	}
-
-	updated := DeactivateControl(existing, model.ControlDomainReview)
-
-	assert.Len(t, updated, 1)
-	assert.Equal(t, model.ControlWorktreeIsolation, updated[0].ControlID)
-}
-
 func TestMergeMonotonicRefreshesPolicyMetadata(t *testing.T) {
 	t.Parallel()
 	// Existing control has stale mode (blocking) and old policy version.
@@ -69,9 +42,6 @@ func TestMergeMonotonicRefreshesPolicyMetadata(t *testing.T) {
 	// Metadata should be refreshed from the candidate.
 	assert.Equal(t, model.ControlModeAdvisory, ctrl.Mode, "mode must be refreshed")
 	assert.Equal(t, []string{"blast_radius=high", "domain_present"}, ctrl.TriggeredBy, "triggers must be refreshed")
-
-	// Not a new activation — it was an existing control.
-	assert.Empty(t, result.NewActivations, "refreshed existing control is not a new activation")
 }
 
 func TestMergeMonotonicPreservesExistingWithoutCandidate(t *testing.T) {

--- a/internal/engine/governance/snapshot.go
+++ b/internal/engine/governance/snapshot.go
@@ -15,9 +15,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// SnapshotFileName is the canonical file name for the governance sidecar.
-const SnapshotFileName = "governance_snapshot.yaml"
-
 // SnapshotPath returns the canonical path for a change's governance snapshot.
 func SnapshotPath(root, slug string) string {
 	return state.GovernanceSnapshotCachePath(root, slug)

--- a/internal/engine/progression/authority.go
+++ b/internal/engine/progression/authority.go
@@ -412,10 +412,6 @@ type proofReuseDigestCheck struct {
 	label     string
 }
 
-func CloseoutRecoveryRemediation() string {
-	return closeoutRecoveryRemediation
-}
-
 // closeoutAssuranceAttestationBlockers enforces Layer 1 of issue #47. When
 // assurance is required for the change's effective preset (standard/strict),
 // the passing final-closeout record must carry the assurance-complete
@@ -939,10 +935,6 @@ func crossStageContextDistinctBlockers(
 // goal/closeout stages to this lattice.
 func crossStageContextReviewStagesForSelectedSkills(selectedReviewSkills []string) map[string]struct{} {
 	return crossStageContextOwnedReviewStagesForSelectedSkills(selectedReviewSkills)
-}
-
-func crossStageContextShipStagesForSelectedSkills(selectedReviewSkills []string) map[string]struct{} {
-	return crossStageContextReviewStagesForSelectedSkills(selectedReviewSkills)
 }
 
 func selectedReviewSkillsForAuthority(authority ReviewAuthority) []string {

--- a/internal/engine/progression/authority_test.go
+++ b/internal/engine/progression/authority_test.go
@@ -993,8 +993,8 @@ func TestShipCrossStageContextNoDoubleFire(t *testing.T) {
 
 	selectedReviewers := []string{SkillSpecComplianceReview, SkillCodeQualityReview, SkillIndependentReview}
 	selectedReviewersWithSecurity := engineskill.SelectedReviewSkills(engineskill.ReviewSkillSelection{SecurityReviewSelected: true})
-	shipStages := crossStageContextShipStagesForSelectedSkills(selectedReviewers)
-	shipStagesWithSecurity := crossStageContextShipStagesForSelectedSkills(selectedReviewersWithSecurity)
+	shipStages := crossStageContextReviewStagesForSelectedSkills(selectedReviewers)
+	shipStagesWithSecurity := crossStageContextReviewStagesForSelectedSkills(selectedReviewersWithSecurity)
 
 	t.Run("review-owned spec/code edge does not re-fire at ship", func(t *testing.T) {
 		t.Parallel()

--- a/internal/engine/progression/evidence_digests_test.go
+++ b/internal/engine/progression/evidence_digests_test.go
@@ -1387,10 +1387,10 @@ func TestExecutionSummaryFreshnessUsesTaskPlanHashNotTaskMTime(t *testing.T) {
 
 	afterEvidence := capturedAt.Add(time.Hour)
 	require.NoError(t, os.Chtimes(tasksPath, afterEvidence, afterEvidence))
-	assert.Equal(t, ctxpack.EvidenceFreshnessFresh, state.ExecutionSummaryFreshness(root, change, summary))
+	assert.Equal(t, string(ctxpack.EvidenceFreshnessFresh), state.ExecutionSummaryFreshnessDiagnostics(root, change, summary).Status)
 
 	require.NoError(t, os.WriteFile(tasksPath, []byte(realChangedDigestTasks()), 0o644))
-	assert.Equal(t, ctxpack.EvidenceFreshnessStale, state.ExecutionSummaryFreshness(root, change, summary))
+	assert.Equal(t, string(ctxpack.EvidenceFreshnessStale), state.ExecutionSummaryFreshnessDiagnostics(root, change, summary).Status)
 }
 
 func TestWaveOrchestrationInputDigestUsesRuntimeTaskEvidenceNotExecutionSummary(t *testing.T) {

--- a/internal/engine/progression/evidence_repair.go
+++ b/internal/engine/progression/evidence_repair.go
@@ -460,24 +460,3 @@ func sensitiveEvidenceRepairTarget(root string, change model.Change, summary *mo
 		Blockers:    report.Blockers,
 	}, nil
 }
-
-// scopeContractDriftOnly reports whether every scope-contract blocker is
-// out-of-scope drift (a changed file outside the plan) rather than missing task
-// changed-file evidence. Drift is non-destructive: the recorded wave evidence is
-// still valid — the worktree merely holds a file outside the plan (e.g. an
-// untracked scratch file or build artifact). Such a case must block visibly with
-// remediation, not silently clear wave-orchestration/execution-summary evidence
-// and mutate state. Missing task changed-file evidence
-// (scope_contract_changed_files_missing / scope_contract_missing) also blocks,
-// but its repair target points at S2_IMPLEMENT-owned task evidence.
-func scopeContractDriftOnly(blockers []model.ReasonCode) bool {
-	if len(blockers) == 0 {
-		return false
-	}
-	for _, blocker := range blockers {
-		if blocker.Code != scopecontract.ReasonScopeContractDrift {
-			return false
-		}
-	}
-	return true
-}

--- a/internal/engine/progression/freshness_guard_test.go
+++ b/internal/engine/progression/freshness_guard_test.go
@@ -62,19 +62,24 @@ func TestGenericEvidenceFreshnessDoesNotUseTimestampOrdering(t *testing.T) {
 	t.Parallel()
 
 	repoRoot := repositoryRootForFreshnessGuard(t)
-	contextFile := parseFreshnessGuardFile(t, repoRoot, "internal/engine/context/context.go")
-	disallowed := disallowedSelectorCalls(contextFile, []selectorCallMatch{
-		{receiverSuffix: "EvidenceTimestamp", selector: "Before"},
-		{receiverSuffix: "LatestRelevantUpdateAt", selector: "After"},
-		{receiverSuffix: "LatestRelevantUpdateAt", selector: "Before"},
-	})
-	if len(disallowed) > 0 {
-		t.Fatalf("generic evidence freshness must not compare timestamp ordering: %v", disallowed)
-	}
 
+	// The execution-summary freshness path must not resurrect an artifact-clock
+	// baseline helper.
 	summaryFile := parseFreshnessGuardFile(t, repoRoot, "internal/state/execution_summary.go")
 	if hasFunctionDecl(summaryFile, "latestExecutionRelevantUpdateAt") {
 		t.Fatalf("execution-summary freshness must not keep artifact-clock baseline helpers")
+	}
+
+	// The generic evidence-freshness evaluator (EvaluateEvidenceFreshness and its
+	// EvidenceFreshnessInput) is structural-only: it compares expected vs current
+	// structural inputs and must never reintroduce the removed timestamp fields
+	// (EvidenceTimestamp / LatestRelevantUpdateAt) or timestamp ordering. Importing
+	// "time" is the precondition for any of those, so forbid it outright at this
+	// boundary.
+	contextFile := parseFreshnessGuardFile(t, repoRoot, "internal/engine/context/context.go")
+	if fileImportsPackage(contextFile, "time") {
+		t.Fatalf("internal/engine/context/context.go must not import \"time\": " +
+			"generic evidence freshness must stay structural and must not reintroduce timestamp fields or ordering")
 	}
 }
 
@@ -214,6 +219,18 @@ func hasFunctionDecl(file *ast.File, name string) bool {
 	for _, decl := range file.Decls {
 		fn, ok := decl.(*ast.FuncDecl)
 		if ok && fn.Name.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func fileImportsPackage(file *ast.File, importPath string) bool {
+	for _, imp := range file.Imports {
+		if imp.Path == nil {
+			continue
+		}
+		if strings.Trim(imp.Path.Value, "`\"") == importPath {
 			return true
 		}
 	}

--- a/internal/engine/progression/scope_contract_gate_test.go
+++ b/internal/engine/progression/scope_contract_gate_test.go
@@ -89,25 +89,31 @@ func TestScopeContractRepairTargetEmptyWhenSummaryNotReady(t *testing.T) {
 	assert.Empty(t, target.SkillName, "no repair without a ready execution summary")
 }
 
-// Out-of-scope drift (a changed file outside the plan) is non-destructive and
-// must block visibly instead of clearing wave evidence; missing task
-// changed-file evidence routes to explicit repair (issue #136).
-func TestScopeContractDriftOnly(t *testing.T) {
+// Out-of-scope drift (a task records a changed file outside its planned
+// target_files) must route to the same non-destructive S2_IMPLEMENT repair as
+// missing changed-file evidence, carrying the scope_contract_drift cause so the
+// gate blocks visibly instead of clearing wave evidence (issue #136). This
+// drives the real scopeContractRepairTarget gate rather than re-asserting a
+// hand-rolled drift predicate.
+func TestScopeContractRepairTargetRoutesDriftToS2Repair(t *testing.T) {
 	t.Parallel()
+	root, change := seedScopeContractChange(t, model.StateS3Review)
 
-	drift := model.NewReasonCode(scopecontract.ReasonScopeContractDrift, "scratch.txt")
-	missing := model.NewReasonCode(scopecontract.ReasonScopeContractChangedFilesMissing, "t-01")
+	// task-a is planned for cmd/next.go but records a changed file outside that
+	// scope, so the only contract failure is out-of-scope drift.
+	target, err := scopeContractRepairTarget(root, change, codeTaskSummary([]string{"scratch.txt"}))
+	require.NoError(t, err)
 
-	assert.True(t, scopeContractDriftOnly([]model.ReasonCode{drift}),
-		"a sole drift blocker is drift-only")
-	assert.True(t, scopeContractDriftOnly([]model.ReasonCode{drift, drift}),
-		"multiple drift blockers are still drift-only")
-	assert.False(t, scopeContractDriftOnly([]model.ReasonCode{drift, missing}),
-		"a mix with missing-evidence is not drift-only")
-	assert.False(t, scopeContractDriftOnly([]model.ReasonCode{missing}),
-		"missing-evidence alone is not drift-only")
-	assert.False(t, scopeContractDriftOnly(nil),
-		"no blockers is not drift-only")
+	assert.Equal(t, SkillWaveOrchestration, target.SkillName)
+	assert.Equal(t, model.StateS2Implement, target.State)
+
+	specs := model.ReasonSpecs(target.Blockers)
+	assert.Contains(t, specs, scopecontract.ReasonScopeContractDrift+":scratch.txt",
+		"drift must surface the out-of-scope file as the scope_contract_drift cause")
+	for _, spec := range specs {
+		assert.NotContains(t, spec, scopecontract.ReasonScopeContractChangedFilesMissing,
+			"a task that recorded changed files must not also report missing-evidence")
+	}
 }
 
 func TestSensitiveEvidenceRepairTargetReturnsS2RepairWhenMarkerMissing(t *testing.T) {

--- a/internal/engine/progression/wave_sync.go
+++ b/internal/engine/progression/wave_sync.go
@@ -133,11 +133,7 @@ func evaluateGovernedWaveExecution(root string, change model.Change, mutate bool
 
 	planDriftBlockers := taskEvidencePlanHashBlockers(tasksPlanHash, tasks)
 	executionSummary := BuildExecutionSummary(record.RunVersion, tasks, record.Timestamp, &record)
-	if len(planDriftBlockers) == 0 {
-		executionSummary.TasksPlanHash = tasksPlanHash
-	} else {
-		executionSummary.TasksPlanHash = tasksPlanHash
-	}
+	executionSummary.TasksPlanHash = tasksPlanHash
 	if len(parseIssues) > 0 || len(planDriftBlockers) > 0 {
 		executionSummary.OpenBlockers = model.NormalizeReasonCodes(append(executionSummary.OpenBlockers, model.ReasonCodesFromSpecs(append(parseIssues, planDriftBlockers...))...))
 		executionSummary.SyncDerivedFields()
@@ -147,19 +143,18 @@ func evaluateGovernedWaveExecution(root string, change model.Change, mutate bool
 	// "ready" summary exists, refineS2WaveExecutionSkillBlockers short-circuits
 	// the preview path, so a returned-only blocker would vanish from read-only
 	// surfaces after the partial summary is written (issue #95 REQ-001).
-	var incompleteBlockers []model.ReasonCode
-	incompleteBlockers = IncompleteExecutionTaskBlockers(wavePlan, executionSummary.TaskRunMap())
+	incompleteBlockers := IncompleteExecutionTaskBlockers(wavePlan, executionSummary.TaskRunMap())
 	if len(incompleteBlockers) > 0 {
 		executionSummary.OpenBlockers = model.NormalizeReasonCodes(append(executionSummary.OpenBlockers, incompleteBlockers...))
 		executionSummary.SyncDerivedFields()
 	}
-	// Resolve the preset policy once here so the preset-sensitive safety nets
-	// (#5 test/impl distinctness, #6 degraded-dispatch justification) fail closed
-	// on standard/strict and stay advisory on light, without changing
-	// SyncGovernedWaveExecution's signature or its call sites. Both the mutate and
-	// preview paths flow through this point, so a single resolution covers them.
-	// authority.go in this same package already imports governance, so this adds no
-	// new cross-package edge. Fail closed on a resolution error.
+	// Resolve the preset policy once here so the preset-sensitive degraded-dispatch
+	// justification safety net fails closed on standard/strict and stays advisory
+	// on light, without changing SyncGovernedWaveExecution's signature or its call
+	// sites. Both the mutate and preview paths flow through this point, so a single
+	// resolution covers them. authority.go in this same package already imports
+	// governance, so this adds no new cross-package edge. Fail closed on a
+	// resolution error.
 	policy, err := governance.ResolvePresetPolicy(root, change)
 	if err != nil {
 		return WaveSyncResult{}, err
@@ -875,114 +870,6 @@ func waveStarted(wavePlanWave model.WavePlanWave, recorded map[string]struct{}) 
 	return false
 }
 
-// distinctnessPlanTask is the flattened (id, kind, targets, wave index) view of a
-// wave-plan task the test/impl-distinctness gate reasons over. It is derived
-// solely from engine-owned plan structure; no host-supplied session_id is read.
-type distinctnessPlanTask struct {
-	id        string
-	kind      model.TaskKind
-	targets   []string
-	waveIndex int
-}
-
-// TestImplDistinctnessBlockers enforces the relational test≠impl invariant
-// (REQ-003): for any task_kind=code task whose target_files are SHARED with at
-// least one other task, the plan MUST also dispatch — in an earlier wave — a
-// structurally distinct task_kind=test task that overlaps the same target_files.
-// The distinctness is derived only from engine-owned task_kind + target_files +
-// wave ordering; it NEVER keys on the host-supplied session_id (which is host-set,
-// excluded on the empty default, and therefore an invalid discriminator). A code
-// task whose target_files are not shared with any other task carries no
-// requirement and is skipped, so a single isolated implementation task is never
-// punished. Overlap uses wave.TargetCoversPath in both directions, the same scope
-// predicate the planner's conflict detection relies on, so "shares target_files"
-// here means exactly what "conflicts" means there. The gate is advisory on light
-// (enforced=false returns nil).
-func TestImplDistinctnessBlockers(plan model.WavePlan, enforced bool) []model.ReasonCode {
-	if !enforced || len(plan.Waves) == 0 {
-		return nil
-	}
-	flat := make([]distinctnessPlanTask, 0)
-	for _, planWave := range plan.Waves {
-		for _, planTask := range planWave.Tasks {
-			flat = append(flat, distinctnessPlanTask{
-				id:        planTask.TaskID,
-				kind:      planTask.TaskKind,
-				targets:   planTask.TargetFiles,
-				waveIndex: planWave.WaveIndex,
-			})
-		}
-	}
-	blockers := []model.ReasonCode{}
-	for _, code := range flat {
-		if code.kind != model.TaskKindCode {
-			continue
-		}
-		if !taskSharesTargets(code, flat) {
-			// Not shared with any peer task: no relational requirement.
-			continue
-		}
-		if hasPrecedingDistinctTest(code, flat) {
-			continue
-		}
-		blockers = append(blockers, model.NewReasonCode("wave_test_impl_not_distinct", code.id))
-	}
-	return model.NormalizeReasonCodes(blockers)
-}
-
-// taskSharesTargets reports whether task's target_files overlap any OTHER task's
-// target_files, using the planner's directional scope predicate in both
-// directions so a parent-directory target and a contained file count as shared.
-func taskSharesTargets(task distinctnessPlanTask, all []distinctnessPlanTask) bool {
-	for _, other := range all {
-		if other.id == task.id {
-			continue
-		}
-		if targetsOverlap(task.targets, other.targets) {
-			return true
-		}
-	}
-	return false
-}
-
-// hasPrecedingDistinctTest reports whether a structurally distinct task_kind=test
-// task (different id) whose target_files overlap the code task's target_files is
-// dispatched before it (strictly earlier wave index).
-func hasPrecedingDistinctTest(code distinctnessPlanTask, all []distinctnessPlanTask) bool {
-	for _, candidate := range all {
-		if candidate.kind != model.TaskKindTest {
-			continue
-		}
-		if candidate.id == code.id {
-			continue
-		}
-		if candidate.waveIndex >= code.waveIndex {
-			continue
-		}
-		if targetsOverlap(candidate.targets, code.targets) {
-			return true
-		}
-	}
-	return false
-}
-
-// targetsOverlap reports whether two target_files sets share scope, evaluated as
-// mutual coverage via wave.TargetCoversPath (the planner's conflict primitive) so
-// the overlap notion matches the conflict detection used elsewhere.
-func targetsOverlap(left, right []string) bool {
-	for _, file := range right {
-		if wave.TargetCoversPath(left, file) {
-			return true
-		}
-	}
-	for _, file := range left {
-		if wave.TargetCoversPath(right, file) {
-			return true
-		}
-	}
-	return false
-}
-
 // ExecutorAgentBlockers reports, for every wave dispatched parallel_subagents,
 // each planned task that has no recorded executor_agent handle. A parallel_subagents
 // dispatch claims each task ran in its own subagent within the shared worktree;
@@ -1093,32 +980,6 @@ func BuildResumeCompletedTasks(summary model.ExecutionSummary) map[string]bool {
 		}
 	}
 	return completed
-}
-
-func tasksPlanChangedSinceTaskEvidenceBlockers(
-	previousHash string,
-	tasks []model.ExecutionTaskSummary,
-	currentHash string,
-) []string {
-	currentHash = strings.TrimSpace(currentHash)
-	previousHash = strings.TrimSpace(previousHash)
-	if currentHash == "" || previousHash == "" || len(tasks) == 0 {
-		return nil
-	}
-	if previousHash == currentHash && previousHash != "" {
-		return nil
-	}
-
-	staleTasks := make([]string, 0, len(tasks))
-	for _, task := range tasks {
-		staleTasks = append(staleTasks, task.TaskID)
-	}
-	slices.Sort(staleTasks)
-	blockers := make([]string, 0, len(staleTasks))
-	for _, taskID := range staleTasks {
-		blockers = append(blockers, "tasks_plan_changed_since_task_evidence:"+taskID)
-	}
-	return blockers
 }
 
 func taskEvidencePlanHashBlockers(

--- a/internal/engine/progression/wave_sync_test.go
+++ b/internal/engine/progression/wave_sync_test.go
@@ -9,11 +9,22 @@ import (
 	"time"
 
 	"github.com/signalridge/slipway/internal/engine/wave"
+	"github.com/signalridge/slipway/internal/fsutil"
 	"github.com/signalridge/slipway/internal/model"
 	"github.com/signalridge/slipway/internal/state"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// saveWavePlanForTest persists a wave plan by committing the wave-plan write
+// transaction op, mirroring how production materialization commits the plan.
+func saveWavePlanForTest(root, slug string, plan model.WavePlan) error {
+	op, err := state.SaveWavePlanTransactionOp(root, slug, plan)
+	if err != nil {
+		return err
+	}
+	return fsutil.ApplyFileTransaction([]fsutil.FileTransactionOp{op})
+}
 
 func writeTasksAndMaterializeWavePlan(t *testing.T, root string, change model.Change, tasks string) string {
 	t.Helper()
@@ -181,53 +192,48 @@ func TestBuildExecutionSummaryPreservesDistinctTaskBlockerDetails(t *testing.T) 
 	assert.Len(t, summary.OpenBlockers, 2)
 }
 
-func TestTasksPlanChangedSinceTaskEvidenceBlockersTracksAllTasksWhenHashChanges(t *testing.T) {
+func TestTaskEvidencePlanHashBlockersTracksTasksWithDriftedHash(t *testing.T) {
 	t.Parallel()
 
-	tasksPlanUpdatedAt := time.Date(2026, 4, 6, 12, 0, 0, 0, time.UTC)
-	blockers := tasksPlanChangedSinceTaskEvidenceBlockers(
-		"previous-hash",
+	blockers := taskEvidencePlanHashBlockers(
+		"current-hash",
 		[]model.ExecutionTaskSummary{
 			{
-				TaskID:     "fresh-task",
-				CapturedAt: tasksPlanUpdatedAt.Add(time.Second),
+				TaskID:          "fresh-task",
+				FreshnessInputs: model.ExecutionTaskFreshnessInputs{TasksPlanHash: "current-hash"},
 			},
 			{
-				TaskID:     "missing-capture",
-				CapturedAt: time.Time{},
+				TaskID:          "missing-hash",
+				FreshnessInputs: model.ExecutionTaskFreshnessInputs{TasksPlanHash: ""},
 			},
 			{
-				TaskID:     "stale-task",
-				CapturedAt: tasksPlanUpdatedAt.Add(-time.Second),
+				TaskID:          "stale-task",
+				FreshnessInputs: model.ExecutionTaskFreshnessInputs{TasksPlanHash: "previous-hash"},
 			},
 		},
-		"current-hash",
 	)
 
 	assert.Equal(t, []string{
-		"tasks_plan_changed_since_task_evidence:fresh-task",
-		"tasks_plan_changed_since_task_evidence:missing-capture",
+		"tasks_plan_changed_since_task_evidence:missing-hash",
 		"tasks_plan_changed_since_task_evidence:stale-task",
 	}, blockers)
 }
 
-func TestTasksPlanChangedSinceTaskEvidenceBlockersAppliesOnFirstExecution(t *testing.T) {
+func TestTaskEvidencePlanHashBlockersEmptyWhenExpectedHashMissing(t *testing.T) {
 	t.Parallel()
 
-	tasksPlanUpdatedAt := time.Date(2026, 4, 6, 12, 0, 0, 0, time.UTC)
-	blockers := tasksPlanChangedSinceTaskEvidenceBlockers(
+	blockers := taskEvidencePlanHashBlockers(
 		"",
 		[]model.ExecutionTaskSummary{
 			{
-				TaskID:     "fresh-task",
-				CapturedAt: tasksPlanUpdatedAt.Add(time.Second),
+				TaskID:          "fresh-task",
+				FreshnessInputs: model.ExecutionTaskFreshnessInputs{TasksPlanHash: "current-hash"},
 			},
 			{
-				TaskID:     "stale-task",
-				CapturedAt: tasksPlanUpdatedAt.Add(-time.Second),
+				TaskID:          "stale-task",
+				FreshnessInputs: model.ExecutionTaskFreshnessInputs{TasksPlanHash: "previous-hash"},
 			},
 		},
-		"current-hash",
 	)
 
 	assert.Empty(t, blockers)
@@ -641,7 +647,7 @@ func TestSyncGovernedWaveExecutionUsesEffectiveParallelForDispatchMode(t *testin
 				RunVersion: 1,
 				References: tt.references,
 			})
-			require.NoError(t, state.SaveWavePlan(root, tt.slug, model.WavePlan{
+			require.NoError(t, saveWavePlanForTest(root, tt.slug, model.WavePlan{
 				Version:     model.WavePlanVersion,
 				GeneratedAt: recordedAt.Add(-time.Hour),
 				TotalTasks:  2,
@@ -2445,219 +2451,4 @@ func TestWaveRunsEqualDetectsDispatchModeChange(t *testing.T) {
 
 	assert.True(t, waveRunsEqual(base, base), "identical runs are equal")
 	assert.False(t, waveRunsEqual(base, flipped), "a dispatch_mode change must not be treated as equal")
-}
-
-func TestImplDistinctnessBlockersGate(t *testing.T) {
-	t.Parallel()
-
-	sharedTargets := []string{"internal/x.go"}
-
-	tests := []struct {
-		name     string
-		plan     model.WavePlan
-		enforced bool
-		want     bool // whether a wave_test_impl_not_distinct blocker for t-code is expected
-	}{
-		{
-			name: "shared-targets code without a preceding distinct test blocks",
-			plan: model.WavePlan{
-				Version: model.WavePlanVersion,
-				Waves: []model.WavePlanWave{
-					{WaveIndex: 1, Tasks: []model.WavePlanTask{
-						{TaskID: "t-code", TargetFiles: sharedTargets, TaskKind: model.TaskKindCode},
-						{TaskID: "t-peer", TargetFiles: sharedTargets, TaskKind: model.TaskKindCode},
-					}},
-				},
-			},
-			enforced: true,
-			want:     true,
-		},
-		{
-			name: "preceding test wave overlapping targets passes",
-			plan: model.WavePlan{
-				Version: model.WavePlanVersion,
-				Waves: []model.WavePlanWave{
-					{WaveIndex: 1, Tasks: []model.WavePlanTask{
-						{TaskID: "t-test", TargetFiles: sharedTargets, TaskKind: model.TaskKindTest},
-					}},
-					{WaveIndex: 2, Tasks: []model.WavePlanTask{
-						{TaskID: "t-code", TargetFiles: sharedTargets, TaskKind: model.TaskKindCode},
-					}},
-				},
-			},
-			enforced: true,
-			want:     false,
-		},
-		{
-			name: "disjoint targets carry no requirement",
-			plan: model.WavePlan{
-				Version: model.WavePlanVersion,
-				Waves: []model.WavePlanWave{
-					{WaveIndex: 1, Tasks: []model.WavePlanTask{
-						{TaskID: "t-code", TargetFiles: []string{"internal/a.go"}, TaskKind: model.TaskKindCode},
-						{TaskID: "t-peer", TargetFiles: []string{"internal/b.go"}, TaskKind: model.TaskKindCode},
-					}},
-				},
-			},
-			enforced: true,
-			want:     false,
-		},
-		{
-			name: "same-wave test does not satisfy (must precede)",
-			plan: model.WavePlan{
-				Version: model.WavePlanVersion,
-				Waves: []model.WavePlanWave{
-					{WaveIndex: 1, Tasks: []model.WavePlanTask{
-						{TaskID: "t-test", TargetFiles: sharedTargets, TaskKind: model.TaskKindTest},
-						{TaskID: "t-code", TargetFiles: sharedTargets, TaskKind: model.TaskKindCode},
-					}},
-				},
-			},
-			enforced: true,
-			want:     true,
-		},
-		{
-			name: "advisory on light (enforced=false) raises nothing",
-			plan: model.WavePlan{
-				Version: model.WavePlanVersion,
-				Waves: []model.WavePlanWave{
-					{WaveIndex: 1, Tasks: []model.WavePlanTask{
-						{TaskID: "t-code", TargetFiles: sharedTargets, TaskKind: model.TaskKindCode},
-						{TaskID: "t-peer", TargetFiles: sharedTargets, TaskKind: model.TaskKindCode},
-					}},
-				},
-			},
-			enforced: false,
-			want:     false,
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			blockers := TestImplDistinctnessBlockers(tt.plan, tt.enforced)
-			assert.Equal(t, tt.want, hasWaveReasonCode(blockers, "wave_test_impl_not_distinct", "t-code"))
-		})
-	}
-}
-
-// TestImplDistinctnessBlockers_SessionIDIrrelevant proves the gate takes no
-// session_id and is decided only by task_kind + target_files + wave order
-// (REQ-003): the WavePlanTask struct carries no session_id field, so the same plan
-// yields the same verdict regardless of any host-chosen session value. The two
-// shared-target code tasks with no preceding test always block; flipping a
-// preceding distinct test always clears it — neither depends on a session id that
-// the structure cannot even express.
-func TestImplDistinctnessBlockers_SessionIDIrrelevant(t *testing.T) {
-	t.Parallel()
-
-	shared := []string{"internal/x.go"}
-	blockedPlan := model.WavePlan{
-		Version: model.WavePlanVersion,
-		Waves: []model.WavePlanWave{
-			{WaveIndex: 1, Tasks: []model.WavePlanTask{
-				{TaskID: "t-code", TargetFiles: shared, TaskKind: model.TaskKindCode},
-				{TaskID: "t-peer", TargetFiles: shared, TaskKind: model.TaskKindCode},
-			}},
-		},
-	}
-	clearedPlan := model.WavePlan{
-		Version: model.WavePlanVersion,
-		Waves: []model.WavePlanWave{
-			{WaveIndex: 1, Tasks: []model.WavePlanTask{
-				{TaskID: "t-test", TargetFiles: shared, TaskKind: model.TaskKindTest},
-			}},
-			{WaveIndex: 2, Tasks: []model.WavePlanTask{
-				{TaskID: "t-code", TargetFiles: shared, TaskKind: model.TaskKindCode},
-			}},
-		},
-	}
-
-	// Verdict is fully determined by plan structure; no session id participates.
-	assert.True(t, hasWaveReasonCode(TestImplDistinctnessBlockers(blockedPlan, true), "wave_test_impl_not_distinct", "t-code"))
-	assert.Empty(t, TestImplDistinctnessBlockers(clearedPlan, true))
-}
-
-// TestSyncGovernedWaveExecutionTestImplDistinctnessPresetGating proves
-// test/impl distinctness is not a S2 wave-execution hard blocker. The pure
-// analyzer still exists for review, but wave synchronization should not stop
-// execution before S3 review convergence.
-func TestSyncGovernedWaveExecutionTestImplDistinctnessPresetGating(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name    string
-		preset  model.WorkflowPreset
-		slug    string
-		wantHit bool
-	}{
-		{name: "strict defers to review", preset: model.WorkflowPresetStrict, slug: "wave-sync-distinct-strict", wantHit: false},
-		{name: "light is advisory", preset: model.WorkflowPresetLight, slug: "wave-sync-distinct-light", wantHit: false},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			root := t.TempDir()
-			slug := tt.slug
-			recordedAt := time.Date(2026, 4, 6, 10, 0, 0, 0, time.UTC)
-			change := model.NewChange(slug)
-			change.CurrentState = model.StateS2Implement
-			change.PlanSubStep = model.PlanSubStepNone
-			change.WorkflowPreset = tt.preset
-			require.NoError(t, state.SaveChange(root, change))
-
-			writeVerificationForTest(t, root, slug, SkillWaveOrchestration, model.VerificationRecord{
-				Verdict:    model.VerificationVerdictPass,
-				Blockers:   []model.ReasonCode{},
-				Timestamp:  recordedAt,
-				RunVersion: 1,
-			})
-			// Two code tasks share internal/x.go with no preceding test task, so the
-			// shared-targets code task t-code has no distinct preceding test. The
-			// shared file forces them into one sequential wave (no parallel dispatch
-			// evidence needed), isolating the #5 distinctness gate.
-			writeTasksAndMaterializeWavePlan(t, root, change, `# Tasks
-
-- [x] `+"`t-code`"+` Implement the feature
-  - target_files: ["internal/x.go"]
-  - task_kind: code
-
-- [x] `+"`t-peer`"+` Extend the same file
-  - target_files: ["internal/x.go"]
-  - task_kind: code
-`)
-
-			writeTaskEvidence := func(taskID string) {
-				t.Helper()
-				taskEvidence := map[string]any{
-					"task_id":             taskID,
-					"run_summary_version": 1,
-					"task_kind":           "code",
-					"verdict":             "pass",
-					"changed_files":       []string{"internal/x.go"},
-					"target_files":        []string{"internal/x.go"},
-					"blockers":            []string{},
-					"evidence_ref":        "test:" + taskID,
-					"captured_at":         recordedAt.Format(time.RFC3339Nano),
-					"freshness_inputs":    expectedTaskFreshnessInputsForWavePlan(t, root, change, 1, taskID),
-				}
-				raw, err := json.Marshal(taskEvidence)
-				require.NoError(t, err)
-				taskPath := filepath.Join(state.EvidenceTasksDir(root, slug), taskID+".json")
-				require.NoError(t, os.MkdirAll(filepath.Dir(taskPath), 0o755))
-				require.NoError(t, os.WriteFile(taskPath, raw, 0o644))
-			}
-			writeTaskEvidence("t-code")
-			writeTaskEvidence("t-peer")
-
-			result, err := SyncGovernedWaveExecution(root, change)
-			require.NoError(t, err)
-			assert.Equal(t, tt.wantHit, hasWaveReasonCode(result.Blockers, "wave_test_impl_not_distinct", "t-code"),
-				"distinctness must not hard-block wave sync, got %+v", result.Blockers)
-		})
-	}
 }

--- a/internal/engine/sensitiveevidence/evaluate.go
+++ b/internal/engine/sensitiveevidence/evaluate.go
@@ -87,11 +87,7 @@ func Evaluate(summary *model.ExecutionSummary, extraChangedFiles []string) Repor
 			continue
 		}
 		report.Status = StatusFail
-		report.MissingEvidence = append(report.MissingEvidence, MissingEvidence{
-			File:     file.File,
-			Category: file.Category,
-			Marker:   file.Marker,
-		})
+		report.MissingEvidence = append(report.MissingEvidence, MissingEvidence(file))
 		report.Blockers = append(report.Blockers, model.NewReasonCode(
 			ReasonSensitiveEvidenceMissing,
 			file.Category+":"+file.File,

--- a/internal/engine/skill/skill.go
+++ b/internal/engine/skill/skill.go
@@ -155,23 +155,6 @@ func LookupDefinitionInRegistry(registry []Definition, name string) (Definition,
 	return def, ok
 }
 
-func RequiredSkillsForStateWithRegistry(
-	registry []Definition,
-	needsDiscovery bool,
-	state model.WorkflowState,
-	closeoutRequired bool,
-	planSubSteps ...model.PlanSubStep,
-) []string {
-	return RequiredSkillsForStateWithRegistryWithReviewSelection(
-		registry,
-		needsDiscovery,
-		state,
-		closeoutRequired,
-		ReviewSkillSelection{},
-		planSubSteps...,
-	)
-}
-
 func RequiredSkillsForStateWithRegistryWithReviewSelection(
 	registry []Definition,
 	needsDiscovery bool,
@@ -214,10 +197,6 @@ func RequiredSkillsForStateWithRegistryWithReviewSelection(
 	}
 	slices.Sort(required)
 	return required
-}
-
-func FilterRequiredSkillsForWorkflowProfile(required []string, profile model.WorkflowProfile) []string {
-	return FilterRequiredSkillsForWorkflowProfileWithReviewSelection(required, profile, ReviewSkillSelection{})
 }
 
 func FilterRequiredSkillsForWorkflowProfileWithReviewSelection(

--- a/internal/engine/skill/skill_test.go
+++ b/internal/engine/skill/skill_test.go
@@ -12,11 +12,12 @@ import (
 )
 
 func requiredSkillsForState(needsDiscovery bool, state model.WorkflowState, closeoutRequired bool) []string {
-	return RequiredSkillsForStateWithRegistry(
+	return RequiredSkillsForStateWithRegistryWithReviewSelection(
 		definitionsToSortedSlice(defaultGovernanceRegistry),
 		needsDiscovery,
 		state,
 		closeoutRequired,
+		ReviewSkillSelection{},
 	)
 }
 

--- a/internal/engine/wave/wave.go
+++ b/internal/engine/wave/wave.go
@@ -22,11 +22,6 @@ type Wave struct {
 	Nodes []Node `json:"nodes"`
 }
 
-type TaskResult struct {
-	TaskID       string   `json:"task_id"`
-	ChangedFiles []string `json:"changed_files,omitempty"`
-}
-
 type ControlDecision string
 
 const (
@@ -39,12 +34,6 @@ type ControlCheckpoint struct {
 	WaveIndex        int               `json:"wave_index"`
 	NonPassTaskIDs   []string          `json:"non_pass_task_ids"`
 	AllowedDecisions []ControlDecision `json:"allowed_decisions"`
-}
-
-type ExecutionResult struct {
-	TaskResults map[string]model.TaskRun `json:"task_results"`
-	Checkpoint  *ControlCheckpoint       `json:"checkpoint,omitempty"`
-	Aborted     bool                     `json:"aborted,omitempty"`
 }
 
 // PlanWaves computes the wave assignment for the given tasks from their

--- a/internal/engine/wave/wave_test.go
+++ b/internal/engine/wave/wave_test.go
@@ -1,7 +1,6 @@
 package wave
 
 import (
-	"encoding/json"
 	"slices"
 	"strings"
 	"testing"
@@ -585,21 +584,4 @@ func TestAnalyzeWaveNarrowingCauses(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
-}
-
-func TestExecutionResultJSONUsesTaskResultsKey(t *testing.T) {
-	t.Parallel()
-
-	raw, err := json.Marshal(ExecutionResult{
-		TaskResults: map[string]model.TaskRun{
-			"task-a": {
-				TaskID:            "task-a",
-				RunSummaryVersion: 1,
-				Verdict:           model.TaskVerdictPass,
-			},
-		},
-	})
-	require.NoError(t, err)
-	assert.Contains(t, string(raw), `"task_results"`)
-	assert.NotContains(t, string(raw), `"task_runs"`)
 }

--- a/internal/model/change_authority.go
+++ b/internal/model/change_authority.go
@@ -12,19 +12,6 @@ func (c *Change) AdvancePlanSubStep(next PlanSubStep) {
 	c.PlanSubStep = next
 }
 
-// EnterIntake records a transition into S0_INTAKE and seeds its entry substep.
-func (c *Change) EnterIntake() []string {
-	c.CurrentState = StateS0Intake
-	c.IntakeSubStep = IntakeEntrySubStep()
-
-	var cleared []string
-	if c.PlanSubStep != PlanSubStepNone {
-		c.PlanSubStep = PlanSubStepNone
-		cleared = append(cleared, "plan_substep")
-	}
-	return cleared
-}
-
 // EnterPlanning records a transition into S1_PLAN and seeds the entry substep.
 func (c *Change) EnterPlanning(needsDiscovery bool) []string {
 	c.NeedsDiscovery = needsDiscovery
@@ -74,15 +61,6 @@ func (c *Change) TransitionTo(state WorkflowState) []string {
 	return cleared
 }
 
-// ClearActiveCheckpoint clears the active checkpoint authority, if present.
-func (c *Change) ClearActiveCheckpoint() bool {
-	if c.ActiveCheckpoint == nil {
-		return false
-	}
-	c.ActiveCheckpoint = nil
-	return true
-}
-
 // ClearAutoPassHistory clears the auto-pass trace carried on the current state.
 func (c *Change) ClearAutoPassHistory() bool {
 	if c.LastAutoPassedStates == nil {
@@ -90,14 +68,6 @@ func (c *Change) ClearAutoPassHistory() bool {
 	}
 	c.LastAutoPassedStates = nil
 	return true
-}
-
-// ResetEvidenceRefs clears runtime evidence references while preserving the
-// non-nil map convention used by Change normalization.
-func (c *Change) ResetEvidenceRefs() bool {
-	hadRefs := len(c.EvidenceRefs) > 0
-	c.EvidenceRefs = map[string]string{}
-	return hadRefs
 }
 
 // RecordEvidenceRef records or updates one evidence reference.
@@ -139,19 +109,5 @@ func (c *Change) RecordPlanAuditIterations(iterations int) bool {
 		return false
 	}
 	c.PlanAuditIterations = iterations
-	return true
-}
-
-// ResetPlanAuditIterations clears plan-audit loop history.
-func (c *Change) ResetPlanAuditIterations() bool {
-	return c.RecordPlanAuditIterations(0)
-}
-
-// ResetReviewIntentDriftFailures clears review intent-drift retry history.
-func (c *Change) ResetReviewIntentDriftFailures() bool {
-	if c.ReviewIntentDriftFailures == 0 {
-		return false
-	}
-	c.ReviewIntentDriftFailures = 0
 	return true
 }

--- a/internal/model/evidence_digests.go
+++ b/internal/model/evidence_digests.go
@@ -19,7 +19,6 @@ type EvidenceDigests struct {
 type SkillDigest struct {
 	VerdictTimestamp time.Time         `yaml:"verdict_timestamp,omitempty" json:"verdict_timestamp,omitempty"`
 	Inputs           map[string]string `yaml:"inputs" json:"inputs"`
-	LegacyRunVersion int               `yaml:"run_version,omitempty" json:"-"`
 }
 
 type SuiteResult struct {
@@ -144,7 +143,6 @@ func (r SuiteResult) SharedReviewerInputDigests() (map[string]string, error) {
 }
 
 func (d *SkillDigest) Normalize() {
-	d.LegacyRunVersion = 0
 	if !d.VerdictTimestamp.IsZero() {
 		d.VerdictTimestamp = d.VerdictTimestamp.UTC()
 	}

--- a/internal/model/reason_code.go
+++ b/internal/model/reason_code.go
@@ -714,10 +714,6 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 		Severity: ReasonSeverityError,
 		Message:  "Wave run task linkage does not match wave-plan.yaml",
 	},
-	"wave_test_impl_not_distinct": {
-		Severity: ReasonSeverityError,
-		Message:  "A task_kind=code task shares target files with no distinct preceding task_kind=test task",
-	},
 	"workspace_scope_config_missing": {
 		Severity: ReasonSeverityError,
 		Message:  "Bound worktree scope config is missing",

--- a/internal/model/reason_code_contract_test.go
+++ b/internal/model/reason_code_contract_test.go
@@ -209,7 +209,6 @@ func canonicalReasonCodeSnapshot() []string {
 		"wave_runs_missing",
 		"wave_runs_unreadable",
 		"wave_task_linkage_mismatch",
-		"wave_test_impl_not_distinct",
 		"workspace_scope_config_missing",
 		"workspace_scope_marker_missing",
 		"worktree_metadata_persist_failed",
@@ -287,6 +286,31 @@ func TestReviewOriginHandleVocabularyRetired(t *testing.T) {
 	_, inRemediations := blockerRemediations[retired]
 	assert.Falsef(t, inRemediations,
 		"the remediation vocabulary must not define the retired review-origin blocker %q", retired)
+
+	assert.Falsef(t, IsCanonicalReasonCode(retired),
+		"%q must no longer be recognized as a canonical reason code", retired)
+}
+
+// The REQ-003 test/impl distinctness gate is retired — it was never wired into
+// the live wave-execution blocker aggregator — so its blocker vocabulary must be
+// fully removed: no canonical reason definition, no remediation vocabulary entry,
+// and no public recognition as a canonical code, so nothing downgrades a stray
+// occurrence to `unknown_reason_code` by silently treating it as live. The
+// retired code is kept as a string literal on purpose: any Go identifier for it
+// is deleted together with the vocabulary, and this contract must keep compiling
+// after that.
+func TestWaveTestImplDistinctnessVocabularyRetired(t *testing.T) {
+	t.Parallel()
+
+	const retired = "wave_test_impl_not_distinct"
+
+	_, inRegistry := canonicalReasonDefinitions[retired]
+	assert.Falsef(t, inRegistry,
+		"the canonical reason registry must not define the retired test/impl distinctness blocker %q", retired)
+
+	_, inRemediations := blockerRemediations[retired]
+	assert.Falsef(t, inRemediations,
+		"the remediation vocabulary must not define the retired test/impl distinctness blocker %q", retired)
 
 	assert.Falsef(t, IsCanonicalReasonCode(retired),
 		"%q must no longer be recognized as a canonical reason code", retired)

--- a/internal/model/recovery.go
+++ b/internal/model/recovery.go
@@ -571,11 +571,6 @@ var blockerRemediations = map[string]blockerRemediation{
 		CommandTemplate: "slipway run",
 		Class:           RecoveryClassRerunSkill,
 	},
-	"wave_test_impl_not_distinct": {
-		Remediation:     "A code task shares target files with no distinct preceding test task; split the work so a task_kind=test task is dispatched before its dependent task_kind=code task, then re-run wave-orchestration.",
-		CommandTemplate: "slipway run",
-		Class:           RecoveryClassRefreshWave,
-	},
 	"degraded_dispatch_justification_missing": {
 		Remediation:     "A degraded_sequential dispatch needs a genuine tool-unavailable justification; record degraded_dispatch_justification:wave=<n>:tool_unavailable=<detail> and re-run wave-orchestration.",
 		CommandTemplate: "slipway run",
@@ -995,10 +990,6 @@ func selectPrimaryStep(steps []RecoveryStep) RecoveryStep {
 }
 
 func lessRecoveryStep(a, b RecoveryStep) bool {
-	oa, ob := recoveryPrimaryOverrideRank(a), recoveryPrimaryOverrideRank(b)
-	if oa != ob {
-		return oa < ob
-	}
 	pa, pb := recoveryClassRank(a.RecoveryClass), recoveryClassRank(b.RecoveryClass)
 	if pa != pb {
 		return pa < pb
@@ -1013,8 +1004,6 @@ func lessRecoveryStep(a, b RecoveryStep) bool {
 	}
 	return a.Code < b.Code
 }
-
-func recoveryPrimaryOverrideRank(step RecoveryStep) int { return 1 }
 
 func recoveryClassRank(class RecoveryClass) int {
 	for i, c := range recoveryClassPriority {

--- a/internal/model/recovery_test.go
+++ b/internal/model/recovery_test.go
@@ -158,7 +158,6 @@ func inScopeProducedRecoverySpecs() []string {
 		"context_origin_handle_invalid",
 		"cross_stage_context_not_distinct:spec-compliance-review|code-quality-review",
 		"plan_audit_origin_invalid",
-		"wave_test_impl_not_distinct",
 		"degraded_dispatch_justification_missing",
 	}
 }

--- a/internal/state/evidence_digests.go
+++ b/internal/state/evidence_digests.go
@@ -15,6 +15,16 @@ import (
 
 const EvidenceDigestsFileName = "evidence-digests.yaml"
 
+// errUnusableEvidenceCache marks an evidence-digests cache whose contents cannot
+// be decoded or validated as-is — e.g. a legacy file still carrying the removed
+// per-skill run_version key that KnownFields(true) now rejects, or any other
+// structurally invalid cache. evidence-digests.yaml is a gitignored,
+// freshness-bound runtime cache that the owning stage regenerates on its next
+// record, so optional readers treat an unusable cache as absent and let it
+// regenerate instead of hard-failing read-only surfaces (status/next/validate).
+// Genuine I/O errors are NOT marked with this sentinel and still surface.
+var errUnusableEvidenceCache = errors.New("evidence digests cache is unusable and must regenerate")
+
 func EvidenceDigestsPathForRead(root, slug string) string {
 	return filepath.Join(verificationDirPathForRead(root, slug), EvidenceDigestsFileName)
 }
@@ -44,6 +54,16 @@ func LoadOptionalEvidenceDigestsForChange(root string, change model.Change) (*mo
 	digests, err := LoadEvidenceDigestsForChange(root, change)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		// A decodable-but-unusable cache (a removed legacy key or otherwise
+		// structurally invalid content) is a regenerable runtime artifact, not a
+		// hard failure. Reading it as absent keeps read-only readiness surfaces
+		// working and forces the owning stage to re-record evidence (fail
+		// closed), which overwrites the stale cache — the "caches regenerate"
+		// contract carried by the public surface instead of a manual deletion.
+		// Genuine I/O errors are not marked with this sentinel and still surface.
+		if errors.Is(err, errUnusableEvidenceCache) {
 			return nil, nil
 		}
 		return nil, err
@@ -80,11 +100,11 @@ func loadEvidenceDigestsFromPath(path string) (model.EvidenceDigests, error) {
 	decoder := yaml.NewDecoder(bytes.NewReader(raw))
 	decoder.KnownFields(true)
 	if err := decoder.Decode(&digests); err != nil {
-		return model.EvidenceDigests{}, fmt.Errorf("parse evidence digests: %w", err)
+		return model.EvidenceDigests{}, fmt.Errorf("parse evidence digests: %w: %w", errUnusableEvidenceCache, err)
 	}
 	digests.Normalize()
 	if err := digests.Validate(); err != nil {
-		return model.EvidenceDigests{}, fmt.Errorf("invalid evidence digests: %w", err)
+		return model.EvidenceDigests{}, fmt.Errorf("invalid evidence digests: %w: %w", errUnusableEvidenceCache, err)
 	}
 	return digests, nil
 }

--- a/internal/state/evidence_digests_test.go
+++ b/internal/state/evidence_digests_test.go
@@ -70,6 +70,43 @@ skills: {}
 	assert.Contains(t, err.Error(), "field unexpected")
 }
 
+// A legacy evidence-digests cache that still carries the removed per-skill
+// run_version key must not hard-fail the read-only readiness surfaces.
+// evidence-digests.yaml is a gitignored, regenerable runtime cache, so the
+// optional change-based reader treats an unusable cache as absent and lets the
+// owning stage regenerate it. The strict slug-based reader still rejects the
+// unknown legacy key.
+func TestLoadOptionalEvidenceDigestsSelfHealsUnusableLegacyCache(t *testing.T) {
+	t.Parallel()
+
+	root := createRuntimeLayout(t)
+	slug := "digest-legacy-run-version"
+	change := saveActiveChangeForTest(t, root, slug)
+
+	dir := VerificationDir(root, slug)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	legacy := []byte(`version: 1
+skills:
+  goal-verification:
+    run_version: 1
+    inputs:
+      some-input: sha256:abc
+`)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, EvidenceDigestsFileName), legacy, 0o644))
+
+	// Optional change-based read self-heals: the unusable legacy cache is treated
+	// as absent (regenerate), not surfaced as a parse error that would block
+	// status/next/validate.
+	got, err := LoadOptionalEvidenceDigestsForChange(root, change)
+	require.NoError(t, err)
+	assert.Nil(t, got, "an unusable legacy run_version cache must read as absent so the owning stage regenerates it")
+
+	// The strict slug-based reader still rejects the removed legacy key.
+	_, strictErr := LoadEvidenceDigests(root, slug)
+	require.Error(t, strictErr)
+	assert.Contains(t, strictErr.Error(), "run_version")
+}
+
 // LoadEvidenceDigests and evidenceDigestsReadPath are slug-based read helpers
 // used only by these tests; production reads digests through the change-based
 // LoadEvidenceDigestsForChange path.

--- a/internal/state/execution_summary.go
+++ b/internal/state/execution_summary.go
@@ -259,18 +259,6 @@ func SaveExecutionSummary(root, slug string, summary model.ExecutionSummary) err
 	return fsutil.WriteFileAtomic(path, raw, 0o644)
 }
 
-func RemoveExecutionSummary(root, slug string) error {
-	dir, err := resolveVerificationDirForWrite(root, slug)
-	if err != nil {
-		return fmt.Errorf("resolve execution summary dir for %q: %w", slug, err)
-	}
-	path := filepath.Join(dir, ExecutionSummaryFileName)
-	if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return err
-	}
-	return nil
-}
-
 // LatestRelevantExecutionRunVersion returns the execution-summary run version
 // only for states that are expected to surface execution evidence. Callers
 // that already know the workflow state should prefer this helper.
@@ -395,32 +383,18 @@ func ApplyExecutionSummaryFreshnessInputs(summary *model.ExecutionSummary, chang
 	}
 }
 
-func ExecutionSummaryFreshness(root string, change model.Change, summary *model.ExecutionSummary) ctxpack.EvidenceFreshness {
-	if !ExecutionSummaryReady(summary) || strings.TrimSpace(change.Slug) == "" {
-		return ctxpack.EvidenceFreshnessUnknown
-	}
-
-	evidenceTimestamp := summary.CapturedAt.UTC()
-	latestRelevantUpdateAt := time.Time{}
-	evidenceArtifact := executionSummaryEvidenceArtifact(root, change)
-	freshness, _, _ := executionSummaryFreshnessEvaluation(root, change, summary, evidenceArtifact, latestRelevantUpdateAt, evidenceTimestamp)
-	return freshness
-}
-
 func executionSummaryFreshnessEvaluation(
 	root string,
 	change model.Change,
 	summary *model.ExecutionSummary,
 	evidenceArtifact string,
-	latestRelevantUpdateAt time.Time,
-	evidenceTimestamp time.Time,
 ) (ctxpack.EvidenceFreshness, []ExecutionTaskInputDifference, []ExecutionFreshnessPair) {
 	taskInputDiffs := taskFreshnessInputDiffs(root, change, summary)
 	planningPairs := stalePlanningPairs(root, change, summary, evidenceArtifact)
 	if len(taskInputDiffs) > 0 || len(planningPairs) > 0 {
 		return ctxpack.EvidenceFreshnessStale, taskInputDiffs, planningPairs
 	}
-	inputs := collectTaskEvidenceFreshnessInputs(change, summary, latestRelevantUpdateAt, evidenceTimestamp)
+	inputs := collectTaskEvidenceFreshnessInputs(change, summary)
 	if len(inputs) == 0 {
 		return ctxpack.EvidenceFreshnessUnknown, nil, nil
 	}
@@ -445,10 +419,8 @@ func ExecutionSummaryFreshnessDiagnostics(root string, change model.Change, summ
 	}
 
 	diagnostics.PathAuthority = ExecutionPathAuthorityDiagnostics(root, change, summary.RunSummaryVersion)
-	evidenceTimestamp := summary.CapturedAt.UTC()
-	latestRelevantUpdateAt := time.Time{}
 	evidenceArtifact := executionSummaryEvidenceArtifact(root, change)
-	freshness, taskInputDiffs, planningPairs := executionSummaryFreshnessEvaluation(root, change, summary, evidenceArtifact, latestRelevantUpdateAt, evidenceTimestamp)
+	freshness, taskInputDiffs, planningPairs := executionSummaryFreshnessEvaluation(root, change, summary, evidenceArtifact)
 	diagnostics.Status = string(freshness)
 
 	diagnostics.TaskInputDiffs = taskInputDiffs
@@ -820,8 +792,6 @@ func formatFreshnessTime(t time.Time) string {
 func collectTaskEvidenceFreshnessInputs(
 	change model.Change,
 	summary *model.ExecutionSummary,
-	latestRelevantUpdateAt time.Time,
-	defaultEvidenceTimestamp time.Time,
 ) []ctxpack.EvidenceFreshnessInput {
 	if !ExecutionSummaryReady(summary) {
 		return nil
@@ -829,16 +799,10 @@ func collectTaskEvidenceFreshnessInputs(
 
 	inputs := []ctxpack.EvidenceFreshnessInput{}
 	for _, task := range summary.Tasks {
-		evidenceTs := task.CapturedAt.UTC()
-		if evidenceTs.IsZero() {
-			evidenceTs = defaultEvidenceTimestamp
-		}
 		expected := ExpectedExecutionTaskFreshnessInputs(change, summary.RunSummaryVersion, task.TaskID, summary.TasksPlanHash)
 		inputs = append(inputs, ctxpack.EvidenceFreshnessInput{
 			ExpectedStructuralInput: expected.FieldMap(),
 			CurrentStructuralInput:  task.FreshnessInputs.FieldMap(),
-			EvidenceTimestamp:       evidenceTs,
-			LatestRelevantUpdateAt:  latestRelevantUpdateAt,
 		})
 	}
 	return inputs

--- a/internal/state/execution_summary_test.go
+++ b/internal/state/execution_summary_test.go
@@ -289,7 +289,7 @@ func TestExecutionSummaryFreshnessIgnoresSummaryCapturedAtForPerTaskFreshness(t 
 		},
 	}
 
-	assert.Equal(t, ctxpack.EvidenceFreshnessFresh, ExecutionSummaryFreshness(root, change, summary))
+	assert.Equal(t, string(ctxpack.EvidenceFreshnessFresh), ExecutionSummaryFreshnessDiagnostics(root, change, summary).Status)
 	diagnostics := ExecutionSummaryFreshnessDiagnostics(root, change, summary)
 	assert.Equal(t, "fresh", diagnostics.Status)
 	assert.Empty(t, diagnostics.StalePairs)
@@ -317,7 +317,7 @@ func TestExecutionSummaryFreshnessTreatsReadySummaryWithoutTasksAsUnknown(t *tes
 	require.NoError(t, err)
 	require.True(t, ExecutionSummaryReady(&loaded))
 
-	assert.Equal(t, ctxpack.EvidenceFreshnessUnknown, ExecutionSummaryFreshness(root, change, &loaded))
+	assert.Equal(t, string(ctxpack.EvidenceFreshnessUnknown), ExecutionSummaryFreshnessDiagnostics(root, change, &loaded).Status)
 	diagnostics := ExecutionSummaryFreshnessDiagnostics(root, change, &loaded)
 	assert.Equal(t, string(ctxpack.EvidenceFreshnessUnknown), diagnostics.Status)
 	assert.Empty(t, diagnostics.TaskInputDiffs)
@@ -444,7 +444,7 @@ func TestExecutionSummaryFreshnessTreatsTasksPlanHashMismatchAsStale(t *testing.
 	loaded, err := LoadExecutionSummary(root, change.Slug)
 	require.NoError(t, err)
 
-	assert.Equal(t, ctxpack.EvidenceFreshnessStale, ExecutionSummaryFreshness(root, change, &loaded))
+	assert.Equal(t, string(ctxpack.EvidenceFreshnessStale), ExecutionSummaryFreshnessDiagnostics(root, change, &loaded).Status)
 	diagnostics := ExecutionSummaryFreshnessDiagnostics(root, change, &loaded)
 	assert.Equal(t, "stale", diagnostics.Status)
 	require.NotNil(t, diagnostics.FirstStaleCause)
@@ -517,7 +517,7 @@ func TestExecutionSummaryFreshnessTreatsTasksPlanScopeHashMismatchAsS3TaskPlanDr
 
 	loaded, err := LoadExecutionSummary(root, change.Slug)
 	require.NoError(t, err)
-	assert.Equal(t, ctxpack.EvidenceFreshnessStale, ExecutionSummaryFreshness(root, change, &loaded))
+	assert.Equal(t, string(ctxpack.EvidenceFreshnessStale), ExecutionSummaryFreshnessDiagnostics(root, change, &loaded).Status)
 	diagnostics := ExecutionSummaryFreshnessDiagnostics(root, change, &loaded)
 	assert.Equal(t, "stale", diagnostics.Status)
 	require.NotNil(t, diagnostics.FirstStaleCause)

--- a/internal/state/repair_test.go
+++ b/internal/state/repair_test.go
@@ -186,7 +186,7 @@ func TestRepairExecutionStateUsesEffectiveParallelWhenRecoveringWaveRuns(t *test
 			}
 			require.Len(t, plan.Waves, 1)
 			plan.Waves[0].Parallel = tt.persistedParallel
-			require.NoError(t, SaveWavePlan(root, change.Slug, plan))
+			require.NoError(t, saveWavePlanForTest(root, change.Slug, plan))
 
 			// A valid parallel dispatch token lets the recovered run record a
 			// parallel mode when the wave is effectively parallel; the engine no

--- a/internal/state/verification_test.go
+++ b/internal/state/verification_test.go
@@ -208,7 +208,7 @@ func TestListVerificationsSkipsWavePlanArtifacts(t *testing.T) {
 		Blockers:  []model.ReasonCode{},
 		Timestamp: time.Now().UTC(),
 	})
-	require.NoError(t, SaveWavePlan(root, slug, model.WavePlan{
+	require.NoError(t, saveWavePlanForTest(root, slug, model.WavePlan{
 		Version:       model.WavePlanVersion,
 		GeneratedAt:   time.Now().UTC(),
 		TasksPlanHash: "abc123",

--- a/internal/state/wave_execution.go
+++ b/internal/state/wave_execution.go
@@ -69,14 +69,6 @@ func LoadOptionalWavePlanForChange(root string, change model.Change) (*model.Wav
 	return &plan, nil
 }
 
-func SaveWavePlan(root, slug string, plan model.WavePlan) error {
-	op, err := SaveWavePlanTransactionOp(root, slug, plan)
-	if err != nil {
-		return err
-	}
-	return fsutil.ApplyFileTransaction([]fsutil.FileTransactionOp{op})
-}
-
 func SaveWavePlanTransactionOp(root, slug string, plan model.WavePlan) (fsutil.FileTransactionOp, error) {
 	plan.Normalize()
 	if err := plan.Validate(); err != nil {
@@ -423,18 +415,6 @@ func SaveWaveRuns(root, slug string, runVersion int, runs []model.WaveRun) error
 		}
 		path := filepath.Join(dir, fmt.Sprintf("wave-%02d.yaml", run.WaveIndex))
 		if err := fsutil.WriteFileAtomic(path, raw, 0o644); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func ResetWaveExecution(root, slug string) error {
-	for _, path := range []string{
-		WaveEvidenceDir(root, slug),
-		filepath.Join(verificationDirPathForRead(root, slug), WavePlanFileName),
-	} {
-		if err := os.RemoveAll(path); err != nil {
 			return err
 		}
 	}

--- a/internal/state/wave_execution_transaction_test.go
+++ b/internal/state/wave_execution_transaction_test.go
@@ -12,6 +12,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// saveWavePlanForTest persists a wave plan by committing the wave-plan write
+// transaction op, mirroring how production materialization commits the plan.
+func saveWavePlanForTest(root, slug string, plan model.WavePlan) error {
+	op, err := SaveWavePlanTransactionOp(root, slug, plan)
+	if err != nil {
+		return err
+	}
+	return fsutil.ApplyFileTransaction([]fsutil.FileTransactionOp{op})
+}
+
 func TestMaterializeWavePlanTransactionOpDefersWriteUntilApplied(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tmpl/templates/skills/final-closeout/SKILL.md.tmpl
+++ b/internal/tmpl/templates/skills/final-closeout/SKILL.md.tmpl
@@ -110,7 +110,7 @@ reuse verdict with a manual freshness judgment.
 ## Assurance Artifact Verification
 On light preset, skip this section — `assurance.md` is optional.
 
-`assurance.md` is deferred (issue #141): the engine does not pre-seed it. It is
+`assurance.md` is deferred (the deferred-assurance authoring contract): the engine does not pre-seed it. It is
 authored at `S3_REVIEW` from `slipway instructions assurance` and must exist with
 real content before the change can leave `S3_REVIEW` — a missing file fails closed
 as `assurance_contract_missing`. If it has not been authored yet, author it from

--- a/internal/tmpl/templates/skills/wave-orchestration/SKILL.md.tmpl
+++ b/internal/tmpl/templates/skills/wave-orchestration/SKILL.md.tmpl
@@ -31,7 +31,7 @@ documents into the coordinator just to prepare task briefs. Instead, pass
 paths to task executors along with `input_context.codebase_map_status` and
 `input_context.codebase_map_doc_states`.
 
-PR #112 preserves the codebase-map relevance/staleness self-check: it is
+The codebase-map relevance/staleness self-check is preserved: it is
 relocated to executor-owned relevance/staleness self-check work, not removed.
 `input_context.codebase_map_status` still reflects content presence, not scope
 relevance, and the codebase-map relevance advisory fires for `populated` and
@@ -175,7 +175,7 @@ gate unless a task owns a genuinely isolated command.
 - Pass file paths only; executors read source files in their own context.
 - Inputs: task ID, acceptance criteria, changed-file scope, technique references, locked decisions.
 - For tasks that may need repository-map guidance, pass `input_context.codebase_map_dir` and relevant `input_context.codebase_map_docs` paths instead of inlining map content.
-- Pass `input_context.codebase_map_doc_states` whenever map metadata is present so executors can perform the PR #112 relevance/staleness self-check.
+- Pass `input_context.codebase_map_doc_states` whenever map metadata is present so executors can perform the codebase-map relevance/staleness self-check.
 - Outputs: `task_id`, `verdict`, `changed_files`, `test_summary`, `evidence_ref`, `blockers`, and concise `notes`.
 - Write scopes must be disjoint, or the brief must name the merge strategy.
 - For test-bearing work, isolate the `task_kind=test` test-authoring step from

--- a/internal/tmpl/templates/skills/wave-orchestration/references/executor-dispatch-reference.md
+++ b/internal/tmpl/templates/skills/wave-orchestration/references/executor-dispatch-reference.md
@@ -28,8 +28,9 @@ metadata instead:
 Each executor performs the relevance/staleness self-check before relying on a
 map document. Treat `scaffold_only`, `baseline`, or `missing` doc states as
 non-durable for that document, and report stale or irrelevant map guidance in
-`test_summary` or blocker evidence. This preserves PR #112 while keeping bulky
-map content out of the coordinator context.
+`test_summary` or blocker evidence. This preserves the codebase-map
+relevance/staleness self-check while keeping bulky map content out of the
+coordinator context.
 
 ## Runtime Boundary
 - A `parallel: true` wave (from `slipway next --json`) is dispatched concurrently by default: one fresh executor per task, spawned together, then wait for the whole wave.

--- a/internal/tmpl/thin_host_content_test.go
+++ b/internal/tmpl/thin_host_content_test.go
@@ -79,7 +79,7 @@ func TestThinHostWaveOrchestrationDelegatesCodebaseMapReads(t *testing.T) {
 	assert.Contains(t, flatContent, "keep the coordinator context to `input_context.wave_plan`")
 	assert.Contains(t, flatContent, "pass `input_context.codebase_map_dir` and relevant `input_context.codebase_map_docs` paths")
 	assert.Contains(t, flatContent, "executor-owned relevance/staleness self-check")
-	assert.Contains(t, flatContent, "PR #112")
+	assert.Contains(t, flatContent, "codebase-map relevance/staleness self-check")
 	assert.Contains(t, flatContent, "input_context.codebase_map_doc_states")
 
 	ref, err := Content("skills/wave-orchestration/references/executor-dispatch-reference.md")

--- a/internal/toolgen/ownership_manifest.go
+++ b/internal/toolgen/ownership_manifest.go
@@ -149,28 +149,6 @@ func buildOwnershipManifest(toolID string, generated map[string]ownershipManifes
 	}
 }
 
-func classifyOwnership(root string, manifest ownershipManifest, relPath string) (ownershipClassification, error) {
-	rel, err := normalizeOwnershipPath(relPath)
-	if err != nil {
-		return "", err
-	}
-	record, ok := manifest.index()[rel]
-	if !ok {
-		return ownershipUnknownUserFile, nil
-	}
-	sum, err := hashFile(filepath.Join(root, filepath.FromSlash(rel)))
-	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return ownershipManagedMissingFile, nil
-		}
-		return "", err
-	}
-	if sum == record.SHA256 {
-		return ownershipPristineManagedFile, nil
-	}
-	return ownershipManagedModifiedFile, nil
-}
-
 func normalizeOwnershipPath(name string) (string, error) {
 	name = strings.TrimSpace(name)
 	if name == "" {

--- a/internal/toolgen/ownership_manifest_test.go
+++ b/internal/toolgen/ownership_manifest_test.go
@@ -39,15 +39,17 @@ func TestClassifyOwnership(t *testing.T) {
 	}
 	require.NoError(t, os.WriteFile(modifiedPath, []byte("user edit"), 0o644))
 
-	got, err := classifyOwnership(root, manifest, ".claude/skills/slipway-new/SKILL.md")
+	plan := &toolRefreshPlan{root: root, previousIndex: manifest.index()}
+
+	got, err := plan.classifyExistingRelPath(".claude/skills/slipway-new/SKILL.md", false)
 	require.NoError(t, err)
 	assert.Equal(t, ownershipPristineManagedFile, got)
 
-	got, err = classifyOwnership(root, manifest, ".claude/skills/slipway-run/SKILL.md")
+	got, err = plan.classifyExistingRelPath(".claude/skills/slipway-run/SKILL.md", false)
 	require.NoError(t, err)
 	assert.Equal(t, ownershipManagedModifiedFile, got)
 
-	got, err = classifyOwnership(root, manifest, ".claude/skills/user-owned/SKILL.md")
+	got, err = plan.classifyExistingRelPath(".claude/skills/user-owned/SKILL.md", false)
 	require.NoError(t, err)
 	assert.Equal(t, ownershipUnknownUserFile, got)
 }

--- a/internal/toolgen/support_files_test.go
+++ b/internal/toolgen/support_files_test.go
@@ -32,7 +32,7 @@ func TestEmitSupportFilesCopiesReferences(t *testing.T) {
 	}
 
 	dst := t.TempDir()
-	require.NoError(t, emitSkillSupportFilesFromFS(srcFS, "refs-only", dst, true))
+	require.NoError(t, emitSkillSupportFilesFromFSWithPlan(srcFS, "refs-only", dst, true, nil))
 
 	for _, name := range []string{"topic-a.md", "topic-b.md"} {
 		_, err := os.Stat(filepath.Join(dst, "references", name))
@@ -50,7 +50,7 @@ func TestEmitSupportFilesSkipsEmpty(t *testing.T) {
 	}
 
 	dst := t.TempDir()
-	require.NoError(t, emitSkillSupportFilesFromFS(srcFS, "bare", dst, true))
+	require.NoError(t, emitSkillSupportFilesFromFSWithPlan(srcFS, "bare", dst, true, nil))
 
 	entries, err := os.ReadDir(dst)
 	require.NoError(t, err)
@@ -74,7 +74,7 @@ func TestEmitSupportFilesRefreshPrunesStaleArtifacts(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dst, "references", "stale.md"), []byte("# stale\n"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(dst, "scripts", "stale.sh"), []byte("#!/usr/bin/env bash\nexit 0\n"), 0o755))
 
-	require.NoError(t, emitSkillSupportFilesFromFS(srcFS, "sample", dst, true))
+	require.NoError(t, emitSkillSupportFilesFromFSWithPlan(srcFS, "sample", dst, true, nil))
 
 	_, err := os.Stat(filepath.Join(dst, "references", "stale.md"))
 	assert.True(t, os.IsNotExist(err), "refresh should prune stale reference files")
@@ -99,7 +99,7 @@ func TestEmitSupportFilesOmitsScriptArtifacts(t *testing.T) {
 	}
 
 	dst := t.TempDir()
-	require.NoError(t, emitSkillSupportFilesFromFS(srcFS, "python-helper", dst, true))
+	require.NoError(t, emitSkillSupportFilesFromFSWithPlan(srcFS, "python-helper", dst, true, nil))
 
 	_, err := os.Stat(filepath.Join(dst, "scripts", "merge-sarif.py"))
 	assert.True(t, os.IsNotExist(err), "script helpers must not be copied into generated skill trees")
@@ -117,7 +117,7 @@ func TestEmitSupportFilesOmitsSharedGitHubHelpers(t *testing.T) {
 	}
 
 	dst := t.TempDir()
-	require.NoError(t, emitSkillSupportFilesFromFS(srcFS, "review-comment-triage", dst, true))
+	require.NoError(t, emitSkillSupportFilesFromFSWithPlan(srcFS, "review-comment-triage", dst, true, nil))
 
 	_, err := os.Stat(filepath.Join(dst, "scripts", "gh-common.sh"))
 	assert.True(t, os.IsNotExist(err), "shared script helpers must not be copied into generated skill trees")

--- a/internal/toolgen/toolgen.go
+++ b/internal/toolgen/toolgen.go
@@ -1700,13 +1700,10 @@ func emitSkillSupportFiles(root string, cfg ToolConfig, skillID string, refresh 
 	return emitSkillSupportFilesFromFSWithPlan(tmpl.TemplateFS(), skillID, dstBase, refresh, plan)
 }
 
-// emitSkillSupportFilesFromFS is the testable core: it sources support files
-// from an arbitrary fs.FS rooted like tmpl.TemplateFS() (so paths begin with
-// "skills/<id>/...") and writes them under dstBase on the local filesystem.
-func emitSkillSupportFilesFromFS(srcFS fs.FS, skillID, dstBase string, refresh bool) error {
-	return emitSkillSupportFilesFromFSWithPlan(srcFS, skillID, dstBase, refresh, nil)
-}
-
+// emitSkillSupportFilesFromFSWithPlan is the testable core: it sources support
+// files from an arbitrary fs.FS rooted like tmpl.TemplateFS() (so paths begin
+// with "skills/<id>/...") and writes them under dstBase on the local
+// filesystem.
 func emitSkillSupportFilesFromFSWithPlan(srcFS fs.FS, skillID, dstBase string, refresh bool, plan *toolRefreshPlan) error {
 	for _, sub := range optionalSkillSupportDirs {
 		dstDir := filepath.Join(dstBase, sub)
@@ -2089,10 +2086,6 @@ func defaultFileModeForPath(path string) os.FileMode {
 		return 0o755
 	}
 	return 0o644
-}
-
-func mergeHookSettingsJSON(root string, cfg ToolConfig, refresh bool) error {
-	return mergeHookSettingsJSONWithPlan(root, cfg, refresh, nil)
 }
 
 func mergePiRegistrationSettingsJSONWithPlan(root string, cfg ToolConfig, refresh bool, plan *toolRefreshPlan) error {

--- a/internal/toolgen/toolgen_test.go
+++ b/internal/toolgen/toolgen_test.go
@@ -410,7 +410,7 @@ func TestDetectExistingTools(t *testing.T) {
 	assert.Equal(t, []string{"claude", "cursor"}, detected)
 }
 
-func TestDetectExistingToolsIgnoresBareP1HostDirectories(t *testing.T) {
+func TestDetectExistingToolsIgnoresBareUnmanagedHostDirectories(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
 
@@ -427,7 +427,7 @@ func TestDetectExistingToolsIgnoresBareP1HostDirectories(t *testing.T) {
 	}
 
 	assert.Empty(t, DetectExistingTools(root),
-		"bare P1 host directories must not trigger refresh auto-detection without Slipway sentinels")
+		"bare unmanaged host directories must not trigger refresh auto-detection without Slipway sentinels")
 }
 
 func TestHasGeneratedAdapter(t *testing.T) {
@@ -2901,7 +2901,7 @@ func TestMergeHookSettingsPrunesStaleHookFormsAndPreservesUserHooks(t *testing.T
 	require.NoError(t, os.MkdirAll(filepath.Dir(settingsPath), 0o755))
 	require.NoError(t, os.WriteFile(settingsPath, []byte(seed), 0o644))
 
-	require.NoError(t, mergeHookSettingsJSON(root, cfg, true))
+	require.NoError(t, mergeHookSettingsJSONWithPlan(root, cfg, true, nil))
 
 	first, err := os.ReadFile(settingsPath)
 	require.NoError(t, err)
@@ -2941,7 +2941,7 @@ func TestMergeHookSettingsPrunesStaleHookFormsAndPreservesUserHooks(t *testing.T
 	)
 
 	// Refresh is idempotent: a second merge does not duplicate or mutate.
-	require.NoError(t, mergeHookSettingsJSON(root, cfg, true))
+	require.NoError(t, mergeHookSettingsJSONWithPlan(root, cfg, true, nil))
 	second, err := os.ReadFile(settingsPath)
 	require.NoError(t, err)
 	assert.Equal(t, string(first), string(second))


### PR DESCRIPTION
## Summary

Dead-code cleanup driven by a fact-checked audit: the audit was run through adversarial verifiers, and only removals that survived verification were applied. One audit "dead" claim (`EvidenceInputHash`) turned out to be a live guardrail and was deliberately kept.

## Changes

**Removals (zero production callers, confirmed)**
- `state`: `RemoveExecutionSummary`, `ResetWaveExecution`, `SaveWavePlan`, `ExecutionSummaryFreshness` wrappers
- `model`: 4 unused `(*Change)` authority methods, `recoveryPrimaryOverrideRank` + its dead comparator tier (already a constant before this change — removal is behavior-neutral)
- `skill`/`artifact`/`toolgen`/`control`: obsolete pre-`*WithX` wrappers (`FilterRequiredSkillsForWorkflowProfile`, `RequiredSkillsForStateWithRegistry`, `ParseDecisionLockedDecisions`, `classifyOwnership`, `emitSkillSupportFilesFromFS`, `mergeHookSettingsJSON`, `DeactivateControl`, `DeriveControlsResult.NewActivations`)
- `governance`: unused `SnapshotFileName` const; `wave`: `TaskResult`/`ExecutionResult`
- `cmd`: collapse the retired wave-plan "authoritative projection" chain to the live derived view — the `buildWavePlan` branch that fed it was already dead (both if/else arms returned `derivedWavePlanView`), so user-visible output and JSON contract are unchanged

**Retire unwired gate** — the `test != impl` distinctness gate (REQ-003) was never wired into the live gate aggregator (`SyncGovernedWaveExecution`): delete the `TestImplDistinctnessBlockers` cluster, the orphaned `wave_test_impl_not_distinct` reason code, recovery vocab, and goldens. A negative-assertion contract test (`TestWaveTestImplDistinctnessVocabularyRetired`) is added so the retired code cannot silently reappear.

**Breaking compat cleanup** — drop `SkillDigest.LegacyRunVersion` and the `EvidenceFreshnessInput` legacy timestamp fields. The evidence-digests cache is a gitignored, freshness-bound runtime artifact, so optional readers now self-heal: a decodable-but-unusable cache (e.g. one still carrying the removed `run_version` key) reads as **absent** and the owning stage regenerates it, instead of hard-failing read-only readiness surfaces (status/next/validate) under `KnownFields(true)`. The `errUnusableEvidenceCache` sentinel scopes this to parse/validate failures only; genuine I/O errors still surface and strict readers still reject unknown fields. Existence remains gated by the verification record (not the digest), so self-heal cannot fabricate freshness.

**New: `SLIPWAY_CONTEXT_WINDOW_TOKENS` parity** — stop the alias scan only on a valid (parsable, positive) override, so a malformed higher-priority alias cannot mask a valid legacy `SPECLANE_` value or silently revert the context guard to the default window (mirrors `contextPressureWindowTokens`).

**Naming / lint** — `registry_b2..b6` → domain names (byte-identical except comments; registration order unchanged); strip PR#/issue# leaks from shipped skill templates; rename L2/L3 and S5/S6 test fixtures to behavior names; fix `SA4006` + `S1021` (plus one `S1016` equivalent conversion).

**Kept (verifier-confirmed load-bearing)** — `EvidenceInputHash` guardrail, fsutil rollback test seams, retired-state canonicalization, `ResolveNextSkill` contract name, all legacy self-heal/migration logic.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` — all green (28 packages, 0 failures)
- Adversarial dead-code review across 5 dimensions (state/model · skill/toolgen/control + cmd collapse · REQ-003 gate retirement · env-var/renames/contracts · evidence-digests self-heal): **0 blockers / 0 majors**. Independently confirmed: the retired gate had zero production callers and was absent from the live blocker aggregator (retiring it removes no active protection); evidence-digest self-heal cannot fabricate freshness (existence is gated by the verification record, not the digest) and does not swallow I/O errors (the sentinel wraps only parse/validate paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
