### PR TITLE
fix(plan-audit): frame task evidence as acceptance criteria, not a metadata key

### DIFF
--- a/internal/tmpl/templates/skills/plan-audit/SKILL.md
+++ b/internal/tmpl/templates/skills/plan-audit/SKILL.md
@@ -169,7 +169,9 @@ failure modes, alternatives, tradeoffs, and concrete risks.
 
 Audit tasks as execution units, not prose:
 - split by bounded outcome, not file name alone
-- require each task to name its evidence shape (`verdict` / `artifact` / `checklist`)
+- require each task's acceptance criteria to name the concrete evidence that
+  will prove it done — a passing check, a produced artifact, or a satisfied
+  checklist
 - require task acceptance criteria to be satisfiable during S2 implementation; do
   not accept criteria that require future S3 review or closeout evidence
   before the workflow can legally reach those states


### PR DESCRIPTION
## Problem (#302)
The `slipway-plan-audit` skill instructed auditors to *"require each task to name its evidence shape (`verdict` / `artifact` / `checklist`)"*. Agents followed this literally and added an `evidence_shape:` metadata line to `tasks.md`, but the tasks contract has no such key — so `slipway validate` rejected the plan with `tasks_checklist_invalid_format: ... unknown metadata key "evidence_shape"` at the **S1 plan-audit gate**, exactly when the agent was trying to make the plan more compliant.

## Fix
Reframe the audit lens as a property of each task's **acceptance criteria** (prose) rather than a task field. The evidence kinds (a passing check / a produced artifact / a satisfied checklist) stay illustrative, and no nonexistent metadata key is implied — so the skill text can't drift from the tasks contract.

Template-only change; the generated per-adapter skill copies (`.claude/`, `.codex/`, …) are gitignored and regenerated by `slipway init`.

## Verification
- `go build ./...` green
- `go test ./internal/toolgen/` green
- Regenerated adapter copies; old wording gone, new wording present.

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)