### PR TITLE
feat(handoff): close session-handoff continuity loop (W2 pressure escalation, R2 resume protocol, R3 SessionStart cleanup)

### DIFF
--- a/artifacts/changes/archived/close-the-per-change-session-handoff-continuity-loop-by-wiri/change.yaml
+++ b/artifacts/changes/archived/close-the-per-change-session-handoff-continuity-loop-by-wiri/change.yaml
@@ -1,0 +1,39 @@
+version: 1
+slug: close-the-per-change-session-handoff-continuity-loop-by-wiri
+description: 'Close the per-change session-handoff continuity loop by wiring its WRITE trigger and READ resume-protocol onto Slipway''s public surfaces. The `slipway handoff write/show` command already shipped (#312); today nothing auto-triggers a handoff write and no documented resume path tells a fresh session how to re-enter a specific change, so the loop stays 100% manual. v1 scope = two directive-only wires: (W2) escalate the context-pressure hook''s CRITICAL-threshold message from a soft suggestion into an imperative directive that tells the agent to author the handoff NOW via `slipway handoff write --section <name>` before its next action (covering long-stage mid-flight context death that stage-completion can''t); (R2) add a ''Continuing A Change In A Fresh Session'' resume-protocol section to the generated slipway workflow skill (status --json -> pick --change if multi-active -> handoff show --change <slug> -> next), plus a toolgen test guard asserting the section ships. No engine auto-write of bytes: the WRITE is auto-TRIGGERED at the right moment but the narrative judgment is authored by the agent, so handoff updated_at stays tied to real authoring and staleness stays honest. Deferred and explicitly out of scope: W1 stage-completion directive in cmd/run.go, R3 stripping session_start_hook auto change-state lines, and the engine metadata/fact auto-write floor. This alters public contracts (the host-automation hook message and the generated skill surface) so it runs through the governed flow for formal contract review.'
+status: done
+current_state: DONE
+complexity_level: simple
+base_ref: HEAD
+created_at: 2026-06-24T03:04:31.284117Z
+quality_mode: standard
+workflow_preset: light
+worktree_branch: feat/close-the-per-change-session-handoff-continuity-loop-by-wiri
+artifact_schema: core
+artifacts:
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: a657aa7e20468cef43fe90fa9383b831363a35649182805d8c3c20283950c09a
+        updated_at: 2026-06-24T03:19:25.923749239Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: 1f4ffdc74b29be96396d650094ed97500039687e864a1da658fd491d16d185ca
+        updated_at: 2026-06-24T03:22:27.698165723Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: 54bc3ba065bfa284dbd4bace2c818487ad3b46e795daeec359d57eb201b71419
+        updated_at: 2026-06-24T03:48:57.949148762Z
+evidence_refs:
+    code-quality-review: .worktrees/close-the-per-change-session-handoff-continuity-loop-by-wiri/artifacts/changes/close-the-per-change-session-handoff-continuity-loop-by-wiri/verification/code-quality-review.yaml
+    goal-verification: .worktrees/close-the-per-change-session-handoff-continuity-loop-by-wiri/artifacts/changes/close-the-per-change-session-handoff-continuity-loop-by-wiri/verification/goal-verification.yaml
+    independent-review: .worktrees/close-the-per-change-session-handoff-continuity-loop-by-wiri/artifacts/changes/close-the-per-change-session-handoff-continuity-loop-by-wiri/verification/independent-review.yaml
+    intake-clarification: .worktrees/close-the-per-change-session-handoff-continuity-loop-by-wiri/artifacts/changes/close-the-per-change-session-handoff-continuity-loop-by-wiri/verification/intake-clarification.yaml
+    plan-audit: .worktrees/close-the-per-change-session-handoff-continuity-loop-by-wiri/artifacts/changes/close-the-per-change-session-handoff-continuity-loop-by-wiri/verification/plan-audit.yaml
+    spec-compliance-review: .worktrees/close-the-per-change-session-handoff-continuity-loop-by-wiri/artifacts/changes/close-the-per-change-session-handoff-continuity-loop-by-wiri/verification/spec-compliance-review.yaml
+    wave-orchestration: .worktrees/close-the-per-change-session-handoff-continuity-loop-by-wiri/artifacts/changes/close-the-per-change-session-handoff-continuity-loop-by-wiri/verification/wave-orchestration.yaml

--- a/artifacts/changes/archived/close-the-per-change-session-handoff-continuity-loop-by-wiri/intent.md
+++ b/artifacts/changes/archived/close-the-per-change-session-handoff-continuity-loop-by-wiri/intent.md
@@ -1,0 +1,129 @@
+# Intent
+
+## Summary
+Close the per-change session-handoff continuity loop by aligning its WRITE trigger and READ surfaces around Slipway's public CLI. The `slipway handoff write/show` command already shipped (#312); today nothing auto-triggers a handoff write, no documented resume path tells a fresh session how to re-enter a specific change, and a global SessionStart hook auto-injects change-state every session (it pushed a stale phantom binding into this very session). v1 scope = three coordinated edits: (W2) escalate the context-pressure hook's CRITICAL-threshold message from a soft suggestion into an imperative directive that tells the agent to author the handoff NOW via `slipway handoff write --section <name>` before its next action (covering long-stage mid-flight context death); (R2) add a 'Continuing A Change In A Fresh Session' resume-protocol section to the generated slipway workflow skill (status --json -> pick --change if multi-active -> handoff show --change <slug> -> next), plus a toolgen test guard; (R3) delete the redundant read-side SessionStart change-state injection so the explicit R2 path is the single sanctioned read surface, keeping only the entry-skill routing pointer. No engine auto-write of bytes: the WRITE is auto-TRIGGERED at the right moment but the narrative judgment is authored by the agent, so handoff updated_at stays tied to real authoring and staleness stays honest. Deferred and explicitly out of scope: W1 stage-completion directive in cmd/run.go and the engine metadata/fact auto-write floor. This alters public contracts (the context-pressure hook message, the generated skill surface, and the SessionStart hook output) so it runs through the governed flow for formal contract review.
+## Complexity Assessment
+simple
+<!-- Rationale: -->
+The design is fully converged (no discovery). Scope is two directive-only edits
+plus one test guard plus one mechanical hook simplification (delete the redundant
+SessionStart change-state injection and its now-dead helpers). It touches a hook
+message, a generated-skill template, a toolgen test, and the SessionStart hook —
+all in `cmd/` and `internal/`. No new commands, gates, hooks, or schema; the
+work is well-understood and low-risk per surface. The sensitivity is that three
+edits touch public contracts (the context-pressure hook message, the generated
+skill surface, and the SessionStart hook output), which is why this runs through
+the governed flow for contract review rather than a direct edit.
+
+## In Scope
+- **W2 — escalate the context-pressure hook CRITICAL message.** In
+  `cmd/context_pressure_hook.go`, the `contextPressureMessage` CRITICAL-threshold
+  branch (ratio >= 0.70) changes from a soft suggestion into an imperative
+  directive: tell the agent to author the handoff NOW, before its next action,
+  via `slipway handoff write --section <name>` for the judgment sections
+  (Current Position, Next Session Focus, Risks And Blockers). The WARNING branch
+  (ratio >= 0.60) stays soft.
+- **R2 — documented fresh-session resume protocol.** In
+  `internal/tmpl/templates/skills/workflow/SKILL.md.tmpl`, add a
+  "Continuing A Change In A Fresh Session" section after the existing
+  `## Runtime Session Handoff` block: `slipway status --json` -> pick `--change`
+  when multiple changes are active -> `slipway handoff show --change <slug>`
+  (read the narrative first) -> `slipway next`.
+- **R2 guard — toolgen test.** In `internal/toolgen/toolgen_test.go`, add a guard
+  asserting the generated slipway workflow skill ships the resume-protocol
+  section, so the contract can't silently regress.
+- **R3 — delete the redundant read-side SessionStart hook injection.** In
+  `cmd/session_start_hook.go`, stop auto-injecting change-state into every
+  session: remove the active-worktree `next --json` view, the bound-elsewhere
+  `session_handoff_info: ... bound to <worktree>` pointer, and the
+  `session_handoff_present`/path/brief summary. KEEP the `slipway_entry_skill`
+  routing pointer (it now routes the agent to the slipway skill carrying the R2
+  resume protocol). Remove the helpers that become dead
+  (`sessionStartNextJSON`, `sessionStartBoundWorktreeHandoff`,
+  `firstBoundChange`, `sessionStartHandoffSummary`, and now-unused output
+  plumbing) and update `cmd/session_start_hook_test.go` to the entry-skill-only
+  contract. This makes the explicit R2 resume path the single sanctioned read
+  surface instead of competing with a global auto-read that injects stale /
+  phantom bindings (observed live this session).
+- Regenerate any committed generated skill artifacts that the template change
+  affects, so the generated surface stays in sync with its template.
+
+## Out of Scope
+- **W1** — stage-completion handoff directive in `cmd/run.go` after a real
+  advance plus `next` Warnings rendering. Deferred.
+- **Engine metadata/fact auto-write floor** — engine writing handoff bytes or
+  auto-bumping `updated_at`. Deferred on purpose: auto-bump would let
+  `HandoffStaleness` report fresh on an unwritten judgment section.
+- No changes to the `slipway handoff` command itself (shipped in #312), no new
+  hook, no PreCompact wiring, no lifecycle-gate changes. Handoff stays
+  advisory-only — not authority, evidence, freshness input, or a gate.
+
+## Constraints
+- The W2 message MUST keep the substrings the existing hook tests assert:
+  `slipway handoff write`, `The handoff is advisory`, `slipway status --json`,
+  `slipway next --json`; and MUST avoid `lifecycle authority`,
+  `governed evidence`, `freshness input` (wording that would falsely elevate the
+  advisory handoff into authority).
+- No engine auto-write of handoff bytes, so `updated_at` stays tied to real
+  agent authoring and `HandoffStaleness` cannot lie.
+- The generated skill surface stays hook-agnostic / portable across hosts
+  (Claude, Codex): the resume protocol uses only CLI commands.
+- R3 keeps the SessionStart hook's `slipway_entry_skill` routing pointer and its
+  fail-silent (exit 0) contract on both the Claude XML and Codex JSON output
+  paths; only change-state injection is removed.
+- Preserve unrelated active work (the `merge-the-goal-verification-...`
+  S1_PLAN change in its own worktree).
+
+## Acceptance Signals
+- `go test ./...` is green across all packages, including the new toolgen guard.
+- The context-pressure hook tests pass with the escalated imperative wording and
+  all four required substrings retained; none of the forbidden substrings appear.
+- The generated slipway workflow skill (`.claude/skills/slipway/SKILL.md` and the
+  equivalent generated host surfaces) contains the
+  "Continuing A Change In A Fresh Session" resume-protocol section with the
+  status -> change -> handoff show -> next sequence.
+- The SessionStart hook output contains only the `slipway_entry_skill` routing
+  pointer (plus hard-error diagnostics); it no longer emits any
+  `session_handoff_info`, active-change `next --json`, or `session_handoff_*`
+  change-state. `cmd/session_start_hook_test.go` is updated to assert this
+  entry-skill-only contract and stays green.
+- `gofmt -s` / golangci-lint clean; the architecture test passes.
+
+## Open Questions
+None — design converged; `needs_discovery` is false.
+
+## Approved Summary
+Close the per-change session-handoff continuity loop with three coordinated edits
+that make Slipway's public CLI the single sanctioned handoff surface:
+
+- **W2 (write trigger):** `cmd/context_pressure_hook.go` CRITICAL-threshold
+  message (ratio >= 0.70) escalates from a soft suggestion into an imperative
+  directive — author the handoff NOW, before the next action, via
+  `slipway handoff write --section <name>`. WARNING stays soft.
+- **R2 (read/resume):** the generated slipway workflow skill gains a
+  "Continuing A Change In A Fresh Session" resume-protocol section
+  (`status --json` -> pick `--change` if multi-active ->
+  `handoff show --change <slug>` -> `next`), guarded by a toolgen test.
+- **R3 (delete redundant hook):** `cmd/session_start_hook.go` stops
+  auto-injecting change-state every session (removes the active-worktree
+  `next --json` view, the bound-elsewhere `session_handoff_info` pointer, and the
+  handoff summary), keeping ONLY the `slipway_entry_skill` routing pointer that
+  routes the agent to the skill carrying R2. Dead helpers and the hook test are
+  updated to the entry-skill-only contract.
+
+The engine never auto-writes handoff bytes, so `updated_at` stays tied to real
+agent authoring and `HandoffStaleness` stays honest. Handoff remains
+advisory-only — not authority, evidence, freshness input, or a gate.
+
+**Out of scope (deferred):** W1 (stage-completion handoff directive in
+`cmd/run.go` + `next` Warnings rendering) and the engine metadata/fact
+auto-write floor.
+
+**Primary acceptance signal:** `go test ./...` green across all packages,
+including the new toolgen guard and the updated SessionStart hook test, with the
+context-pressure hook tests passing under the escalated wording (four required
+substrings kept, authority-elevating ones avoided).
+
+Confirmed by user on 2026-06-24 (scope expanded from W2+R2 to add R3 at user
+request; R3 deletion boundary confirmed: keep `slipway_entry_skill`, remove only
+the change-state auto-injection).

--- a/artifacts/changes/archived/close-the-per-change-session-handoff-continuity-loop-by-wiri/requirements.md
+++ b/artifacts/changes/archived/close-the-per-change-session-handoff-continuity-loop-by-wiri/requirements.md
@@ -1,0 +1,93 @@
+# Requirements
+
+## Requirements
+
+### Requirement: Context-pressure CRITICAL message is an imperative write directive
+REQ-001: At the CRITICAL context-pressure threshold (ratio >= 0.70) the hook
+message produced by `contextPressureMessage` MUST be an imperative directive that
+tells the agent to author the per-change handoff NOW, before its next action, via
+`slipway handoff write --section <name>`, naming the judgment sections to write.
+The WARNING threshold (ratio in [0.60, 0.70)) MUST remain a soft, non-imperative
+suggestion.
+
+#### Scenario: CRITICAL pressure emits an imperative write directive
+GIVEN the context-usage ratio is at or above 0.70
+WHEN the context-pressure hook renders its message
+THEN the message imperatively directs the agent to author the handoff before its
+next action via `slipway handoff write --section`
+AND it names handoff judgment sections to write.
+
+#### Scenario: WARNING pressure stays a soft suggestion
+GIVEN the context-usage ratio is at or above 0.60 but below 0.70
+WHEN the context-pressure hook renders its message
+THEN the message remains a soft suggestion and is not an imperative "now" directive.
+
+### Requirement: Generated slipway skill documents the fresh-session resume protocol
+REQ-002: The generated slipway workflow skill (`SKILL.md`) MUST include a
+"Continuing A Change In A Fresh Session" resume-protocol section that documents
+the explicit read path: run `slipway status --json`, select `--change` when more
+than one change is active, run `slipway handoff show --change <slug>` to read the
+narrative first, then `slipway next`.
+
+#### Scenario: Resume protocol is present in the generated skill
+GIVEN the generated slipway workflow skill
+WHEN its content is inspected
+THEN it contains a "Continuing A Change In A Fresh Session" section
+AND that section names the `slipway status --json` -> `--change` ->
+`slipway handoff show --change` -> `slipway next` sequence.
+
+### Requirement: A contract test guards the resume protocol against regression
+REQ-003: The toolgen test suite MUST assert that the generated slipway workflow
+skill ships the resume-protocol section, so the section cannot silently regress
+out of the generated surface.
+
+#### Scenario: Removing the resume section fails the guard
+GIVEN the toolgen test suite
+WHEN the generated slipway workflow skill does not contain the resume-protocol
+section
+THEN a toolgen test fails.
+
+### Requirement: SessionStart hook stops auto-injecting change-state
+REQ-004: The SessionStart hook MUST NOT auto-inject per-session change-state —
+neither the active-worktree `next --json` view, nor the bound-elsewhere
+`session_handoff_info: ... bound to <worktree>` pointer, nor the
+`session_handoff_present` / `session_handoff_path` / handoff-brief summary. It
+MUST still emit the `slipway_entry_skill` routing pointer and MUST remain
+fail-silent (exit 0) on both the Claude XML and Codex JSON output paths.
+
+#### Scenario: Bound-elsewhere session emits only the entry-skill pointer
+GIVEN a session opens in a worktree with no active change of its own while a
+change is bound to another worktree
+WHEN the SessionStart hook runs
+THEN its output contains the `slipway_entry_skill` routing pointer
+AND its output contains no `session_handoff_info`, no active-change `next --json`
+payload, and no `session_handoff_present` / `session_handoff_path` change-state.
+
+#### Scenario: Hook stays fail-silent on internal error
+GIVEN the SessionStart hook encounters an internal error (for example a root or
+state-lock failure)
+WHEN it runs
+THEN it still exits 0 and never surfaces a blocking failure.
+
+### Requirement: Handoff stays advisory and the engine never auto-writes its bytes
+REQ-005: The change MUST NOT introduce any engine auto-writing of handoff bytes
+or auto-bumping of handoff `updated_at`, so handoff freshness stays tied to real
+agent authoring. The escalated CRITICAL message MUST retain the substrings the
+hook contract asserts (`slipway handoff write`, `The handoff is advisory`,
+`slipway status --json`, `slipway next --json`) and MUST avoid authority-elevating
+wording (`lifecycle authority`, `governed evidence`, `freshness input`).
+
+#### Scenario: Escalated message keeps required substrings and avoids forbidden ones
+GIVEN the escalated CRITICAL context-pressure message
+WHEN its text is inspected
+THEN it contains `slipway handoff write`, `The handoff is advisory`,
+`slipway status --json`, and `slipway next --json`
+AND it contains none of `lifecycle authority`, `governed evidence`, or
+`freshness input`.
+
+#### Scenario: No new engine handoff auto-write path is introduced
+GIVEN the implemented change
+WHEN the handoff write surfaces are reviewed
+THEN no engine code path writes handoff bytes or bumps handoff `updated_at`
+automatically; handoff bytes are written only by an explicit
+`slipway handoff write` invocation.

--- a/artifacts/changes/archived/close-the-per-change-session-handoff-continuity-loop-by-wiri/tasks.md
+++ b/artifacts/changes/archived/close-the-per-change-session-handoff-continuity-loop-by-wiri/tasks.md
@@ -1,0 +1,21 @@
+# Tasks
+
+## Task List
+
+- [x] `t-01` Escalate the context-pressure hook CRITICAL message into an imperative "author the handoff now" write directive; keep WARNING soft and retain the required substrings while avoiding authority-elevating wording
+  - depends_on: []
+  - target_files: [cmd/context_pressure_hook.go, cmd/context_pressure_hook_test.go]
+  - task_kind: code
+  - covers: [REQ-001, REQ-005]
+
+- [x] `t-02` Remove the SessionStart hook's change-state auto-injection (active-worktree next view, bound-elsewhere session_handoff_info pointer, handoff summary) and its now-dead helpers; keep only the slipway_entry_skill routing pointer and the fail-silent contract; update the hook test
+  - depends_on: []
+  - target_files: [cmd/session_start_hook.go, cmd/session_start_hook_test.go, cmd/auto_mode_test.go]
+  - task_kind: code
+  - covers: [REQ-004]
+
+- [x] `t-03` Add a "Continuing A Change In A Fresh Session" resume-protocol section to the generated slipway workflow skill template after the Runtime Session Handoff block, and add a toolgen guard asserting the generated skill ships it
+  - depends_on: []
+  - target_files: [internal/tmpl/templates/skills/workflow/SKILL.md.tmpl, internal/toolgen/toolgen_test.go]
+  - task_kind: code
+  - covers: [REQ-002, REQ-003]

--- a/cmd/auto_mode_test.go
+++ b/cmd/auto_mode_test.go
@@ -681,14 +681,18 @@ func approvedSummarySection(intent string) string {
 }
 
 // (finding #5) Config-level execution.auto must reach the real command entry
-// points, not just the helper layer. These drive `slipway intake` through the
-// root cobra command and the `session-start` hook through makeHookCmd, with auto
-// set only via .slipway.yaml. At S0 intake the next skill is intake-clarification
-// (a skill_handoff), so non-guardrail auto softens the boundary to
-// evidence_continuation while a guardrail domain — and auto off — keep the
-// hard_stop. The guardrail-vs-non-guardrail pair proves both that auto was read
-// from config and threaded, and that the guardrail exclusion still fails closed
-// through these entries.
+// points, not just the helper layer. This drives `slipway intake` through the
+// root cobra command with auto set only via .slipway.yaml. At S0 intake the next
+// skill is intake-clarification (a skill_handoff), so non-guardrail auto softens
+// the boundary to evidence_continuation while a guardrail domain — and auto off —
+// keep the hard_stop. The guardrail-vs-non-guardrail pair proves both that auto
+// was read from config and threaded, and that the guardrail exclusion still fails
+// closed through this entry.
+//
+// The SessionStart hook is intentionally not exercised here: it no longer injects
+// the auto-softened `next --json` change-state view (REQ-004 retired that
+// auto-injection); it emits only the slipway_entry_skill routing pointer. The
+// stage command remains the real entry that threads execution.auto.
 func TestConfigAutoReachesStageAndHookEntries(t *testing.T) {
 	setup := func(t *testing.T, auto bool, guardrail string) string {
 		t.Helper()
@@ -732,34 +736,6 @@ func TestConfigAutoReachesStageAndHookEntries(t *testing.T) {
 
 		off := stageJSON(t, setup(t, false, ""))
 		assert.Contains(t, off, "hard_stop", "auto off must keep the legacy hard_stop")
-	})
-
-	t.Run("session_start_hook", func(t *testing.T) {
-		hookJSON := func(t *testing.T, root string) string {
-			t.Helper()
-			var out string
-			withWorkspace(t, root, func() {
-				cmd := makeHookCmd()
-				cmd.SetArgs([]string{"session-start", "--tool", "claude"})
-				var buf bytes.Buffer
-				cmd.SetOut(&buf)
-				require.NoError(t, cmd.Execute())
-				out = buf.String()
-			})
-			return out
-		}
-
-		soft := hookJSON(t, setup(t, true, ""))
-		assert.Contains(t, soft, "evidence_continuation",
-			"config auto must thread into the session-start hook view")
-		assert.NotContains(t, soft, "hard_stop")
-
-		guard := hookJSON(t, setup(t, true, string(model.GuardrailDomainAuthAuthZ)))
-		assert.Contains(t, guard, "hard_stop",
-			"guardrail domain must keep the hook view hard-stop under auto")
-
-		off := hookJSON(t, setup(t, false, ""))
-		assert.Contains(t, off, "hard_stop", "auto off must keep the hook view hard-stop")
 	})
 }
 

--- a/cmd/context_pressure_hook.go
+++ b/cmd/context_pressure_hook.go
@@ -492,11 +492,14 @@ func contextPressureMessage(result contextPressureResult) string {
 	switch result.State {
 	case contextPressureCritical:
 		return fmt.Sprintf(
-			"CONTEXT CRITICAL: usage is approximately %d%%. Context pressure is high; "+
-				"run `slipway handoff write` to refresh the per-change advisory handoff "+
-				"before continuing in a fresh context. "+
-				"The handoff is advisory; fresh sessions still run `slipway status --json` "+
-				"and `slipway next --json`.",
+			"CONTEXT CRITICAL: usage is approximately %d%% (>= 70%%). Author the per-change "+
+				"handoff NOW, before your next action, so the next session can continue: run "+
+				"`slipway handoff write --section \"Current Position\"`, "+
+				"`slipway handoff write --section \"Next Session Focus\"`, and "+
+				"`slipway handoff write --section \"Risks And Blockers\"` to capture your "+
+				"current judgment in those sections. "+
+				"The handoff is advisory; the next session still runs `slipway status --json` "+
+				"and `slipway next --json` before acting.",
 			result.Percent,
 		)
 	default:

--- a/cmd/context_pressure_hook_test.go
+++ b/cmd/context_pressure_hook_test.go
@@ -88,8 +88,16 @@ func TestContextPressureHookCommandEmitsAdditionalContextAtCriticalThreshold(t *
 	assert.Contains(t, additionalContext, "The handoff is advisory")
 	assert.Contains(t, additionalContext, "slipway status --json")
 	assert.Contains(t, additionalContext, "slipway next --json")
+	assert.Contains(t, additionalContext, "70%")
+	// The CRITICAL message is an imperative "author the handoff now" directive that
+	// names the judgment sections to write via `slipway handoff write --section`.
+	assert.Contains(t, additionalContext, "NOW, before your next action")
+	assert.Contains(t, additionalContext, `slipway handoff write --section "Current Position"`)
+	assert.Contains(t, additionalContext, `slipway handoff write --section "Next Session Focus"`)
+	assert.Contains(t, additionalContext, `slipway handoff write --section "Risks And Blockers"`)
 	assert.NotContains(t, additionalContext, "lifecycle authority")
 	assert.NotContains(t, additionalContext, "governed evidence")
+	assert.NotContains(t, additionalContext, "freshness input")
 }
 
 func TestContextPressureHookCommandReadsLiveUsageFromClaudeTranscript(t *testing.T) {
@@ -239,6 +247,16 @@ func TestContextPressureMessagesKeepRuntimeHandoffAdvisory(t *testing.T) {
 	assert.Contains(t, critical, "slipway status --json")
 	assert.Contains(t, critical, "slipway next --json")
 	assert.Contains(t, warning, "slipway handoff write")
+
+	// The CRITICAL message is escalated into an imperative "author the handoff
+	// now" directive naming the judgment sections, while the WARNING message stays
+	// a soft suggestion that does not issue an imperative "now" directive.
+	assert.Contains(t, critical, "NOW, before your next action")
+	assert.Contains(t, critical, `slipway handoff write --section "Current Position"`)
+	assert.Contains(t, critical, `slipway handoff write --section "Next Session Focus"`)
+	assert.Contains(t, critical, `slipway handoff write --section "Risks And Blockers"`)
+	assert.NotContains(t, warning, "NOW, before your next action")
+	assert.NotContains(t, warning, "--section")
 
 	for name, message := range map[string]string{
 		"critical": critical,

--- a/cmd/handoff.go
+++ b/cmd/handoff.go
@@ -163,15 +163,6 @@ func readHandoffDocument(root, changeSlug string) (state.HandoffDocument, bool, 
 	return doc, true, nil
 }
 
-func handoffBriefForChange(root, changeSlug string) (string, bool, error) {
-	doc, ok, err := readHandoffDocument(root, changeSlug)
-	if err != nil || !ok {
-		return "", ok, err
-	}
-	brief := state.HandoffBrief(doc)
-	return brief, strings.TrimSpace(brief) != "", nil
-}
-
 func resolveHandoffChangeRef(root, changeSlug string) (changeRef, bool, error) {
 	ref, err := resolveActiveChangeRef(root, changeSlug)
 	if err == nil {

--- a/cmd/session_start_hook.go
+++ b/cmd/session_start_hook.go
@@ -2,12 +2,9 @@ package cmd
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
-	"os"
 	"strings"
 
-	"github.com/signalridge/slipway/internal/state"
 	"github.com/spf13/cobra"
 )
 
@@ -17,13 +14,13 @@ func makeSessionStartHookCmd() *cobra.Command {
 	var toolID string
 	cmd := &cobra.Command{
 		Use:    "session-start",
-		Short:  "Emit SessionStart Slipway handoff context",
+		Short:  "Emit SessionStart Slipway entry-skill routing pointer",
 		Hidden: true,
 		Args:   cobra.NoArgs,
 		Run: func(cmd *cobra.Command, _ []string) {
 			// Fail silent: this hook is inlined into automatic host hooks and must
 			// never surface a blocking or non-zero failure. Any internal error
-			// (root lookup, state lock, JSON, write) is swallowed to a clean exit 0.
+			// (root lookup, JSON, write) is swallowed to a clean exit 0.
 			_ = runSessionStartHook(cmd, toolID)
 		},
 	}
@@ -31,131 +28,29 @@ func makeSessionStartHookCmd() *cobra.Command {
 	return cmd
 }
 
+// runSessionStartHook emits only the slipway_entry_skill routing pointer. It no
+// longer auto-injects per-session change-state (no active-worktree `next --json`
+// view, no bound-elsewhere handoff pointer, no handoff-brief summary): the
+// per-change handoff is authored explicitly and read with `slipway handoff show
+// --change <slug>`; lifecycle authority comes from `slipway status --json` /
+// `slipway next --json`. The only conditional output is a hard-error diagnostic
+// when the project root cannot be resolved.
 func runSessionStartHook(cmd *cobra.Command, toolID string) error {
 	toolID = strings.TrimSpace(toolID)
 
-	root, err := projectRootFromCommand(cmd)
-	if err != nil {
-		return writeSessionStartHookOutput(
-			cmd.OutOrStdout(),
-			toolID,
-			"",
-			"",
-			[]string{"hook_diagnostic: slipway root failed: " + normalizeHookDiagnostic(err.Error())},
-			"",
-		)
+	var diagnostics []string
+	if _, err := projectRootFromCommand(cmd); err != nil {
+		diagnostics = append(diagnostics, "hook_diagnostic: slipway root failed: "+normalizeHookDiagnostic(err.Error()))
 	}
-
-	var (
-		diagnostics []string
-		handoffInfo string
-		changeSlug  string
-	)
-	nextJSON, changeSlug, err := sessionStartNextJSON(cmd, root)
-	if err != nil {
-		// A change bound to another worktree is an expected, informational state
-		// when a session opens with no active change of its own: point the host
-		// at the bound change instead of an alarming next-failed diagnostic.
-		if handoffInfo = sessionStartBoundWorktreeHandoff(err); handoffInfo == "" {
-			diagnostics = append(diagnostics, "hook_diagnostic: slipway next --json failed: "+normalizeHookDiagnostic(err.Error()))
-		}
-	}
-
-	handoffSummary := sessionStartHandoffSummary(root, changeSlug)
-	if nextJSON == "" && handoffInfo == "" && handoffSummary == "" && len(diagnostics) == 0 {
-		return nil
-	}
-	return writeSessionStartHookOutput(cmd.OutOrStdout(), toolID, nextJSON, handoffInfo, diagnostics, handoffSummary)
+	return writeSessionStartHookOutput(cmd.OutOrStdout(), toolID, diagnostics)
 }
 
-// sessionStartBoundWorktreeHandoff renders the friendly informational line for
-// the change_bound_to_other_worktree precondition. When a session opens where
-// no change is active for the current worktree while a change is bound
-// elsewhere, the host is pointed at that change instead of seeing an alarming
-// "next --json failed" diagnostic. Returns "" for any other error or when the
-// bound change details are incomplete, so the caller falls back to the
-// diagnostic path.
-func sessionStartBoundWorktreeHandoff(err error) string {
-	cliErr := asCLIError(err)
-	if cliErr == nil || cliErr.ErrorCode != "change_bound_to_other_worktree" {
-		return ""
-	}
-	slug, worktreePath := firstBoundChange(cliErr.Details)
-	if slug == "" || worktreePath == "" {
-		return ""
-	}
-	return fmt.Sprintf(
-		"session_handoff_info: no active change in this worktree; active change %s is bound to %s; cd there or use --change %s to act",
-		slug, worktreePath, slug,
-	)
-}
-
-// firstBoundChange extracts the slug and worktree path of the first bound change
-// from a change_bound_to_other_worktree error's details payload.
-func firstBoundChange(details map[string]any) (slug, worktreePath string) {
-	changes, ok := details["bound_changes"].([]map[string]string)
-	if !ok || len(changes) == 0 {
-		return "", ""
-	}
-	return changes[0]["slug"], changes[0]["worktree_path"]
-}
-
-func sessionStartNextJSON(cmd *cobra.Command, root string) (string, string, error) {
-	ref, err := resolveActiveChangeRef(root, "")
-	if err != nil {
-		return "", "", err
-	}
-
-	auto, err := resolveEffectiveAuto(root, nil, false, false)
-	if err != nil {
-		return "", "", err
-	}
-
-	var out string
-	err = withChangeStateLock(root, ref.Slug, "hook session-start", func() error {
-		view, err := buildNextHandoffSourceView(root, ref, true, false, false, auto)
-		if err != nil {
-			return err
-		}
-		applyNextInvocationWorkspacePath(cmd, root, &view)
-		raw, err := json.MarshalIndent(buildNextHandoffView(view), "", "  ")
-		if err != nil {
-			return err
-		}
-		out = string(raw)
-		return nil
-	})
-	return out, ref.Slug, err
-}
-
-func sessionStartHandoffSummary(root, slug string) string {
-	slug = strings.TrimSpace(slug)
-	if slug == "" {
-		return ""
-	}
-	if err := state.ValidateChangeSlug(slug); err != nil {
-		return ""
-	}
-	handoffPath := state.ChangeHandoffPath(root, slug)
-	if brief, ok, err := handoffBriefForChange(root, slug); err == nil && ok {
-		if before, _, ok := strings.Cut(brief, " focus="); ok {
-			return before
-		}
-		return brief
-	}
-	present := "false"
-	if _, err := os.Stat(handoffPath); err == nil {
-		present = "true"
-	}
-	return fmt.Sprintf("session_handoff_present: %s\nsession_handoff_path: %s", present, handoffPath)
-}
-
-func writeSessionStartHookOutput(w io.Writer, toolID, nextJSON, handoffInfo string, diagnostics []string, handoffSummary string) error {
+func writeSessionStartHookOutput(w io.Writer, toolID string, diagnostics []string) error {
 	if strings.EqualFold(strings.TrimSpace(toolID), "codex") {
 		output := map[string]any{
 			"hookSpecificOutput": map[string]any{
 				"hookEventName":     "SessionStart",
-				"additionalContext": sessionStartAdditionalContext(toolID, nextJSON, handoffInfo, diagnostics, handoffSummary),
+				"additionalContext": sessionStartAdditionalContext(toolID, diagnostics),
 			},
 		}
 		encoded, err := json.Marshal(output)
@@ -165,11 +60,11 @@ func writeSessionStartHookOutput(w io.Writer, toolID, nextJSON, handoffInfo stri
 		_, _ = w.Write(encoded)
 		return nil
 	}
-	_, err := io.WriteString(w, sessionStartXMLContext(toolID, nextJSON, handoffInfo, diagnostics, handoffSummary))
+	_, err := io.WriteString(w, sessionStartXMLContext(toolID, diagnostics))
 	return err
 }
 
-func sessionStartXMLContext(toolID, nextJSON, handoffInfo string, diagnostics []string, handoffSummary string) string {
+func sessionStartXMLContext(toolID string, diagnostics []string) string {
 	var b strings.Builder
 	b.WriteString(`<slipway-session-start`)
 	if strings.TrimSpace(toolID) != "" {
@@ -181,14 +76,6 @@ func sessionStartXMLContext(toolID, nextJSON, handoffInfo string, diagnostics []
 	b.WriteString("slipway_entry_skill: This repository is governed by Slipway. To drive any non-trivial change through the governed lifecycle, load the \"")
 	b.WriteString(sessionStartEntrySkill)
 	b.WriteString("\" skill - the entry point that routes new/next/run/done.\n")
-	if nextJSON != "" {
-		b.WriteString(nextJSON)
-		b.WriteByte('\n')
-	}
-	if strings.TrimSpace(handoffInfo) != "" {
-		b.WriteString(handoffInfo)
-		b.WriteByte('\n')
-	}
 	for _, diagnostic := range diagnostics {
 		diagnostic = strings.TrimSpace(diagnostic)
 		if diagnostic == "" {
@@ -197,16 +84,12 @@ func sessionStartXMLContext(toolID, nextJSON, handoffInfo string, diagnostics []
 		b.WriteString(diagnostic)
 		b.WriteByte('\n')
 	}
-	if strings.TrimSpace(handoffSummary) != "" {
-		b.WriteString(handoffSummary)
-		b.WriteByte('\n')
-	}
 	b.WriteString("</slipway-session-start>\n")
 	return b.String()
 }
 
-func sessionStartAdditionalContext(toolID, nextJSON, handoffInfo string, diagnostics []string, handoffSummary string) string {
-	xml := sessionStartXMLContext(toolID, nextJSON, handoffInfo, diagnostics, handoffSummary)
+func sessionStartAdditionalContext(toolID string, diagnostics []string) string {
+	xml := sessionStartXMLContext(toolID, diagnostics)
 	xml = strings.TrimPrefix(xml, `<slipway-session-start tool="codex">`+"\n")
 	xml = strings.TrimPrefix(xml, "<slipway-session-start>\n")
 	xml = strings.TrimSuffix(xml, "</slipway-session-start>\n")

--- a/cmd/session_start_hook_test.go
+++ b/cmd/session_start_hook_test.go
@@ -3,34 +3,36 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
-	"io"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/signalridge/slipway/internal/model"
-	"github.com/signalridge/slipway/internal/state"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestSessionStartHookEmitsCompiledHandoff(t *testing.T) {
+// assertNoSessionStartChangeState pins REQ-004: the SessionStart hook must not
+// auto-inject any per-session change-state — neither the active-worktree
+// `next --json` view, nor the bound-elsewhere pointer, nor the handoff summary.
+func assertNoSessionStartChangeState(t *testing.T, body string) {
+	t.Helper()
+	assert.NotContains(t, body, "session_handoff")
+	assert.NotContains(t, body, "session_handoff_info")
+	assert.NotContains(t, body, "session_handoff_present")
+	assert.NotContains(t, body, "session_handoff_path")
+	assert.NotContains(t, body, `"current_state"`)
+	assert.NotContains(t, body, `"next_skill"`)
+	assert.NotContains(t, body, "bound to")
+	assert.NotContains(t, body, "--change")
+}
+
+func TestSessionStartHookEmitsOnlyEntrySkillPointer(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, levelNonDiscovery, "session-start compiled handoff")
-
-		handoffPath := state.ChangeHandoffPath(root, slug)
-		require.NoError(t, os.MkdirAll(filepath.Dir(handoffPath), 0o755))
-		writeCmd := commandForRoot(t, root, makeHandoffCmd())
-		writeCmd.SetArgs([]string{"write", "--section", "Next Session Focus"})
-		writeCmd.SetIn(strings.NewReader("handoff body must not be embedded"))
-		writeCmd.SetOut(io.Discard)
-		require.NoError(t, writeCmd.Execute())
-		legacyPath := filepath.Join(state.GitRuntimeDir(root), "handoff.md")
-		require.NoError(t, os.MkdirAll(filepath.Dir(legacyPath), 0o755))
-		require.NoError(t, os.WriteFile(legacyPath, []byte("legacy handoff body must not be embedded"), 0o644))
+		// An active change of this worktree must NOT cause any change-state
+		// auto-injection; only the entry-skill routing pointer is emitted.
+		createGovernedRequest(t, root, levelNonDiscovery, "session-start entry-skill only")
 
 		cmd := makeHookCmd()
 		cmd.SetArgs([]string{"session-start", "--tool", "claude"})
@@ -40,39 +42,10 @@ func TestSessionStartHookEmitsCompiledHandoff(t *testing.T) {
 
 		body := out.String()
 		assert.Contains(t, body, `<slipway-session-start tool="claude">`)
-		assert.Contains(t, body, `"slug": "`+slug+`"`)
 		assert.Contains(t, body, "slipway_entry_skill:")
-		assert.Contains(t, body, "session_handoff: slug="+slug)
-		assert.Contains(t, body, "path="+handoffPath)
-		assert.NotContains(t, body, "handoff body must not be embedded")
-		assert.NotContains(t, body, legacyPath)
-		assert.NotContains(t, body, "legacy handoff body must not be embedded")
-	})
-}
-
-func TestSessionStartHandoffSummaryUsesCommandOwnedBrief(t *testing.T) {
-	root := t.TempDir()
-	withWorkspace(t, root, func() {
-		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, levelNonDiscovery, "session-start command owned brief")
-
-		writeCmd := commandForRoot(t, root, makeHandoffCmd())
-		writeCmd.SetArgs([]string{"write", "--change", slug, "--section", "Next Session Focus"})
-		writeCmd.SetIn(strings.NewReader("hook should trim this body"))
-		writeCmd.SetOut(io.Discard)
-		require.NoError(t, writeCmd.Execute())
-
-		brief, ok, err := handoffBriefForChange(root, slug)
-		require.NoError(t, err)
-		require.True(t, ok)
-		expected := brief
-		if before, _, ok := strings.Cut(brief, " focus="); ok {
-			expected = before
-		}
-
-		summary := sessionStartHandoffSummary(root, slug)
-		assert.Equal(t, expected, summary)
-		assert.NotContains(t, summary, "hook should trim this body")
+		assert.Contains(t, body, `load the "slipway" skill`)
+		assertNoSessionStartChangeState(t, body)
+		assert.NotContains(t, body, "hook_diagnostic:")
 	})
 }
 
@@ -80,10 +53,7 @@ func TestSessionStartHookEmitsCodexAdditionalContext(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, levelNonDiscovery, "codex session-start handoff")
-		writeCmd := commandForRoot(t, root, makeHandoffCmd())
-		writeCmd.SetOut(io.Discard)
-		require.NoError(t, writeCmd.Execute())
+		createGovernedRequest(t, root, levelNonDiscovery, "codex session-start entry skill")
 
 		cmd := makeHookCmd()
 		cmd.SetArgs([]string{"session-start", "--tool", "codex"})
@@ -99,37 +69,22 @@ func TestSessionStartHookEmitsCodexAdditionalContext(t *testing.T) {
 		var payload map[string]map[string]string
 		require.NoError(t, json.Unmarshal(out.Bytes(), &payload))
 		additionalContext := payload["hookSpecificOutput"]["additionalContext"]
-		assert.Contains(t, additionalContext, `"slug": "`+slug+`"`)
-		assert.Contains(t, additionalContext, "session_handoff: slug="+slug)
+		assert.Contains(t, additionalContext, "slipway_entry_skill:")
+		assertNoSessionStartChangeState(t, additionalContext)
 	})
 }
 
-func TestSessionStartHookReportsOnlyCurrentChangeHandoffAcrossBoundWorktrees(t *testing.T) {
+func TestSessionStartHookBoundElsewhereEmitsOnlyEntrySkill(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
 		initGitRepoForWorktreeTests(t, root)
 
-		currentSlug := createGovernedRequest(t, root, levelNonDiscovery, "current worktree handoff")
-		currentChange, err := state.LoadChange(root, currentSlug)
-		require.NoError(t, err)
-		currentChange.WorktreePath = root
-		require.NoError(t, state.SaveChange(root, currentChange))
-
-		otherWorktreePath := filepath.Join(t.TempDir(), "other-worktree")
-		runGit(t, root, "worktree", "add", otherWorktreePath, "-b", "other-worktree")
-		otherChange := model.NewChange("other-bound-change")
-		otherChange.CurrentState = model.StateS1Plan
-		otherChange.PlanSubStep = model.PlanSubStepBundle
-		otherChange.WorktreePath = otherWorktreePath
-		require.NoError(t, state.SaveChange(root, otherChange))
-
-		currentHandoffPath := state.ChangeHandoffPath(root, currentSlug)
-		otherHandoffPath := state.ChangeHandoffPath(root, otherChange.Slug)
-		require.NoError(t, os.MkdirAll(filepath.Dir(currentHandoffPath), 0o755))
-		require.NoError(t, os.MkdirAll(filepath.Dir(otherHandoffPath), 0o755))
-		require.NoError(t, os.WriteFile(currentHandoffPath, []byte("current body must not be embedded"), 0o644))
-		require.NoError(t, os.WriteFile(otherHandoffPath, []byte("other body must not be embedded"), 0o644))
+		// A change bound to another worktree must no longer produce a
+		// "session_handoff_info: ... bound to <worktree>" pointer; the hook emits
+		// only the entry-skill routing pointer.
+		worktreePath := t.TempDir() + "/bound-worktree"
+		runGit(t, root, "worktree", "add", worktreePath, "-b", "bound-worktree")
 
 		cmd := makeHookCmd()
 		cmd.SetArgs([]string{"session-start", "--tool", "claude"})
@@ -138,12 +93,9 @@ func TestSessionStartHookReportsOnlyCurrentChangeHandoffAcrossBoundWorktrees(t *
 		require.NoError(t, cmd.Execute())
 
 		body := out.String()
-		assert.Contains(t, body, `"slug": "`+currentSlug+`"`)
-		assert.Contains(t, body, "session_handoff_present: true")
-		assert.Contains(t, body, "session_handoff_path: "+currentHandoffPath)
-		assert.NotContains(t, body, otherHandoffPath)
-		assert.NotContains(t, body, "current body must not be embedded")
-		assert.NotContains(t, body, "other body must not be embedded")
+		assert.Contains(t, body, "slipway_entry_skill:")
+		assertNoSessionStartChangeState(t, body)
+		assert.NotContains(t, body, "hook_diagnostic: slipway next --json failed:")
 	})
 }
 
@@ -151,7 +103,7 @@ func TestSessionStartHookBareCommandOmitsUnknownToolAttribute(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {
 		initTestWorkspace(t, root)
-		slug := createGovernedRequest(t, root, levelNonDiscovery, "session-start bare command")
+		createGovernedRequest(t, root, levelNonDiscovery, "session-start bare command")
 
 		cmd := makeHookCmd()
 		cmd.SetArgs([]string{"session-start"})
@@ -163,35 +115,8 @@ func TestSessionStartHookBareCommandOmitsUnknownToolAttribute(t *testing.T) {
 		assert.Contains(t, body, `<slipway-session-start>`)
 		assert.NotContains(t, body, `tool="unknown"`)
 		assert.NotContains(t, body, `tool=""`)
-		assert.Contains(t, body, `"slug": "`+slug+`"`)
-	})
-}
-
-func TestSessionStartHookTreatsBoundWorktreeChangeAsInformational(t *testing.T) {
-	root := t.TempDir()
-	withWorkspace(t, root, func() {
-		initTestWorkspace(t, root)
-		initGitRepoForWorktreeTests(t, root)
-
-		worktreePath := filepath.Join(t.TempDir(), "bound-worktree")
-		runGit(t, root, "worktree", "add", worktreePath, "-b", "bound-worktree")
-		change := model.NewChange("bound-change")
-		change.WorktreePath = worktreePath
-		require.NoError(t, state.SaveChange(root, change))
-		normalizedWorktreePath, err := state.NormalizePath(worktreePath)
-		require.NoError(t, err)
-
-		cmd := makeHookCmd()
-		cmd.SetArgs([]string{"session-start", "--tool", "claude"})
-		var out bytes.Buffer
-		cmd.SetOut(&out)
-		require.NoError(t, cmd.Execute())
-
-		body := out.String()
-		assert.Contains(t, body, "session_handoff_info: no active change in this worktree")
-		assert.Contains(t, body, "active change bound-change is bound to "+normalizedWorktreePath)
-		assert.Contains(t, body, "use --change bound-change to act")
-		assert.NotContains(t, body, "hook_diagnostic: slipway next --json failed:")
+		assert.Contains(t, body, "slipway_entry_skill:")
+		assertNoSessionStartChangeState(t, body)
 	})
 }
 
@@ -212,14 +137,15 @@ func TestSessionStartHookSurfacesRootFailureDiagnostic(t *testing.T) {
 
 	body := out.String()
 	assert.Contains(t, body, `<slipway-session-start tool="bad&quot;tool">`)
+	assert.Contains(t, body, "slipway_entry_skill:")
 	assert.Contains(t, body, "hook_diagnostic: slipway root failed:")
 }
 
-// TestSessionStartHookFailsSilentOnUnusableInput pins REQ-003: the SessionStart
-// hook is inlined into automatic host hooks, so it must always exit 0 (Execute
-// returns nil, never panics) even when stdin is empty or malformed garbage. The
-// subcommand does not consume stdin, but the fail-silent contract must hold for
-// any host-supplied input.
+// TestSessionStartHookFailsSilentOnUnusableInput pins the fail-silent contract:
+// the SessionStart hook is inlined into automatic host hooks, so it must always
+// exit 0 (Execute returns nil, never panics) even when stdin is empty or
+// malformed garbage. The subcommand does not consume stdin, but the contract
+// must hold for any host-supplied input.
 func TestSessionStartHookFailsSilentOnUnusableInput(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {

--- a/internal/tmpl/templates/skills/workflow/SKILL.md.tmpl
+++ b/internal/tmpl/templates/skills/workflow/SKILL.md.tmpl
@@ -88,6 +88,22 @@ gate. A fresh session must still run `slipway status --json` and
 `slipway next --json`, obey lifecycle gates, and rely on CLI-owned freshness and
 evidence checks before advancing.
 
+## Continuing A Change In A Fresh Session
+When you open a fresh session to resume in-flight governed work, drive the resume
+entirely through the CLI — never reconstruct lifecycle state from memory, source,
+or old chat. This read path is hook-agnostic and portable across hosts:
+1. Run `slipway status --json` to discover the active change(s) and lifecycle state.
+2. If more than one change is active, select the one you are resuming and pass
+   `--change <slug>` to the commands below so you act on the right change.
+3. Run `slipway handoff show --change <slug>` and read the advisory narrative
+   first — it carries the prior session's Current Position, Next Session Focus,
+   and Risks And Blockers.
+4. Then run `slipway next` (add `--change <slug>` when more than one is active) to
+   get the authoritative next governed step.
+
+The handoff in step 3 is advisory context only; `slipway status` and
+`slipway next` remain the lifecycle authority for what to do next.
+
 ## Delegation Surface
 Detailed command contracts live in `references/command-reference.md`. For
 commands that ship generated command surfaces, prefer those surfaces over

--- a/internal/toolgen/toolgen_test.go
+++ b/internal/toolgen/toolgen_test.go
@@ -774,6 +774,13 @@ func TestWorkflowSkillGenerationAndReference(t *testing.T) {
 		assert.NotContains(t, s, "skip `slipway next --json`", "%s: stale next bypass wording leaked", cfg.ID)
 		assert.NotContains(t, s, "skip lifecycle gates", "%s: stale lifecycle bypass wording leaked", cfg.ID)
 		assert.NotContains(t, s, "skip evidence checks", "%s: stale evidence bypass wording leaked", cfg.ID)
+		// REQ-002/REQ-003: the generated workflow skill must ship the fresh-session
+		// resume protocol that drives status -> --change -> handoff show -> next.
+		assert.Contains(t, s, "## Continuing A Change In A Fresh Session", "%s: missing fresh-session resume protocol section", cfg.ID)
+		assert.Contains(t, sText, "Run `slipway status --json` to discover the active change", "%s: resume protocol missing status --json step", cfg.ID)
+		assert.Contains(t, sText, "select the one you are resuming and pass `--change <slug>`", "%s: resume protocol missing multi-change --change selection step", cfg.ID)
+		assert.Contains(t, sText, "Run `slipway handoff show --change <slug>` and read the advisory narrative first", "%s: resume protocol missing handoff show step", cfg.ID)
+		assert.Contains(t, sText, "Then run `slipway next`", "%s: resume protocol missing next step", cfg.ID)
 		assert.Contains(t, s, "`references/command-reference.md`", "%s: missing workflow reference handoff", cfg.ID)
 		assert.Contains(t, s, filepath.ToSlash(SkillIndexPath(cfg)), "%s: missing workflow skill index path", cfg.ID)
 		assert.Contains(t, s, "informational only", "%s: missing skill index authority boundary", cfg.ID)


### PR DESCRIPTION
Closes the per-change session-handoff continuity loop across three surfaces so a fresh session can reliably pick up an in-flight governed change.

## What changed

- **W2 — context-pressure escalation**: `cmd/context_pressure_hook.go` now escalates at the CRITICAL threshold to an imperative `slipway handoff write --section` directive that names the Current Position / Next Session Focus / Risks And Blockers sections. The WARNING threshold stays soft, and the runtime handoff remains explicitly advisory (status/next still re-derived from JSON in a fresh session).
- **R2 — resume protocol**: the generated workflow skill (`internal/tmpl/templates/skills/workflow/SKILL.md.tmpl`) gains a "Continuing A Change In A Fresh Session" section documenting the CLI-only, hook-agnostic read path: `slipway status --json` -> select `--change <slug>` when multiple changes are active -> `slipway handoff show --change <slug>` (read the narrative first) -> `slipway next`. `internal/toolgen/toolgen_test.go` guards that every host ships the section and its ordered sequence.
- **R3 — SessionStart cleanup**: `cmd/session_start_hook.go` stops auto-injecting change-state and now emits only the entry-skill routing pointer (plus a hard-error root diagnostic), fail-silent exit 0 on both the Claude XML and Codex JSON paths. Retired the now-dead handoff-summary helpers; `cmd/session_start_hook_test.go` and `cmd/auto_mode_test.go` updated to the entry-skill-only contract.

## Acceptance

- `go test ./...` green (full suite).
- All four S3 reviews PASS with distinct fresh-context origins: spec-compliance-review (layer R0), independent-review (IR1), code-quality-review (IR1), goal-verification (fresh suite proof). Governed change driven to `done` and archived under `artifacts/changes/archived/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)