### PR TITLE
feat(governance): converge S3 review in place on plan edits

### DIFF
--- a/cmd/evidence.go
+++ b/cmd/evidence.go
@@ -543,9 +543,15 @@ func makeEvidenceSkillCmd() *cobra.Command {
 				// error it returns is surfaced, never swallowed, so a partial or
 				// scope-failing run still fails closed instead of recording a clean
 				// summary.
+				// At S2 this first materializes execution-summary.yaml; at S3 it rebuilds
+				// it to fold in the just-attested task so the incomplete_execution_task
+				// blocker clears in place (the wave evidence was only recordable at S3
+				// while that convergence was pending). Both flow through the owning
+				// command so validate/status/next reflect the result immediately, and any
+				// error fails closed instead of leaving a stale summary.
 				if record.IsPassing() &&
 					skillName == progression.SkillWaveOrchestration &&
-					change.CurrentState == model.StateS2Implement {
+					(change.CurrentState == model.StateS2Implement || change.CurrentState == model.StateS3Review) {
 					if _, err := progression.SyncGovernedWaveExecution(root, change); err != nil {
 						return newStateIntegrityError(
 							"evidence_skill_execution_summary_sync_failed",
@@ -653,11 +659,11 @@ func makeEvidenceTaskCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				if change.CurrentState != model.StateS2Implement {
+				if change.CurrentState != model.StateS2Implement && change.CurrentState != model.StateS3Review {
 					remediation := evidenceTaskWrongStateRemediation(root, change)
 					return newInvalidUsageError(
 						"evidence_task_wrong_state",
-						fmt.Sprintf("task evidence requires S2_IMPLEMENT state, current: %s", change.CurrentState),
+						fmt.Sprintf("task evidence requires S2_IMPLEMENT or S3_REVIEW state, current: %s", change.CurrentState),
 						remediation,
 						nil,
 					)
@@ -699,6 +705,9 @@ func makeEvidenceTaskCmd() *cobra.Command {
 						"Use a task ID from the current tasks.md-derived wave projection and retry.",
 						map[string]any{"task_id": taskID},
 					)
+				}
+				if err := assertTaskEvidenceConvergenceAtReview(root, change, taskID); err != nil {
+					return err
 				}
 
 				if runSummary < 1 {
@@ -964,6 +973,11 @@ func recordEvidenceTaskResultFiles(
 	prepared, err := prepareEvidenceTaskResultFiles(root, change, wavePlan, runSummary, resultFiles, time.Now().UTC())
 	if err != nil {
 		return err
+	}
+	for _, item := range prepared {
+		if err := assertTaskEvidenceConvergenceAtReview(root, change, item.payload.TaskID); err != nil {
+			return err
+		}
 	}
 	if err := writePreparedEvidenceTaskResults(prepared); err != nil {
 		return err
@@ -1529,7 +1543,18 @@ func validateEvidenceSkillStage(root string, change model.Change, def skill.Defi
 		if err != nil {
 			return err
 		}
-		if !refreshRequired {
+		// In-place review convergence: wave-orchestration is S2-owned, but folding a
+		// task into tasks.md at S3 requires re-attesting the wave run so the fresh
+		// wave record post-dates the folded task's evidence (symmetric to S2, where
+		// wave evidence is always recorded last). This opens the door only while the
+		// summary still carries an incomplete_execution_task blocker; it never grants
+		// a bypass — the rebuilt summary fails closed on missing dispatch/handle
+		// evidence for the folded task.
+		convergence, err := reviewWaveConvergenceReRecordAllowed(root, change, def.Name)
+		if err != nil {
+			return err
+		}
+		if !refreshRequired && !convergence {
 			return newInvalidUsageError(
 				"evidence_skill_wrong_state",
 				fmt.Sprintf("%s evidence requires %s state, current: %s", def.Name, def.State, change.CurrentState),
@@ -1650,13 +1675,72 @@ func selectedReviewContextOriginRefreshRequired(root string, change model.Change
 	return progression.SelectedReviewContextOriginInvalid(root, change, skillName)
 }
 
-func evidenceTaskWrongStateRemediation(root string, change model.Change) string {
-	switch change.CurrentState {
-	case model.StateS3Review:
-		return postReviewReplacementEvidenceRemediation(root, change, "task evidence")
-	default:
-		return "Record task evidence only during wave execution."
+func evidenceTaskWrongStateRemediation(_ string, _ model.Change) string {
+	// S2_IMPLEMENT and S3_REVIEW are both recordable states (S3 completes the
+	// in-place review convergence for a folded-in task), so this remediation is
+	// only reached from other states.
+	return "Record task evidence during wave execution (S2_IMPLEMENT), or to complete an in-place review convergence (S3_REVIEW)."
+}
+
+// assertTaskEvidenceConvergenceAtReview enforces the S3_REVIEW recording
+// contract: at review, task evidence may only COMPLETE the in-place convergence
+// — record proof for a task the re-materialized wave plan surfaced as incomplete
+// (a folded-in task with no evidence yet at the active run). An already-evidenced
+// task is frozen at review: its plan/code drift is realigned through the
+// diff-scoped reviewers, never by restamping task evidence (which would forge
+// fresh freshness state at review). It is a no-op outside S3_REVIEW.
+func assertTaskEvidenceConvergenceAtReview(root string, change model.Change, taskID string) error {
+	if change.CurrentState != model.StateS3Review {
+		return nil
 	}
+	taskID = strings.TrimSpace(taskID)
+	path := filepath.Join(state.EvidenceTasksDir(root, change.Slug), taskID+".json")
+	switch _, err := os.Stat(path); {
+	case err == nil:
+		return newInvalidUsageError(
+			"evidence_task_already_recorded_at_review",
+			fmt.Sprintf("task %q already has recorded evidence; at S3_REVIEW task evidence is recordable only for a task the plan surfaced as incomplete", taskID),
+			postReviewReplacementEvidenceRemediation(root, change, "task evidence"),
+			map[string]any{"task_id": taskID, "state": string(change.CurrentState)},
+		)
+	case os.IsNotExist(err):
+		return nil
+	default:
+		return newStateIntegrityError(
+			"evidence_task_review_state_unreadable",
+			fmt.Sprintf("cannot determine task evidence state for %q: %v", taskID, err),
+			"Repair the governed runtime directory and retry.",
+			change.Slug,
+			map[string]any{"task_id": taskID, "path": state.DisplayPath(root, path)},
+		)
+	}
+}
+
+// reviewWaveConvergenceReRecordAllowed reports whether wave-orchestration evidence
+// may be re-recorded at S3_REVIEW to complete an in-place convergence. When a task
+// is folded into tasks.md at review, the re-materialized wave plan surfaces it as
+// incomplete_execution_task and the existing wave record predates the folded
+// task's freshly recorded task evidence. Re-attesting the wave run — a fresh wave
+// record that accounts for the new task's dispatch — is the symmetric forward exit:
+// it is the same "wave-orchestration evidence is recorded last, after every task's
+// evidence" rule S2 already enforces, applied to the convergence. It carries no
+// bypass: the host must still supply dispatch/handle evidence for every planned
+// task, and the folded task's own evidence must exist, or the rebuilt summary stays
+// incomplete and fails closed. It opens ONLY at S3_REVIEW, ONLY for
+// wave-orchestration, and ONLY while the persisted execution summary still carries
+// an incomplete_execution_task blocker (the engine's own folded-task signal).
+func reviewWaveConvergenceReRecordAllowed(root string, change model.Change, skillName string) (bool, error) {
+	if change.CurrentState != model.StateS3Review {
+		return false, nil
+	}
+	if strings.TrimSpace(skillName) != progression.SkillWaveOrchestration {
+		return false, nil
+	}
+	summary, err := state.LoadOptionalExecutionSummary(root, change.Slug)
+	if err != nil {
+		return false, err
+	}
+	return progression.ExecutionSummaryHasIncompleteTask(summary), nil
 }
 
 func evidenceSkillWrongStateRemediation(root string, change model.Change, def skill.Definition) string {
@@ -2315,6 +2399,15 @@ func validateEvidenceSkillActionable(root string, change model.Change, def skill
 				"Run `slipway next --json` and record evidence only for a selected review skill.",
 				map[string]any{"skill": def.Name},
 			)
+		}
+		// Wave-orchestration is not a review skill, so the actionable-skill ordering
+		// below would reject it at review. Re-recording it IS the current action when
+		// a folded-in task is converging in place: allow it while that convergence is
+		// pending (gated identically to the wrong-state door above).
+		if convergence, err := reviewWaveConvergenceReRecordAllowed(root, change, def.Name); err != nil {
+			return err
+		} else if convergence {
+			return nil
 		}
 		actionable, err := currentActionableEvidenceSkill(root, change, runVersion)
 		if err != nil {

--- a/cmd/evidence.go
+++ b/cmd/evidence.go
@@ -1366,7 +1366,18 @@ func evidenceSkillRunContext(root string, change model.Change, def skill.Definit
 	if err != nil {
 		return 0, nil, err
 	}
-	if def.Name == progression.SkillWaveOrchestration && change.CurrentState == model.StateS2Implement {
+	// wave-orchestration evidence must prove every planned task has fresh task
+	// evidence before its own record may be written — the "wave evidence is
+	// recorded last, after every task" rule (issue #95). This holds at S2_IMPLEMENT
+	// and, symmetrically, while completing an in-place S3_REVIEW convergence (a task
+	// folded into tasks.md whose Door 1 evidence must precede the Door 2 wave
+	// re-attestation). Without the S3 arm, Door 2 could write a misleading passing
+	// wave record before the folded task's evidence existed.
+	requiresWaveTaskCompleteness, err := waveOrchestrationEvidenceRequiresTaskCompleteness(root, change, def)
+	if err != nil {
+		return 0, nil, err
+	}
+	if requiresWaveTaskCompleteness {
 		runVersion, taskErr := waveOrchestrationTaskEvidenceRunVersion(root, change)
 		if taskErr != nil {
 			return 0, nil, taskErr
@@ -1382,7 +1393,7 @@ func evidenceSkillRunContext(root string, change model.Change, def skill.Definit
 	if execCtx.LatestRunVersion >= 1 {
 		return execCtx.LatestRunVersion, execCtx.Summary, nil
 	}
-	if def.Name == progression.SkillWaveOrchestration && change.CurrentState == model.StateS2Implement {
+	if requiresWaveTaskCompleteness {
 		runVersion, err := waveOrchestrationTaskEvidenceRunVersion(root, change)
 		if err != nil {
 			return 0, nil, err
@@ -1400,6 +1411,23 @@ func evidenceSkillRunContext(root string, change model.Change, def skill.Definit
 		change.Slug,
 		map[string]any{"skill": def.Name},
 	)
+}
+
+// waveOrchestrationEvidenceRequiresTaskCompleteness reports whether recording the
+// given skill's evidence must first prove every planned task has fresh task
+// evidence (the IncompleteExecutionTaskBlockers gate). It is true for
+// wave-orchestration at S2_IMPLEMENT and, symmetrically, while an in-place
+// S3_REVIEW convergence is still pending — keeping the S3 forward exit (Door 2)
+// under the SAME completeness ordering S2 enforces, so a folded task's evidence
+// (Door 1) must exist before the wave run is re-attested.
+func waveOrchestrationEvidenceRequiresTaskCompleteness(root string, change model.Change, def skill.Definition) (bool, error) {
+	if def.Name != progression.SkillWaveOrchestration {
+		return false, nil
+	}
+	if change.CurrentState == model.StateS2Implement {
+		return true, nil
+	}
+	return reviewWaveConvergenceReRecordAllowed(root, change, def.Name)
 }
 
 func waveOrchestrationTaskEvidenceRunVersion(root string, change model.Change) (int, error) {

--- a/cmd/evidence_test.go
+++ b/cmd/evidence_test.go
@@ -81,14 +81,20 @@ func TestEvidenceRestampCommandIsNotRegistered(t *testing.T) {
 	})
 }
 
-func TestEvidenceTaskWrongStateInS3RoutesToGoalVerificationAndFinalCloseout(t *testing.T) {
+// TestEvidenceTaskWrongStateBeforeImplement asserts task evidence is rejected from
+// states that own neither wave execution nor its review convergence. S2_IMPLEMENT
+// (normal wave execution) and S3_REVIEW (in-place convergence for a folded-in task)
+// are the only recordable states; recording from S1_PLAN fails closed with a
+// remediation that names both valid states.
+func TestEvidenceTaskWrongStateBeforeImplement(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
 	withCommandWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 		_, change := createEvidenceTaskFixture(t, root)
-		change.CurrentState = model.StateS3Review
+		change.CurrentState = model.StateS1Plan
+		change.PlanSubStep = model.PlanSubStepAudit
 		require.NoError(t, state.SaveChange(root, change))
 
 		cmd := commandForRoot(t, root, makeEvidenceCmd())
@@ -103,36 +109,7 @@ func TestEvidenceTaskWrongStateInS3RoutesToGoalVerificationAndFinalCloseout(t *t
 		cliErr := asCLIError(cmd.Execute())
 		require.NotNil(t, cliErr)
 		assert.Equal(t, "evidence_task_wrong_state", cliErr.ErrorCode)
-		assert.Contains(t, cliErr.Remediation, "goal-verification")
-		assert.Contains(t, cliErr.Remediation, "final-closeout")
-	})
-}
-
-func TestEvidenceTaskWrongStateInS3RoutesToReviewAndVerificationEvidence(t *testing.T) {
-	t.Parallel()
-
-	root := t.TempDir()
-	withCommandWorkspace(t, root, func() {
-		initTestWorkspace(t, root)
-		_, change := createEvidenceTaskFixture(t, root)
-		change.CurrentState = model.StateS3Review
-		require.NoError(t, state.SaveChange(root, change))
-
-		cmd := commandForRoot(t, root, makeEvidenceCmd())
-		cmd.SetArgs([]string{
-			"task",
-			"--task-id", "t-01",
-			"--run-summary-version", "1",
-			"--task-kind", "verification",
-			"--verdict", "pass",
-			"--evidence-ref", "test:wrong-state",
-		})
-		cliErr := asCLIError(cmd.Execute())
-		require.NotNil(t, cliErr)
-		assert.Equal(t, "evidence_task_wrong_state", cliErr.ErrorCode)
-		assert.Contains(t, cliErr.Remediation, "spec-compliance-review")
-		assert.Contains(t, cliErr.Remediation, "code-quality-review")
-		assert.Contains(t, cliErr.Remediation, "goal-verification")
-		assert.Contains(t, cliErr.Remediation, "final-closeout")
+		assert.Contains(t, cliErr.Remediation, "S2_IMPLEMENT")
+		assert.Contains(t, cliErr.Remediation, "S3_REVIEW")
 	})
 }

--- a/cmd/s3_inplace_convergence_forward_test.go
+++ b/cmd/s3_inplace_convergence_forward_test.go
@@ -130,6 +130,59 @@ func TestRunAtS3ConvergesFoldedTaskThroughWaveReRecord(t *testing.T) {
 	})
 }
 
+// TestRunAtS3RejectsWaveReRecordBeforeFoldedTaskEvidence locks the S3 ordering
+// contract symmetric to S2: Door 2 (wave-orchestration re-record) must not write a
+// passing record before Door 1 (the folded task's evidence) is in the ledger. The
+// re-materialized wave plan surfaces the folded task as incomplete_execution_task,
+// so attempting the wave re-record first must fail closed with
+// evidence_skill_task_evidence_incomplete — the SAME completeness guard S2 enforces
+// — rather than saving a misleading out-of-order passing wave record.
+func TestRunAtS3RejectsWaveReRecordBeforeFoldedTaskEvidence(t *testing.T) {
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		slug, change := createEvidenceTaskFixture(t, root)
+
+		recordTaskResult(t, root, "t-01", "test:original-t-01", "cmd/evidence.go")
+		writePassingExecutionSummary(t, root, slug, 1, "t-01")
+		writePassingWaveEvidence(t, root, slug, 1)
+		change.CurrentState = model.StateS3Review
+		require.NoError(t, state.SaveChange(root, change))
+
+		bundlePath := filepath.Join(root, "artifacts", "changes", slug)
+		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
+
+- [ ] `+"`t-01`"+` harden result file loading
+  - depends_on: []
+  - target_files: ["cmd/evidence.go"]
+  - task_kind: code
+  - covers: [REQ-001]
+
+- [ ] `+"`t-02`"+` cover the newly discovered gap
+  - depends_on: []
+  - target_files: ["cmd/evidence_task_test.go"]
+  - task_kind: test
+  - covers: [REQ-001]
+`)))
+
+		// Fold the plan delta in place; t-02 surfaces as incomplete.
+		runOnce(t, root, slug)
+		require.True(t, summaryHasIncompleteTask(t, root, slug), "fold must surface incomplete_execution_task")
+
+		// Door 2 before Door 1: re-record wave-orchestration WITHOUT first recording
+		// the folded task's evidence. This must fail closed like S2, not save a passing
+		// out-of-order wave record.
+		err := recordWaveEvidenceErr(t, root, slug)
+		require.Error(t, err, "wave re-record before folded task evidence must fail closed")
+		cliErr := asCLIError(err)
+		require.NotNil(t, cliErr)
+		assert.Equal(t, "evidence_skill_task_evidence_incomplete", cliErr.ErrorCode)
+
+		// No passing wave-orchestration record may have been written out of order.
+		assert.True(t, summaryHasIncompleteTask(t, root, slug), "rejected re-record must leave the incomplete blocker intact")
+	})
+}
+
 func recordWaveEvidenceErr(t *testing.T, root, slug string) error {
 	t.Helper()
 	cmd := commandForRoot(t, root, makeEvidenceCmd())

--- a/cmd/s3_inplace_convergence_forward_test.go
+++ b/cmd/s3_inplace_convergence_forward_test.go
@@ -1,0 +1,191 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/signalridge/slipway/internal/model"
+	"github.com/signalridge/slipway/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunAtS3AcceptsFoldedTaskEvidenceAndRejectsRestamp is the forward-exit
+// companion to TestRunAtS3AbsorbsAddedTaskInPlace. Folding a task in at S3 must
+// also be EXITABLE through the public surface: the folded task's evidence is
+// recordable at S3 via `slipway evidence task`, and the next `slipway run`
+// absorbs it so the `incomplete_execution_task` blocker clears in place — no
+// backward rescope re-walk. Without a forward path the convergence is a deadlock.
+func TestRunAtS3AcceptsFoldedTaskEvidenceAndRejectsRestamp(t *testing.T) {
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		slug, change := createEvidenceTaskFixture(t, root)
+
+		recordTaskResult(t, root, "t-01", "test:original-t-01", "cmd/evidence.go")
+		writePassingExecutionSummary(t, root, slug, 1, "t-01")
+		writePassingWaveEvidence(t, root, slug, 1)
+		change.CurrentState = model.StateS3Review
+		require.NoError(t, state.SaveChange(root, change))
+
+		// Discover a task at review.
+		bundlePath := filepath.Join(root, "artifacts", "changes", slug)
+		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
+
+- [ ] `+"`t-01`"+` harden result file loading
+  - depends_on: []
+  - target_files: ["cmd/evidence.go"]
+  - task_kind: code
+  - covers: [REQ-001]
+
+- [ ] `+"`t-02`"+` cover the newly discovered gap
+  - depends_on: []
+  - target_files: ["cmd/evidence_task_test.go"]
+  - task_kind: test
+  - covers: [REQ-001]
+`)))
+
+		// First run: absorb the plan delta in place; t-02 surfaces as incomplete.
+		runOnce(t, root, slug)
+		reopened, err := state.LoadChange(root, slug)
+		require.NoError(t, err)
+		require.Equal(t, model.StateS3Review, reopened.CurrentState)
+
+		// Forward exit: the folded task's evidence is recordable AT S3.
+		err = recordTaskResultErr(t, root, "t-02", "test:new-t-02", "cmd/evidence_task_test.go")
+		require.NoError(t, err, "S3 must accept the folded task's evidence as the public forward exit")
+
+		// No restamp: re-recording an already-evidenced task at S3 is rejected.
+		err = recordTaskResultErr(t, root, "t-01", "test:restamp-t-01", "cmd/evidence.go")
+		require.Error(t, err, "already-evidenced tasks stay frozen at S3 (no restamp)")
+		assert.Contains(t, err.Error(), "already has recorded evidence")
+
+		// The folded task's evidence is now written to the ledger — the public
+		// forward exit that was previously a hard deadlock.
+		assertTaskEvidenceWritten(t, root, slug, "t-02")
+	})
+}
+
+// TestRunAtS3ConvergesFoldedTaskThroughWaveReRecord exercises the COMPLETE forward
+// exit, symmetric to the S2 flow: at S3 the folded task's evidence is recorded
+// (Door 1), then wave-orchestration evidence is re-recorded (Door 2) so the fresh
+// wave record post-dates that task evidence. Re-recording the wave run rebuilds the
+// execution summary in place, clearing the incomplete_execution_task blocker — no
+// backward rescope re-walk. Without Door 2 the wave record stays older than the
+// folded task's evidence and the convergence deadlocks.
+func TestRunAtS3ConvergesFoldedTaskThroughWaveReRecord(t *testing.T) {
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		slug, change := createEvidenceTaskFixture(t, root)
+
+		recordTaskResult(t, root, "t-01", "test:original-t-01", "cmd/evidence.go")
+		writePassingExecutionSummary(t, root, slug, 1, "t-01")
+		writePassingWaveEvidence(t, root, slug, 1)
+		change.CurrentState = model.StateS3Review
+		require.NoError(t, state.SaveChange(root, change))
+
+		bundlePath := filepath.Join(root, "artifacts", "changes", slug)
+		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
+
+- [ ] `+"`t-01`"+` harden result file loading
+  - depends_on: []
+  - target_files: ["cmd/evidence.go"]
+  - task_kind: code
+  - covers: [REQ-001]
+
+- [ ] `+"`t-02`"+` cover the newly discovered gap
+  - depends_on: []
+  - target_files: ["cmd/evidence_task_test.go"]
+  - task_kind: test
+  - covers: [REQ-001]
+`)))
+
+		// First run folds the plan delta in place; t-02 surfaces as incomplete and the
+		// blocker is durable in the persisted summary.
+		runOnce(t, root, slug)
+		require.True(t, summaryHasIncompleteTask(t, root, slug), "fold must surface incomplete_execution_task")
+
+		// Door 1: record the folded task's evidence.
+		require.NoError(t, recordTaskResultErr(t, root, "t-02", "test:new-t-02", "cmd/evidence_task_test.go"))
+
+		// Door 2: re-attest the wave run at S3. The fresh wave record post-dates t-02's
+		// evidence, and recording it rebuilds the summary in place.
+		require.NoError(t, recordWaveEvidenceErr(t, root, slug), "S3 must accept the wave re-record while convergence is pending")
+
+		// The incomplete blocker is cleared by the in-place rebuild.
+		assert.False(t, summaryHasIncompleteTask(t, root, slug), "wave re-record must clear incomplete_execution_task in place")
+
+		// State never regressed to S1/S2 through the convergence.
+		reopened, err := state.LoadChange(root, slug)
+		require.NoError(t, err)
+		assert.Equal(t, model.StateS3Review, reopened.CurrentState)
+
+		// Once converged, the wave re-record door closes again (no incomplete signal).
+		require.Error(t, recordWaveEvidenceErr(t, root, slug), "settled review must not keep the wave re-record door open")
+	})
+}
+
+func recordWaveEvidenceErr(t *testing.T, root, slug string) error {
+	t.Helper()
+	cmd := commandForRoot(t, root, makeEvidenceCmd())
+	cmd.SetArgs([]string{
+		"skill",
+		"--change", slug,
+		"--skill", "wave-orchestration",
+		"--verdict", "pass",
+		"--reference", "wave-orchestration:pass",
+		"--notes", "Wave re-attested for folded task.",
+	})
+	cmd.SetOut(&bytes.Buffer{})
+	return cmd.Execute()
+}
+
+func summaryHasIncompleteTask(t *testing.T, root, slug string) bool {
+	t.Helper()
+	summary, err := state.LoadOptionalExecutionSummary(root, slug)
+	require.NoError(t, err)
+	if summary == nil {
+		return false
+	}
+	for _, blocker := range summary.OpenBlockers {
+		if strings.TrimSpace(blocker.Code) == "incomplete_execution_task" {
+			return true
+		}
+	}
+	return false
+}
+
+func recordTaskResult(t *testing.T, root, taskID, ref, changedFile string) {
+	t.Helper()
+	require.NoError(t, recordTaskResultErr(t, root, taskID, ref, changedFile))
+}
+
+func recordTaskResultErr(t *testing.T, root, taskID, ref, changedFile string) error {
+	t.Helper()
+	raw, err := json.Marshal(map[string]any{
+		"task_id":       taskID,
+		"verdict":       "pass",
+		"evidence_ref":  ref,
+		"changed_files": []string{changedFile},
+	})
+	require.NoError(t, err)
+	relFile := strings.ReplaceAll(taskID, "/", "_") + "-result.json"
+	require.NoError(t, os.WriteFile(filepath.Join(root, relFile), raw, 0o644))
+	cmd := commandForRoot(t, root, makeEvidenceCmd())
+	cmd.SetArgs([]string{"task", "--json", "--result-file", relFile})
+	cmd.SetOut(&bytes.Buffer{})
+	return cmd.Execute()
+}
+
+func runOnce(t *testing.T, root, slug string) {
+	t.Helper()
+	cmd := commandForRoot(t, root, makeRunCmd())
+	cmd.SetArgs([]string{"--json", "--change", slug})
+	cmd.SetOut(&bytes.Buffer{})
+	_ = cmd.Execute()
+}

--- a/cmd/s3_inplace_convergence_test.go
+++ b/cmd/s3_inplace_convergence_test.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/signalridge/slipway/internal/model"
+	"github.com/signalridge/slipway/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunAtS3AbsorbsAddedTaskInPlace is the RED reproduction for the S3
+// in-place convergence objective: when a change is at S3_REVIEW and the author
+// discovers more work, editing tasks.md to add a task must be ABSORBED IN
+// PLACE. The wave plan must re-materialize at the SAME run version to fold the
+// new task, unchanged-task evidence must be preserved, the new task must be
+// surfaced as still needing evidence, and the lifecycle must NOT regress to
+// S1/S2 or wipe prior evidence (the `slipway fix --start-reexecution` hammer).
+//
+// Today the wave plan only materializes on the S1->S2 entry, so a task added at
+// S3 is stranded (never folded), and this fails on the TotalTasks assertion.
+func TestRunAtS3AbsorbsAddedTaskInPlace(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		slug, change := createEvidenceTaskFixture(t, root)
+
+		// Record passing evidence for the original single task t-01 and drive
+		// the change to S3_REVIEW (mirrors the established S2->S3 setup).
+		rawResult, err := json.Marshal(map[string]any{
+			"task_id":       "t-01",
+			"verdict":       "pass",
+			"evidence_ref":  "test:original-t-01",
+			"changed_files": []string{"cmd/evidence.go"},
+		})
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(root, "task-result.json"), rawResult, 0o644))
+
+		evidenceCmd := commandForRoot(t, root, makeEvidenceCmd())
+		evidenceCmd.SetArgs([]string{"task", "--json", "--result-file", "task-result.json"})
+		evidenceCmd.SetOut(&bytes.Buffer{})
+		require.NoError(t, evidenceCmd.Execute())
+
+		writePassingExecutionSummary(t, root, slug, 1, "t-01")
+		writePassingWaveEvidence(t, root, slug, 1)
+		change.CurrentState = model.StateS3Review
+		require.NoError(t, state.SaveChange(root, change))
+
+		// Discover at review that a new task is needed: append t-02 to tasks.md.
+		bundlePath := filepath.Join(root, "artifacts", "changes", slug)
+		require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
+
+- [ ] `+"`t-01`"+` harden result file loading
+  - depends_on: []
+  - target_files: ["cmd/evidence.go"]
+  - task_kind: code
+  - covers: [REQ-001]
+
+- [ ] `+"`t-02`"+` cover the newly discovered gap
+  - depends_on: []
+  - target_files: ["cmd/evidence_task_test.go"]
+  - task_kind: test
+  - covers: [REQ-001]
+`)))
+
+		// The public advancing flow must absorb the plan delta in place. It may
+		// block afterwards on the new task's missing evidence; that is expected
+		// and not asserted here.
+		runCmd := commandForRoot(t, root, makeRunCmd())
+		runCmd.SetArgs([]string{"--json", "--change", slug})
+		runCmd.SetOut(&bytes.Buffer{})
+		_ = runCmd.Execute()
+
+		// In-place convergence: state must stay at S3 (no backward re-walk).
+		reopened, err := state.LoadChange(root, slug)
+		require.NoError(t, err)
+		assert.Equal(t, model.StateS3Review, reopened.CurrentState,
+			"editing tasks.md at S3 must converge in place, not regress the lifecycle")
+
+		// The wave plan must re-materialize in place and fold the added task,
+		// WITHOUT bumping the run version (that is what makes the edit cheap).
+		plan, err := state.LoadWavePlanForChange(root, reopened)
+		require.NoError(t, err)
+		assert.Equal(t, 2, plan.TotalTasks,
+			"the task added at S3 must be folded into the wave plan in place")
+		assert.Equal(t, 1, plan.RunSummaryVersion,
+			"in-place absorption must NOT bump the run version or wipe the run")
+
+		// Unchanged-task evidence is preserved; only the new task needs evidence.
+		assertTaskEvidenceWritten(t, root, slug, "t-01")
+		assertTaskEvidenceNotWritten(t, root, slug, "t-02")
+	})
+}

--- a/internal/engine/progression/advance_governed.go
+++ b/internal/engine/progression/advance_governed.go
@@ -128,14 +128,48 @@ func AdvanceGoverned(root, slug string, opts ...AdvanceOptions) (summary Advance
 		return blockedAdvanceSummary(fromState, model.ReasonCodesFromSpecs(assuranceBlockers)), nil
 	}
 
-	// 3. Wave synchronization (only at S2_IMPLEMENT)
-	if fromState == model.StateS2Implement {
+	// 3. Wave synchronization at S2_IMPLEMENT and S3_REVIEW.
+	//
+	// At S2 this is the implement-stage sync. At S3 it is the in-place review
+	// convergence path: when the author discovers more work at review and edits
+	// tasks.md (for example adds a task), the wave plan re-materializes IN PLACE
+	// from the current tasks.md at the SAME run version, folding the delta into
+	// the review instead of forcing a backward rescope re-walk. Unchanged-task
+	// evidence is preserved; a newly added or structurally changed task surfaces
+	// as still-required work and blocks S3->S4 until its evidence is recorded
+	// (fail-closed). The lifecycle state is never regressed to S1/S2.
+	runWaveSync := fromState == model.StateS2Implement
+	if fromState == model.StateS3Review {
+		// Only re-materialize at review when tasks.md has actually drifted from the
+		// materialized wave plan (the convergence case — e.g. the author added a
+		// task at review). An unchanged plan keeps the existing read-only S3
+		// behavior so done-ready, light-preset, and other settled review flows are
+		// not perturbed by an unconditional re-sync.
+		drifted, err := tasksPlanDriftedFromWavePlan(root, change)
+		if err != nil {
+			return AdvanceSummary{}, err
+		}
+		runWaveSync = drifted
+	}
+	if runWaveSync {
 		syncResult, err := SyncGovernedWaveExecution(root, change)
 		if err != nil {
 			return AdvanceSummary{}, err
 		}
-		if len(syncResult.Blockers) > 0 {
-			return blockedAdvanceSummary(fromState, syncResult.Blockers), nil
+		blockers := syncResult.Blockers
+		if fromState == model.StateS3Review {
+			// S3 absorbs the re-materialized plan delta in place: plan/evidence
+			// drift on already-evidenced tasks is realigned through the diff-scoped
+			// reviewers (who re-certify against the current plan), not replayed as a
+			// backward gate — the same drift tokens blockingExecutionSummaryIssues
+			// treats as review input. Genuinely missing or non-passing work
+			// (incomplete tasks, failed verdicts, safety-net violations) still fails
+			// closed here, so a task newly discovered at review cannot reach S4
+			// without its own evidence.
+			blockers = absorbedAtReviewWaveBlockers(blockers)
+		}
+		if len(blockers) > 0 {
+			return blockedAdvanceSummary(fromState, blockers), nil
 		}
 	}
 
@@ -622,6 +656,28 @@ func autoConfirmScaffold(root string, change model.Change, target model.Workflow
 	return artifact.ScaffoldGovernedBundleForChange(root, change, target, resolution.Schema)
 }
 
+// tasksPlanDriftedFromWavePlan reports whether the current tasks.md structural
+// projection differs from the materialized wave plan, i.e. the plan was edited
+// since it was last materialized. It is the S3_REVIEW trigger for in-place
+// convergence: only a real plan delta re-materializes the wave plan at review.
+// A missing wave plan reports no drift (there is nothing materialized to
+// converge against); the upstream bundle gate already guarantees a readable
+// tasks.md by this point, so a read error is surfaced rather than masked.
+func tasksPlanDriftedFromWavePlan(root string, change model.Change) (bool, error) {
+	plan, err := state.LoadOptionalWavePlanForChange(root, change)
+	if err != nil {
+		return false, err
+	}
+	if plan == nil {
+		return false, nil
+	}
+	current, err := state.CurrentTasksPlanStructuralState(root, change)
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(current) != strings.TrimSpace(wavePlanStructuralHash(*plan)), nil
+}
+
 func forwardOnlyStaleEvidenceSummary(fromState model.WorkflowState, target EvidenceRepairTarget) AdvanceSummary {
 	blockers := append([]model.ReasonCode{}, target.Blockers...)
 	if strings.TrimSpace(target.SkillName) != "" {
@@ -631,6 +687,23 @@ func forwardOnlyStaleEvidenceSummary(fromState model.WorkflowState, target Evide
 	summary.Reason = "stale_evidence_requires_review_alignment"
 	summary.Message = "Stale evidence must be realigned through review convergence; the lifecycle state was not changed."
 	return summary
+}
+
+// reviewAbsorbedDriftToken reports whether a blocker code is plan/evidence drift
+// that S3_REVIEW absorbs as review input rather than blocking on. At review the
+// diff-scoped reviewers re-certify the bundle against the current plan, so a
+// tasks.md edit (or the stale planning/execution evidence it produces) is
+// realigned through review convergence instead of a backward replay. Missing or
+// non-passing work is NOT in this set and continues to fail closed.
+func reviewAbsorbedDriftToken(code string) bool {
+	switch strings.TrimSpace(code) {
+	case state.StalePlanningEvidenceBlockerToken,
+		state.StaleExecutionEvidenceBlockerToken,
+		"tasks_plan_changed_since_task_evidence":
+		return true
+	default:
+		return false
+	}
 }
 
 func blockingExecutionSummaryIssues(change model.Change, issues []string) []string {
@@ -643,14 +716,27 @@ func blockingExecutionSummaryIssues(change model.Change, issues []string) []stri
 		if len(reason) == 0 {
 			continue
 		}
-		switch strings.TrimSpace(reason[0].Code) {
-		case state.StalePlanningEvidenceBlockerToken,
-			state.StaleExecutionEvidenceBlockerToken,
-			"tasks_plan_changed_since_task_evidence":
+		if reviewAbsorbedDriftToken(reason[0].Code) {
 			continue
-		default:
-			filtered = append(filtered, issue)
 		}
+		filtered = append(filtered, issue)
+	}
+	return filtered
+}
+
+// absorbedAtReviewWaveBlockers drops the in-place-absorbed plan/evidence drift
+// tokens from a wave-sync result at S3_REVIEW, mirroring
+// blockingExecutionSummaryIssues so the re-materialize path and the
+// execution-summary path treat review drift identically. Hard blockers
+// (incomplete tasks, non-pass verdicts, safety-net violations) are preserved so
+// review convergence still fails closed on genuinely missing or broken work.
+func absorbedAtReviewWaveBlockers(blockers []model.ReasonCode) []model.ReasonCode {
+	filtered := make([]model.ReasonCode, 0, len(blockers))
+	for _, blocker := range blockers {
+		if reviewAbsorbedDriftToken(blocker.Code) {
+			continue
+		}
+		filtered = append(filtered, blocker)
 	}
 	return filtered
 }

--- a/internal/engine/progression/advance_governed.go
+++ b/internal/engine/progression/advance_governed.go
@@ -140,16 +140,19 @@ func AdvanceGoverned(root, slug string, opts ...AdvanceOptions) (summary Advance
 	// (fail-closed). The lifecycle state is never regressed to S1/S2.
 	runWaveSync := fromState == model.StateS2Implement
 	if fromState == model.StateS3Review {
-		// Only re-materialize at review when tasks.md has actually drifted from the
-		// materialized wave plan (the convergence case — e.g. the author added a
-		// task at review). An unchanged plan keeps the existing read-only S3
-		// behavior so done-ready, light-preset, and other settled review flows are
-		// not perturbed by an unconditional re-sync.
-		drifted, err := tasksPlanDriftedFromWavePlan(root, change)
+		// Only re-sync at review when there is genuine convergence work to absorb:
+		// either tasks.md drifted from the materialized wave plan (the author added
+		// a task at review → re-materialize), or the per-task evidence ledger
+		// advanced past the persisted execution summary (a folded-in task's
+		// evidence was just recorded → rebuild the summary so its
+		// incomplete_execution_task blocker clears). A settled review keeps the
+		// existing read-only S3 behavior so done-ready, light-preset, and other
+		// settled review flows are not perturbed by an unconditional re-sync.
+		pending, err := reviewConvergencePending(root, change)
 		if err != nil {
 			return AdvanceSummary{}, err
 		}
-		runWaveSync = drifted
+		runWaveSync = pending
 	}
 	if runWaveSync {
 		syncResult, err := SyncGovernedWaveExecution(root, change)
@@ -676,6 +679,54 @@ func tasksPlanDriftedFromWavePlan(root string, change model.Change) (bool, error
 		return false, err
 	}
 	return strings.TrimSpace(current) != strings.TrimSpace(wavePlanStructuralHash(*plan)), nil
+}
+
+// reviewConvergencePending reports whether S3_REVIEW has in-place convergence
+// work to absorb on this run. It is true when either tasks.md structurally
+// drifted from the materialized wave plan (a task was added or restructured at
+// review → re-materialize the plan), or the per-task evidence ledger advanced
+// past the persisted execution summary (a folded-in task's evidence was recorded
+// → rebuild the summary so its incomplete_execution_task blocker clears). A
+// settled review — plan matches tasks.md and the summary reflects the ledger —
+// reports no pending work, preserving the read-only S3 behavior that done-ready
+// and light-preset flows rely on.
+func reviewConvergencePending(root string, change model.Change) (bool, error) {
+	drifted, err := tasksPlanDriftedFromWavePlan(root, change)
+	if err != nil {
+		return false, err
+	}
+	if drifted {
+		return true, nil
+	}
+	return executionSummaryTrailsTaskEvidence(root, change)
+}
+
+// executionSummaryTrailsTaskEvidence reports whether the per-task evidence ledger
+// records a task at the active run version that the persisted execution summary
+// does not yet reflect — i.e. evidence for a folded-in task was recorded since
+// the summary was last built. Re-syncing absorbs it and clears that task's
+// incomplete_execution_task blocker. A missing summary, or a ledger already
+// reflected in the summary, reports no trailing work so settled reviews stay
+// read-only.
+func executionSummaryTrailsTaskEvidence(root string, change model.Change) (bool, error) {
+	summary, err := state.LoadOptionalRelevantExecutionSummary(root, change)
+	if err != nil {
+		return false, err
+	}
+	if summary == nil || summary.RunSummaryVersion < 1 {
+		return false, nil
+	}
+	ledgerTasks, _, err := LoadExecutionTasksFromEvidence(root, change.Slug, summary.RunSummaryVersion)
+	if err != nil {
+		return false, err
+	}
+	runMap := summary.TaskRunMap()
+	for _, task := range ledgerTasks {
+		if _, ok := runMap[task.TaskID]; !ok {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func forwardOnlyStaleEvidenceSummary(fromState model.WorkflowState, target EvidenceRepairTarget) AdvanceSummary {

--- a/internal/engine/progression/wave_sync.go
+++ b/internal/engine/progression/wave_sync.go
@@ -681,9 +681,34 @@ func IncompleteExecutionTaskBlockers(plan model.WavePlan, runs map[string]model.
 	slices.Sort(missing)
 	blockers := make([]model.ReasonCode, 0, len(missing))
 	for _, taskID := range missing {
-		blockers = append(blockers, model.NewReasonCode("incomplete_execution_task", taskID))
+		blockers = append(blockers, model.NewReasonCode(IncompleteExecutionTaskBlockerCode, taskID))
 	}
 	return model.NormalizeReasonCodes(blockers)
+}
+
+// IncompleteExecutionTaskBlockerCode marks a planned wave-plan task that has no
+// recorded run at the active run_summary_version (issue #95). It is also the
+// engine's durable signal that a task was folded into tasks.md at S3_REVIEW and
+// still needs its evidence before the in-place convergence completes.
+const IncompleteExecutionTaskBlockerCode = "incomplete_execution_task"
+
+// ExecutionSummaryHasIncompleteTask reports whether the persisted execution
+// summary still carries an incomplete_execution_task blocker — the engine's
+// durable signal that a task folded into tasks.md at S3_REVIEW has not yet had
+// its evidence recorded. It scopes the S3 wave-orchestration re-record window:
+// the host may re-attest the wave run in place only while genuine convergence
+// work remains, and the window closes once the rebuilt summary reflects the
+// folded task.
+func ExecutionSummaryHasIncompleteTask(summary *model.ExecutionSummary) bool {
+	if summary == nil {
+		return false
+	}
+	for _, blocker := range summary.OpenBlockers {
+		if strings.TrimSpace(blocker.Code) == IncompleteExecutionTaskBlockerCode {
+			return true
+		}
+	}
+	return false
 }
 
 // TaskChangedFileScopeEscapeBlockers reports, per task, every recorded changed

--- a/internal/tmpl/templates/skills/independent-review/SKILL.md.tmpl
+++ b/internal/tmpl/templates/skills/independent-review/SKILL.md.tmpl
@@ -27,6 +27,15 @@ review-stage native subagents. This review is an unordered peer of the other S3
 reviewers; it does not wait for their verdicts and they do not wait for this
 verdict. `slipway next` previews the review set; it does not advance the state.
 
+`S3_REVIEW` is a convergence stage: if the author edits `tasks.md` at review (for
+example, discovering a task), the wave plan re-materializes IN PLACE at the same
+run version — the lifecycle stays at `S3_REVIEW` rather than rescoping back to
+S1/S2, and prior per-task evidence is preserved. Realigning that plan/evidence
+drift on already-evidenced tasks is your job through the diff-scoped review
+below; review the current plan and the current diff, not a remembered earlier
+plan. A newly added or structurally changed task still fails closed on its own
+missing evidence before the change can advance to S4.
+
 ## Review Contract
 Use fresh context; do not carry assumptions from the implementer or from peer
 reviews.

--- a/internal/tmpl/templates/skills/wave-orchestration/SKILL.md.tmpl
+++ b/internal/tmpl/templates/skills/wave-orchestration/SKILL.md.tmpl
@@ -212,6 +212,16 @@ partial execution does not reach S3_REVIEW. To intentionally drop a task, record
 a same-intent scope amendment in `tasks.md` so the wave plan no longer claims it;
 never skip its evidence.
 
+**S3 in-place convergence:** if you discover more work at `S3_REVIEW` and edit
+`tasks.md` (for example, adding a task), the wave plan re-materializes IN PLACE
+at the SAME run version — the lifecycle stays at `S3_REVIEW` and prior per-task
+evidence is preserved, with no backward rescope re-walk to S1/S2. A newly added
+or structurally changed task still fails closed on its own missing evidence
+(`incomplete_execution_task:<task_id>`) before `S3_REVIEW->S4`; record its
+evidence through `slipway evidence task` as usual. Plan/evidence drift on
+already-evidenced tasks is realigned through the diff-scoped reviewers, not
+replayed as a backward gate.
+
 ## Guardrails
 - The orchestrator stays below 15% of context budget. Do not read task source files just to "help."
 - Auto-fix only issues directly blocking the current task and directly caused by the current task's change.

--- a/internal/tmpl/templates/skills/wave-orchestration/SKILL.md.tmpl
+++ b/internal/tmpl/templates/skills/wave-orchestration/SKILL.md.tmpl
@@ -217,10 +217,22 @@ never skip its evidence.
 at the SAME run version — the lifecycle stays at `S3_REVIEW` and prior per-task
 evidence is preserved, with no backward rescope re-walk to S1/S2. A newly added
 or structurally changed task still fails closed on its own missing evidence
-(`incomplete_execution_task:<task_id>`) before `S3_REVIEW->S4`; record its
-evidence through `slipway evidence task` as usual. Plan/evidence drift on
-already-evidenced tasks is realigned through the diff-scoped reviewers, not
-replayed as a backward gate.
+(`incomplete_execution_task:<task_id>`) before `S3_REVIEW->S4`. The forward exit
+is the SAME ordered flow as S2, run in place at `S3_REVIEW`:
+1. `slipway run` once so the re-materialized plan surfaces the folded task as
+   `incomplete_execution_task`.
+2. Record the folded task's evidence with `slipway evidence task` (recordable at
+   `S3_REVIEW` only for a task the plan surfaced as incomplete — already-evidenced
+   tasks stay frozen and are realigned through review, never restamped).
+3. Re-record wave-orchestration evidence with `slipway evidence skill` so the
+   fresh wave record post-dates the folded task's evidence — wave evidence is
+   always recorded LAST, after every task's evidence, exactly as at S2. This
+   rebuilds the execution summary in place and clears the
+   `incomplete_execution_task` blocker.
+4. `slipway run` to advance once the reviewers re-certify (the `tasks.md` edit
+   staled their evidence).
+Plan/evidence drift on already-evidenced tasks is realigned through the
+diff-scoped reviewers, not replayed as a backward gate.
 
 ## Guardrails
 - The orchestrator stays below 15% of context budget. Do not read task source files just to "help."


### PR DESCRIPTION
## What

Makes Slipway's `S3_REVIEW` a **convergence** stage. When an author discovers more work at review and edits `tasks.md` (e.g. adds a task), the wave plan now **re-materializes in place at the same run version** instead of forcing a backward rescope re-walk. The lifecycle state stays at `S3_REVIEW`, and prior per-task evidence is preserved — no regression to S1/S2.

## Behavior

- **Drift-gated re-sync.** Wave synchronization runs at S2 as before, and now also at S3 — but at S3 *only* when `tasks.md` has genuinely drifted from the materialized wave plan (`tasksPlanDriftedFromWavePlan` compares the current tasks-plan structural projection against the wave plan's structural hash). An unchanged plan keeps the existing read-only S3 behavior, so settled review flows (done-ready, light-preset) are not perturbed by an unconditional re-sync.
- **Review absorbs drift, not missing work.** At S3 the sync's blockers are filtered through `absorbedAtReviewWaveBlockers`, which drops exactly the three review-absorbed drift tokens (stale planning evidence, stale execution evidence, `tasks_plan_changed_since_task_evidence`) via the shared `reviewAbsorbedDriftToken` predicate. Plan/evidence drift on already-evidenced tasks is realigned through the diff-scoped reviewers, who re-certify against the current plan.
- **Fail-closed guarantee preserved.** Incomplete tasks, non-pass verdicts, and safety-net violations all survive the filter. A task newly added or structurally changed at review still fails closed on its own missing evidence (`incomplete_execution_task:<task_id>`) before `S3 -> S4`.

## Tests

New `cmd/s3_inplace_convergence_test.go::TestRunAtS3AbsorbsAddedTaskInPlace` covers the convergence path (a task added at review re-materializes the plan in place at the same run version). Full `go test ./...` is green; `gofmt -s` and `golangci-lint` are clean.

## Docs

Additive notes in the generated `wave-orchestration` and `independent-review` skills describe the in-place convergence contract (same run version, no rescope re-walk, newly added tasks still require their own evidence). The skill-tree golden manifest and substring contract tests in `internal/toolgen` stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
