### PR TITLE
feat(hooks): inject open change's handoff excerpt into SessionStart

### DIFF
--- a/cmd/handoff.go
+++ b/cmd/handoff.go
@@ -163,15 +163,6 @@ func readHandoffDocument(root, changeSlug string) (state.HandoffDocument, bool, 
 	return doc, true, nil
 }
 
-func handoffBriefForChange(root, changeSlug string) (string, bool, error) {
-	doc, ok, err := readHandoffDocument(root, changeSlug)
-	if err != nil || !ok {
-		return "", ok, err
-	}
-	brief := state.HandoffBrief(doc)
-	return brief, strings.TrimSpace(brief) != "", nil
-}
-
 func resolveHandoffChangeRef(root, changeSlug string) (changeRef, bool, error) {
 	ref, err := resolveActiveChangeRef(root, changeSlug)
 	if err == nil {

--- a/cmd/session_start_hook.go
+++ b/cmd/session_start_hook.go
@@ -55,8 +55,15 @@ func runSessionStartHook(cmd *cobra.Command, toolID string) error {
 	if err != nil {
 		// A change bound to another worktree is an expected, informational state
 		// when a session opens with no active change of its own: point the host
-		// at the bound change instead of an alarming next-failed diagnostic.
-		if handoffInfo = sessionStartBoundWorktreeHandoff(err); handoffInfo == "" {
+		// at the bound change instead of an alarming next-failed diagnostic, and
+		// thread that change's slug so its handoff excerpt is surfaced below. The
+		// bound change has no next --json here, so the handoff is the only
+		// continuity signal the next agent gets.
+		boundSlug, boundInfo := sessionStartBoundWorktreeHandoff(err)
+		if boundInfo != "" {
+			handoffInfo = boundInfo
+			changeSlug = boundSlug
+		} else {
 			diagnostics = append(diagnostics, "hook_diagnostic: slipway next --json failed: "+normalizeHookDiagnostic(err.Error()))
 		}
 	}
@@ -69,22 +76,23 @@ func runSessionStartHook(cmd *cobra.Command, toolID string) error {
 }
 
 // sessionStartBoundWorktreeHandoff renders the friendly informational line for
-// the change_bound_to_other_worktree precondition. When a session opens where
-// no change is active for the current worktree while a change is bound
-// elsewhere, the host is pointed at that change instead of seeing an alarming
-// "next --json failed" diagnostic. Returns "" for any other error or when the
-// bound change details are incomplete, so the caller falls back to the
-// diagnostic path.
-func sessionStartBoundWorktreeHandoff(err error) string {
+// the change_bound_to_other_worktree precondition and returns the bound change
+// slug alongside it. When a session opens where no change is active for the
+// current worktree while a change is bound elsewhere, the host is pointed at
+// that change instead of seeing an alarming "next --json failed" diagnostic, and
+// the returned slug lets the caller surface that change's handoff excerpt.
+// Returns ("", "") for any other error or when the bound change details are
+// incomplete, so the caller falls back to the diagnostic path.
+func sessionStartBoundWorktreeHandoff(err error) (slug, info string) {
 	cliErr := asCLIError(err)
 	if cliErr == nil || cliErr.ErrorCode != "change_bound_to_other_worktree" {
-		return ""
+		return "", ""
 	}
 	slug, worktreePath := firstBoundChange(cliErr.Details)
 	if slug == "" || worktreePath == "" {
-		return ""
+		return "", ""
 	}
-	return fmt.Sprintf(
+	return slug, fmt.Sprintf(
 		"session_handoff_info: no active change in this worktree; active change %s is bound to %s; cd there or use --change %s to act",
 		slug, worktreePath, slug,
 	)
@@ -137,11 +145,10 @@ func sessionStartHandoffSummary(root, slug string) string {
 		return ""
 	}
 	handoffPath := state.ChangeHandoffPath(root, slug)
-	if brief, ok, err := handoffBriefForChange(root, slug); err == nil && ok {
-		if before, _, ok := strings.Cut(brief, " focus="); ok {
-			return before
+	if doc, ok, err := readHandoffDocument(root, slug); err == nil && ok {
+		if excerpt := strings.TrimSpace(state.HandoffExcerpt(doc)); excerpt != "" {
+			return excerpt
 		}
-		return brief
 	}
 	present := "false"
 	if _, err := os.Stat(handoffPath); err == nil {

--- a/cmd/session_start_hook_test.go
+++ b/cmd/session_start_hook_test.go
@@ -25,7 +25,7 @@ func TestSessionStartHookEmitsCompiledHandoff(t *testing.T) {
 		require.NoError(t, os.MkdirAll(filepath.Dir(handoffPath), 0o755))
 		writeCmd := commandForRoot(t, root, makeHandoffCmd())
 		writeCmd.SetArgs([]string{"write", "--section", "Next Session Focus"})
-		writeCmd.SetIn(strings.NewReader("handoff body must not be embedded"))
+		writeCmd.SetIn(strings.NewReader("resume wave-3 evidence capture"))
 		writeCmd.SetOut(io.Discard)
 		require.NoError(t, writeCmd.Execute())
 		legacyPath := filepath.Join(state.GitRuntimeDir(root), "handoff.md")
@@ -44,35 +44,32 @@ func TestSessionStartHookEmitsCompiledHandoff(t *testing.T) {
 		assert.Contains(t, body, "slipway_entry_skill:")
 		assert.Contains(t, body, "session_handoff: slug="+slug)
 		assert.Contains(t, body, "path="+handoffPath)
-		assert.NotContains(t, body, "handoff body must not be embedded")
+		// The authored continuity section is surfaced as a bounded excerpt.
+		assert.Contains(t, body, "session_handoff_excerpt:")
+		assert.Contains(t, body, "resume wave-3 evidence capture")
+		// The deprecated repo-global handoff is never embedded.
 		assert.NotContains(t, body, legacyPath)
 		assert.NotContains(t, body, "legacy handoff body must not be embedded")
 	})
 }
 
-func TestSessionStartHandoffSummaryUsesCommandOwnedBrief(t *testing.T) {
+func TestSessionStartHandoffSummaryEmitsAuthoredExcerpt(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, levelNonDiscovery, "session-start command owned brief")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "session-start authored excerpt")
 
 		writeCmd := commandForRoot(t, root, makeHandoffCmd())
 		writeCmd.SetArgs([]string{"write", "--change", slug, "--section", "Next Session Focus"})
-		writeCmd.SetIn(strings.NewReader("hook should trim this body"))
+		writeCmd.SetIn(strings.NewReader("resume the worktree-preflight rewrite"))
 		writeCmd.SetOut(io.Discard)
 		require.NoError(t, writeCmd.Execute())
 
-		brief, ok, err := handoffBriefForChange(root, slug)
-		require.NoError(t, err)
-		require.True(t, ok)
-		expected := brief
-		if before, _, ok := strings.Cut(brief, " focus="); ok {
-			expected = before
-		}
-
 		summary := sessionStartHandoffSummary(root, slug)
-		assert.Equal(t, expected, summary)
-		assert.NotContains(t, summary, "hook should trim this body")
+		assert.Contains(t, summary, "session_handoff: slug="+slug)
+		assert.Contains(t, summary, "session_handoff_excerpt:")
+		assert.Contains(t, summary, "## Next Session Focus")
+		assert.Contains(t, summary, "resume the worktree-preflight rewrite")
 	})
 }
 
@@ -192,6 +189,40 @@ func TestSessionStartHookTreatsBoundWorktreeChangeAsInformational(t *testing.T) 
 		assert.Contains(t, body, "active change bound-change is bound to "+normalizedWorktreePath)
 		assert.Contains(t, body, "use --change bound-change to act")
 		assert.NotContains(t, body, "hook_diagnostic: slipway next --json failed:")
+	})
+}
+
+func TestSessionStartHookSurfacesBoundChangeHandoffExcerpt(t *testing.T) {
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		initGitRepoForWorktreeTests(t, root)
+
+		worktreePath := filepath.Join(t.TempDir(), "bound-worktree")
+		runGit(t, root, "worktree", "add", worktreePath, "-b", "bound-worktree")
+		change := model.NewChange("bound-change")
+		change.WorktreePath = worktreePath
+		require.NoError(t, state.SaveChange(root, change))
+
+		writeCmd := commandForRoot(t, root, makeHandoffCmd())
+		writeCmd.SetArgs([]string{"write", "--change", change.Slug, "--section", "Next Session Focus"})
+		writeCmd.SetIn(strings.NewReader("finish the bound-worktree migration"))
+		writeCmd.SetOut(io.Discard)
+		require.NoError(t, writeCmd.Execute())
+
+		cmd := makeHookCmd()
+		cmd.SetArgs([]string{"session-start", "--tool", "claude"})
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		require.NoError(t, cmd.Execute())
+
+		body := out.String()
+		// The pointer line and the bound change's handoff excerpt are both
+		// surfaced even though next --json is unavailable in this worktree.
+		assert.Contains(t, body, "session_handoff_info: no active change in this worktree")
+		assert.Contains(t, body, "session_handoff: slug=bound-change")
+		assert.Contains(t, body, "session_handoff_excerpt:")
+		assert.Contains(t, body, "finish the bound-worktree migration")
 	})
 }
 

--- a/internal/state/handoff.go
+++ b/internal/state/handoff.go
@@ -19,7 +19,27 @@ const (
 	handoffHeaderOpen  = "<!-- slipway:handoff-machine-header"
 	handoffHeaderClose = "slipway:handoff-machine-header -->"
 	handoffTimeFormat  = time.RFC3339Nano
+
+	// handoffPendingPlaceholder is the body the engine writes for every section
+	// of a freshly scaffolded handoff. A section still carrying this exact body
+	// is unauthored and must not be surfaced as continuity content.
+	handoffPendingPlaceholder = "_Agent-authored narrative pending._"
+
+	// handoffExcerptSectionMaxRunes bounds each section body surfaced in the
+	// SessionStart excerpt so the host context budget stays protected. The fixed
+	// handoff template means the excerpt is deterministic; only oversized authored
+	// bodies are truncated, with a pointer to the full narrative.
+	handoffExcerptSectionMaxRunes = 400
 )
+
+// handoffExcerptSections is the fixed, ordered set of continuity sections
+// surfaced in the SessionStart excerpt. The handoff template is fixed, so the
+// excerpt always pulls the same well-known sections when authored.
+var handoffExcerptSections = []string{
+	"Current Position",
+	"Next Session Focus",
+	"Risks And Blockers",
+}
 
 var handoffSectionNames = []string{
 	"Current Position",
@@ -162,6 +182,76 @@ func HandoffBrief(doc HandoffDocument) string {
 	)
 }
 
+// HandoffExcerpt renders a bounded, host-injectable view of a handoff for
+// SessionStart context. It leads with the machine brief line, then appends the
+// authored continuity sections from the fixed handoff template. Unauthored
+// placeholder bodies are skipped; when no section is authored the excerpt
+// degrades to the brief plus an explicit unauthored marker so the host knows
+// the handoff exists but carries no continuity yet. A stale handoff is flagged
+// so the host re-authors before relying on it. Returns "" when the document
+// carries no slug.
+func HandoffExcerpt(doc HandoffDocument) string {
+	brief := HandoffBrief(doc)
+	if brief == "" {
+		return ""
+	}
+	var b strings.Builder
+	if strings.EqualFold(strings.TrimSpace(doc.Header.Staleness), "stale") {
+		b.WriteString("session_handoff_stale: true; lifecycle advanced after this handoff — re-author via `slipway handoff write` before relying on it\n")
+	}
+	b.WriteString(brief)
+	b.WriteByte('\n')
+
+	sections := authoredHandoffSections(doc.Narrative)
+	if len(sections) == 0 {
+		b.WriteString("session_handoff_unauthored: true; no continuity recorded — run `slipway handoff write --section \"Next Session Focus\"` to capture it")
+		return strings.TrimRight(b.String(), "\n")
+	}
+	b.WriteString("session_handoff_excerpt:\n")
+	for _, section := range sections {
+		b.WriteString("## ")
+		b.WriteString(section[0])
+		b.WriteByte('\n')
+		b.WriteString(truncateHandoffBody(section[1], handoffExcerptSectionMaxRunes))
+		b.WriteByte('\n')
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// authoredHandoffSections returns the fixed-template continuity sections that
+// carry real agent-authored content, in template order, skipping any section
+// whose body is still the engine placeholder.
+func authoredHandoffSections(narrative string) [][2]string {
+	out := make([][2]string, 0, len(handoffExcerptSections))
+	for _, section := range handoffExcerptSections {
+		body := strings.TrimSpace(extractHandoffSection(narrative, section))
+		if !handoffSectionAuthored(body) {
+			continue
+		}
+		out = append(out, [2]string{section, body})
+	}
+	return out
+}
+
+// handoffSectionAuthored reports whether a section body carries real content
+// rather than the engine's unauthored placeholder.
+func handoffSectionAuthored(body string) bool {
+	body = strings.TrimSpace(body)
+	return body != "" && body != handoffPendingPlaceholder
+}
+
+// truncateHandoffBody bounds a section body to maxRunes, appending a pointer to
+// the full narrative when truncated. Truncation is rune-aware so multibyte
+// content is never split mid-rune.
+func truncateHandoffBody(body string, maxRunes int) string {
+	body = strings.TrimSpace(body)
+	runes := []rune(body)
+	if len(runes) <= maxRunes {
+		return body
+	}
+	return strings.TrimSpace(string(runes[:maxRunes])) + " …(run `slipway handoff show` for full text)"
+}
+
 func HandoffStaleness(root string, change model.Change, updatedAt time.Time) string {
 	if updatedAt.IsZero() {
 		return "unknown"
@@ -227,7 +317,7 @@ func ensureHandoffNarrativeSkeleton(raw string) string {
 	for _, section := range handoffSectionNames {
 		body := extractHandoffSection(raw, section)
 		if strings.TrimSpace(body) == "" {
-			body = "_Agent-authored narrative pending._"
+			body = handoffPendingPlaceholder
 		}
 		b.WriteString("\n## ")
 		b.WriteString(section)

--- a/internal/state/handoff_test.go
+++ b/internal/state/handoff_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -102,6 +103,107 @@ func TestHandoffBriefIsBoundedDescriptor(t *testing.T) {
 	assert.Contains(t, brief, "Finish command tests.")
 	assert.NotContains(t, brief, "current_state")
 	assert.NotContains(t, brief, "next_skill")
+}
+
+func TestHandoffExcerptEmitsAuthoredSectionsAndSkipsPlaceholders(t *testing.T) {
+	doc := HandoffDocument{
+		Path: "/repo/.git/slipway/runtime/changes/demo/handoff.md",
+		Header: HandoffHeader{
+			Slug:       "demo",
+			Generation: 2,
+			UpdatedAt:  time.Date(2026, 6, 23, 1, 2, 3, 0, time.UTC),
+			Staleness:  "fresh",
+		},
+		Narrative: "## Current Position\nWave 2 of 3 implemented.\n\n## Next Session Focus\nResume wave-3 evidence capture.\n\n## Risks And Blockers\n" + handoffPendingPlaceholder + "\n",
+	}
+	excerpt := HandoffExcerpt(doc)
+	assert.Contains(t, excerpt, "session_handoff: slug=demo")
+	assert.Contains(t, excerpt, "session_handoff_excerpt:")
+	assert.Contains(t, excerpt, "## Current Position")
+	assert.Contains(t, excerpt, "Wave 2 of 3 implemented.")
+	assert.Contains(t, excerpt, "## Next Session Focus")
+	assert.Contains(t, excerpt, "Resume wave-3 evidence capture.")
+	// A placeholder section carries no continuity and must be skipped.
+	assert.NotContains(t, excerpt, "## Risks And Blockers")
+	assert.NotContains(t, excerpt, handoffPendingPlaceholder)
+	assert.NotContains(t, excerpt, "session_handoff_unauthored")
+	assert.NotContains(t, excerpt, "session_handoff_stale")
+}
+
+func TestHandoffExcerptDegradesToUnauthoredMarkerWhenAllPlaceholders(t *testing.T) {
+	doc := HandoffDocument{
+		Header: HandoffHeader{
+			Slug:      "demo",
+			UpdatedAt: time.Date(2026, 6, 23, 1, 2, 3, 0, time.UTC),
+			Staleness: "fresh",
+		},
+		Narrative: ensureHandoffNarrativeSkeleton(""),
+	}
+	excerpt := HandoffExcerpt(doc)
+	assert.Contains(t, excerpt, "session_handoff: slug=demo")
+	assert.Contains(t, excerpt, "session_handoff_unauthored: true")
+	assert.NotContains(t, excerpt, "session_handoff_excerpt:")
+}
+
+func TestHandoffExcerptFlagsStaleHandoffBeforeContent(t *testing.T) {
+	doc := HandoffDocument{
+		Header: HandoffHeader{
+			Slug:      "demo",
+			UpdatedAt: time.Date(2026, 6, 23, 1, 2, 3, 0, time.UTC),
+			Staleness: "stale",
+		},
+		Narrative: "## Next Session Focus\nResume wave-3.\n",
+	}
+	excerpt := HandoffExcerpt(doc)
+	assert.True(t, strings.HasPrefix(excerpt, "session_handoff_stale: true"), excerpt)
+	assert.Contains(t, excerpt, "Resume wave-3.")
+}
+
+func TestHandoffExcerptTruncatesOversizedSectionBody(t *testing.T) {
+	long := strings.Repeat("x", handoffExcerptSectionMaxRunes+50)
+	doc := HandoffDocument{
+		Header: HandoffHeader{
+			Slug:      "demo",
+			UpdatedAt: time.Date(2026, 6, 23, 1, 2, 3, 0, time.UTC),
+			Staleness: "fresh",
+		},
+		Narrative: "## Next Session Focus\n" + long + "\n",
+	}
+	excerpt := HandoffExcerpt(doc)
+	assert.Contains(t, excerpt, "run `slipway handoff show` for full text")
+	assert.NotContains(t, excerpt, long)
+}
+
+func TestHandoffExcerptReturnsEmptyWithoutSlug(t *testing.T) {
+	assert.Equal(t, "", HandoffExcerpt(HandoffDocument{Narrative: "## Next Session Focus\nx\n"}))
+}
+
+// TestArchiveChangeRemovesAdvisoryHandoff pins the invariant the SessionStart
+// excerpt relies on: SessionStart surfaces a handoff only for an open change,
+// because archive removes the handoff with the rest of the per-change runtime
+// state. Lives here (a handoff-owned file) rather than lifecycle_test.go so the
+// archive surface stays decoupled from handoff awareness.
+func TestArchiveChangeRemovesAdvisoryHandoff(t *testing.T) {
+	root := createRuntimeLayout(t)
+	slug := "handoff-archive"
+	change := model.NewChange(slug)
+	change.Status = model.ChangeStatusDone
+	change.CurrentState = model.StateDone
+	change.PlanSubStep = model.PlanSubStepNone
+	require.NoError(t, SaveChange(root, change))
+
+	_, err := WriteHandoff(root, change, HandoffWriteOptions{Section: "Next Session Focus", SectionBody: "resume"})
+	require.NoError(t, err)
+	handoffPath := ChangeHandoffPath(root, slug)
+	_, err = os.Stat(handoffPath)
+	require.NoError(t, err)
+
+	_, err = ArchiveChange(root, change, model.ChangeStatusDone)
+	require.NoError(t, err)
+
+	_, err = os.Stat(handoffPath)
+	require.Error(t, err)
+	assert.True(t, os.IsNotExist(err))
 }
 
 func TestHandoffHeaderKeysExcludeLifecycleAuthorityFields(t *testing.T) {


### PR DESCRIPTION
## Problem

When a session opens with no active change in the current worktree but a change is bound to another worktree, the SessionStart hook surfaced only the terse pointer line:

> `session_handoff_info: ... cd there or use --change <slug> to act`

The handoff was **dropped entirely** — `sessionStartNextJSON` returns an empty slug on the `change_bound_to_other_worktree` precondition, so `sessionStartHandoffSummary` short-circuited and the authored continuity never reached the next agent. Even active-here changes only got a single brief line with the focus stripped. That is the "不够清晰 / not clear enough" complaint.

## Fix

- **Thread the bound slug** through `runSessionStartHook` so both active-here and bound-elsewhere cases surface the handoff. The bound case has no `next --json`, so the handoff is its only continuity signal.
- **Brief → bounded excerpt**: new `state.HandoffExcerpt` renders the machine brief plus the authored continuity sections of the fixed handoff template (`Current Position`, `Next Session Focus`, `Risks And Blockers`), skipping unauthored placeholders, rune-capped per section to protect the host context budget.
- **Honest degradation**: an all-placeholder handoff emits the brief plus `session_handoff_unauthored: true` naming the remediation command instead of injecting noise; a `stale` handoff (lifecycle advanced after it was written) is flagged so the host re-authors first.

The excerpt is safe to surface unconditionally: archive already removes the per-change runtime dir (and with it the handoff) via `removePerChangeLocalRuntimeState`, so only an **open** change ever has one. That invariant is now pinned from the handoff-owned test file, keeping the archive surface decoupled from handoff awareness (per `TestHandoffIsNotGateEvidenceOrFreshnessInput`).

## Dogfood

Running the real hook in this repo against the bound `fix-evidence-and-recovery-ux` change now emits the brief + a `stale` flag + an `unauthored` marker (that handoff was scaffolded but never filled) — exactly the honest output, where before there was only the pointer line.

## Tests

- `internal/state`: `HandoffExcerpt` authored / unauthored / stale / truncation / no-slug; `ArchiveChangeRemovesAdvisoryHandoff`.
- `cmd`: SessionStart now embeds the authored excerpt (contract reversal of the old "must not be embedded"); new bound-worktree excerpt-injection test.
- Full `internal/state` and `cmd` packages green; `gofmt -s` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)