### PR TITLE
fix(governance): stop false reviewer context-origin diagnostic for multi-fix evidence (#319)

### DIFF
--- a/artifacts/changes/archived/fix-the-misleading-reviewer-context-origin-diagnostic-report/change.yaml
+++ b/artifacts/changes/archived/fix-the-misleading-reviewer-context-origin-diagnostic-report/change.yaml
@@ -1,0 +1,39 @@
+version: 1
+slug: fix-the-misleading-reviewer-context-origin-diagnostic-report
+description: 'Fix the misleading reviewer context-origin diagnostic reported in issue #319. When reviewer evidence records multiple context_origin:stage=fix handles (one per fresh-context repair subagent across S3 fix batches, exactly as the slipway fix command instructs) alongside the single context_origin:stage=review handle, `slipway validate` falsely reports that the selected reviewer recorded no context-origin handle and tells the user to re-run the reviewer in a fresh native subagent. Root cause: model.ContextOriginHandlesFromVerification (internal/model/context_attestation.go) treats every stage as single-valued and fails the entire record closed when any single stage carries multiple distinct handles; because the fix stage is inherently multi-valued, the multiple fix handles poison the parse so the unique, well-formed review handle becomes unreadable. The same single-valued constraint also defeats the fix-handle HandleSet collection in crossStageContextParticipants (internal/engine/progression/authority.go), which already expects a multi-valued fix participant. Make the documented review+fix evidence shape validate cleanly: parse fix as a multi-valued stage with set semantics while keeping single-valued stages (review, plan_origin, audit_origin) fail-closed on genuinely conflicting handles, so multiple fix handles no longer mask the review handle and the cross-stage independence lattice receives the full fix handle set. Keep the slipway fix command instructions aligned with the accepted shape. Must not weaken fail-closed safety for single-valued stages or introduce any attestation bypass.'
+status: done
+current_state: DONE
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-06-24T12:21:36.194328Z
+quality_mode: standard
+workflow_preset: light
+worktree_branch: feat/fix-the-misleading-reviewer-context-origin-diagnostic-report
+artifact_schema: core
+artifacts:
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: f1ef8bd9eaec10b88db44760a231f2eea2c4f3aaea0342b1b350d483aaecf47b
+        updated_at: 2026-06-24T12:32:50.278777043Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: 26775c4debbdcd3d147bd63c8aab3311eb9bcb96d86e0ff1afbf4e8fc96afc69
+        updated_at: 2026-06-24T12:43:33.183571408Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: 01133b216cee24ce0828400330e79f54751846e0d1916061687e36b27081a518
+        updated_at: 2026-06-24T13:23:16.938637482Z
+evidence_refs:
+    code-quality-review: .worktrees/fix-the-misleading-reviewer-context-origin-diagnostic-report/artifacts/changes/fix-the-misleading-reviewer-context-origin-diagnostic-report/verification/code-quality-review.yaml
+    independent-review: .worktrees/fix-the-misleading-reviewer-context-origin-diagnostic-report/artifacts/changes/fix-the-misleading-reviewer-context-origin-diagnostic-report/verification/independent-review.yaml
+    intake-clarification: .worktrees/fix-the-misleading-reviewer-context-origin-diagnostic-report/artifacts/changes/fix-the-misleading-reviewer-context-origin-diagnostic-report/verification/intake-clarification.yaml
+    plan-audit: .worktrees/fix-the-misleading-reviewer-context-origin-diagnostic-report/artifacts/changes/fix-the-misleading-reviewer-context-origin-diagnostic-report/verification/plan-audit.yaml
+    ship-verification: .worktrees/fix-the-misleading-reviewer-context-origin-diagnostic-report/artifacts/changes/fix-the-misleading-reviewer-context-origin-diagnostic-report/verification/ship-verification.yaml
+    spec-compliance-review: .worktrees/fix-the-misleading-reviewer-context-origin-diagnostic-report/artifacts/changes/fix-the-misleading-reviewer-context-origin-diagnostic-report/verification/spec-compliance-review.yaml
+    wave-orchestration: .worktrees/fix-the-misleading-reviewer-context-origin-diagnostic-report/artifacts/changes/fix-the-misleading-reviewer-context-origin-diagnostic-report/verification/wave-orchestration.yaml

--- a/artifacts/changes/archived/fix-the-misleading-reviewer-context-origin-diagnostic-report/intent.md
+++ b/artifacts/changes/archived/fix-the-misleading-reviewer-context-origin-diagnostic-report/intent.md
@@ -1,0 +1,104 @@
+# Intent
+
+## Summary
+Fix the misleading reviewer context-origin diagnostic reported in issue #319. When reviewer evidence records multiple context_origin:stage=fix handles (one per fresh-context repair subagent across S3 fix batches, exactly as the slipway fix command instructs) alongside the single context_origin:stage=review handle, `slipway validate` falsely reports that the selected reviewer recorded no context-origin handle and tells the user to re-run the reviewer in a fresh native subagent. Root cause: model.ContextOriginHandlesFromVerification (internal/model/context_attestation.go) treats every stage as single-valued and fails the entire record closed when any single stage carries multiple distinct handles; because the fix stage is inherently multi-valued, the multiple fix handles poison the parse so the unique, well-formed review handle becomes unreadable. The same single-valued constraint also defeats the fix-handle HandleSet collection in crossStageContextParticipants (internal/engine/progression/authority.go), which already expects a multi-valued fix participant. Make the documented review+fix evidence shape validate cleanly: parse fix as a multi-valued stage with set semantics while keeping single-valued stages (review, plan_origin, audit_origin) fail-closed on genuinely conflicting handles, so multiple fix handles no longer mask the review handle and the cross-stage independence lattice receives the full fix handle set. Keep the slipway fix command instructions aligned with the accepted shape. Must not weaken fail-closed safety for single-valued stages or introduce any attestation bypass.
+
+## Complexity Assessment
+complex
+<!-- Rationale: -->
+Small code surface but safety-sensitive: the change edits the fail-closed grammar
+that feeds the cross-stage context-independence lattice (a governance safety gate).
+It must distinguish single-valued stages (still fail-closed on conflict) from the
+inherently multi-valued fix stage, touch multiple consumers in authority.go, keep
+generated fix instructions aligned, and add regression coverage — all without
+introducing any attestation bypass.
+
+## Guardrail Domains
+<!-- none detected -->
+None classified. The work is internal governance evidence-validation logic, not
+Auth/Credentials/Financial/Schema/Irreversible/External-API. It nonetheless
+touches fail-closed Review-And-Safety logic, so it must remain fail-closed for
+single-valued stages.
+
+## In Scope
+- `internal/model/context_attestation.go`: make context-origin handle parsing
+  distinguish single-valued stages from the multi-valued `fix` stage. `fix` may
+  carry multiple distinct handles (set semantics); `review`, `plan_origin`,
+  `audit_origin` stay single-valued and fail closed on genuinely conflicting
+  handles. Ensure `ReviewContextOriginHandleFromVerification` resolves the unique
+  review handle even when multiple `stage=fix` handles are present in the same record.
+- `internal/engine/progression/authority.go`: `crossStageContextParticipants`
+  correctly collects every `stage=fix` handle on each reviewer record into the
+  fix `HandleSet` (no longer dropped by the single-valued constraint), and stops
+  emitting the false `context_origin_handle_invalid` "no context-origin handle
+  for selected reviewer" blocker when only the multi-fix shape is present.
+- `internal/tmpl/templates/_partials/command-fix-body.tmpl`: align the fix
+  instruction text so it is explicit that a reviewer's evidence may accumulate
+  multiple `context_origin:stage=fix` handles (one per repair subagent / batch).
+- Regression tests: `internal/model/context_attestation_test.go` (multi-fix +
+  single-review coexistence; fix set extraction; single-valued stages still fail
+  closed) and the authority-layer participant/blocker tests (multi-fix reviewer
+  evidence no longer false-flags the review handle; fix HandleSet is complete).
+- Regenerate any generated skill/command surface affected by the tmpl edit.
+
+## Out of Scope
+- No change to the single-valued fail-closed semantics of `review`,
+  `plan_origin`, `audit_origin`, or the executor handle-set stage.
+- No new attestation bypass, force-close, restamp, or private-attestation path.
+- No refactor of unrelated lattice logic or the wave-execution token grammar.
+- Not fixing issue #263 (recovery dead-end replacing already-passing invalid
+  context-origin evidence) — related but distinct.
+- No change to ship-verification (#322) gate behavior beyond what the parsing fix
+  transitively corrects.
+
+## Constraints
+- Must preserve fail-closed safety: single-valued stages still reject conflicting
+  handles; only genuinely multi-valued stages (fix) accept a handle set.
+- Smallest clean design; keep code, generated skills, docs, and instructions
+  aligned as one product surface.
+- Full `go test ./...` green; gofmt -s and golangci-lint (incl. gofmt simplify) clean.
+
+## Acceptance Signals
+- New unit test: a reviewer record carrying multiple distinct
+  `context_origin:stage=fix=<h>` references plus one `context_origin:stage=review=<h>`
+  resolves the review handle (ok=true) instead of failing closed.
+- The fix-stage handles are extractable as a complete set; `review`/`plan_origin`/
+  `audit_origin` still fail closed on two different handles for the same stage.
+- `crossStageContextParticipants` no longer emits the
+  `context_origin_handle_invalid` reviewer-missing blocker for the multi-fix shape,
+  and the fix participant `HandleSet` contains every recorded fix handle.
+- End-to-end: reviewer evidence with multiple fix handles + one review handle no
+  longer produces "recorded no context-origin handle for selected reviewer" from
+  `slipway validate`.
+- fix command instruction text matches the accepted evidence shape.
+- Full test suite and lint pass from the current worktree.
+
+## Open Questions
+None.
+
+## Deferred Ideas
+- Consider a small explicit single-valued-vs-multi-valued stage classification
+  table if more multi-valued stages emerge later; not needed for this change.
+
+## Approved Summary
+Confirmed 2026-06-24T12:32:14Z by user.
+
+This change fixes the misleading reviewer context-origin diagnostic (#319) by making
+the context-origin handle grammar treat `fix` as a multi-valued stage — a reviewer's
+evidence may carry one `context_origin:stage=fix` handle per repair subagent — while
+keeping `review`, `plan_origin`, and `audit_origin` single-valued and fail-closed on
+genuinely conflicting handles. Multiple fix handles therefore no longer mask the
+unique reviewer handle, `slipway validate` stops falsely reporting "recorded no
+context-origin handle for selected reviewer", and the cross-stage independence lattice
+receives the complete fix handle set.
+
+Scope: `internal/model/context_attestation.go` parsing, the
+`internal/engine/progression/authority.go` fix-handle collection and reviewer-missing
+blocker, the `slipway fix` command instruction text, and regression tests.
+
+Out of scope: single-valued stages keep their fail-closed semantics; no attestation
+bypass/force-close/restamp; issue #263 is not addressed.
+
+Primary acceptance signal: reviewer evidence with multiple `stage=fix` handles plus
+one `stage=review` handle validates cleanly (the review handle resolves, no
+reviewer-missing blocker), with the full Go test suite and lint green.

--- a/artifacts/changes/archived/fix-the-misleading-reviewer-context-origin-diagnostic-report/requirements.md
+++ b/artifacts/changes/archived/fix-the-misleading-reviewer-context-origin-diagnostic-report/requirements.md
@@ -1,0 +1,109 @@
+# Requirements
+
+## Requirements
+
+### Requirement: Reviewer handle resolves despite multiple fix handles
+REQ-001: The system MUST resolve the unique `context_origin:stage=review=<handle>`
+reference on a reviewer record even when that same record also carries multiple
+distinct `context_origin:stage=fix=<handle>` references. The presence of more than
+one `stage=fix` handle MUST NOT cause the whole-record context-origin parse to fail
+closed and mask the review handle.
+
+#### Scenario: review handle reads through coexisting multi-fix handles
+GIVEN a passing reviewer verification record whose references include
+`context_origin:stage=review=ctx-review` plus
+`context_origin:stage=fix=ctx-fix-1` and `context_origin:stage=fix=ctx-fix-2`
+WHEN `ReviewContextOriginHandleFromVerification` parses that record
+THEN it returns ok=true with the resolved handle `ctx-review`.
+
+#### Scenario: record with only multiple fix handles has no review handle
+GIVEN a passing reviewer record whose only context-origin references are
+`context_origin:stage=fix=ctx-fix-1` and `context_origin:stage=fix=ctx-fix-2`
+WHEN `ReviewContextOriginHandleFromVerification` parses that record
+THEN it returns ok=false because no `stage=review` handle is present, without
+failing closed on the fix multiplicity.
+
+### Requirement: Single-valued stages remain fail-closed
+REQ-002: The system MUST keep the single-valued context-origin stages —
+`review`, `plan_origin`, and `audit_origin` — fail-closed: two references naming
+the same single-valued stage with two different handles MUST be rejected as
+ambiguous evidence rather than letting one reference win. This change MUST NOT
+introduce any attestation bypass, force-close, restamp, or private-attestation
+path for any stage.
+
+#### Scenario: conflicting review handles still fail closed
+GIVEN a reviewer record carrying
+`context_origin:stage=review=ctx-a` and `context_origin:stage=review=ctx-b`
+WHEN the context-origin handles are parsed
+THEN the parse fails closed (ok=false) and no review handle is resolved.
+
+#### Scenario: conflicting plan/audit-origin handles still fail closed
+GIVEN a record carrying two different `plan_origin:<handle>` references (or two
+different `audit_origin:<handle>` references)
+WHEN `PlanOriginHandleFromVerification` (respectively
+`AuditOriginHandleFromVerification`) parses it
+THEN the parse fails closed (ok=false), unchanged from current behavior.
+
+### Requirement: Fix stage exposes a complete handle set
+REQ-003: The system MUST expose every distinct recorded `context_origin:stage=fix`
+handle on a record as a deduplicated set with set semantics, so the multi-valued
+`fix` stage contributes its full handle set to the cross-stage independence
+lattice. Repeated identical fix handles MUST collapse to one set member.
+
+#### Scenario: all distinct fix handles are extracted
+GIVEN a record carrying `context_origin:stage=fix=ctx-fix-1`,
+`context_origin:stage=fix=ctx-fix-2`, and a repeated
+`context_origin:stage=fix=ctx-fix-1`
+WHEN the fix handle set is extracted from that record
+THEN the result is the deduplicated set {ctx-fix-1, ctx-fix-2}.
+
+#### Scenario: a record with no fix handles yields an empty set
+GIVEN a record whose references carry no `context_origin:stage=fix` token
+WHEN the fix handle set is extracted
+THEN the result is an empty set (not a parse failure).
+
+### Requirement: Authority layer stops the false reviewer-missing blocker for the multi-fix shape
+REQ-004: The cross-stage context-participants builder MUST NOT emit the
+`context_origin_handle_invalid` "recorded no context-origin handle for selected
+reviewer" blocker for a passing reviewer record that carries a valid review handle
+alongside multiple fix handles. It MUST collect every recorded `stage=fix` handle
+across the selected reviewers into the `fix` participant `HandleSet`.
+
+#### Scenario: multi-fix reviewer evidence is not false-flagged and fix set is complete
+GIVEN a selected reviewer with a passing record carrying one valid review handle
+and two distinct fix handles
+WHEN `crossStageContextParticipants` builds the lattice participants
+THEN no `context_origin_handle_invalid` reviewer-missing blocker is returned for
+that reviewer, and the `fix` participant `HandleSet` contains both fix handles.
+
+#### Scenario: end-to-end validate no longer reports the misleading diagnostic
+GIVEN reviewer evidence with multiple `stage=fix` handles plus one `stage=review`
+handle for a selected reviewer
+WHEN `slipway validate` evaluates the change
+THEN it does not report that the selected reviewer recorded no context-origin
+handle and does not instruct the user to re-run the reviewer in a fresh subagent.
+
+### Requirement: Fix command instructions match the accepted evidence shape
+REQ-005: The generated `slipway fix` command surface MUST make explicit that a
+reviewer's evidence may accumulate multiple `context_origin:stage=fix` handles —
+one per fresh-context repair subagent / batch — and the template contract test
+MUST pin that wording.
+
+#### Scenario: fix command body documents multiple fix handles
+GIVEN the rendered `command-fix-body` surface
+WHEN its content is inspected
+THEN it states that a reviewer may record more than one
+`context_origin:stage=fix=<handle>` (one per repair subagent / batch), and the
+existing reexecution-mode contract assertions still hold.
+
+### Requirement: Full verification from the current worktree
+REQ-006: The change MUST keep the full Go test suite (`go test ./...`) and the
+project lint gate (golangci-lint, including gofmt simplify) green from the current
+worktree, with new regression coverage for the multi-fix behavior added rather
+than relaxing the existing single-valued fail-closed tests.
+
+#### Scenario: suite and lint pass with new coverage
+GIVEN the implemented change in the current worktree
+WHEN `go test ./...` and the lint gate are run
+THEN both pass, and the previously existing same-stage fail-closed test cases
+remain present and green.

--- a/artifacts/changes/archived/fix-the-misleading-reviewer-context-origin-diagnostic-report/tasks.md
+++ b/artifacts/changes/archived/fix-the-misleading-reviewer-context-origin-diagnostic-report/tasks.md
@@ -1,0 +1,27 @@
+# Tasks
+
+## Task List
+
+- [x] `t-01` Model grammar: make `fix` a multi-valued context-origin stage. In internal/model/context_attestation.go add an explicit single-vs-multi-valued stage classifier (only `fix` is multi-valued) and update `ContextOriginHandlesFromVerification` so the same-stage fail-closed guard applies to single-valued stages only — multi-valued `fix` references no longer poison the whole-record parse and are not stored in the single-valued map. Add `FixContextOriginHandleSetFromVerification(record)` that returns the deduplicated set of every recorded `stage=fix` handle (set semantics, never fail-closed, non-nil empty set when absent), mirroring `ExecutorParticipantHandleSetFromVerification`. Confirm `ReviewContextOriginHandleFromVerification` now resolves the unique review handle when multiple `stage=fix` handles coexist. In context_attestation_test.go ADD cases (review handle resolves alongside multiple distinct fix handles; record with only multiple fix handles yields no review handle without failing closed; fix set extraction dedup; empty fix set) and KEEP the existing single-valued same-stage fail-closed cases green (do not relax them).
+  - depends_on: []
+  - target_files: ["internal/model/context_attestation.go", "internal/model/context_attestation_test.go"]
+  - task_kind: code
+  - covers: [REQ-001, REQ-002, REQ-003]
+
+- [x] `t-02` Authority feeder: collect the complete fix handle set and stop the false reviewer-missing blocker. In internal/engine/progression/authority.go rewrite the `crossStageContextParticipants` fix-stage block to union `model.FixContextOriginHandleSetFromVerification` across every selected reviewer's passing record into the `fix` participant `HandleSet` (instead of reading a single `handles[fix]` via the now-single-valued map). The selected-reviewer loop is unchanged: because the model parse no longer fails closed on multi-fix, `ReviewContextOriginHandleFromVerification` resolves and the `context_origin_handle_invalid` reviewer-missing blocker is no longer emitted for the multi-fix shape. In authority_test.go ADD coverage: a passing reviewer record with one review handle plus multiple distinct fix handles produces no reviewer-missing blocker and a `fix` participant `HandleSet` containing every fix handle.
+  - depends_on: [t-01]
+  - target_files: ["internal/engine/progression/authority.go", "internal/engine/progression/authority_test.go"]
+  - task_kind: code
+  - covers: [REQ-004]
+
+- [x] `t-03` Fix command instructions: in internal/tmpl/templates/_partials/command-fix-body.tmpl make explicit that a reviewer's evidence may accumulate multiple `context_origin:stage=fix=<handle>` references — one per fresh-context repair subagent / batch — without invalidating the single `context_origin:stage=review` handle. In internal/tmpl/templates_test.go add a contract assertion pinning the new multi-fix wording, keeping the existing fix-body reexecution-mode assertions intact.
+  - depends_on: []
+  - target_files: ["internal/tmpl/templates/_partials/command-fix-body.tmpl", "internal/tmpl/templates_test.go"]
+  - task_kind: code
+  - covers: [REQ-005]
+
+- [x] `t-04` Integration verification: run focused (`go test ./internal/model/... ./internal/engine/progression/... ./internal/tmpl/...`), repository-wide (`go test ./...`), and lint (golangci-lint, incl. gofmt simplify) gates from the current worktree; confirm end-to-end that reviewer evidence with multiple `stage=fix` handles plus one `stage=review` handle no longer yields the "recorded no context-origin handle for selected reviewer" diagnostic; record implementation evidence.
+  - depends_on: [t-01, t-02, t-03]
+  - target_files: ["artifacts/changes/fix-the-misleading-reviewer-context-origin-diagnostic-report/verification/implementation.md"]
+  - task_kind: verification
+  - covers: [REQ-004, REQ-006]

--- a/internal/engine/progression/authority.go
+++ b/internal/engine/progression/authority.go
@@ -522,6 +522,14 @@ func crossStageContextParticipants(
 		participants[skillName] = model.ContextParticipant{Handle: handle.Handle}
 	}
 
+	// fix <- every selected reviewer's recorded context_origin:stage=fix handles,
+	// unioned into one set. The fix stage is multi-valued — a reviewer's record
+	// accumulates one handle per fresh-context repair subagent / batch — so the
+	// model exposes it as a never-fail-closed set rather than the single-valued
+	// handles map. Reading it through FixContextOriginHandleSetFromVerification
+	// (rather than the single-valued map, which no longer stores fix) collects
+	// every fix handle across all selected reviewers without poisoning a reviewer's
+	// own review-handle parse.
 	if _, want := stages[model.StageContextFix]; want {
 		fixHandles := map[string]struct{}{}
 		for _, skillName := range reviewParticipantSkillNames(stages) {
@@ -529,15 +537,9 @@ func crossStageContextParticipants(
 			if !ok || !record.IsPassing() {
 				continue
 			}
-			handles, ok := model.ContextOriginHandlesFromVerification(record)
-			if !ok {
-				continue
+			for handle := range model.FixContextOriginHandleSetFromVerification(record) {
+				fixHandles[handle] = struct{}{}
 			}
-			handle, ok := handles[model.StageContextFix]
-			if !ok || strings.TrimSpace(handle.Handle) == "" {
-				continue
-			}
-			fixHandles[handle.Handle] = struct{}{}
 		}
 		if len(fixHandles) > 0 {
 			participants[model.StageContextFix] = model.ContextParticipant{HandleSet: fixHandles}

--- a/internal/engine/progression/authority_test.go
+++ b/internal/engine/progression/authority_test.go
@@ -713,6 +713,66 @@ func TestCrossStageContextDistinctBlockers(t *testing.T) {
 		assert.Equal(t, model.StageContextFix+"|"+SkillSpecComplianceReview, blockers[0].Detail)
 	})
 
+	t.Run("multiple distinct fix handles emit no reviewer-missing blocker and union into the fix set", func(t *testing.T) {
+		t.Parallel()
+		root, change := newRoot(t, "lattice-multi-fix-context")
+		// A selected/passing reviewer carries one valid review handle PLUS two
+		// distinct fix handles. The now-multi-valued fix stage must not poison the
+		// record parse, so the reviewer's review handle still resolves (no
+		// context_origin_handle_invalid reviewer-missing blocker), and every fix
+		// handle must land in the fix participant set.
+		records := reviewContextRecords("handle-spec", "handle-code")
+		spec := records[SkillSpecComplianceReview]
+		spec.References = append(spec.References,
+			contextOriginRef(model.StageContextFix, "fix-handle-a"),
+			contextOriginRef(model.StageContextFix, "fix-handle-b"),
+		)
+		records[SkillSpecComplianceReview] = spec
+
+		// (a) No reviewer-missing blocker: the review handles are distinct and the
+		// fix handles collide with nothing, so the lattice is clean.
+		blockers := crossStageContextDistinctBlockers(root, change, records, reviewStages, ownedReview, true)
+		assert.Empty(t, blockers)
+		assert.False(t, hasReasonCode(blockers, "context_origin_handle_invalid"),
+			"multi-fix records must not emit the false reviewer-missing blocker")
+
+		// (b) The fix participant HandleSet must contain BOTH fix handles across the
+		// selected reviewers.
+		participants, invalid := crossStageContextParticipants(root, change, records, reviewStages)
+		require.Empty(t, invalid)
+		fixParticipant, ok := participants[model.StageContextFix]
+		require.True(t, ok, "fix participant must be present when any reviewer records a fix handle")
+		_, hasA := fixParticipant.HandleSet["fix-handle-a"]
+		_, hasB := fixParticipant.HandleSet["fix-handle-b"]
+		assert.True(t, hasA, "fix-handle-a must be unioned into the fix participant set")
+		assert.True(t, hasB, "fix-handle-b must be unioned into the fix participant set")
+		assert.Len(t, fixParticipant.HandleSet, 2, "exactly the two distinct fix handles are collected")
+	})
+
+	t.Run("fix handles union across multiple selected reviewers", func(t *testing.T) {
+		t.Parallel()
+		root, change := newRoot(t, "lattice-multi-reviewer-fix-context")
+		// Distinct fix handles recorded on DIFFERENT selected reviewers must all
+		// flow into one shared fix participant set, not just the first reviewer's.
+		records := reviewContextRecords("handle-spec", "handle-code")
+		spec := records[SkillSpecComplianceReview]
+		spec.References = append(spec.References, contextOriginRef(model.StageContextFix, "fix-from-spec"))
+		records[SkillSpecComplianceReview] = spec
+		code := records[SkillCodeQualityReview]
+		code.References = append(code.References, contextOriginRef(model.StageContextFix, "fix-from-code"))
+		records[SkillCodeQualityReview] = code
+
+		participants, invalid := crossStageContextParticipants(root, change, records, reviewStages)
+		require.Empty(t, invalid)
+		fixParticipant, ok := participants[model.StageContextFix]
+		require.True(t, ok)
+		_, hasSpecFix := fixParticipant.HandleSet["fix-from-spec"]
+		_, hasCodeFix := fixParticipant.HandleSet["fix-from-code"]
+		assert.True(t, hasSpecFix, "the spec reviewer's fix handle must be in the union")
+		assert.True(t, hasCodeFix, "the code reviewer's fix handle must be in the union")
+		assert.Len(t, fixParticipant.HandleSet, 2)
+	})
+
 	t.Run("present-passing record missing its handle fails closed", func(t *testing.T) {
 		t.Parallel()
 		root, change := newRoot(t, "lattice-missing-handle")

--- a/internal/model/context_attestation.go
+++ b/internal/model/context_attestation.go
@@ -58,13 +58,29 @@ type ContextOriginHandle struct {
 	Handle string
 }
 
+// isMultiValuedContextOriginStage reports whether a context-origin stage may
+// legitimately record more than one distinct handle on a single record. Only
+// the fix stage is multi-valued: a reviewer's record accumulates one
+// context_origin:stage=fix handle per fresh-context repair subagent / batch, so
+// multiple distinct fix handles are expected rather than ambiguous. Every other
+// stage (review, plan_origin, audit_origin, executor) is single-valued and
+// stays fail-closed on conflicting handles.
+func isMultiValuedContextOriginStage(stage string) bool {
+	return stage == StageContextFix
+}
+
 // ContextOriginHandlesFromVerification extracts the per-stage context handles a
-// record attests via context_origin:stage=<stage>=<handle>. The result is keyed
-// by stage. ok is false when no well-formed handle is present, or when the
-// record carries conflicting handles for the same stage — ambiguous evidence
+// record attests via context_origin:stage=<stage>=<handle>, restricted to the
+// single-valued stages. The result is keyed by stage. ok is false when no
+// well-formed single-valued handle is present, or when the record carries
+// conflicting handles for the same single-valued stage — ambiguous evidence
 // fails closed (mirroring ExecutorAgentHandlesFromVerification) rather than
 // letting the last reference win. A repeated identical handle for a stage is
 // idempotent.
+//
+// Multi-valued stages (fix) are intentionally excluded: their references neither
+// poison the whole-record parse on multiplicity nor land in this single-valued
+// map. Use FixContextOriginHandleSetFromVerification to read the fix handle set.
 func ContextOriginHandlesFromVerification(record VerificationRecord) (map[string]ContextOriginHandle, bool) {
 	handles := map[string]ContextOriginHandle{}
 	for _, ref := range record.References {
@@ -72,10 +88,16 @@ func ContextOriginHandlesFromVerification(record VerificationRecord) (map[string
 		if !ok {
 			continue
 		}
+		if isMultiValuedContextOriginStage(stage) {
+			// Multi-valued stage handles are read as a set elsewhere; they do
+			// not participate in the single-valued fail-closed guard and are not
+			// stored here.
+			continue
+		}
 		if existing, seen := handles[stage]; seen && existing.Handle != handle {
-			// Two references naming the same stage with different handles are
-			// ambiguous; the gate fails closed rather than letting the last
-			// reference win.
+			// Two references naming the same single-valued stage with different
+			// handles are ambiguous; the gate fails closed rather than letting
+			// the last reference win.
 			return nil, false
 		}
 		handles[stage] = ContextOriginHandle{Stage: stage, Handle: handle}
@@ -148,6 +170,26 @@ func ReviewContextOriginHandleFromVerification(record VerificationRecord) (Conte
 		return ContextOriginHandle{}, false
 	}
 	return handle, true
+}
+
+// FixContextOriginHandleSetFromVerification flattens every
+// context_origin:stage=fix=<handle> reference a record attests into a deduped
+// set of fix context handles. The fix stage is multi-valued — a reviewer's
+// record accumulates one handle per fresh-context repair subagent / batch — so
+// this NEVER fails closed on multiplicity; it simply collects the distinct
+// handles. Blank handles are skipped by the parser. The result is never nil so
+// callers can range over it safely; an absence of fix handles yields an empty
+// set. This mirrors ExecutorParticipantHandleSetFromVerification.
+func FixContextOriginHandleSetFromVerification(record VerificationRecord) map[string]struct{} {
+	set := map[string]struct{}{}
+	for _, ref := range record.References {
+		stage, handle, ok := parseContextOriginReference(ref)
+		if !ok || stage != StageContextFix {
+			continue
+		}
+		set[handle] = struct{}{}
+	}
+	return set
 }
 
 func singleStageHandleFromVerification(record VerificationRecord, prefix, stage string) (ContextOriginHandle, bool) {

--- a/internal/model/context_attestation_test.go
+++ b/internal/model/context_attestation_test.go
@@ -319,6 +319,28 @@ func TestReviewContextOriginHandleFromVerification(t *testing.T) {
 			wantOK:     true,
 			wantHandle: "ctx-reviewer",
 		},
+		{
+			name: "review handle reads through coexisting multiple distinct fix handles",
+			record: VerificationRecord{
+				References: []string{
+					"context_origin:stage=review=ctx-review",
+					"context_origin:stage=fix=ctx-fix-1",
+					"context_origin:stage=fix=ctx-fix-2",
+				},
+			},
+			wantOK:     true,
+			wantHandle: "ctx-review",
+		},
+		{
+			name: "record with only multiple fix handles has no review handle without failing closed",
+			record: VerificationRecord{
+				References: []string{
+					"context_origin:stage=fix=ctx-fix-1",
+					"context_origin:stage=fix=ctx-fix-2",
+				},
+			},
+			wantOK: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -334,6 +356,71 @@ func TestReviewContextOriginHandleFromVerification(t *testing.T) {
 			}
 			assert.Equal(t, StageContextReview, got.Stage)
 			assert.Equal(t, tt.wantHandle, got.Handle)
+		})
+	}
+}
+
+func TestFixContextOriginHandleSetFromVerification(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		record VerificationRecord
+		want   map[string]struct{}
+	}{
+		{
+			name: "single fix handle flattened to a set",
+			record: VerificationRecord{
+				References: []string{"context_origin:stage=fix=ctx-fix-1"},
+			},
+			want: map[string]struct{}{"ctx-fix-1": {}},
+		},
+		{
+			name: "distinct fix handles deduplicated",
+			record: VerificationRecord{
+				References: []string{
+					"context_origin:stage=fix=ctx-fix-1",
+					"context_origin:stage=fix=ctx-fix-2",
+					"context_origin:stage=fix=ctx-fix-1",
+				},
+			},
+			want: map[string]struct{}{"ctx-fix-1": {}, "ctx-fix-2": {}},
+		},
+		{
+			name: "fix handles coexisting with other stages are still collected",
+			record: VerificationRecord{
+				References: []string{
+					"context_origin:stage=review=ctx-review",
+					"context_origin:stage=fix=ctx-fix-1",
+					"context_origin:stage=fix=ctx-fix-2",
+				},
+			},
+			want: map[string]struct{}{"ctx-fix-1": {}, "ctx-fix-2": {}},
+		},
+		{
+			name: "no fix token yields non-nil empty set",
+			record: VerificationRecord{
+				References: []string{"context_origin:stage=review=ctx-review"},
+			},
+			want: map[string]struct{}{},
+		},
+		{
+			name: "empty references yields non-nil empty set",
+			record: VerificationRecord{
+				References: nil,
+			},
+			want: map[string]struct{}{},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := FixContextOriginHandleSetFromVerification(tt.record)
+			assert.NotNil(t, got)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/internal/tmpl/templates/_partials/command-fix-body.tmpl
+++ b/internal/tmpl/templates/_partials/command-fix-body.tmpl
@@ -25,6 +25,7 @@ slipway fix --start-reexecution
 - Record reviewer evidence through `slipway evidence skill`, including both:
   - `context_origin:stage=review=<reviewer-handle>`
   - `context_origin:stage=fix=<repair-subagent-handle>`
+- A reviewer's evidence may accumulate multiple `context_origin:stage=fix=<repair-subagent-handle>` references — one per fresh-context repair subagent / batch — without invalidating the single `context_origin:stage=review` handle. The fix stage is multi-valued; the review stage stays single-valued.
 - Then run `slipway review` to close the finding.
 - Intent conflict is not a fix. If a reviewer records `new_change_required:intent_conflict`, start a new governed change.
 - Do not use `slipway repair` for review findings; `repair` is local integrity only.

--- a/internal/tmpl/templates_test.go
+++ b/internal/tmpl/templates_test.go
@@ -1575,6 +1575,16 @@ func TestPromptSurfaceTemplateContracts(t *testing.T) {
 		assert.Contains(t, content, "--start-reexecution")
 	})
 
+	t.Run("fix body permits multiple fix-stage context origins per reviewer", func(t *testing.T) {
+		content := renderPromptSurfaceForTest(t, "commands/command-entry.md.tmpl", "fix", "command-fix-body", "claude")
+		// A reviewer's evidence may accumulate more than one fix-stage origin
+		// handle (one per fresh-context repair subagent / batch) without
+		// invalidating the single review-stage handle.
+		assert.Contains(t, content, "A reviewer's evidence may accumulate multiple `context_origin:stage=fix=<repair-subagent-handle>` references")
+		assert.Contains(t, content, "one per fresh-context repair subagent / batch")
+		assert.Contains(t, content, "without invalidating the single `context_origin:stage=review` handle")
+	})
+
 	t.Run("every prompt surface has matching body partial", func(t *testing.T) {
 		partials := promptSurfaceBodyTemplates(t)
 		require.Len(t, partials, 22)


### PR DESCRIPTION
## Summary
Fixes #319 — the misleading `slipway validate` diagnostic *"recorded no context-origin handle for selected reviewer"*.

A reviewer's evidence accumulates one `context_origin:stage=fix=<handle>` per fresh-context repair subagent/batch (exactly as `slipway fix` instructs). The single-valued same-stage guard in `ContextOriginHandlesFromVerification` failed the whole record closed when any stage carried multiple handles, so the multiple fix handles poisoned the parse and masked the unique `stage=review` handle — emitting a false reviewer-missing blocker and telling the user to re-run the reviewer.

## Change
- **`internal/model/context_attestation.go`**: classify `fix` as the only multi-valued context-origin stage; the same-stage fail-closed guard now applies to single-valued stages only; new `FixContextOriginHandleSetFromVerification` returns the deduplicated fix handle set (set semantics, non-nil empty when absent). `review`/`plan_origin`/`audit_origin` stay single-valued and fail-closed.
- **`internal/engine/progression/authority.go`**: `crossStageContextParticipants` unions the full fix handle set across selected reviewers into the fix participant `HandleSet`; the false `context_origin_handle_invalid` reviewer-missing blocker is no longer emitted for the multi-fix shape.
- **`internal/tmpl/templates/_partials/command-fix-body.tmpl`** (+ contract test): document that a reviewer may record multiple fix handles, one per repair subagent.
- Regression tests added in the model and authority layers; the existing single-valued fail-closed tests are preserved, not relaxed.

## Safety
No attestation bypass, force-close, restamp, or private-attestation path. Single-valued stages keep their fail-closed semantics.

## Verification
- `go test ./...` → **28 ok / 0 FAIL**
- `golangci-lint run ./...` → **0 issues** (incl. gofmt simplify)
- Dogfooded through Slipway's own S3: spec-compliance + code-quality + independent reviews and the terminal ship-verification gate all PASS, each recorded under a **distinct** `context_origin:stage=review` handle — the very multi-fix lattice this PR repairs validated cleanly end-to-end.

Closes #319.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
