### PR TITLE
fix(governance): repair evidence-recording and recovery UX defects (#310, #311)

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -502,14 +502,23 @@ type unknownOrphan struct {
 	Err  error
 }
 
+// archivedResidueOrphan pairs an orphan active-bundle slug with the archived
+// terminal record for the same slug. Recovery deletes only active-state residue;
+// the archived record and source commits are retained.
+type archivedResidueOrphan struct {
+	Slug        string
+	ArchivePath string
+}
+
 // orphanClassification splits orphan-bundle slugs into the unmanaged-worktree
 // case (preserve-first, never discard), the ownership-unknown case (the git
 // cross-check failed, so fail closed to preserve-first), and the plain
 // discardable residue.
 type orphanClassification struct {
-	Unmanaged []unmanagedOrphan
-	Unknown   []unknownOrphan
-	Plain     []string
+	Unmanaged       []unmanagedOrphan
+	Unknown         []unknownOrphan
+	ArchivedResidue []archivedResidueOrphan
+	Plain           []string
 }
 
 // classifyOrphanBundles cross-checks each orphan slug against git
@@ -542,6 +551,10 @@ func classifyOrphanBundlesWith(root string, orphans []string, match slugWorktree
 			class.Unmanaged = append(class.Unmanaged, unmanagedOrphan{Slug: slug, Match: m})
 			continue
 		}
+		if archived, ok := archivedResidueOrphanForSlug(root, slug); ok {
+			class.ArchivedResidue = append(class.ArchivedResidue, archived)
+			continue
+		}
 		class.Plain = append(class.Plain, slug)
 	}
 	return class
@@ -563,6 +576,37 @@ func unknownOrphanSlugs(orphans []unknownOrphan) []string {
 	return slugs
 }
 
+func archivedResidueOrphanSlugs(orphans []archivedResidueOrphan) []string {
+	slugs := make([]string, 0, len(orphans))
+	for _, o := range orphans {
+		slugs = append(slugs, o.Slug)
+	}
+	return slugs
+}
+
+func archivedActiveResidueReason(orphan archivedResidueOrphan) model.ReasonCode {
+	return model.ReasonCode{
+		Code:     "orphaned_change_bundle",
+		Severity: model.ReasonSeverityError,
+		// Build the message from the shared model sentinel so the prose the model
+		// matcher (isArchivedActiveResidueReason) keys on cannot drift from the
+		// prose produced here across the package boundary (F2).
+		Message: fmt.Sprintf("%s%q remains; archived record and source commits are not deletion targets", model.ArchivedActiveResidueMessagePrefix, orphan.Slug),
+		Detail:  orphan.Slug,
+	}
+}
+
+func archivedResidueOrphanForSlug(root, slug string) (archivedResidueOrphan, bool) {
+	if _, err := state.LoadArchivedChange(root, slug); err != nil {
+		return archivedResidueOrphan{}, false
+	}
+	archivePath := filepath.ToSlash(filepath.Join("artifacts", "changes", "archived", slug, "change.yaml"))
+	if path, err := state.ArchivedChangeFilePathForRead(root, slug); err == nil {
+		archivePath = state.DisplayPath(root, path)
+	}
+	return archivedResidueOrphan{Slug: slug, ArchivePath: archivePath}, true
+}
+
 func orphanedChangeBundleError(root, slug string) *CLIError {
 	orphans, err := orphanedChangeBundleSlugs(root, slug)
 	if err != nil || len(orphans) == 0 {
@@ -580,6 +624,9 @@ func orphanedChangeBundleError(root, slug string) *CLIError {
 	}
 	for _, u := range class.Unknown {
 		reasons = append(reasons, model.NewReasonCode("orphaned_bundle_ownership_unknown", u.Slug))
+	}
+	for _, archived := range class.ArchivedResidue {
+		reasons = append(reasons, archivedActiveResidueReason(archived))
 	}
 	reasons = append(reasons, orphanedChangeBundleReasons(class.Plain)...)
 
@@ -622,12 +669,45 @@ func orphanedChangeBundleError(root, slug string) *CLIError {
 			details["orphaned_change_bundles"] = class.Plain
 			remediation += fmt.Sprintf(" Separately, the abandoned residue with no live worktree can be discarded with `slipway delete --change %s` for: %s.", class.Plain[0], strings.Join(class.Plain, ", "))
 		}
+		if len(class.ArchivedResidue) > 0 {
+			archived := class.ArchivedResidue[0]
+			details["orphaned_active_residue_archived_changes"] = archivedResidueOrphanSlugs(class.ArchivedResidue)
+			details["archive_path"] = archived.ArchivePath
+			remediation += " Separately, " + archivedActiveResidueRemediation(archived)
+		}
 		return newCLIErrorWithReasons(
 			categoryPrecondition,
 			errorCode,
 			message,
 			remediation,
 			primarySlug,
+			reasons,
+			details,
+		)
+	}
+
+	if len(class.ArchivedResidue) > 0 {
+		primary := class.ArchivedResidue[0]
+		message := fmt.Sprintf("active-state residue for archived change %q is missing its change.yaml authority", primary.Slug)
+		remediation := archivedActiveResidueRemediation(primary)
+		if len(class.ArchivedResidue) > 1 {
+			message = "active-state residue remains for archived changes: " + strings.Join(archivedResidueOrphanSlugs(class.ArchivedResidue), ", ")
+			remediation = fmt.Sprintf("Discard each stale active-state residue with `slipway delete --change <slug>`; first suggested command: `slipway delete --change %s`. Archived records and source commits are not deletion targets.", primary.Slug)
+		}
+		details := map[string]any{
+			"orphaned_active_residue_archived_changes": archivedResidueOrphanSlugs(class.ArchivedResidue),
+			"archive_path": primary.ArchivePath,
+		}
+		if len(class.Plain) > 0 {
+			details["orphaned_change_bundles"] = class.Plain
+			remediation += fmt.Sprintf(" Separately, abandoned residue with no archived record can be discarded with `slipway delete --change %s` for: %s.", class.Plain[0], strings.Join(class.Plain, ", "))
+		}
+		return newCLIErrorWithReasons(
+			categoryPrecondition,
+			"orphaned_active_residue_archived_change",
+			message,
+			remediation,
+			primary.Slug,
 			reasons,
 			details,
 		)
@@ -664,6 +744,13 @@ func unmanagedWorktreeOrphanRemediation(slug string, match state.SlugWorktreeMat
 	return fmt.Sprintf(
 		"A live git worktree Slipway does not manage holds work for %q at %s. Inspect and preserve that worktree and its branch first — Slipway never removes a worktree it did not provision. Once its work is merged or saved, discard only the stale bundle residue with `slipway delete --change %s` (never pass --worktree).",
 		slug, location, slug,
+	)
+}
+
+func archivedActiveResidueRemediation(orphan archivedResidueOrphan) string {
+	return fmt.Sprintf(
+		"Active-state residue for archived change %q remains under artifacts/changes/%s. Remove only that stale active-state residue with `slipway delete --change %s`. The archived record at %s and source commits are not deletion targets.",
+		orphan.Slug, orphan.Slug, orphan.Slug, orphan.ArchivePath,
 	)
 }
 

--- a/cmd/evidence.go
+++ b/cmd/evidence.go
@@ -903,9 +903,10 @@ func makeEvidenceTaskCmd() *cobra.Command {
 }
 
 type preparedEvidenceTaskResult struct {
-	payload progression.TaskEvidencePayload
-	path    string
-	view    evidenceTaskView
+	payload    progression.TaskEvidencePayload
+	path       string
+	resultFile string
+	view       evidenceTaskView
 }
 
 func normalizeEvidenceTaskResultFileArgs(resultFiles []string) []string {
@@ -1080,6 +1081,7 @@ func prepareEvidenceTaskResultFiles(
 		}
 		seenTasks[taskID] = resultFile
 
+		sessionID := strings.TrimSpace(result.SessionID)
 		planTask, ok := findEvidenceWavePlanTask(wavePlan, taskID)
 		if !ok {
 			return nil, newInvalidUsageError(
@@ -1174,12 +1176,13 @@ func prepareEvidenceTaskResultFiles(
 			Blockers:          blockers,
 			CapturedAt:        commandCapturedAt.Format(time.RFC3339Nano),
 			FreshnessInputs:   state.ExpectedExecutionTaskFreshnessInputs(change, runSummary, taskID, wavePlan.TasksPlanHash),
-			SessionID:         strings.TrimSpace(result.SessionID),
+			SessionID:         sessionID,
 		}
 		path := filepath.Join(state.EvidenceTasksDir(root, change.Slug), taskID+".json")
 		prepared = append(prepared, preparedEvidenceTaskResult{
-			payload: payload,
-			path:    path,
+			payload:    payload,
+			path:       path,
+			resultFile: resultFile,
 			view: evidenceTaskView{
 				Slug:              change.Slug,
 				TaskID:            taskID,
@@ -1190,7 +1193,104 @@ func prepareEvidenceTaskResultFiles(
 			},
 		})
 	}
+	if err := rejectDuplicateEvidenceTaskResultSessions(root, change, runSummary, prepared); err != nil {
+		return nil, err
+	}
 	return prepared, nil
+}
+
+type evidenceTaskResultSessionOwner struct {
+	taskID     string
+	resultFile string
+}
+
+func rejectDuplicateEvidenceTaskResultSessions(root string, change model.Change, runSummary int, prepared []preparedEvidenceTaskResult) error {
+	replacedTasks := map[string]struct{}{}
+	for _, item := range prepared {
+		replacedTasks[item.payload.TaskID] = struct{}{}
+	}
+
+	sessionOwners, err := existingEvidenceTaskResultSessionOwners(root, change, runSummary, replacedTasks)
+	if err != nil {
+		return err
+	}
+	for _, item := range prepared {
+		sessionID := strings.TrimSpace(item.payload.SessionID)
+		if sessionID == "" {
+			continue
+		}
+		if previous, ok := sessionOwners[sessionID]; ok && previous.taskID != item.payload.TaskID {
+			return newInvalidUsageError(
+				"evidence_task_result_file_duplicate_session",
+				fmt.Sprintf("multiple task results use session_id %q", sessionID),
+				"Use a distinct session_id per task executor in the active run, or omit session_id when no executor identity is available.",
+				map[string]any{
+					"session_id":            sessionID,
+					"first_task_id":         previous.taskID,
+					"duplicate_task_id":     item.payload.TaskID,
+					"first_result_file":     previous.resultFile,
+					"duplicate_result_file": item.resultFile,
+				},
+			)
+		}
+		sessionOwners[sessionID] = evidenceTaskResultSessionOwner{
+			taskID:     item.payload.TaskID,
+			resultFile: item.resultFile,
+		}
+	}
+	return nil
+}
+
+func existingEvidenceTaskResultSessionOwners(
+	root string,
+	change model.Change,
+	runSummary int,
+	replacedTasks map[string]struct{},
+) (map[string]evidenceTaskResultSessionOwner, error) {
+	dir := state.EvidenceTasksDir(root, change.Slug)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return map[string]evidenceTaskResultSessionOwner{}, nil
+		}
+		return nil, newStateIntegrityError(
+			"evidence_task_existing_evidence_load_failed",
+			fmt.Sprintf("failed to read existing task evidence %q: %v", state.DisplayPath(root, dir), err),
+			"Repair the runtime task evidence before importing task result evidence.",
+			change.Slug,
+			map[string]any{"path": state.DisplayPath(root, dir)},
+		)
+	}
+
+	sessionOwners := map[string]evidenceTaskResultSessionOwner{}
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		task, _, sessionID, err := progression.ParseTaskEvidence(root, path, runSummary)
+		if err != nil {
+			var versionMismatch progression.TaskEvidenceRunVersionMismatchError
+			if errors.As(err, &versionMismatch) {
+				continue
+			}
+			return nil, newStateIntegrityError(
+				"evidence_task_existing_evidence_invalid",
+				fmt.Sprintf("failed to parse existing task evidence %q: %v", state.DisplayPath(root, path), err),
+				"Repair or remove malformed task evidence before importing task result evidence.",
+				change.Slug,
+				map[string]any{"path": state.DisplayPath(root, path)},
+			)
+		}
+		if _, replaced := replacedTasks[task.TaskID]; replaced || strings.TrimSpace(sessionID) == "" {
+			continue
+		}
+		sessionOwners[strings.TrimSpace(sessionID)] = evidenceTaskResultSessionOwner{
+			taskID:     task.TaskID,
+			resultFile: state.DisplayPath(root, path),
+		}
+	}
+	return sessionOwners, nil
 }
 
 func writePreparedEvidenceTaskResults(prepared []preparedEvidenceTaskResult) error {

--- a/cmd/evidence_task_test.go
+++ b/cmd/evidence_task_test.go
@@ -265,6 +265,60 @@ func TestEvidenceTaskResultFileBatchRejectsDuplicateTaskWithoutWritingEvidence(t
 	})
 }
 
+func TestEvidenceTaskResultFileBatchRejectsDuplicateSessionWithoutWritingEvidence(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		slug, _ := createMultiTaskEvidenceTaskFixture(t, root)
+		writeTaskResultFileWithSessionID(t, filepath.Join(root, "task-result-t-01.json"), "t-01", "test:batch-t-01", "cmd/evidence.go", "executor-a")
+		writeTaskResultFileWithSessionID(t, filepath.Join(root, "task-result-t-02.json"), "t-02", "test:batch-t-02", "cmd/evidence_task_test.go", "executor-a")
+
+		cmd := commandForRoot(t, root, makeEvidenceCmd())
+		cmd.SetArgs([]string{
+			"task",
+			"--json",
+			"--result-file", "task-result-t-01.json",
+			"--result-file", "task-result-t-02.json",
+		})
+		cliErr := asCLIError(cmd.Execute())
+		require.NotNil(t, cliErr)
+		assert.Equal(t, "evidence_task_result_file_duplicate_session", cliErr.ErrorCode)
+		assert.Equal(t, "executor-a", cliErr.Details["session_id"])
+		assertTaskEvidenceNotWritten(t, root, slug, "t-01")
+		assertTaskEvidenceNotWritten(t, root, slug, "t-02")
+	})
+}
+
+func TestEvidenceTaskResultFileRejectsDuplicateSessionFromExistingRunEvidence(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		slug, _ := createMultiTaskEvidenceTaskFixture(t, root)
+		writeTaskResultFileWithSessionID(t, filepath.Join(root, "task-result-t-01.json"), "t-01", "test:initial-t-01", "cmd/evidence.go", "executor-a")
+
+		firstCmd := commandForRoot(t, root, makeEvidenceCmd())
+		firstCmd.SetArgs([]string{"task", "--json", "--result-file", "task-result-t-01.json"})
+		firstCmd.SetOut(&bytes.Buffer{})
+		require.NoError(t, firstCmd.Execute())
+
+		writeTaskResultFileWithSessionID(t, filepath.Join(root, "task-result-t-02.json"), "t-02", "test:duplicate-session-t-02", "cmd/evidence_task_test.go", "executor-a")
+		secondCmd := commandForRoot(t, root, makeEvidenceCmd())
+		secondCmd.SetArgs([]string{"task", "--json", "--result-file", "task-result-t-02.json"})
+		cliErr := asCLIError(secondCmd.Execute())
+		require.NotNil(t, cliErr)
+		assert.Equal(t, "evidence_task_result_file_duplicate_session", cliErr.ErrorCode)
+		assert.Equal(t, "executor-a", cliErr.Details["session_id"])
+		assert.Equal(t, "t-01", cliErr.Details["first_task_id"])
+		assert.Equal(t, "t-02", cliErr.Details["duplicate_task_id"])
+		assertTaskEvidenceWritten(t, root, slug, "t-01")
+		assertTaskEvidenceNotWritten(t, root, slug, "t-02")
+	})
+}
+
 func TestEvidenceTaskResultFileBatchInvalidMemberWritesNoEvidence(t *testing.T) {
 	t.Parallel()
 
@@ -1398,6 +1452,19 @@ func writeTaskResultFile(t *testing.T, path, taskID, evidenceRef, changedFile st
 	writeTaskResultFileWithVerdict(t, path, taskID, "pass", evidenceRef, changedFile, nil)
 }
 
+func writeTaskResultFileWithSessionID(t *testing.T, path, taskID, evidenceRef, changedFile, sessionID string) {
+	t.Helper()
+
+	writeTaskResultFilePayload(t, path, map[string]any{
+		"task_id":       taskID,
+		"verdict":       "pass",
+		"evidence_ref":  evidenceRef,
+		"changed_files": []string{changedFile},
+		"blockers":      []string{},
+		"session_id":    sessionID,
+	})
+}
+
 func writeTaskResultFileWithVerdict(
 	t *testing.T,
 	path string,
@@ -1409,13 +1476,19 @@ func writeTaskResultFileWithVerdict(
 ) {
 	t.Helper()
 
-	rawResult, err := json.Marshal(map[string]any{
+	writeTaskResultFilePayload(t, path, map[string]any{
 		"task_id":       taskID,
 		"verdict":       verdict,
 		"evidence_ref":  evidenceRef,
 		"changed_files": []string{changedFile},
 		"blockers":      blockers,
 	})
+}
+
+func writeTaskResultFilePayload(t *testing.T, path string, payload map[string]any) {
+	t.Helper()
+
+	rawResult, err := json.Marshal(payload)
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(path, rawResult, 0o644))
 }

--- a/cmd/next.go
+++ b/cmd/next.go
@@ -433,6 +433,7 @@ func buildNextViewForCommand(root string, ref changeRef, opts nextViewOptions) (
 		view.GuardrailDomain = strings.TrimSpace(governedChange.GuardrailDomain)
 	}
 	finalize := func() (nextView, error) {
+		applyReadyAdvanceDiagnostics(root, governedChange, &view)
 		view.ConfirmationRequirement = deriveConfirmationRequirement(view)
 		view.Recovery = model.BuildRecovery(view.Blockers)
 		return view, nil
@@ -557,6 +558,25 @@ func shouldExposeAdvancedSummaryToCaller(summary progression.AdvanceSummary) boo
 	default:
 		return false
 	}
+}
+
+func applyReadyAdvanceDiagnostics(root string, change *model.Change, view *nextView) {
+	if change == nil || view == nil || view.NextSkill != nil {
+		return
+	}
+	if !hasReasonCode(view.Blockers, "no_skill_required") ||
+		hasReasonCode(view.Blockers, "run_slipway_run_to_advance") ||
+		hasNonPacingBlocker(*view) {
+		return
+	}
+	canAdvance, blockers := noSkillStateAdvanceReadiness(root, *change)
+	if !canAdvance || len(blockers) > 0 {
+		return
+	}
+	view.Blockers = model.NormalizeReasonCodes(append(
+		view.Blockers,
+		model.NewReasonCode("run_slipway_run_to_advance", string(view.CurrentState)),
+	))
 }
 
 func projectDoneReadyForReadOnlyQuery(root string, change *model.Change, advanced *progression.AdvanceSummary) error {
@@ -698,6 +718,8 @@ func deriveConfirmationRequirement(view nextView) confirmationRequirement {
 			return autoStandingAuthorization(reason)
 		}
 		return confirmationHardStop(reason)
+	case hasReasonCode(view.Blockers, "no_skill_required") && !hasNonPacingBlocker(view):
+		return confirmationCommandRequired("run_slipway_run_to_advance")
 	case len(view.Blockers) > 0:
 		return confirmationCommandRequired("blocked_by_governance")
 	case len(view.AutoPassEligible) > 0:

--- a/cmd/orphaned_bundle_unmanaged_worktree_test.go
+++ b/cmd/orphaned_bundle_unmanaged_worktree_test.go
@@ -4,8 +4,10 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/signalridge/slipway/internal/model"
 	"github.com/signalridge/slipway/internal/state"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -61,6 +63,19 @@ func writeOrphanBundle(t *testing.T, root, slug string) {
 	orphans, err := state.OrphanBundleSlugs(root)
 	require.NoError(t, err)
 	require.Contains(t, orphans, slug, "fixture must register %q as an orphan bundle", slug)
+}
+
+func writeArchivedChangeWithActiveResidue(t *testing.T, root, slug string) {
+	t.Helper()
+	change := model.NewChange(slug)
+	change.Status = model.ChangeStatusDone
+	change.CurrentState = model.StateDone
+	require.NoError(t, state.SaveChange(root, change))
+	_, err := state.ArchiveChange(root, change, model.ChangeStatusDone)
+	require.NoError(t, err)
+
+	writeOrphanBundle(t, root, slug)
+	require.FileExists(t, state.BundleArchivedChangeFilePath(root, slug))
 }
 
 // addWorktreeOnBranch adds a real git worktree at path on a freshly-created
@@ -174,6 +189,31 @@ func TestOrphanedChangeBundleErrorNoWorktreeRoute(t *testing.T) {
 	assert.Contains(t, cliErr.Remediation, "slipway delete --change "+slug)
 }
 
+func TestOrphanedChangeBundleErrorArchivedSameSlugTargetsActiveResidue(t *testing.T) {
+	root := orphanRecoveryWorkspace(t)
+	slug := "archived-with-active-residue"
+
+	writeArchivedChangeWithActiveResidue(t, root, slug)
+
+	cliErr := orphanedChangeBundleError(root, slug)
+	require.NotNil(t, cliErr)
+	assert.Equal(t, "orphaned_active_residue_archived_change", cliErr.ErrorCode)
+	assert.Equal(t, categoryPrecondition, cliErr.Category)
+	assert.Equal(t, slug, cliErr.Slug)
+	assert.Contains(t, cliErr.Message, "active-state residue")
+	assert.Contains(t, cliErr.Remediation, "active-state residue")
+	assert.Contains(t, cliErr.Remediation, "archived record")
+	assert.Contains(t, cliErr.Remediation, "source commits are not deletion targets")
+	assert.Contains(t, cliErr.Remediation, "slipway delete --change "+slug)
+	assert.NotContains(t, cliErr.Remediation, "--worktree")
+
+	require.NotEmpty(t, cliErr.Reasons)
+	assert.Equal(t, "orphaned_change_bundle", string(cliErr.Reasons[0].Code))
+	assert.Contains(t, cliErr.Reasons[0].Message, "Active-state residue")
+	require.NotNil(t, cliErr.Details)
+	assert.Equal(t, filepath.ToSlash(filepath.Join("artifacts", "changes", "archived", slug, "change.yaml")), cliErr.Details["archive_path"])
+}
+
 // statusBlockerHasCode reports whether the status --json blockers list carries a
 // reason with the given code. Blockers are encoded as model.ReasonCode objects,
 // so each entry is a map with a "code" field.
@@ -264,6 +304,30 @@ func TestStatusJSONUnmanagedWorktreeOrphanIsNonDestructive(t *testing.T) {
 	assertNonDestructiveUnmanagedRecovery(t, payload, stdout)
 }
 
+func TestStatusJSONArchivedSameSlugOrphanTargetsActiveResidue(t *testing.T) {
+	root := orphanRecoveryWorkspace(t)
+	slug := "archived-with-active-residue"
+
+	writeArchivedChangeWithActiveResidue(t, root, slug)
+
+	stdout, stderr, err := runRootCommandIn(root, []string{"status", "--json", "--change", slug})
+	require.NoError(t, err)
+	require.Empty(t, stderr)
+	payload := decodeJSONMap(t, stdout)
+	assert.Equal(t, "diagnostics", payload["execution_mode"])
+	assert.Nil(t, payload["archived"], "active residue recovery must not render the archived record as the target")
+	assert.True(t, statusBlockerHasCode(t, payload, "orphaned_change_bundle"))
+
+	recovery, ok := payload["recovery"].(map[string]any)
+	require.True(t, ok, "status must surface a recovery object")
+	assert.Equal(t, "discard_change", recovery["recovery_class"])
+	assert.Equal(t, "slipway delete --change "+slug, recovery["primary_command"])
+	assert.Contains(t, stdout, "active-state residue")
+	assert.Contains(t, stdout, "archived record")
+	assert.Contains(t, stdout, "source commits are not deletion targets")
+	assert.NotContains(t, stdout, "--worktree")
+}
+
 // TestOrphanedChangeBundleErrorMixedOrphansClassifyEach is the #285 no-target
 // path: an unmanaged-worktree orphan AND a plain discardable orphan together.
 // The error must LEAD with the non-destructive unmanaged case, keep a reason for
@@ -296,4 +360,110 @@ func TestOrphanedChangeBundleErrorMixedOrphansClassifyEach(t *testing.T) {
 	assert.Contains(t, cliErr.Remediation, "slipway delete --change "+plain)
 	assert.NotContains(t, cliErr.Remediation, "--change <slug>")
 	assert.Contains(t, cliErr.Remediation, "never pass --worktree")
+}
+
+// TestOrphanedChangeBundleErrorTwoArchivedResidueOrphans covers the
+// len(class.ArchivedResidue) > 1 branch: two archived same-slug active-residue
+// orphans surfaced at once. The error must list BOTH slugs, keep a reason for
+// each, still exclude --worktree, and name the archived record / source commits
+// as non-targets. NOT parallel: the workspace helper chdirs.
+func TestOrphanedChangeBundleErrorTwoArchivedResidueOrphans(t *testing.T) {
+	root := orphanRecoveryWorkspace(t)
+	const first = "archived-residue-a"
+	const second = "archived-residue-b"
+	writeArchivedChangeWithActiveResidue(t, root, first)
+	writeArchivedChangeWithActiveResidue(t, root, second)
+
+	cliErr := orphanedChangeBundleError(root, "") // empty slug -> all orphans
+	require.NotNil(t, cliErr)
+	assert.Equal(t, "orphaned_active_residue_archived_change", cliErr.ErrorCode)
+	assert.Equal(t, categoryPrecondition, cliErr.Category)
+
+	// Both archived-residue slugs are named in the message and remediation.
+	assert.Contains(t, cliErr.Message, first)
+	assert.Contains(t, cliErr.Message, second)
+	assert.Contains(t, cliErr.Remediation, "slipway delete --change <slug>")
+	// The first suggested concrete command names one of the residue slugs.
+	assert.True(t,
+		strings.Contains(cliErr.Remediation, "slipway delete --change "+first) ||
+			strings.Contains(cliErr.Remediation, "slipway delete --change "+second),
+		"remediation must offer a concrete first delete command for one residue slug")
+	assert.Contains(t, cliErr.Remediation, "Archived records and source commits are not deletion targets")
+	assert.NotContains(t, cliErr.Remediation, "--worktree")
+
+	// A reason is kept for EACH archived-residue orphan; no orphan is dropped.
+	// Assert the stable Code/Detail fields, not Message prose.
+	residueDetails := []string{}
+	for _, r := range cliErr.Reasons {
+		assert.Equal(t, "orphaned_change_bundle", string(r.Code))
+		residueDetails = append(residueDetails, r.Detail)
+	}
+	assert.ElementsMatch(t, []string{first, second}, residueDetails,
+		"both archived-residue orphans must keep a reason scoped to their slug")
+
+	require.NotNil(t, cliErr.Details)
+	residueSlugs, ok := cliErr.Details["orphaned_active_residue_archived_changes"].([]string)
+	require.True(t, ok, "details must list the archived-residue slugs")
+	assert.ElementsMatch(t, []string{first, second}, residueSlugs)
+	assert.Nil(t, cliErr.Details["orphaned_change_bundles"],
+		"a pure archived-residue case must not carry plain discard details")
+}
+
+// TestOrphanedChangeBundleErrorMixedArchivedResidueAndPlainOrphans covers the
+// `if len(class.Plain) > 0` sub-branch inside the archived-residue block: one
+// archived same-slug active-residue orphan AND one plain orphan (no archived
+// record) in the same scan. Both must be surfaced; the archived-residue path
+// must say archived record / source commits are not targets and exclude
+// --worktree, while the plain path uses the ordinary discard wording. NOT
+// parallel: the workspace helper chdirs.
+func TestOrphanedChangeBundleErrorMixedArchivedResidueAndPlainOrphans(t *testing.T) {
+	root := orphanRecoveryWorkspace(t)
+	const archived = "archived-residue-mixed"
+	const plain = "plain-residue-mixed"
+	writeArchivedChangeWithActiveResidue(t, root, archived)
+	writeOrphanBundle(t, root, plain) // no archived record -> classified Plain
+
+	// Sanity: the plain slug really has no archived record, so it is not folded
+	// into the archived-residue classification.
+	_, archErr := state.LoadArchivedChange(root, plain)
+	require.Error(t, archErr, "plain orphan must have no archived record")
+
+	cliErr := orphanedChangeBundleError(root, "") // empty slug -> all orphans
+	require.NotNil(t, cliErr)
+	// The archived-residue case leads (no unmanaged/unknown present).
+	assert.Equal(t, "orphaned_active_residue_archived_change", cliErr.ErrorCode)
+	assert.Equal(t, categoryPrecondition, cliErr.Category)
+	assert.Equal(t, archived, cliErr.Slug)
+
+	// Archived-residue prose: names the archived slug, the not-a-target framing,
+	// and never escalates to --worktree.
+	assert.Contains(t, cliErr.Remediation, "Active-state residue")
+	assert.Contains(t, cliErr.Remediation, archived)
+	assert.Contains(t, cliErr.Remediation, "source commits are not deletion targets")
+	assert.NotContains(t, cliErr.Remediation, "--worktree")
+	// Plain sub-branch: the plain slug is discardable with the ordinary wording,
+	// distinguished as residue with no archived record.
+	assert.Contains(t, cliErr.Remediation, "no archived record")
+	assert.Contains(t, cliErr.Remediation, "slipway delete --change "+plain)
+
+	// A reason is kept for EACH orphan: the archived-residue one and the plain one.
+	// Assert the stable Code/Detail fields, not Message prose; the archived-vs-plain
+	// split is verified through the structured Details map below.
+	codes := map[string]int{}
+	reasonDetails := []string{}
+	for _, r := range cliErr.Reasons {
+		codes[string(r.Code)]++
+		reasonDetails = append(reasonDetails, r.Detail)
+	}
+	assert.Equal(t, 2, codes["orphaned_change_bundle"], "both orphans must keep an orphaned_change_bundle reason")
+	assert.ElementsMatch(t, []string{archived, plain}, reasonDetails,
+		"each orphan keeps a reason scoped to its own slug")
+
+	require.NotNil(t, cliErr.Details)
+	residueSlugs, ok := cliErr.Details["orphaned_active_residue_archived_changes"].([]string)
+	require.True(t, ok)
+	assert.Equal(t, []string{archived}, residueSlugs)
+	plainSlugs, ok := cliErr.Details["orphaned_change_bundles"].([]string)
+	require.True(t, ok, "the plain orphan must be surfaced in details")
+	assert.Equal(t, []string{plain}, plainSlugs)
 }

--- a/cmd/progression_next_test.go
+++ b/cmd/progression_next_test.go
@@ -2236,6 +2236,135 @@ func TestConfirmationRequirementDistinguishesHardStopFromCommandBoundary(t *test
 	assert.Equal(t, "slipway done", doneReady.NextCommand)
 }
 
+func TestNoSkillRequiredDiagnosticsUseAdvanceCommandBoundary(t *testing.T) {
+	t.Parallel()
+
+	t.Run("S1 injects advance recovery", func(t *testing.T) {
+		change := model.NewChange("ready-no-skill")
+		change.CurrentState = model.StateS1Plan
+		change.PlanSubStep = model.PlanSubStepValidate
+		view := nextView{
+			CurrentState: model.StateS1Plan,
+			Blockers: []model.ReasonCode{
+				model.NewReasonCode("no_skill_required", string(model.StateS1Plan)),
+			},
+		}
+
+		applyReadyAdvanceDiagnostics(t.TempDir(), &change, &view)
+		view.ConfirmationRequirement = deriveConfirmationRequirement(view)
+		view.Recovery = model.BuildRecovery(view.Blockers)
+
+		assert.Contains(t, model.ReasonSpecs(view.Blockers), "run_slipway_run_to_advance:S1_PLAN")
+		assert.Equal(t, "run_slipway_run_to_advance", view.ConfirmationRequirement.Reason)
+		assert.Equal(t, "run slipway run to advance", view.ConfirmationRequirement.NextAction)
+		assert.Equal(t, "command", view.ConfirmationRequirement.NextActionKind)
+		assert.Equal(t, "slipway run", view.ConfirmationRequirement.NextCommand)
+		require.NotNil(t, view.Recovery)
+		assert.Equal(t, "slipway run", view.Recovery.PrimaryCommand)
+		assert.NotContains(t, view.ConfirmationRequirement.Reason, "blocked_by_governance")
+		assert.NotContains(t, view.ConfirmationRequirement.NextAction, "resolve governance blockers")
+	})
+
+	t.Run("S2 no skill info stays command boundary", func(t *testing.T) {
+		view := nextView{
+			CurrentState: model.StateS2Implement,
+			Blockers: []model.ReasonCode{
+				model.NewReasonCode("no_skill_required", string(model.StateS2Implement)),
+			},
+		}
+
+		req := deriveConfirmationRequirement(view)
+
+		assert.Equal(t, "run_slipway_run_to_advance", req.Reason)
+		assert.Equal(t, "run slipway run to advance", req.NextAction)
+		assert.Equal(t, "command", req.NextActionKind)
+		assert.Equal(t, "slipway run", req.NextCommand)
+		assert.NotContains(t, req.Reason, "blocked_by_governance")
+		assert.NotContains(t, req.NextAction, "resolve governance blockers")
+	})
+}
+
+// TestNextDiagnosticsReadyS2ExecuteSurfacesAdvanceNotGovernanceBlock is the
+// REQ-003 end-to-end command contract: a governed change sitting at a ready
+// S2_EXECUTE with passing fresh wave-orchestration evidence (no skill required)
+// must surface an advance handoff through the real `next --json --diagnostics`
+// surface, never the misleading blocked_by_governance dead-end. It exercises the
+// full command rather than the deriveConfirmationRequirement helper directly.
+func TestNextDiagnosticsReadyS2ExecuteSurfacesAdvanceNotGovernanceBlock(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+
+		// Reach a genuinely-ready S2_EXECUTE: a materialized single-task wave plan,
+		// runtime task evidence, and a passing wave-orchestration verification
+		// recorded through the public `slipway evidence skill` surface.
+		slug, _ := createEvidenceTaskFixture(t, root)
+		capturedAt := time.Now().UTC().Add(-time.Minute)
+		writeTaskEvidenceFile(t, root, slug, 1, "t-01", map[string]any{
+			"task_kind":     "verification",
+			"changed_files": []string{"cmd/lifecycle_commands_test.go"},
+			"target_files":  []string{"cmd/lifecycle_commands_test.go"},
+			"evidence_ref":  "go test ./cmd -run TestNextDiagnosticsReadyS2ExecuteSurfacesAdvanceNotGovernanceBlock",
+			"captured_at":   capturedAt.Format(time.RFC3339Nano),
+		})
+		evidenceCmd := commandForRoot(t, root, makeEvidenceCmd())
+		evidenceCmd.SetArgs([]string{
+			"skill",
+			"--json",
+			"--change", slug,
+			"--skill", progression.SkillWaveOrchestration,
+			"--verdict", model.VerificationVerdictPass,
+			"--reference", "wave-orchestration:pass",
+			"--notes", "Wave orchestration passed.",
+		})
+		var evidenceOut bytes.Buffer
+		evidenceCmd.SetOut(&evidenceOut)
+		require.NoError(t, evidenceCmd.Execute())
+
+		// Run the real command surface under test.
+		cmd := commandForRoot(t, root, makeNextCmd())
+		cmd.SetArgs([]string{"--json", "--diagnostics", "--change", slug})
+		var buf bytes.Buffer
+		cmd.SetOut(&buf)
+		require.NoError(t, cmd.Execute())
+
+		// The query-first surface stays read-only at a ready S2_EXECUTE.
+		reloaded, err := state.LoadChange(root, slug)
+		require.NoError(t, err)
+		assert.Equal(t, model.StateS2Implement, reloaded.CurrentState, "next --json --diagnostics must stay read-only")
+
+		// The decoded JSON must not mention the governance-block dead-end anywhere.
+		raw := buf.String()
+		assert.NotContains(t, raw, "blocked_by_governance",
+			"a ready no-skill S2 must not surface blocked_by_governance")
+		assert.NotContains(t, raw, "resolve governance blockers",
+			"a ready no-skill S2 must not tell the operator to resolve governance blockers")
+
+		var view nextView
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &view))
+		assert.Equal(t, model.StateS2Implement, view.CurrentState)
+		assert.Nil(t, view.NextSkill, "a ready S2 advance state requires no skill handoff")
+
+		// The confirmation surface routes the operator to advance with `slipway run`.
+		assert.Equal(t, "run_slipway_run_to_advance", view.ConfirmationRequirement.Reason)
+		assert.Equal(t, "slipway run", view.ConfirmationRequirement.NextCommand)
+		assert.Equal(t, "command", view.ConfirmationRequirement.NextActionKind)
+		assert.NotContains(t, view.ConfirmationRequirement.Reason, "blocked_by_governance")
+		assert.NotContains(t, view.ConfirmationRequirement.NextAction, "resolve governance blockers")
+
+		// The only blocker is the informational no-skill pacing cue, not an error.
+		assert.Contains(t, model.ReasonSpecs(view.Blockers), "no_skill_required:S2_IMPLEMENT")
+		for _, blocker := range view.Blockers {
+			assert.NotEqual(t, "blocked_by_governance", blocker.Code)
+			if blocker.Code == "no_skill_required" {
+				assert.NotEqual(t, model.ReasonSeverityError, blocker.Severity)
+			}
+		}
+	})
+}
+
 func TestNextHandoffViewUsesStructuredConfirmationRequirement(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -227,6 +227,9 @@ func makeStatusCmd() *cobra.Command {
 						return err
 					}
 				}
+				if diag := deleteRecoveryStatusViewForSlug(root, changeSlug); diag != nil {
+					return printStatusView(cmd, root, *diag, outputFormat, hydrate)
+				}
 				change, archived, err := loadStatusChangeBySlug(root, changeSlug)
 				if err != nil {
 					if diag := deleteRecoveryStatusViewForSlug(root, changeSlug); diag != nil {
@@ -465,6 +468,10 @@ func deleteRecoveryStatusViewForSlug(root, slug string) *statusView {
 	for _, u := range class.Unknown {
 		view.Diagnostics = append(view.Diagnostics, ownershipUnknownOrphanRemediation(u.Slug, u.Err))
 		view.Blockers = append(view.Blockers, model.NewReasonCode("orphaned_bundle_ownership_unknown", u.Slug))
+	}
+	for _, archived := range class.ArchivedResidue {
+		view.Diagnostics = append(view.Diagnostics, archivedActiveResidueRemediation(archived))
+		view.Blockers = append(view.Blockers, archivedActiveResidueReason(archived))
 	}
 	for _, slug := range class.Plain {
 		view.Diagnostics = append(view.Diagnostics, fmt.Sprintf(

--- a/cmd/validate_readonly_test.go
+++ b/cmd/validate_readonly_test.go
@@ -116,3 +116,38 @@ func TestValidateOrphanActiveBundleIsZeroWrite(t *testing.T) {
 
 	assert.Equal(t, before, snapshotNonGitTree(t, root))
 }
+
+func TestValidateMalformedVerificationExplainsEngineOwnedRecovery(t *testing.T) {
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "validate malformed verification recovery")
+		change, err := state.LoadChange(root, slug)
+		require.NoError(t, err)
+		change.CurrentState = model.StateS3Review
+		change.PlanSubStep = model.PlanSubStepNone
+		require.NoError(t, state.SaveChange(root, change))
+
+		writeMalformedVerificationFile(t, root, slug, "plan-audit")
+		before := snapshotNonGitTree(t, root)
+
+		cmd := commandForRoot(t, root, makeValidateCmd())
+		cmd.SetArgs([]string{"--json", "--change", slug})
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+
+		err = cmd.Execute()
+		require.Error(t, err)
+
+		cliErr := asCLIError(err)
+		require.NotNil(t, cliErr)
+		assert.Equal(t, "verification_load_failed", cliErr.ErrorCode)
+		errorText := err.Error()
+		assert.Contains(t, errorText, "VerificationRecord")
+		assert.Contains(t, errorText, "verification/plan-audit.yaml")
+		assert.Contains(t, errorText, "verification/plan-audit-notes.md")
+		assert.Contains(t, errorText, "slipway evidence skill --skill plan-audit --notes-file verification/plan-audit-notes.md")
+		assert.Equal(t, before, snapshotNonGitTree(t, root))
+	})
+}

--- a/internal/engine/progression/evidence_digests.go
+++ b/internal/engine/progression/evidence_digests.go
@@ -1083,8 +1083,22 @@ func addWaveOrchestrationInputs(
 	if err != nil {
 		return err
 	}
+	// Exclude lifecycle bookkeeping fields from the wave-plan content digest so a
+	// successful stamp does not immediately go stale when the persisted plan is
+	// re-materialized with the same task structure but a different bookkeeping
+	// value. generated_at is a materialization timestamp; run_summary_version is
+	// the execution iteration counter (its real freshness signal is carried
+	// independently by the runtime_task_evidence input below); the per-wave
+	// parallel flag is derived from config and is documented as excluded from the
+	// wave-plan freshness hashes (see model.WavePlanWave.Parallel). The structural,
+	// scope, and semantic task-plan hashes plus the wave/task shape remain in the
+	// digest, so genuine plan changes are still detected.
 	plan.GeneratedAt = time.Time{}
 	plan.Normalize()
+	plan.RunSummaryVersion = 0
+	for i := range plan.Waves {
+		plan.Waves[i].Parallel = false
+	}
 	planHash, err := model.ComputeInputHash(map[string]any{
 		"wave_plan": plan,
 	})

--- a/internal/engine/progression/evidence_digests_test.go
+++ b/internal/engine/progression/evidence_digests_test.go
@@ -2084,3 +2084,83 @@ func TestWorkspacePathInputHashStableAcrossLineEndingRoundTrip(t *testing.T) {
 	assert.Equal(t, lfDigest, crlfDigest,
 		"evidence digest must be stable across an LF<->CRLF line-ending round-trip")
 }
+
+// TestWaveOrchestrationDigestStableAcrossWavePlanBookkeepingRematerialize is a
+// regression for #310.1: a successful `evidence skill --skill wave-orchestration`
+// stamp must not leave its OWN freshly written evidence stale when the persisted
+// wave-plan.yaml is later re-materialized with the same task structure but a
+// different lifecycle bookkeeping value (generated_at or run_summary_version).
+// The stamp path (StampEvidenceDigestForSkill) and the validate path
+// (skillDigestFreshnessBlockersWithSummary) share certifiedSkillInputDigest, so
+// the digest must depend only on task-plan content, not bookkeeping fields. Before
+// the fix the run_summary_version drift below produced
+// required_skill_stale:wave-orchestration:wave-plan.yaml.
+func TestWaveOrchestrationDigestStableAcrossWavePlanBookkeepingRematerialize(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	change := model.NewChange("wave-orchestration-stamp-self-stale")
+	change.CurrentState = model.StateS2Implement
+	require.NoError(t, state.SaveChange(root, change))
+	writeDigestPlanningBundle(t, root, change, uncheckedDigestTasks())
+
+	// Persist wave-plan.yaml as the engine materializes it before evidence:
+	// epoch-0 generated_at, run_summary_version derived from current state (1).
+	prePlan, err := state.MaterializeWavePlanAt(root, change, time.Unix(0, 0).UTC())
+	require.NoError(t, err)
+	require.Equal(t, 1, prePlan.RunSummaryVersion)
+
+	capturedAt := time.Date(2026, 6, 4, 3, 0, 0, 0, time.UTC)
+	writeWaveDigestTaskEvidence(t, root, change, prePlan.TasksPlanHash, "test:wave", capturedAt)
+	summary := &model.ExecutionSummary{
+		Version:           model.ExecutionSummaryVersion,
+		RunSummaryVersion: 1,
+		CapturedAt:        capturedAt,
+	}
+
+	record := model.VerificationRecord{
+		Verdict:    model.VerificationVerdictPass,
+		Blockers:   []model.ReasonCode{},
+		Timestamp:  capturedAt.Add(time.Minute),
+		RunVersion: 1,
+	}
+	// Stamp wave-orchestration evidence through the same code path `evidence skill`
+	// uses. The stamp must succeed.
+	require.NoError(t, StampEvidenceDigestForSkill(root, change, SkillWaveOrchestration, record, summary))
+	stamped, err := state.LoadEvidenceDigestsForChange(root, change)
+	require.NoError(t, err)
+	require.Contains(t, stamped.Skills, SkillWaveOrchestration)
+
+	// The just-stamped evidence must be fresh immediately.
+	blockers, err := skillDigestFreshnessBlockersWithSummary(root, change, SkillWaveOrchestration, summary)
+	require.NoError(t, err)
+	require.Empty(t, blockers, "freshly stamped wave-orchestration evidence must not be stale")
+
+	// Re-materialize wave-plan.yaml with a different generated_at (display-only)
+	// AND an advanced run_summary_version (bookkeeping). The task structure is
+	// unchanged, so the freshly stamped evidence must remain fresh.
+	bumped, err := state.MaterializeWavePlanAtRunSummaryVersion(root, change, time.Now().UTC(), 2)
+	require.NoError(t, err)
+	require.Equal(t, 2, bumped.RunSummaryVersion)
+
+	blockers, err = skillDigestFreshnessBlockersWithSummary(root, change, SkillWaveOrchestration, summary)
+	require.NoError(t, err)
+	assert.Empty(t, blockers,
+		"re-materializing wave-plan.yaml with new bookkeeping (generated_at/run_summary_version) "+
+			"but identical task structure must not stale the freshly stamped wave-orchestration evidence")
+
+	// A genuine task-plan change must still be detected (the digest is not inert).
+	bundleDir, err := state.GovernedBundleDir(root, change)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(bundleDir, "tasks.md"),
+		[]byte(scopeOnlyDigestTasks()),
+		0o644,
+	))
+	_, err = state.MaterializeWavePlanAt(root, change, time.Now().UTC())
+	require.NoError(t, err)
+	blockers, err = skillDigestFreshnessBlockersWithSummary(root, change, SkillWaveOrchestration, summary)
+	require.NoError(t, err)
+	assert.Contains(t, blockers, "required_skill_stale:wave-orchestration:wave-plan.yaml",
+		"a real task-plan scope change must still stale the wave-plan digest")
+}

--- a/internal/model/recovery.go
+++ b/internal/model/recovery.go
@@ -818,7 +818,7 @@ func BuildRecovery(blockers []ReasonCode) *RecoverySummary {
 	groups := map[groupKey][]ReasonCode{}
 	var order []groupKey
 	for _, rc := range NormalizeReasonCodes(blockers) {
-		remediation, ok := blockerRemediations[rc.Code]
+		remediation, ok := recoveryRemediationForReason(rc)
 		if !ok {
 			continue
 		}
@@ -851,7 +851,7 @@ func BuildRecovery(blockers []ReasonCode) *RecoverySummary {
 func recoveryStepForGroup(group []ReasonCode) RecoveryStep {
 	rep := group[0]
 	rep.Normalize()
-	base := blockerRemediations[rep.Code]
+	base, _ := recoveryRemediationForReason(rep)
 	parsed := parseBlockerForRecovery(rep, base)
 	priority := recoveryPriority(base)
 	if parsed.Code == "missing_required_artifact" {
@@ -868,6 +868,34 @@ func recoveryStepForGroup(group []ReasonCode) RecoveryStep {
 		RecoveryClass: base.Class,
 		priority:      priority,
 	}
+}
+
+func recoveryRemediationForReason(rc ReasonCode) (blockerRemediation, bool) {
+	remediation, ok := blockerRemediations[rc.Code]
+	if !ok {
+		return blockerRemediation{}, false
+	}
+	if isArchivedActiveResidueReason(rc) {
+		return blockerRemediation{
+			Remediation:     "Active-state residue for archived change {subject} remains under artifacts/changes/{subject}. Remove only that stale active-state residue with `slipway delete --change {subject}`. The archived record and source commits are not deletion targets.",
+			CommandTemplate: "slipway delete --change {subject}",
+			Class:           RecoveryClassDiscardChange,
+		}, true
+	}
+	return remediation, true
+}
+
+// ArchivedActiveResidueMessagePrefix is the shared sentinel that marks an
+// orphaned_change_bundle reason as the archived-same-slug active-residue variant
+// (a stale active bundle whose authority moved to the archive). The message
+// producer in cmd/common.go builds its Message with this exact prefix, and
+// isArchivedActiveResidueReason matches on it, so the two prose strings cannot
+// silently drift across the package boundary.
+const ArchivedActiveResidueMessagePrefix = "Active-state residue for archived change "
+
+func isArchivedActiveResidueReason(rc ReasonCode) bool {
+	return rc.Code == "orphaned_change_bundle" &&
+		strings.Contains(rc.Message, ArchivedActiveResidueMessagePrefix)
 }
 
 func missingRequiredArtifactRecoveryPriority(subject string) int {

--- a/internal/model/recovery_test.go
+++ b/internal/model/recovery_test.go
@@ -457,6 +457,29 @@ func TestBuildRecoveryOrphanedChangeBundleRoutesToDelete(t *testing.T) {
 	assert.Contains(t, got.Steps[0].Remediation, "slipway delete --change abandoned-change")
 }
 
+func TestBuildRecoveryArchivedSameSlugActiveResidueRoutesToDeleteWithoutWorktree(t *testing.T) {
+	t.Parallel()
+
+	got := BuildRecovery([]ReasonCode{
+		{
+			Code:     "orphaned_change_bundle",
+			Severity: ReasonSeverityError,
+			Message:  "Active-state residue for archived change \"archived-change\" remains; archived record and source commits are not deletion targets",
+			Detail:   "archived-change",
+		},
+	})
+	require.NotNil(t, got)
+	assert.Equal(t, "slipway delete --change archived-change", got.PrimaryCommand)
+	assert.Equal(t, RecoveryClassDiscardChange, got.RecoveryClass)
+	require.Len(t, got.Steps, 1)
+	assert.Equal(t, "archived-change", got.Steps[0].Subject)
+	assert.Contains(t, got.PrimaryAction, "active-state residue")
+	assert.Contains(t, got.PrimaryAction, "archived record")
+	assert.Contains(t, got.PrimaryAction, "source commits are not deletion targets")
+	assert.NotContains(t, got.PrimaryAction, "--worktree")
+	assert.NotContains(t, got.Steps[0].Remediation, "--worktree")
+}
+
 func TestBuildRecoveryUnmanagedWorktreeOrphanIsNonDestructive(t *testing.T) {
 	t.Parallel()
 

--- a/internal/state/verification.go
+++ b/internal/state/verification.go
@@ -335,6 +335,18 @@ func decodeVerificationStrict(raw []byte, rec *model.VerificationRecord) error {
 	return decoder.Decode(rec)
 }
 
+func verificationRecordRecoveryGuidance(skillName string) string {
+	recordPath := filepath.ToSlash(filepath.Join("verification", skillName+".yaml"))
+	notesPath := filepath.ToSlash(filepath.Join("verification", skillName+"-notes.md"))
+	return fmt.Sprintf(
+		"%s is an engine-owned VerificationRecord file; move free-form notes to %s and pass them through `slipway evidence skill --skill %s --notes-file %s`",
+		recordPath,
+		notesPath,
+		skillName,
+		notesPath,
+	)
+}
+
 // loadVerificationFromPath reads and validates a verification record from a
 // specific file path, avoiding redundant directory resolution.
 func loadVerificationFromPath(path, skillName string) (model.VerificationRecord, error) {
@@ -344,11 +356,11 @@ func loadVerificationFromPath(path, skillName string) (model.VerificationRecord,
 	}
 	var rec model.VerificationRecord
 	if err := decodeVerificationStrict(b, &rec); err != nil {
-		return model.VerificationRecord{}, fmt.Errorf("parse verification %s: %w", skillName, err)
+		return model.VerificationRecord{}, fmt.Errorf("parse verification %s: %w; %s", skillName, err, verificationRecordRecoveryGuidance(skillName))
 	}
 	rec.Normalize()
 	if err := rec.Validate(); err != nil {
-		return model.VerificationRecord{}, fmt.Errorf("invalid verification %s: %w", skillName, err)
+		return model.VerificationRecord{}, fmt.Errorf("invalid verification %s: %w; %s", skillName, err, verificationRecordRecoveryGuidance(skillName))
 	}
 	return rec, nil
 }

--- a/internal/state/verification_test.go
+++ b/internal/state/verification_test.go
@@ -141,6 +141,28 @@ func TestLoadVerificationRejectsUnknownFields(t *testing.T) {
 	assert.Contains(t, err.Error(), "field unexpected")
 }
 
+func TestLoadVerificationMalformedRecordExplainsEngineOwnedRecovery(t *testing.T) {
+	t.Parallel()
+	root := createRuntimeLayout(t)
+	slug := "malformed-guidance"
+	saveActiveChangeForTest(t, root, slug)
+
+	dir := VerificationDir(root, slug)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "plan-audit.yaml"),
+		[]byte("verdict: ["),
+		0o644,
+	))
+
+	_, err := LoadVerification(root, slug, "plan-audit")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "VerificationRecord")
+	assert.Contains(t, err.Error(), "verification/plan-audit.yaml")
+	assert.Contains(t, err.Error(), "verification/plan-audit-notes.md")
+	assert.Contains(t, err.Error(), "slipway evidence skill --skill plan-audit --notes-file verification/plan-audit-notes.md")
+}
+
 func TestLoadVerificationAcceptsStructuredReasonCodes(t *testing.T) {
 	t.Parallel()
 	root := createRuntimeLayout(t)

--- a/internal/tmpl/templates/skills/wave-orchestration/SKILL.md.tmpl
+++ b/internal/tmpl/templates/skills/wave-orchestration/SKILL.md.tmpl
@@ -225,8 +225,16 @@ evidence ledger and this verification record. If refreshing an earlier execution
 run, do not reuse a stale literal value; choose the refreshed run_version and
 record every task with that same value.
 
+`verification/wave-orchestration.yaml` is an engine-owned VerificationRecord
+written only by `slipway evidence skill`; do not hand-write it. Keep free-form
+prose out of it and put any verification notes in
+`verification/wave-orchestration-notes.md`, passed via `slipway evidence skill
+--skill wave-orchestration --notes-file verification/wave-orchestration-notes.md`.
+The fields below are the record's shape, not a file to author by hand.
+
 ```yaml
-# Write to: artifacts/changes/{slug}/verification/wave-orchestration.yaml
+# Engine-owned record shape (written by `slipway evidence skill`):
+# artifacts/changes/{slug}/verification/wave-orchestration.yaml
 verdict: pass
 blockers: []
 timestamp: "<ISO-8601-UTC>"


### PR DESCRIPTION
## Summary
Fixes the confirmed #310/#311 evidence-recording and recovery UX defects, plus the #310.1 wave-plan freshness-digest defect (reproduced on current `main`). Developed for the `fix-evidence-and-recovery-ux` objective and landed as a direct clean PR.

## Fixes
- **Reject invalid shared task sessions early** (`cmd/evidence.go`): `evidence task --result-file` rejects duplicate non-empty `session_id` within an active run before persistence — atomic no-write on conflict, so the batch cannot later invalidate wave-orchestration evidence.
- **Explain engine-owned verification records** (`internal/state/verification.go`, `…/wave-orchestration/SKILL.md.tmpl`): malformed `verification/<skill>.yaml` stays fail-closed but names the engine-owned boundary and routes free-form notes to `verification/<skill>-notes.md` via `evidence skill --notes-file`; the boundary is also stated preventively in the generated wave-orchestration skill guidance.
- **Show ready states as ready** (`cmd/next.go`): `next --json --diagnostics` surfaces advancement (`run_slipway_run_to_advance`) instead of `blocked_by_governance` for ready/no-skill-required states.
- **Disambiguate archived same-slug residue** (`cmd/common.go`, `cmd/status.go`, `internal/model/recovery.go`): orphaned active residue recovery for a slug that also has an archived record names the target as active-state residue, excludes the archive/source commits, and drops `--worktree` from the primary remediation.
- **Keep freshly stamped wave-orchestration evidence fresh** (`internal/engine/progression/evidence_digests.go`, **#310.1**): the wave-plan freshness digest excludes lifecycle bookkeeping (`run_summary_version`, per-wave `parallel`, `generated_at`) so a freshly recorded `evidence skill --skill wave-orchestration` pass does not immediately stale itself when the plan re-materializes at a new run version; structural/scope/semantic task-plan changes still stale it.

## Tests
Each behavior has focused regression coverage, including a RED→GREEN test that a re-materialized wave plan keeps fresh evidence fresh while a real task-plan scope change still stales it. Full `go test ./...` green.

Closes #310
Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)
