### PR TITLE
fix(evidence): allow in-place stale re-cert of upstream governance skills

### DIFF
--- a/cmd/evidence.go
+++ b/cmd/evidence.go
@@ -1415,18 +1415,34 @@ func validateEvidenceSkillStage(root string, change model.Change, def skill.Defi
 		)
 	}
 	if change.CurrentState != def.State {
-		return newInvalidUsageError(
-			"evidence_skill_wrong_state",
-			fmt.Sprintf("%s evidence requires %s state, current: %s", def.Name, def.State, change.CurrentState),
-			evidenceSkillWrongStateRemediation(root, change, def),
-			map[string]any{
-				"skill":          def.Name,
-				"expected":       def.State,
-				"current":        change.CurrentState,
-				"required_state": string(def.State),
-				"current_state":  string(change.CurrentState),
-			},
-		)
+		// In-place stale re-cert: when this skill is the engine-flagged recoverable
+		// stale-repair target, allow recording its fresh evidence at the current
+		// state even though the change has advanced past the skill's owning state.
+		// This mirrors the wrong-substep exception below (1431) and closes the
+		// otherwise-circular dead end where an upstream skill (e.g. intake-clarification,
+		// owned by S0_INTAKE) goes stale after the change has advanced to S1_PLAN:
+		// `evidence skill` rejected it (wrong state), `intake`/`run` would not reopen
+		// to S0, so there was no public path to re-certify. Fail-closed: this opens
+		// ONLY for the skill the engine itself reports as a recoverable stale target,
+		// ONLY while it is stale (gated on staleEvidenceSkillRefreshRequired).
+		refreshRequired, err := staleEvidenceSkillRefreshRequired(root, change, def.Name)
+		if err != nil {
+			return err
+		}
+		if !refreshRequired {
+			return newInvalidUsageError(
+				"evidence_skill_wrong_state",
+				fmt.Sprintf("%s evidence requires %s state, current: %s", def.Name, def.State, change.CurrentState),
+				evidenceSkillWrongStateRemediation(root, change, def),
+				map[string]any{
+					"skill":          def.Name,
+					"expected":       def.State,
+					"current":        change.CurrentState,
+					"required_state": string(def.State),
+					"current_state":  string(change.CurrentState),
+				},
+			)
+		}
 	}
 	if def.State == model.StateS1Plan && def.PlanSubStep != model.PlanSubStepNone && change.PlanSubStep != def.PlanSubStep {
 		refreshRequired, err := staleEvidenceSkillRefreshRequired(root, change, def.Name)

--- a/cmd/evidence_skill_test.go
+++ b/cmd/evidence_skill_test.go
@@ -189,6 +189,111 @@ func TestEvidenceSkillRejectsNonStaleResearchRestampFromAuditSubstep(t *testing.
 	})
 }
 
+func TestEvidenceSkillAllowsStaleUpstreamIntakeRecertAtS1Plan(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "evidence skill recerts stale intake at S1")
+		// S0-owned intake-clarification certifies intent.md at S0_INTAKE, then the
+		// change advances into S1_PLAN. Keep the substep before audit so a fresh
+		// plan-audit cannot supersede the intake drift for this test.
+		change := setEvidenceSkillChangeState(t, root, slug, model.StateS1Plan, model.PlanSubStepNone)
+		writeMinimalGovernedBundle(t, root, change)
+		writeSkillVerification(t, root, slug, progression.SkillIntakeClarification, model.VerificationRecord{
+			Verdict:    model.VerificationVerdictPass,
+			Blockers:   []model.ReasonCode{},
+			Timestamp:  time.Now().UTC(),
+			RunVersion: 0,
+			References: []string{"intake:pass"},
+			Notes:      "Original intake clarification.",
+		})
+		refreshPassingSkillDigestsForTest(t, root, slug, progression.SkillIntakeClarification)
+
+		// Mutate the certified intent.md body after the change advanced past S0, so
+		// the upstream intake-clarification evidence goes stale with no S0 reopen
+		// path. The change must land under a hashed heading (the Intent body), not
+		// the Open Questions section, which the intake digest intentionally ignores.
+		intentPath := filepath.Join(root, "artifacts", "changes", slug, "intent.md")
+		require.NoError(t, os.WriteFile(intentPath, []byte(`# Intent
+INT-001: test fixture intent, clarified scope after planning began.
+
+## Open Questions
+(none)
+`), 0o644))
+
+		// The engine flags the stale upstream skill as a recoverable repair target.
+		// (Readiness blockers intentionally omit intake-clarification staleness today
+		// — that view-path vs advance-path divergence is a tracked follow-up — so the
+		// in-place re-cert exception keys off the repair target, not readiness.)
+		target, ok, err := progression.StaleEvidenceRepairAvailable(root, change, nil)
+		require.NoError(t, err)
+		require.True(t, ok, "engine must flag the stale upstream intake skill as a recoverable repair target")
+		require.Equal(t, progression.SkillIntakeClarification, target.SkillName)
+
+		refreshRequired, err := staleEvidenceSkillRefreshRequired(root, change, progression.SkillIntakeClarification)
+		require.NoError(t, err)
+		require.True(t, refreshRequired, "the wrong-state guard must treat the flagged stale intake skill as refresh-required")
+
+		cmd := commandForRoot(t, root, makeEvidenceCmd())
+		cmd.SetArgs([]string{
+			"skill",
+			"--json",
+			"--change", slug,
+			"--skill", progression.SkillIntakeClarification,
+			"--verdict", model.VerificationVerdictPass,
+			"--reference", "intake:pass",
+			"--notes", "Intake re-certified after current intent updates.",
+		})
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		require.NoError(t, cmd.Execute())
+
+		var view evidenceSkillView
+		require.NoError(t, json.Unmarshal(out.Bytes(), &view))
+		assert.Equal(t, progression.SkillIntakeClarification, view.SkillName)
+		assert.True(t, view.Recorded)
+
+		rec, err := state.LoadVerification(root, slug, progression.SkillIntakeClarification)
+		require.NoError(t, err)
+		assert.Equal(t, "Intake re-certified after current intent updates.", rec.Notes)
+
+		target, ok, err = progression.StaleEvidenceRepairAvailable(root, change, nil)
+		require.NoError(t, err)
+		assert.False(t, ok, "intake re-cert should clear the stale evidence repair target")
+		assert.Empty(t, target.SkillName)
+	})
+}
+
+func TestEvidenceSkillRejectsNonStaleWrongStateSkill(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "evidence skill rejects non-stale wrong state")
+		// An S3-owned review skill at S1_PLAN is at the wrong state and is not a
+		// recoverable stale-repair target, so the wrong-state guard must still fail
+		// closed even with the in-place re-cert exception present.
+		setEvidenceSkillChangeState(t, root, slug, model.StateS1Plan, model.PlanSubStepAudit)
+
+		cmd := commandForRoot(t, root, makeEvidenceCmd())
+		cmd.SetArgs([]string{
+			"skill",
+			"--change", slug,
+			"--skill", progression.SkillSpecComplianceReview,
+			"--verdict", model.VerificationVerdictPass,
+		})
+		cliErr := asCLIError(cmd.Execute())
+		require.NotNil(t, cliErr)
+		assert.Equal(t, "evidence_skill_wrong_state", cliErr.ErrorCode)
+		assert.Equal(t, progression.SkillSpecComplianceReview, cliErr.Details["skill"])
+		assert.Equal(t, string(model.StateS3Review), cliErr.Details["required_state"])
+		assert.Equal(t, string(model.StateS1Plan), cliErr.Details["current_state"])
+	})
+}
+
 func TestEvidenceSkillNotesFileUsesBoundWorktreeWorkspace(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {


### PR DESCRIPTION
## Problem

An upstream governance skill — e.g. `intake-clarification`, owned by `S0_INTAKE` — can go stale (its certified `intent.md` changed) **after** the change has already advanced to `S1_PLAN`. Before this fix there was no public path to re-certify it. Every surface refused:

- `evidence skill` → `evidence_skill_wrong_state`
- `slipway intake` → `intake_state_invalid`
- `slipway run` → `required_skill_stale` + `review_alignment_required` (S3 vocabulary)
- `slipway pivot` → removed

A circular recovery dead end: nothing could advance and nothing could re-cert.

## Root cause

In `cmd/evidence.go`, `validateEvidenceSkillStage`'s wrong-state guard (`if change.CurrentState != def.State { ... return evidence_skill_wrong_state }`) did **not** honor the `staleEvidenceSkillRefreshRequired` exception that the wrong-*substep* guard a few lines below already honors. So an engine-flagged, recoverable stale target that happened to live at an earlier owning state was rejected outright.

## Fix

Apply the same exception in the wrong-state guard: before returning `evidence_skill_wrong_state`, check `staleEvidenceSkillRefreshRequired(root, change, def.Name)` and return `nil` (allow recording) when it is true. This is **fail-closed**:

- opens only for the skill the engine itself reports as a recoverable stale-repair target,
- only while it is actually stale,
- no backward state transition, no bypass, no private attestation path.

It mirrors the existing wrong-substep stale-restamp behavior exactly.

## Proof (dogfood)

On a real stuck change at `S1_PLAN` with a stale `intake-clarification` certification:

- `evidence skill --skill intake-clarification` now **succeeds** (was `evidence_skill_wrong_state`).
- `slipway run` blockers went from `[required_skill_stale, review_alignment_required]` → `[required_skill_missing]`.

Covered by two focused unit tests in `cmd/evidence_skill_test.go`:

- `TestEvidenceSkillAllowsStaleUpstreamIntakeRecertAtS1Plan` (positive: stale S0 `intake-clarification` at `S1_PLAN` → recording allowed; fails without the fix with the exact wrong-state dead-end error).
- `TestEvidenceSkillRejectsNonStaleWrongStateSkill` (negative / fail-closed: a non-stale wrong-state skill still returns `evidence_skill_wrong_state`).

`gofmt -s`, `go vet ./...`, and `go test ./...` are all green.

## Follow-ups (NOT in this PR)

- **D2 — view-path vs advance-path divergence.** `validate` / `next --json` still hide the stale blocker that `run` enforces: `EvaluateGovernanceReadiness` intentionally omits `intake-clarification` staleness from required-skill blockers, while `StaleEvidenceRepairAvailable` (the advance/repair path) flags it. The re-cert exception keys off the repair target so it works regardless, but the read surfaces remain misleading.
- `forwardOnlyStaleEvidenceSummary` still says "review convergence", which misleads for an S1 upstream re-cert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)