### PR TITLE
fix(hooks): render in-repo go-run for codex & settings.json inline hooks

### DIFF
--- a/internal/toolgen/toolgen.go
+++ b/internal/toolgen/toolgen.go
@@ -2062,30 +2062,42 @@ const (
 	codexHooksBlockEnd         = "# END SLIPWAY MANAGED CODEX HOOKS"
 )
 
-// hookLaunch returns the command prefix and existence-probe binary that the
-// generated hook *launcher scripts* use to invoke Slipway from root. Inside the
-// Slipway source module it returns ("go -C <root> run .", "go") so the launcher
-// tracks the worktree build; everywhere else it returns ("slipway", "slipway")
-// so the launcher resolves a release from PATH and the generated config stays
+// hookLaunch returns the command prefix and existence-probe binary that
+// generated hook invocations use to launch Slipway from root. Inside the
+// Slipway source module it returns ("go -C <root> run .", "go") so hooks track
+// the worktree build; everywhere else it returns ("slipway", "slipway") so the
+// inlined command resolves a release from PATH and the generated config stays
 // machine-portable. The go-run prefix is used only when the module root is
 // shell-safe (needs no quoting), so `go -C <root> run .` stays a bare,
 // shell-operator-free token sequence valid across /bin/sh, cmd, and PowerShell.
 //
-// Only launcher-file hosts (cursor, opencode) use this prefix, because their
-// .sh/.ps1/.cmd wrappers probe `go`, discard stderr, and force exit 0 — so a
-// missing toolchain or a momentarily uncompilable worktree can never surface a
-// non-zero hook to the host. The inline-settings surfaces (codex TOML,
-// settings.json) deliberately do NOT use go-run: their command is a single
-// operator-free string with nowhere to attach a fail-silent guard, so a
-// pre-process `go run` failure would run before Slipway starts and bypass the
-// cmd/root.go fail-silent floor entirely, blocking the host. Those surfaces stay
-// on the bare `slipway hook ...` command, which the floor keeps fail-silent
-// under version skew.
+// Both launcher-file hosts (cursor, opencode) and inline-config hosts (codex
+// TOML, settings.json) adopt this prefix in-repo: a dogfooding checkout's
+// generated config is per-machine, never shared, so tracking its own HEAD is
+// strictly safer than a bare `slipway` that resolves a stale PATH release
+// predating the current flag set. Launcher-file wrappers additionally probe
+// `go` and force exit 0; the inline-config surfaces accept that a worktree which
+// fails to compile makes `go run` exit non-zero — a rarer, self-evident edge for
+// an in-repo developer than the version-skew break the go-run form removes.
 func hookLaunch(root string) (prefix, probe string) {
 	if dir := slipwaySourceModuleRoot(root); dir != "" && isShellSafePath(dir) {
 		return "go -C " + dir + " run .", "go"
 	}
 	return "slipway", "slipway"
+}
+
+// applyHookLaunchPrefix rewrites the leading "slipway" token of an inline hook
+// command to the launch prefix for root. It is a no-op for the release prefix,
+// so non-repo generation keeps the bare, PATH-resolved command verbatim.
+func applyHookLaunchPrefix(command, root string) string {
+	prefix, _ := hookLaunch(root)
+	if prefix == "slipway" {
+		return command
+	}
+	if rest, ok := strings.CutPrefix(command, "slipway "); ok {
+		return prefix + " " + rest
+	}
+	return command
 }
 
 // slipwaySourceModuleRoot returns the absolute path of root when root's go.mod
@@ -2288,7 +2300,7 @@ func mergeCodexHooksTOMLWithPlan(root string, cfg ToolConfig, refresh bool, plan
 	} else if !errors.Is(err, fs.ErrNotExist) {
 		return err
 	}
-	content := mergeManagedCodexHooksBlock(existing, renderCodexHooksBlock(cfg))
+	content := mergeManagedCodexHooksBlock(existing, renderCodexHooksBlock(cfg, root))
 	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil { // #nosec G301 -- directory is a user-facing project artifact location.
 		return err
 	}
@@ -2306,14 +2318,20 @@ func codexHookSettingsRoot(root string) string {
 	return root
 }
 
-// renderCodexHooksBlock renders the managed Codex hooks TOML block. The hook
-// commands stay on the bare `slipway hook ...` form even for in-repo generation:
-// a Codex inline command is a single operator-free string, so it cannot wrap a
-// go-run launch to force exit 0, and a pre-process `go run` failure (missing
-// toolchain or a momentarily uncompilable worktree) would escape the
-// cmd/root.go fail-silent floor and block the host. See hookLaunch for the full
-// rationale; only launcher-file hosts dogfood the worktree build via go-run.
-func renderCodexHooksBlock(cfg ToolConfig) string {
+// renderCodexHooksBlock renders the managed Codex hooks TOML block. Inside the
+// Slipway source tree the hook commands are rewritten to the in-repo go-run
+// launch (see hookLaunch) so a dogfooding checkout always runs its own HEAD,
+// not a stale PATH release. This is what keeps the hooks working under version
+// skew: the bare `slipway hook ... --tool codex` form silently breaks the
+// moment the PATH `slipway` predates the `--tool` flag (it exits non-zero with
+// `unknown flag: --tool`, which Codex surfaces as a block), whereas go-run
+// tracks the worktree and always understands the current flag set. `.codex/
+// config.toml` is per-machine (gitignored), so the rewrite is rendered for the
+// local OS and never shared across platforms. The residual edge — a worktree
+// that fails to compile makes `go run` exit non-zero — is rarer and more
+// self-evident for an in-repo developer than the version-skew break it
+// replaces. Non-repo generation keeps the bare, PATH-resolved command verbatim.
+func renderCodexHooksBlock(cfg ToolConfig, root string) string {
 	sessionCommand := strings.TrimSpace(cfg.SessionHook)
 	if sessionCommand == "" {
 		sessionCommand = "slipway hook session-start --tool codex"
@@ -2322,6 +2340,8 @@ func renderCodexHooksBlock(cfg ToolConfig) string {
 	if promptCommand == "" {
 		promptCommand = "slipway hook context-pressure --tool codex"
 	}
+	sessionCommand = applyHookLaunchPrefix(sessionCommand, root)
+	promptCommand = applyHookLaunchPrefix(promptCommand, root)
 	return strings.TrimSpace(fmt.Sprintf(`%s
 # Generated by Slipway. Hooks are inert until Codex trusts this repo and each hook; Slipway never edits global Codex trust.
 [[hooks.SessionStart]]
@@ -2401,15 +2421,14 @@ func mergeHookSettingsJSONWithPlan(root string, cfg ToolConfig, refresh bool, pl
 		return fmt.Errorf("%s contains a non-object hooks field", cfg.SettingsPath)
 	}
 
-	// Settings.json hooks stay on the bare `slipway hook ...` command even for
-	// in-repo generation: the command is a single operator-free string that
-	// cannot force a go-run launch to exit 0, so a pre-process `go run` failure
-	// would bypass the cmd/root.go fail-silent floor and block the host. See
-	// hookLaunch. pruneStaleSlipwayHookCommands still recognizes a previously
-	// written inline go-run command and converts it back to this bare form on
-	// refresh.
-	sessionCmd := sessionStartHookCommand
-	promptCmd := contextPressureHookCommand
+	// Inside the Slipway source tree these inline commands are rewritten to the
+	// in-repo go-run launch (see hookLaunch / renderCodexHooksBlock) so a
+	// dogfooding checkout runs its own HEAD instead of a stale PATH release that
+	// may predate the current `--tool` flag. settings.json is per-machine, so the
+	// rewrite is rendered for the local host. pruneStaleSlipwayHookCommands still
+	// recognizes both the bare and the go-run forms across refreshes.
+	sessionCmd := applyHookLaunchPrefix(sessionStartHookCommand, root)
+	promptCmd := applyHookLaunchPrefix(contextPressureHookCommand, root)
 	if strings.TrimSpace(cfg.SessionEvent) != "" && strings.TrimSpace(cfg.SessionHook) != "" {
 		pruneStaleSlipwayHookCommands(hooks, cfg.SessionEvent, cfg.SessionHook, sessionCmd)
 		mergeHookEventCommand(hooks, cfg.SessionEvent, sessionCmd)

--- a/internal/toolgen/toolgen_test.go
+++ b/internal/toolgen/toolgen_test.go
@@ -3210,42 +3210,33 @@ func TestIsStaleDirectHookCommandAcrossLaunchers(t *testing.T) {
 	}
 }
 
-// In-repo generation dogfoots the worktree build via `go run` ONLY on
-// launcher-file hosts, whose wrapper scripts probe `go`, discard stderr, and
-// force exit 0. The inline-settings surfaces (codex TOML, settings.json) cannot
-// fail-silent a pre-process `go run` failure, so they stay on the bare
-// `slipway hook ...` command even in-repo (the cmd/root.go floor keeps that
-// fail-silent under version skew).
-func TestInRepoGenerationKeepsInlineSettingsHooksBare(t *testing.T) {
+func TestInRepoGenerationRendersGoRunHookCommands(t *testing.T) {
 	root := t.TempDir()
 	writeSlipwayGoMod(t, root)
 	abs, err := filepath.Abs(root)
 	require.NoError(t, err)
 	require.NoError(t, Generate(root, []string{"codex", "claude", "cursor"}, true))
 
-	// Codex inline TOML hooks must stay on the bare release command and must not
-	// embed a go-run launch that could fail before Slipway starts.
+	// Codex inline TOML hooks launch the worktree source via go run. The command
+	// is stored as a TOML basic string, so backslashes in a Windows path are
+	// escaped (C:\dir -> C:\\dir); the assertion mirrors that encoding. On POSIX
+	// abs has no backslashes, so this is a no-op.
 	codexConfig, err := os.ReadFile(filepath.Join(root, ".codex", "config.toml"))
 	require.NoError(t, err)
 	codex := string(codexConfig)
-	assert.Contains(t, codex, "slipway hook session-start --tool codex")
-	assert.Contains(t, codex, "slipway hook context-pressure --tool codex")
-	assert.NotContains(t, codex, "go -C ", "in-repo codex inline hooks must not embed a go-run launch")
-	assert.NotContains(t, codex, "go run", "in-repo codex inline hooks must not embed a go-run launch")
+	codexAbs := strings.ReplaceAll(abs, `\`, `\\`)
+	assert.Contains(t, codex, "go -C "+codexAbs+" run . hook session-start --tool codex")
+	assert.Contains(t, codex, "go -C "+codexAbs+" run . hook context-pressure --tool codex")
+	assert.NotContains(t, codex, `"slipway hook`, "in-repo codex hooks must not embed the bare release command")
 
-	// Claude inline settings.json hooks must likewise stay bare.
+	// Claude inline settings.json hooks launch the worktree source via go run.
 	claudeSettings := filepath.Join(root, ".claude", "settings.json")
 	sessionCommands := hookCommandsForEvent(t, claudeSettings, "SessionStart")
-	assert.Contains(t, sessionCommands, sessionStartHookCommand)
-	assert.NotContains(t, strings.Join(sessionCommands, "\n"), "go -C ",
-		"in-repo settings.json inline hooks must not embed a go-run launch")
+	assert.Contains(t, sessionCommands, "go -C "+abs+" run . hook session-start")
 	postCommands := hookCommandsForEvent(t, claudeSettings, "PostToolUse")
-	assert.Contains(t, postCommands, contextPressureHookCommand)
-	assert.NotContains(t, strings.Join(postCommands, "\n"), "go -C ",
-		"in-repo settings.json inline hooks must not embed a go-run launch")
+	assert.Contains(t, postCommands, "go -C "+abs+" run . hook context-pressure")
 
-	// Cursor launcher scripts DO dogfood the worktree via go run, but only behind
-	// a fail-silent wrapper that probes `go` and forces exit 0.
+	// Cursor launcher scripts probe `go` and dispatch through go run.
 	launcher, err := os.ReadFile(filepath.Join(root, ".cursor", "hooks", "slipway-session-start"))
 	require.NoError(t, err)
 	l := string(launcher)
@@ -3267,15 +3258,11 @@ func TestNonRepoGenerationKeepsBareSlipwayHookCommands(t *testing.T) {
 	assert.NotContains(t, strings.Join(sessionCommands, "\n"), "go -C ")
 }
 
-// An earlier (buggy) build wrote an inline `go -C <root> run . hook ...` command
-// into settings.json. A refresh — in-repo or release — must prune that stale
-// go-run entry and replace it with the bare command, leaving exactly one Slipway
-// entry and preserving user-authored hooks. This is the upgrade path off the
-// version that embedded a non-fail-silent go-run launch inline.
-func TestRefreshConvertsStaleInlineGoRunHookToBare(t *testing.T) {
-	abs, err := filepath.Abs(t.TempDir())
+func TestInRepoRefreshDoesNotDuplicateAcrossDevReleaseSwitch(t *testing.T) {
+	root := t.TempDir()
+	writeSlipwayGoMod(t, root)
+	abs, err := filepath.Abs(root)
 	require.NoError(t, err)
-	staleGoRun := "go -C " + abs + " run . hook session-start"
 	cfg := ToolConfig{
 		ID:           "claude",
 		SettingsPath: filepath.Join(".claude", "settings.json"),
@@ -3283,49 +3270,58 @@ func TestRefreshConvertsStaleInlineGoRunHookToBare(t *testing.T) {
 		SessionHook:  filepath.Join(".claude", "hooks", "slipway-session-start"),
 	}
 
-	for _, tc := range []struct {
-		name   string
-		inRepo bool
-	}{
-		{"in-repo refresh", true},
-		{"release refresh", false},
-	} {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			root := t.TempDir()
-			if tc.inRepo {
-				writeSlipwayGoMod(t, root)
-			}
-			seed := fmt.Sprintf(`{
-			  "hooks": {
-			    "SessionStart": [
-			      {"hooks":[{"type":"command","command":%q}]},
-			      {"matcher":"*","hooks":[{"type":"command","command":"echo user-owned-hook"}]}
-			    ]
-			  }
-			}`, staleGoRun)
-			settingsPath := filepath.Join(root, cfg.SettingsPath)
-			require.NoError(t, os.MkdirAll(filepath.Dir(settingsPath), 0o755))
-			require.NoError(t, os.WriteFile(settingsPath, []byte(seed), 0o644))
+	// A prior release install left the bare command; an in-repo refresh must
+	// replace it with the go-run form and leave exactly one Slipway entry.
+	seed := `{
+	  "hooks": {
+	    "SessionStart": [
+	      {"hooks":[{"type":"command","command":"slipway hook session-start"}]},
+	      {"matcher":"*","hooks":[{"type":"command","command":"echo user-owned-hook"}]}
+	    ]
+	  }
+	}`
+	settingsPath := filepath.Join(root, cfg.SettingsPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(settingsPath), 0o755))
+	require.NoError(t, os.WriteFile(settingsPath, []byte(seed), 0o644))
 
-			require.NoError(t, mergeHookSettingsJSONWithPlan(root, cfg, true, nil))
+	require.NoError(t, mergeHookSettingsJSONWithPlan(root, cfg, true, nil))
 
-			commands := hookCommandsForEvent(t, settingsPath, "SessionStart")
-			assert.Contains(t, commands, sessionStartHookCommand, "the bare command replaces the stale go-run entry")
-			assert.NotContains(t, strings.Join(commands, "\n"), "go -C ", "the stale inline go-run command must be pruned")
-			assert.Equal(t, 1, countCommandOccurrences(commands, sessionStartHookCommand), "exactly one Slipway session-start entry")
-			assert.Contains(t, commands, "echo user-owned-hook", "user-authored hooks survive")
-		})
-	}
+	commands := hookCommandsForEvent(t, settingsPath, "SessionStart")
+	goRun := "go -C " + abs + " run . hook session-start"
+	assert.Contains(t, commands, goRun)
+	assert.NotContains(t, commands, "slipway hook session-start", "stale bare release command must be pruned")
+	assert.Equal(t, 1, countCommandOccurrences(commands, goRun), "exactly one go-run session-start entry")
+	assert.Contains(t, commands, "echo user-owned-hook", "user-authored hooks survive")
+
+	// Switching back to a release install (no slipway go.mod) prunes the go-run
+	// command and restores the bare form without leaving a duplicate.
+	releaseRoot := t.TempDir()
+	releaseSettings := filepath.Join(releaseRoot, cfg.SettingsPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(releaseSettings), 0o755))
+	devOnRelease := fmt.Sprintf(`{
+	  "hooks": {
+	    "SessionStart": [
+	      {"hooks":[{"type":"command","command":%q}]}
+	    ]
+	  }
+	}`, goRun)
+	require.NoError(t, os.WriteFile(releaseSettings, []byte(devOnRelease), 0o644))
+
+	require.NoError(t, mergeHookSettingsJSONWithPlan(releaseRoot, cfg, true, nil))
+	releaseCommands := hookCommandsForEvent(t, releaseSettings, "SessionStart")
+	assert.Contains(t, releaseCommands, sessionStartHookCommand)
+	assert.NotContains(t, strings.Join(releaseCommands, "\n"), "go -C ", "stale go-run command must be pruned on release")
+	assert.Equal(t, 1, countCommandOccurrences(releaseCommands, sessionStartHookCommand))
 }
 
 // A user who hand-writes a `go run . hook ...` entry (a form Slipway never
-// generates — Slipway's go-run launches always carry the `-C <root>` flag) must
-// keep it across a refresh: stale-hook pruning is scoped to Slipway-owned
-// launcher forms. The managed entry stays the bare `slipway hook ...` command.
-func TestRefreshKeepsUserAuthoredBareGoRunHook(t *testing.T) {
+// generates — it always emits `go -C <root> run .`) must keep it across an
+// in-repo refresh: stale-hook pruning is scoped to Slipway-owned launcher forms.
+func TestInRepoRefreshKeepsUserAuthoredBareGoRunHook(t *testing.T) {
 	root := t.TempDir()
 	writeSlipwayGoMod(t, root)
+	abs, err := filepath.Abs(root)
+	require.NoError(t, err)
 	cfg := ToolConfig{
 		ID:           "claude",
 		SettingsPath: filepath.Join(".claude", "settings.json"),
@@ -3349,11 +3345,10 @@ func TestRefreshKeepsUserAuthoredBareGoRunHook(t *testing.T) {
 	require.NoError(t, mergeHookSettingsJSONWithPlan(root, cfg, true, nil))
 
 	commands := hookCommandsForEvent(t, settingsPath, "SessionStart")
-	assert.Contains(t, commands, sessionStartHookCommand, "the managed bare entry survives")
-	assert.Equal(t, 1, countCommandOccurrences(commands, sessionStartHookCommand), "no duplicate managed entry")
+	assert.Contains(t, commands, "go -C "+abs+" run . hook session-start", "the managed go-run entry is merged in")
+	assert.NotContains(t, commands, "slipway hook session-start", "the stale bare release entry is pruned")
 	assert.Contains(t, commands, userHook, "a user-authored bare `go run .` hook must survive refresh")
 }
-
 func countCommandOccurrences(items []string, target string) int {
 	n := 0
 	for _, item := range items {


### PR DESCRIPTION
## Problem

PR #317 added in-repo `go -C <root> run .` hook rendering, but wired it **only into launcher-file hosts** (cursor, opencode). The **inline-config surfaces — codex `config.toml` and `settings.json` — were left on the bare `slipway hook ... --tool codex` form** on the rationale that an inline single string can't attach a fail-silent guard.

That rationale assumes the bare `slipway` on PATH resolves a release that understands the current flags. It doesn't hold under the exact case the go-run feature targets — **dogfooding a newer worktree while an older `slipway` is on PATH**:

- the PATH `slipway` (e.g. 0.32.1) predates `--tool` → bare hook exits non-zero with `unknown flag: --tool`
- Codex surfaces that as a **block, on every session**
- `slipway init` from the repo root **re-renders the bare form every time**, so the block was unfixable from the public surface ("init 一万次没用")

## Fix

Adopt the in-repo go-run launch for the inline-config surfaces too (`renderCodexHooksBlock` + the `settings.json` merge path now apply `applyHookLaunchPrefix`).

- `.codex/config.toml` and `settings.json` are **per-machine (gitignored)**, so the rewrite is rendered for the local host and never shared across platforms — the cross-platform concern that retired the `|| exit 0` form does not apply.
- go-run **tracks the worktree HEAD** and always understands the current flag set.
- Residual edge: a worktree that fails to compile makes `go run` exit non-zero — rarer and more self-evident for an in-repo developer than the version-skew break it replaces.
- **Non-repo generation is unchanged**: still the bare, PATH-resolved command.

## Evidence

- `go test ./...` — 28 packages green; `gofmt` clean.
- Dogfood: `slipway init --refresh --tools codex` from the repo root now renders `go -C <repo> run . hook ... --tool codex`; both hooks exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)