### PR TITLE
fix(toolgen): prune stale command skills

### DIFF
--- a/artifacts/changes/archived/fix-stale-command-skills/assurance.md
+++ b/artifacts/changes/archived/fix-stale-command-skills/assurance.md
@@ -1,0 +1,111 @@
+# Assurance
+
+## Scope Summary
+This change fixes stale generated command skills by changing adapter refresh
+cleanup from name-list matching to generated command-skill content recognition.
+Retired `slipway-<command>` skill directories are recognized by generated
+frontmatter, `surface: skill`, matching `command_id`, absence from the live
+command registry, and the authoritative generated CLI footer.
+
+The implementation is limited to generator cleanup and regression coverage:
+`internal/toolgen/toolgen.go`, `internal/toolgen/toolgen_test.go`, and
+`cmd/template_flag_contract_test.go`. It does not reintroduce retired commands
+or change command execution semantics.
+
+## Verification Verdict
+Implementation-wave verification passed for the planned scope. The focused
+adapter, command-surface, and manifest checks all passed against the current
+worktree before S3 review.
+
+S3 review and terminal ship verification passed on run version 3. The selected
+peer reviews all recorded fresh passing evidence:
+spec-compliance-review, code-quality-review, and independent-review. Terminal
+ship-verification then recorded `verdict: pass` with the authoritative full
+suite, lint, manifest check, diff check, evidence-freshness attestation,
+reviewer-independence attestation, and assurance-completeness attestation.
+
+## Evidence Index
+- `artifacts/changes/fix-stale-command-skills/verification/wave-orchestration-notes.md`
+  records root cause, implementation decisions, and task-level evidence.
+- `artifacts/changes/fix-stale-command-skills/task-results/t-01.json` records
+  regression-test evidence for retired command-skill cleanup and live command ID
+  resolution.
+- `artifacts/changes/fix-stale-command-skills/task-results/t-02.json` records
+  implementation evidence for content-signature cleanup and fail-closed
+  deletion behavior.
+- `artifacts/changes/fix-stale-command-skills/task-results/t-03.json` records
+  focused verification evidence.
+- `artifacts/changes/fix-stale-command-skills/verification/wave-orchestration.yaml`
+  records the wave-orchestration skill verdict.
+- `artifacts/changes/fix-stale-command-skills/verification/spec-compliance-review.yaml`
+  records fresh run-version-3 spec compliance evidence.
+- `artifacts/changes/fix-stale-command-skills/verification/code-quality-review.yaml`
+  records fresh run-version-3 implementation quality evidence.
+- `artifacts/changes/fix-stale-command-skills/verification/independent-review.yaml`
+  records fresh run-version-3 independent review evidence.
+- `artifacts/changes/fix-stale-command-skills/verification/ship-verification.yaml`
+  records terminal ship verification and closeout attestations.
+- `artifacts/changes/fix-stale-command-skills/verification/logs/ship-suite.txt`
+  records the authoritative `go test ./...` proof.
+- Focused verification commands:
+  - `go test ./internal/toolgen -run 'TestGenerateRefreshPrunesRetiredCommandSkillDirsByContent|TestGenerateRefreshPreservesUnknownCleanupTargetsAndRefusesManagedModified|TestGenerateRefreshWithoutOwnershipManifestBootstrapsIntoTrackedState|TestGeneratedAdapterSurfacesStayInSyncWithRegistry|TestCodexCommandSkills|TestCodexCommandSkillsUseCommandRegistryArguments|TestCodexCommandSkillsIncludeTierAndSurface' -count=1`
+  - `go test ./cmd -run 'TestGeneratedCommandSkillIDsResolveOnLiveRootCommands|TestTemplateFlagsMatchCobraCommands|TestCobraFlagsCoveredByRegistryArguments|TestGeneratedCommandEntriesExposeChangeSelectorForSupportedCommands' -count=1`
+  - `go test ./internal/toolgen/cmd/gen-surface-manifest -count=1`
+  - `go run ./internal/toolgen/cmd/gen-surface-manifest --check`
+- Terminal ship verification commands:
+  - `go test ./...`
+  - `golangci-lint run ./...`
+  - `go run ./internal/toolgen/cmd/gen-surface-manifest --check`
+  - `git diff --check`
+
+## Requirement Coverage
+- REQ-001 is covered by `cleanupStaleSkillDirs` and
+  `TestGenerateRefreshPrunesRetiredCommandSkillDirsByContent`, including
+  manifest-absent residue, manifest-tracked residue, and a synthetic retired
+  command ID that was never enumerated in the reported stale set.
+- REQ-002 is covered by post-refresh disk-tree assertions in
+  `TestGenerateRefreshPrunesRetiredCommandSkillDirsByContent` and by
+  `TestGeneratedCommandSkillIDsResolveOnLiveRootCommands`, which resolves
+  generated command-skill `command_id` values through `newRootCmd().Commands()`
+  instead of through the generator registry slice.
+- REQ-003 is covered by tests preserving user-owned adjacent `slipway-*` skills,
+  preserving manifest-absent user-modified generated-shape content, and refusing
+  manifest-tracked user-modified managed content through the existing
+  `managed-modified` fail-closed path.
+- REQ-004 is covered by table-driven command-skill host coverage for every host
+  with `CommandSkillSurface` enabled: codex, kiro, and qwen.
+
+## Residual Risks and Exceptions
+Other retired generated-surface families, such as governance, technique, catalog
+host skills, or nested command entries, may share the same broad registry-coupled
+cleanup pattern. They were documented as out of scope and were not changed here.
+
+`docs/SURFACE-MANIFEST.json` is part of verification scope as a generator/docs
+drift signal. The manifest check reported it is current; the file itself did not
+need content changes.
+
+The codebase map was treated as advisory because live lifecycle output reported
+it may be stale for this change. Implementation and review authority stayed with
+the bound worktree, current governed artifacts, and current source files.
+
+## Rollback Readiness
+Rollback is a normal source revert of the generator and tests touched by this
+change, plus the governed artifact bundle if the governed change is abandoned.
+There is no data migration, external API change, persisted state conversion, or
+irreversible operation.
+
+If rollback is needed after merge, revert the source changes to
+`internal/toolgen/toolgen.go`, `internal/toolgen/toolgen_test.go`, and
+`cmd/template_flag_contract_test.go`, then rerun the adapter and command-surface
+test subset before shipping the revert.
+
+## Archive Decision
+Ready to archive. Active `validate --json` from the bound worktree reports
+fresh evidence, no blockers, and approved `G_ship` before `done`. The archive is
+appropriate because every requirement has implementation, test coverage, fresh
+selected review evidence, terminal ship verification, and rollback guidance.
+
+After `done`, treat the archived bundle as a frozen record. Any later
+verification should run against the source branch or a new active governed
+change rather than describing the archived bundle as revalidated through the
+active validate gate.

--- a/artifacts/changes/archived/fix-stale-command-skills/change.yaml
+++ b/artifacts/changes/archived/fix-stale-command-skills/change.yaml
@@ -1,0 +1,46 @@
+version: 1
+slug: fix-stale-command-skills
+description: fix stale command skills
+status: done
+current_state: DONE
+complexity_level: simple
+base_ref: HEAD
+created_at: 2026-06-25T04:39:19.212354Z
+quality_mode: standard
+workflow_profile: code
+workflow_preset: standard
+worktree_branch: feat/fix-stale-command-skills
+artifact_schema: core
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: d5ec9598c15f5c4c1518fddc980ca6983acd3a433ae0a2692c464cc394d10c31
+        updated_at: 2026-06-25T08:23:14.105481995Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: c82e480b966c6ff128e3b9ea9cf4a5fa900aa1253f7047f301b1a2f57fe03204
+        updated_at: 2026-06-25T05:22:11.547242234Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: 1771f6e8e151982dcb7415583e6c787734034f67b608b50a165aab2a5088c2e0
+        updated_at: 2026-06-25T05:21:16.778018051Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: f6807b58902942875e29b15d40feda5b4bc466f7c044535ccfd6cd77aa27e742
+        updated_at: 2026-06-25T06:08:03.257455554Z
+evidence_refs:
+    code-quality-review: .worktrees/fix-stale-command-skills/artifacts/changes/fix-stale-command-skills/verification/code-quality-review.yaml
+    independent-review: .worktrees/fix-stale-command-skills/artifacts/changes/fix-stale-command-skills/verification/independent-review.yaml
+    intake-clarification: .worktrees/fix-stale-command-skills/artifacts/changes/fix-stale-command-skills/verification/intake-clarification.yaml
+    plan-audit: .worktrees/fix-stale-command-skills/artifacts/changes/fix-stale-command-skills/verification/plan-audit.yaml
+    ship-verification: .worktrees/fix-stale-command-skills/artifacts/changes/fix-stale-command-skills/verification/ship-verification.yaml
+    spec-compliance-review: .worktrees/fix-stale-command-skills/artifacts/changes/fix-stale-command-skills/verification/spec-compliance-review.yaml
+    wave-orchestration: .worktrees/fix-stale-command-skills/artifacts/changes/fix-stale-command-skills/verification/wave-orchestration.yaml

--- a/artifacts/changes/archived/fix-stale-command-skills/intent.md
+++ b/artifacts/changes/archived/fix-stale-command-skills/intent.md
@@ -1,0 +1,71 @@
+# Intent
+
+## Summary
+Fix stale generated command skills so retired command surfaces cannot remain
+discoverable after CLI commands are removed.
+
+## Complexity Assessment
+simple
+The scope is a bounded generator/test repair in the adapter surface area. It
+does not change lifecycle state semantics, command behavior, or external API
+contracts.
+
+## In Scope
+- Update the Slipway toolgen refresh/prune contract so any previously generated
+  command-skill directory for a retired command is removed by class (content
+  signature + command_id absent from the registry), not by a hand-maintained
+  retired-name list, and covering both manifest-tracked and legacy
+  manifest-absent residue.
+- Keep removal fail-closed: route deletion through the ownership-manifest safety
+  path so user-modified content under a retired name is preserved, never
+  silently destroyed.
+- Add regression coverage proving retired command skills (including a synthetic
+  never-enumerated id, manifest-present residue, and every command-skill host)
+  cannot persist after refresh, while user-owned/modified skills survive.
+- Add a non-tautological command-surface contract check that parses each
+  generated command skill `command_id` and asserts it resolves on the live root
+  command tree.
+- Run focused Go tests and manifest checks that cover command/adapter surfaces.
+
+## Out of Scope
+- Do not reintroduce `slipway stats`, `slipway learn`, `slipway checkpoint`,
+  `slipway pivot`, `run --resume-response`, or related retired behavior.
+- Do not submit root-checkout local `.codex/skills` cleanup as the PR fix by
+  itself; the durable fix must live in tracked generator code and tests.
+- Do not alter unrelated active changes or their governed bundles.
+- Other retired generated-surface families (governance/technique/catalog host
+  skills, nested command entries) plausibly share this registry-coupled cleanup
+  leak; they are the same defect class but are deferred to a follow-up unless a
+  generalized content-signature recognizer naturally covers them.
+
+## Constraints
+- Preserve user-owned adjacent adapter files during refresh.
+- Keep the cleanup fail-closed for modified managed files.
+- Keep command behavior and generated command references aligned with
+  `commandRegistry`.
+
+## Open Questions
+None.
+
+## Acceptance Signals
+- Refreshing a generated adapter prunes retired command-skill directories for
+  ANY retired command (including a synthetic never-enumerated id and
+  manifest-present residue), across every command-skill host (REQ-001/004).
+- A directory under a retired name holding user-modified content is preserved,
+  not deleted (REQ-003 fail-closed).
+- A contract test resolves each generated command skill `command_id` against the
+  live root command tree, failing if any maps to a non-registered command
+  (REQ-002; non-tautological).
+- Focused `go test` coverage for `cmd` and `internal/toolgen` passes.
+- `go run ./internal/toolgen/cmd/gen-surface-manifest --check` reports the
+  manifest is current. (REQ-002 generator/docs-drift signal only; it is built
+  from live registries and is structurally blind to on-disk residue, so it does
+  NOT falsify REQ-001 — the behavioral prune tests carry REQ-001.)
+
+## Approved Summary
+Confirmed by user on 2026-06-25T04:41:09Z: implement a PR-ready generator and
+test fix for stale command skills. The change should make retired generated
+command-skill directories prune reliably and add contract coverage so command
+skills cannot point at commands absent from the current CLI/registry. Directly
+deleting root-checkout local `.codex/skills` residue is out of scope unless it
+falls out of the tracked generator behavior.

--- a/artifacts/changes/archived/fix-stale-command-skills/requirements.md
+++ b/artifacts/changes/archived/fix-stale-command-skills/requirements.md
@@ -1,0 +1,75 @@
+# Requirements
+
+## Requirements
+
+### Requirement: Retired command skills are pruned by class, not by name
+REQ-001: The system MUST remove every generated command-skill directory whose
+`command_id` is absent from the current command registry during adapter refresh,
+regardless of whether the command was retired before or after this change, and
+without relying on a hand-maintained list of specific retired command names.
+
+#### Scenario: refresh removes residue for any retired command
+GIVEN a Slipway-generated adapter and a generated-shape command-skill directory
+whose `command_id` is no longer in the current command registry
+WHEN `slipway init --refresh` regenerates the adapter
+THEN the retired command-skill directory is removed from the adapter skill tree.
+
+#### Scenario: refresh removes residue for a command never enumerated in this change
+GIVEN a generated-shape command-skill directory for a synthetic retired
+`command_id` that is not one of the originally reported retired names
+WHEN `slipway init --refresh` regenerates the adapter
+THEN the directory is removed, proving the cleanup generalizes to future
+retirements rather than matching an enumerated set.
+
+#### Scenario: residue recorded in the prior ownership manifest is pruned
+GIVEN a command-skill directory that the previous generation recorded in the
+ownership manifest for a now-retired command
+WHEN `slipway init --refresh` regenerates the adapter
+THEN the directory is removed through the manifest-tracked cleanup path.
+
+### Requirement: No surviving command skill maps to a non-registry command
+REQ-002: After adapter refresh, the system MUST NOT leave any command-skill
+directory on disk whose `command_id` is absent from the live CLI command
+surface, and generated command skills MUST advertise only command IDs that
+resolve to a registered command on the live root command tree.
+
+#### Scenario: post-refresh disk tree has no orphan command skills
+GIVEN an adapter refreshed by Slipway
+WHEN the reconciled on-disk skill tree is inspected
+THEN every surviving `slipway-<id>` command-skill directory carries a
+`command_id` that resolves to a registered command.
+
+#### Scenario: generated command IDs resolve on the live root command
+GIVEN generated command-skill surfaces for a host adapter
+WHEN a contract test parses each generated command skill `command_id`
+THEN every ID resolves to a command registered on the live root command tree
+(`newRootCmd().Commands()`), not merely the registry slice the generator
+iterates, so the check cannot pass tautologically.
+
+### Requirement: User-owned and user-modified skills are preserved fail-closed
+REQ-003: The system MUST preserve user-owned adjacent skill directories during
+adapter refresh, and MUST fail closed (refuse to delete) when a directory under
+a retired command-skill name holds user-authored or user-modified content
+rather than pristine generated content.
+
+#### Scenario: prefixed user-owned skill is preserved
+GIVEN a user-owned `slipway-*` skill directory beside generated adapter skills
+WHEN adapter refresh runs
+THEN the user-owned skill directory remains in place.
+
+#### Scenario: user-modified content under a retired name is preserved
+GIVEN a directory under a retired command-skill name whose SKILL.md carries
+generated-shape frontmatter but a user-modified body
+WHEN adapter refresh runs
+THEN the directory is preserved because the cleanup refuses to delete modified
+managed content, rather than silently destroying the user's edits.
+
+### Requirement: Pruning applies to every command-skill host
+REQ-004: Retired command-skill cleanup MUST apply uniformly to every host
+adapter that emits a command-skill surface, not only the host first reported.
+
+#### Scenario: every command-skill host prunes retired residue
+GIVEN retired generated command-skill residue under each host adapter that
+generates a command-skill surface
+WHEN `slipway init --refresh` regenerates those adapters
+THEN the retired residue is removed for every such host.

--- a/artifacts/changes/archived/fix-stale-command-skills/task-results/t-01.json
+++ b/artifacts/changes/archived/fix-stale-command-skills/task-results/t-01.json
@@ -1,0 +1,11 @@
+{
+  "task_id": "t-01",
+  "verdict": "pass",
+  "evidence_ref": "red-test:go test ./internal/toolgen -run TestGenerateRefreshPrunesRetiredCommandSkillDirsByContent -count=1 failed on retired command-skill residue; contract-test:go test ./cmd -run TestGeneratedCommandSkillIDsResolveOnLiveRootCommands -count=1 passed; review-repair:s3-review-repair:fix-stale-command-skills added before-footer user-modified manifestless preservation and realistic generated-shape retired skill prune coverage; final repair added exact current-rendered candidate coverage plus exact legacy generated stats/learn/checkpoint/pivot samples and shape-preserving user-edit preservation; rerun go test ./internal/toolgen -run TestGenerateRefreshPrunesRetiredCommandSkillDirsByContent -count=1 passed; rerun go test ./cmd -run TestGeneratedCommandSkillIDsResolveOnLiveRootCommands -count=1 passed",
+  "changed_files": [
+    "internal/toolgen/toolgen_test.go",
+    "cmd/template_flag_contract_test.go"
+  ],
+  "blockers": [],
+  "session_id": "codex-inline-wave-1-t-01+repair-019efd7e-c213-7fd2-949b-595af1d657b9+019efd85-8cb9-7530-9d21-9aa7180e64dc+019efda3-1eed-7752-95f3-aecd6004c43f+019efdac-fdcd-7353-b391-d6e23f2f0bed"
+}

--- a/artifacts/changes/archived/fix-stale-command-skills/task-results/t-02.json
+++ b/artifacts/changes/archived/fix-stale-command-skills/task-results/t-02.json
@@ -1,0 +1,10 @@
+{
+  "task_id": "t-02",
+  "verdict": "pass",
+  "evidence_ref": "green-test:go test ./internal/toolgen -run TestGenerateRefreshPrunesRetiredCommandSkillDirsByContent -count=1; contract-test:go test ./cmd -run TestGeneratedCommandSkillIDsResolveOnLiveRootCommands -count=1; review-repair:s3-review-repair:fix-stale-command-skills tightened manifestless retired command-skill cleanup to exact generated-content matching: current rendered command-skill candidates rewritten to retired IDs plus exact legacy generated stats/learn/checkpoint/pivot signatures; user content before/after footer and shape-preserving legacy edits are preserved; manifest-tracked cleanup stays on ownership fail-closed path; rerun go test ./internal/toolgen -run TestGenerateRefreshPrunesRetiredCommandSkillDirsByContent -count=1 passed; black-box root stale samples codex/kiro/qwen stats/learn/checkpoint plus codex pivot all pruned",
+  "changed_files": [
+    "internal/toolgen/toolgen.go"
+  ],
+  "blockers": [],
+  "session_id": "codex-inline-wave-2-t-02+repair-019efd7e-c213-7fd2-949b-595af1d657b9+019efd85-8cb9-7530-9d21-9aa7180e64dc+019efda3-1eed-7752-95f3-aecd6004c43f+019efdac-fdcd-7353-b391-d6e23f2f0bed"
+}

--- a/artifacts/changes/archived/fix-stale-command-skills/task-results/t-03.json
+++ b/artifacts/changes/archived/fix-stale-command-skills/task-results/t-03.json
@@ -1,0 +1,12 @@
+{
+  "task_id": "t-03",
+  "verdict": "pass",
+  "evidence_ref": "verification:go test ./internal/toolgen -run 'TestGenerateRefreshPrunesRetiredCommandSkillDirsByContent|TestGenerateRefreshPreservesUnknownCleanupTargetsAndRefusesManagedModified|TestGenerateRefreshWithoutOwnershipManifestBootstrapsIntoTrackedState|TestGeneratedAdapterSurfacesStayInSyncWithRegistry|TestCodexCommandSkills|TestCodexCommandSkillsUseCommandRegistryArguments|TestCodexCommandSkillsIncludeTierAndSurface' -count=1; go test ./cmd -run 'TestGeneratedCommandSkillIDsResolveOnLiveRootCommands|TestTemplateFlagsMatchCobraCommands|TestCobraFlagsCoveredByRegistryArguments|TestGeneratedCommandEntriesExposeChangeSelectorForSupportedCommands' -count=1; go test ./internal/toolgen/cmd/gen-surface-manifest -count=1; go run ./internal/toolgen/cmd/gen-surface-manifest --check; git diff --check; black-box copied real root stale samples into a temp repo and refresh pruned codex/kiro/qwen stats/learn/checkpoint plus codex pivot",
+  "changed_files": [
+    "internal/toolgen/toolgen_test.go",
+    "cmd/template_flag_contract_test.go",
+    "docs/SURFACE-MANIFEST.json"
+  ],
+  "blockers": [],
+  "session_id": "codex-inline-wave-3-t-03+repair-019efd7e-c213-7fd2-949b-595af1d657b9+019efd85-8cb9-7530-9d21-9aa7180e64dc+019efda3-1eed-7752-95f3-aecd6004c43f+019efdac-fdcd-7353-b391-d6e23f2f0bed"
+}

--- a/artifacts/changes/archived/fix-stale-command-skills/tasks.md
+++ b/artifacts/changes/archived/fix-stale-command-skills/tasks.md
@@ -1,0 +1,36 @@
+# Tasks
+
+## Task List
+
+- [x] `t-01` Add regression coverage proving retired command-skill cleanup
+  generalizes by class — a synthetic never-enumerated retired id, both
+  manifest-absent (legacy) and manifest-present residue, and every
+  command-skill host (codex, kiro, qwen, table-driven) — while staying
+  fail-closed so a retired-named dir holding user-modified generated-shape
+  content is preserved; plus a non-tautological contract test that resolves each
+  generated command skill `command_id` on the live root command tree
+  (`newRootCmd().Commands()`, not the registry slice the generator iterates).
+  - depends_on: []
+  - target_files: [internal/toolgen/toolgen_test.go, cmd/template_flag_contract_test.go]
+  - task_kind: test
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004]
+
+- [x] `t-02` Make refresh prune retired command-skill directories by content
+  signature for discovery (generated shape plus a `command_id` absent from the
+  current registry) while routing every deletion through the ownership-manifest
+  fail-closed path for safety (sha256 managed-modified refusal for
+  manifest-tracked residue; exact canonical-body match for manifest-absent
+  legacy residue). No hand-maintained retired-name list, and do not grow the
+  registry-derived static set in `allGeneratedSkillDirNameSet`. Fix locus is
+  `cleanupStaleSkillDirs` in toolgen.go, cfg-parameterized so it covers every
+  command-skill host.
+  - depends_on: [t-01]
+  - target_files: [internal/toolgen/toolgen.go, internal/toolgen/install_profiles.go]
+  - task_kind: code
+  - covers: [REQ-001, REQ-003, REQ-004]
+
+- [x] `t-03` Run focused adapter and command-surface verification.
+  - depends_on: [t-02]
+  - target_files: [internal/toolgen/toolgen_test.go, cmd/template_flag_contract_test.go, docs/SURFACE-MANIFEST.json]
+  - task_kind: verification
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004]

--- a/cmd/template_flag_contract_test.go
+++ b/cmd/template_flag_contract_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -13,6 +14,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 // TestTemplateFlagsMatchCobraCommands verifies that every --flag referenced
@@ -185,6 +187,92 @@ func TestGeneratedCommandEntriesExposeChangeSelectorForSupportedCommands(t *test
 		require.NoError(t, err)
 		assert.Contains(t, string(raw), "--change <slug>", "generated command entry for %s must surface the explicit change selector", id)
 	}
+}
+
+func TestGeneratedCommandSkillIDsResolveOnLiveRootCommands(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	var toolIDs []string
+	for _, cfg := range toolgen.Registry() {
+		if cfg.CommandSkillSurface {
+			toolIDs = append(toolIDs, cfg.ID)
+		}
+	}
+	require.NotEmpty(t, toolIDs)
+	require.NoError(t, toolgen.Generate(root, toolIDs, true))
+
+	liveRootCommands := map[string]struct{}{}
+	for _, cmd := range newRootCmd().Commands() {
+		liveRootCommands[cmd.Name()] = struct{}{}
+	}
+
+	found := map[string]struct{}{}
+	for _, cfg := range toolgen.Registry() {
+		if !cfg.CommandSkillSurface {
+			continue
+		}
+		skillsRoot := filepath.Join(root, cfg.SkillsDir)
+		err := filepath.WalkDir(skillsRoot, func(path string, d fs.DirEntry, walkErr error) error {
+			if walkErr != nil || d.IsDir() || d.Name() != "SKILL.md" {
+				return walkErr
+			}
+			meta, ok, err := generatedCommandSkillMetadata(path)
+			if err != nil || !ok {
+				return err
+			}
+			found[cfg.ID+"/"+meta.CommandID] = struct{}{}
+			_, resolves := liveRootCommands[meta.CommandID]
+			assert.Truef(t, resolves,
+				"%s generated command skill %s points at command_id %q, but newRootCmd().Commands() does not register it",
+				cfg.ID, path, meta.CommandID)
+			assert.Equal(t, "slipway-"+meta.CommandID, filepath.Base(filepath.Dir(path)),
+				"%s generated command skill path must match command_id", cfg.ID)
+			return nil
+		})
+		require.NoError(t, err)
+	}
+	require.NotEmpty(t, found, "expected generated command-skill metadata for at least one host")
+}
+
+type commandSkillMetadata struct {
+	CommandID string `yaml:"command_id"`
+	Surface   string `yaml:"surface"`
+}
+
+func generatedCommandSkillMetadata(path string) (commandSkillMetadata, bool, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return commandSkillMetadata{}, false, err
+	}
+	block, ok := leadingFrontmatterBlock(string(raw))
+	if !ok {
+		return commandSkillMetadata{}, false, nil
+	}
+	var meta commandSkillMetadata
+	if err := yaml.Unmarshal([]byte(block), &meta); err != nil {
+		return commandSkillMetadata{}, false, err
+	}
+	if strings.TrimSpace(meta.CommandID) == "" || strings.TrimSpace(meta.Surface) != "skill" {
+		return commandSkillMetadata{}, false, nil
+	}
+	meta.CommandID = strings.TrimSpace(meta.CommandID)
+	meta.Surface = strings.TrimSpace(meta.Surface)
+	return meta, true, nil
+}
+
+func leadingFrontmatterBlock(content string) (string, bool) {
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+	content = strings.TrimLeft(content, "\n")
+	if !strings.HasPrefix(content, "---\n") {
+		return "", false
+	}
+	rest := strings.TrimPrefix(content, "---\n")
+	end := strings.Index(rest, "\n---")
+	if end < 0 {
+		return "", false
+	}
+	return rest[:end], true
 }
 
 // TestCobraFlagsCoveredByRegistryArguments is the reverse contract of

--- a/internal/toolgen/toolgen.go
+++ b/internal/toolgen/toolgen.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/signalridge/slipway/internal/engine/capability"
+	"github.com/signalridge/slipway/internal/fsutil"
 	"github.com/signalridge/slipway/internal/state"
 	"github.com/signalridge/slipway/internal/tmpl"
 	"gopkg.in/yaml.v3"
@@ -1368,6 +1369,15 @@ func cleanupStaleSkillDirs(
 		if _, ok := expected[name]; ok {
 			continue
 		}
+		if cfg.CommandSkillSurface && entry.IsDir() {
+			cleaned, err := cleanupRetiredCommandSkillDir(plan, cfg, filepath.Join(skillsRoot, name))
+			if err != nil {
+				return err
+			}
+			if cleaned {
+				continue
+			}
+		}
 		if _, ok := managed[name]; ok {
 			if err := removePathIfExistsWithPlan(plan, filepath.Join(skillsRoot, name)); err != nil {
 				return err
@@ -1375,6 +1385,420 @@ func cleanupStaleSkillDirs(
 		}
 	}
 	return nil
+}
+
+type retiredCommandSkillDir struct {
+	generatedContent bool
+	manifestTracked  bool
+}
+
+func cleanupRetiredCommandSkillDir(plan *toolRefreshPlan, cfg ToolConfig, dir string) (bool, error) {
+	retired, ok, err := inspectRetiredCommandSkillDir(plan, cfg, dir)
+	if err != nil || !ok {
+		return ok, err
+	}
+	if retired.manifestTracked {
+		return true, removePathIfExistsWithPlanPolicy(plan, dir, false)
+	}
+	if !retired.generatedContent {
+		return true, nil
+	}
+	if err := removeVerifiedManifestlessRetiredCommandSkillDir(plan, dir); err != nil {
+		return true, err
+	}
+	return true, nil
+}
+
+func inspectRetiredCommandSkillDir(plan *toolRefreshPlan, cfg ToolConfig, dir string) (retiredCommandSkillDir, bool, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return retiredCommandSkillDir{}, false, nil
+		}
+		return retiredCommandSkillDir{}, false, err
+	}
+	skillPath := filepath.Join(dir, "SKILL.md")
+	raw, err := os.ReadFile(skillPath) // #nosec G304 -- path is rooted under the adapter skills directory.
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return retiredCommandSkillDir{}, false, nil
+		}
+		return retiredCommandSkillDir{}, false, err
+	}
+
+	content := normalizeTemplateLineEndings(string(raw))
+	fm, _, err := splitSkillFrontmatter(content)
+	if err != nil {
+		return retiredCommandSkillDir{}, false, nil
+	}
+	var meta struct {
+		Name      string `yaml:"name"`
+		CommandID string `yaml:"command_id"`
+		Surface   string `yaml:"surface"`
+	}
+	if err := yaml.Unmarshal([]byte(fm), &meta); err != nil {
+		return retiredCommandSkillDir{}, false, nil
+	}
+	commandID := strings.TrimSpace(meta.CommandID)
+	if commandID == "" || strings.TrimSpace(meta.Surface) != "skill" {
+		return retiredCommandSkillDir{}, false, nil
+	}
+	if _, live := commandRegistryMap[commandID]; live {
+		return retiredCommandSkillDir{}, false, nil
+	}
+	if filepath.Base(dir) != adapterSkillName(commandID) {
+		return retiredCommandSkillDir{}, false, nil
+	}
+	if name := strings.TrimSpace(meta.Name); name != "" && name != adapterSkillName(commandID) {
+		return retiredCommandSkillDir{}, false, nil
+	}
+
+	manifestTracked, err := manifestTracksPath(plan, skillPath)
+	if err != nil {
+		return retiredCommandSkillDir{}, false, err
+	}
+	generatedContent, err := commandSkillDirHasSingleGeneratedSkillFile(entries, content, cfg, commandID)
+	if err != nil {
+		return retiredCommandSkillDir{}, false, err
+	}
+	return retiredCommandSkillDir{
+		generatedContent: generatedContent,
+		manifestTracked:  manifestTracked,
+	}, true, nil
+}
+
+func manifestTracksPath(plan *toolRefreshPlan, path string) (bool, error) {
+	if plan == nil {
+		return false, nil
+	}
+	rel, insideRoot, err := plan.relativePath(path)
+	if err != nil || !insideRoot {
+		return false, err
+	}
+	_, ok := plan.previousIndex[rel]
+	return ok, nil
+}
+
+func commandSkillDirHasSingleGeneratedSkillFile(entries []os.DirEntry, content string, cfg ToolConfig, commandID string) (bool, error) {
+	if len(entries) != 1 || entries[0].IsDir() || entries[0].Name() != "SKILL.md" {
+		return false, nil
+	}
+	return isGeneratedCommandSkillContent(content, cfg, commandID)
+}
+
+func isGeneratedCommandSkillContent(content string, cfg ToolConfig, commandID string) (bool, error) {
+	content = normalizeTemplateLineEndings(content)
+	for _, sourceID := range commandIDs() {
+		candidate, err := renderedCommandSkillAsRetiredCommand(cfg, sourceID, commandID)
+		if err != nil {
+			return false, err
+		}
+		if content == candidate {
+			return true, nil
+		}
+	}
+	if matchesLegacyGeneratedCommandSkillSignature(content, cfg, commandID) {
+		return true, nil
+	}
+	return false, nil
+}
+
+const legacyGeneratedCommandSkillTrigger = "<legacy-command-trigger>"
+
+type legacyGeneratedCommandSkillSignature struct {
+	commandID              string
+	description            string
+	class                  string
+	tier                   string
+	includeInstallMetadata bool
+	body                   string
+}
+
+// legacyGeneratedCommandSkillSignatures is a generated-content signature set for
+// pre-manifest command-skill residue. Names alone are never deletion authority:
+// callers only reach these signatures after parsing a command_id, confirming it
+// is absent from the current command registry, and checking the full file body.
+var legacyGeneratedCommandSkillSignatures = []legacyGeneratedCommandSkillSignature{
+	{
+		commandID:              "stats",
+		description:            "Show repo-wide governance freshness and workflow statistics",
+		class:                  string(CommandClassQuery),
+		tier:                   "diagnostics",
+		includeInstallMetadata: true,
+		body: legacyGeneratedCommandSkillBody(
+			"# Stats",
+			"",
+			"Show repo-wide governance freshness and workflow statistics across every change.",
+			"",
+			"## Invocation",
+			"```bash",
+			"slipway stats --json",
+			"```",
+			"",
+			"## Contract",
+			"- Read-only repo-wide observability: active/archived counts, freshness summaries,",
+			"  and workflow statistics. It is not scoped to a single change — use",
+			"  `slipway status` for the active change.",
+			"",
+			"## Flags",
+			"- `--json`: JSON output",
+			"",
+			"## Arguments",
+			"```text",
+			"[--json]",
+			"```",
+			"",
+			"## Prerequisites",
+			"- `.slipway.yaml` must exist (run `slipway init` first)",
+		),
+	},
+	{
+		commandID:              "learn",
+		description:            "Preview governance learning proposals from lifecycle evidence",
+		class:                  string(CommandClassQuery),
+		tier:                   "diagnostics",
+		includeInstallMetadata: true,
+		body: legacyGeneratedCommandSkillBody(
+			"# Learn",
+			"",
+			"Preview read-only governance learning proposals derived from accumulated",
+			"lifecycle evidence.",
+			"",
+			"## Invocation",
+			"```bash",
+			"slipway learn --preview --json",
+			"```",
+			"",
+			"## Contract",
+			"- Read-only and non-mutating: it surfaces *proposed* governance adjustments for",
+			"  human review; it never applies them. Proposals are advisory only.",
+			"- `--preview` is the default. This is a maintainer/observability surface, not a",
+			"  step in driving a single change.",
+			"",
+			"## Flags",
+			"- `--preview`: generate read-only governance learning proposals (default true)",
+			"- `--json`: JSON output",
+			"",
+			"## Arguments",
+			"```text",
+			"[--preview] [--json]",
+			"```",
+			"",
+			"## Prerequisites",
+			"- `.slipway.yaml` must exist (run `slipway init` first)",
+		),
+	},
+	{
+		commandID:              "checkpoint",
+		description:            "Set an active checkpoint to pause wave execution and request user input",
+		class:                  string(CommandClassMutation),
+		tier:                   "situational",
+		includeInstallMetadata: true,
+		body: legacyGeneratedCommandSkillBody(
+			"# Checkpoint",
+			"",
+			"Pause wave execution and request user input for a specific task.",
+			"",
+			"## Invocation",
+			"```bash",
+			"slipway checkpoint --task-id <task_id> [--type <type>] [--allowed-responses <responses>] --json",
+			"```",
+			"",
+			"## Contract",
+			"- Sets an active checkpoint on the current governed change.",
+			"- Only valid during `S2_IMPLEMENT` state.",
+			"- Only one checkpoint can be active at a time.",
+			"- Resume with `slipway run --resume-response \"<response>\"`.",
+			"- After checkpoint resume, a **fresh subagent MUST be spawned** — do NOT continue in the same context.",
+			"",
+			"## When to Use",
+			"- Task encounters a blocker requiring human judgment (architectural decision, ambiguous requirement).",
+			"- Task encounters deviation that requires user decision.",
+			"- Retry budget exhausted — surface failure to user for decision.",
+			"",
+			"## Flags",
+			"- `--task-id <id>`: ID of the paused task (required)",
+			"- `--type <type>`: Checkpoint type — `human_verify` (default), `decision`, `human_action`",
+			"- `--allowed-responses <responses>`: Comma-separated allowed response values (required for `type=decision`)",
+			"- `--json`: JSON output",
+			"- `--change <slug>`: target a specific active change",
+			"",
+			"## Arguments",
+			"```text",
+			"--task-id <id> [--type human_verify|decision|human_action] [--allowed-responses <value> ...] [--json] [--change <slug>]",
+			"```",
+			"",
+			"## Prerequisites",
+			"- `.slipway.yaml` must exist (run `slipway init` first)",
+			"- An active governed change must be in S2_IMPLEMENT with a materialized wave plan (run `slipway repair` if `wave-plan.yaml` is missing).",
+		),
+	},
+	{
+		commandID:   "pivot",
+		description: "Reroute or rescope an active change",
+		class:       string(CommandClassMutation),
+		tier:        "situational",
+		body: legacyGeneratedCommandSkillBody(
+			"# Pivot",
+			"",
+			"Reroute (re-evaluate the routing/discovery decision) or rescope (reopen intake to",
+			"amend scope) an active change. Both set `needs_discovery=true` and clear",
+			"execution residue.",
+			"",
+			"## Invocation",
+			"```bash",
+			"slipway pivot --reroute",
+			"slipway pivot --rescope",
+			"```",
+			"",
+			"## Contract",
+			"- Show pivot summary with before/after state.",
+			"- Confirm pivot action with user before executing.",
+			"- `--reroute` (the default when no flag is given) is valid in `S1_PLAN`,",
+			"  `S2_EXECUTE`, `S3_REVIEW`, or `S4_VERIFY`; it returns the change to `S1_PLAN`",
+			"  with discovery forced on. An invalid state is blocked (`pivot_state_invalid`).",
+			"- `--rescope` is valid in `S2_EXECUTE`, `S3_REVIEW`, or `S4_VERIFY`; it returns",
+			"  the change to `S0_INTAKE` (intake/clarify) and clears the intent",
+			"  `## Approved Summary` so it must be re-confirmed. Before execution",
+			"  (`S0_INTAKE`/`S1_PLAN`) and terminal states are blocked",
+			"  (`rescope_state_invalid`).",
+			"",
+			"## Flags",
+			"- `--reroute`: Re-evaluate routing/discovery and re-enter `S1_PLAN` (valid in S1_PLAN/S2_EXECUTE/S3_REVIEW/S4_VERIFY).",
+			"- `--rescope`: Reopen intake — return to `S0_INTAKE` to amend scope, clearing the Approved Summary (valid in S2_EXECUTE/S3_REVIEW/S4_VERIFY).",
+			"- `--json`: JSON output",
+			"- `--change <slug>`: target a specific active change",
+			"",
+			"## Arguments",
+			"```text",
+			"[--reroute|--rescope] [--json] [--change <slug>]",
+			"```",
+			"",
+			"## Prerequisites",
+			"- `.slipway.yaml` must exist (run `slipway init` first)",
+			"- an active change must exist, or pass `--change <slug>` when supported.",
+		),
+	},
+}
+
+func legacyGeneratedCommandSkillBody(lines ...string) string {
+	return strings.Join(lines, "\n")
+}
+
+func matchesLegacyGeneratedCommandSkillSignature(content string, cfg ToolConfig, commandID string) bool {
+	content, ok := normalizeLegacyGeneratedCommandSkillTrigger(content, cfg, commandID)
+	if !ok {
+		return false
+	}
+	for _, signature := range legacyGeneratedCommandSkillSignatures {
+		if signature.commandID != commandID {
+			continue
+		}
+		if content == signature.content() {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeLegacyGeneratedCommandSkillTrigger(content string, cfg ToolConfig, commandID string) (string, bool) {
+	triggerLine := "trigger: \"" + commandTrigger(cfg, commandID) + "\"\n"
+	if strings.Count(content, triggerLine) != 1 {
+		return "", false
+	}
+	normalized := "trigger: \"" + legacyGeneratedCommandSkillTrigger + "\"\n"
+	return strings.Replace(content, triggerLine, normalized, 1), true
+}
+
+func (s legacyGeneratedCommandSkillSignature) content() string {
+	var b strings.Builder
+	b.WriteString("---\n")
+	b.WriteString("name: ")
+	b.WriteString(adapterSkillName(s.commandID))
+	b.WriteByte('\n')
+	b.WriteString("description: ")
+	b.WriteString(yamlDoubleQuoted(s.description))
+	b.WriteByte('\n')
+	if s.includeInstallMetadata {
+		b.WriteString("install_profiles:\n")
+		b.WriteString("  - full\n")
+		b.WriteString("requires: []\n")
+	}
+	b.WriteString("command_id: \"")
+	b.WriteString(s.commandID)
+	b.WriteString("\"\n")
+	b.WriteString("trigger: \"")
+	b.WriteString(legacyGeneratedCommandSkillTrigger)
+	b.WriteString("\"\n")
+	b.WriteString("class: \"")
+	b.WriteString(s.class)
+	b.WriteString("\"\n")
+	b.WriteString("tier: \"")
+	b.WriteString(s.tier)
+	b.WriteString("\"\n")
+	b.WriteString("surface: \"skill\"\n")
+	b.WriteString("---\n")
+	b.WriteString(strings.TrimRight(s.body, "\n"))
+	b.WriteString("\n\n")
+	b.WriteString(commandSkillFooter(s.commandID))
+	b.WriteByte('\n')
+	return b.String()
+}
+
+func renderedCommandSkillAsRetiredCommand(cfg ToolConfig, sourceID, retiredID string) (string, error) {
+	content, err := renderCommandSkill(cfg, sourceID)
+	if err != nil {
+		return "", err
+	}
+	return rewriteGeneratedCommandSkillIdentity(content, cfg, sourceID, retiredID)
+}
+
+func rewriteGeneratedCommandSkillIdentity(content string, cfg ToolConfig, fromID, toID string) (string, error) {
+	content = normalizeTemplateLineEndings(content)
+	replacements := []struct {
+		old string
+		new string
+	}{
+		{
+			old: "name: " + adapterSkillName(fromID) + "\n",
+			new: "name: " + adapterSkillName(toID) + "\n",
+		},
+		{
+			old: "command_id: \"" + fromID + "\"\n",
+			new: "command_id: \"" + toID + "\"\n",
+		},
+		{
+			old: "trigger: \"" + commandTrigger(cfg, fromID) + "\"\n",
+			new: "trigger: \"" + commandTrigger(cfg, toID) + "\"\n",
+		},
+		{
+			old: commandSkillFooter(fromID),
+			new: commandSkillFooter(toID),
+		},
+	}
+	for _, replacement := range replacements {
+		if count := strings.Count(content, replacement.old); count != 1 {
+			return "", fmt.Errorf("generated command skill %q identity marker count for %q: got %d, want 1", fromID, replacement.old, count)
+		}
+		content = strings.Replace(content, replacement.old, replacement.new, 1)
+	}
+	return content, nil
+}
+
+func commandSkillFooter(commandID string) string {
+	return fmt.Sprintf("Invoke the authoritative `slipway %s` CLI surface directly; do not reimplement Slipway lifecycle semantics.", commandID)
+}
+
+func removeVerifiedManifestlessRetiredCommandSkillDir(plan *toolRefreshPlan, dir string) error {
+	if plan != nil {
+		_, insideRoot, err := plan.relativePath(dir)
+		if err != nil || !insideRoot {
+			return err
+		}
+		plan.ops = append(plan.ops, fsutil.RemoveAllTransactionOp(dir))
+		return nil
+	}
+	return removePathIfExists(dir)
 }
 
 func generatedSkillDirNameSet(cfg ToolConfig) map[string]struct{} {

--- a/internal/toolgen/toolgen_test.go
+++ b/internal/toolgen/toolgen_test.go
@@ -1340,6 +1340,582 @@ func TestGenerateRefreshPrunesOnlyGeneratedTopLevelSkillEntries(t *testing.T) {
 	assert.NoError(t, err, "skill index should live under workflow references")
 }
 
+func TestGenerateRefreshPrunesRetiredCommandSkillDirsByContent(t *testing.T) {
+	retiredSkills := []struct {
+		id       string
+		sourceID string
+	}{
+		{id: "synthetic-query-retired-command", sourceID: "next"},
+		{id: "synthetic-mutation-retired-command", sourceID: "new"},
+		{id: "synthetic-setup-retired-command", sourceID: "init"},
+		{id: "synthetic-never-enumerated-retired-command", sourceID: "preset"},
+	}
+
+	t.Run("manifest absent residue from a real generated command body is pruned", func(t *testing.T) {
+		root := t.TempDir()
+		cfg := toolRegistry["codex"]
+
+		require.NoError(t, Generate(root, []string{cfg.ID}, true))
+
+		id := "synthetic-realistic-retired"
+		sourceID := "next"
+		sourceSkill, err := os.ReadFile(commandSkillPath(root, cfg, sourceID))
+		require.NoError(t, err)
+		skillPath := commandSkillPath(root, cfg, id)
+		require.NoError(t, os.MkdirAll(filepath.Dir(skillPath), 0o755))
+		require.NoError(t, os.WriteFile(
+			skillPath,
+			[]byte(rewriteGeneratedCommandSkillIdentityForTest(t, string(sourceSkill), cfg, sourceID, id)),
+			0o644,
+		))
+
+		require.NoError(t, Generate(root, []string{cfg.ID}, true))
+
+		_, err = os.Stat(filepath.Dir(skillPath))
+		assert.True(t, os.IsNotExist(err), "refresh should prune realistic manifestless generated command skill residue")
+		assertNoOrphanCommandSkills(t, root, cfg)
+	})
+
+	t.Run("manifest absent realistic legacy stats sample is pruned", func(t *testing.T) {
+		for _, cfg := range commandSkillHostConfigs(t) {
+			t.Run(cfg.ID, func(t *testing.T) {
+				root := t.TempDir()
+
+				require.NoError(t, Generate(root, []string{cfg.ID}, true))
+
+				skillPath := commandSkillPath(root, cfg, "stats")
+				require.NoError(t, os.MkdirAll(filepath.Dir(skillPath), 0o755))
+				require.NoError(t, os.WriteFile(
+					skillPath,
+					[]byte(realisticLegacyRetiredCommandSkillForTest(t, cfg, "stats")),
+					0o644,
+				))
+
+				require.NoError(t, Generate(root, []string{cfg.ID}, true))
+
+				_, err := os.Stat(filepath.Dir(skillPath))
+				assert.True(t, os.IsNotExist(err), "%s refresh should prune realistic legacy stats residue", cfg.ID)
+				assertNoOrphanCommandSkills(t, root, cfg)
+			})
+		}
+	})
+
+	t.Run("manifest absent legacy generated command samples are pruned", func(t *testing.T) {
+		legacyIDs := []string{"stats", "learn", "checkpoint", "pivot"}
+		for _, cfg := range commandSkillHostConfigs(t) {
+			t.Run(cfg.ID, func(t *testing.T) {
+				root := t.TempDir()
+
+				require.NoError(t, Generate(root, []string{cfg.ID}, true))
+
+				for _, id := range legacyIDs {
+					skillPath := commandSkillPath(root, cfg, id)
+					require.NoError(t, os.MkdirAll(filepath.Dir(skillPath), 0o755))
+					require.NoError(t, os.WriteFile(
+						skillPath,
+						[]byte(realisticLegacyRetiredCommandSkillForTest(t, cfg, id)),
+						0o644,
+					))
+				}
+
+				require.NoError(t, Generate(root, []string{cfg.ID}, true))
+
+				for _, id := range legacyIDs {
+					_, err := os.Stat(filepath.Dir(commandSkillPath(root, cfg, id)))
+					assert.True(t, os.IsNotExist(err), "%s refresh should prune realistic legacy command skill %s", cfg.ID, id)
+				}
+				assertNoOrphanCommandSkills(t, root, cfg)
+			})
+		}
+	})
+
+	t.Run("manifest absent residue for every command skill host", func(t *testing.T) {
+		for _, cfg := range commandSkillHostConfigs(t) {
+			t.Run(cfg.ID, func(t *testing.T) {
+				root := t.TempDir()
+
+				require.NoError(t, Generate(root, []string{cfg.ID}, true))
+
+				for _, retired := range retiredSkills {
+					skillPath := commandSkillPath(root, cfg, retired.id)
+					require.NoError(t, os.MkdirAll(filepath.Dir(skillPath), 0o755))
+					require.NoError(t, os.WriteFile(
+						skillPath,
+						[]byte(generatedRetiredCommandSkill(t, cfg, retired.sourceID, retired.id)),
+						0o644,
+					))
+				}
+				userOwnedSkill := commandSkillPath(root, cfg, "user-owned")
+				require.NoError(t, os.MkdirAll(filepath.Dir(userOwnedSkill), 0o755))
+				require.NoError(t, os.WriteFile(userOwnedSkill, []byte("keep user-owned skill"), 0o644))
+
+				require.NoError(t, Generate(root, []string{cfg.ID}, true))
+
+				for _, retired := range retiredSkills {
+					_, err := os.Stat(filepath.Dir(commandSkillPath(root, cfg, retired.id)))
+					assert.True(t, os.IsNotExist(err), "%s refresh should remove retired generated command skill %s", cfg.ID, retired.id)
+				}
+				_, err := os.Stat(userOwnedSkill)
+				assert.NoError(t, err, "%s refresh must preserve adjacent user-owned skill dirs", cfg.ID)
+				assertNoOrphanCommandSkills(t, root, cfg)
+			})
+		}
+	})
+
+	t.Run("manifest tracked residue is pruned", func(t *testing.T) {
+		for _, cfg := range commandSkillHostConfigs(t) {
+			t.Run(cfg.ID, func(t *testing.T) {
+				root := t.TempDir()
+
+				require.NoError(t, Generate(root, []string{cfg.ID}, true))
+
+				id := "synthetic-manifest-tracked-retired-command"
+				skillPath := commandSkillPath(root, cfg, id)
+				require.NoError(t, os.MkdirAll(filepath.Dir(skillPath), 0o755))
+				require.NoError(t, os.WriteFile(skillPath, []byte(generatedRetiredCommandSkill(t, cfg, "new", id)), 0o644))
+				addOwnershipManifestFiles(t, root, cfg, skillPath)
+
+				require.NoError(t, Generate(root, []string{cfg.ID}, true))
+
+				_, err := os.Stat(filepath.Dir(skillPath))
+				assert.True(t, os.IsNotExist(err), "%s refresh should prune manifest-tracked retired generated command skill", cfg.ID)
+				assertNoOrphanCommandSkills(t, root, cfg)
+			})
+		}
+	})
+
+	t.Run("manifest absent user modified generated shape is preserved", func(t *testing.T) {
+		root := t.TempDir()
+		cfg := toolRegistry["codex"]
+
+		require.NoError(t, Generate(root, []string{cfg.ID}, true))
+
+		afterFooterID := "synthetic-user-modified-after-footer-command"
+		afterFooterSkill := commandSkillPath(root, cfg, afterFooterID)
+		require.NoError(t, os.MkdirAll(filepath.Dir(afterFooterSkill), 0o755))
+		require.NoError(t, os.WriteFile(afterFooterSkill, []byte(userModifiedRetiredCommandSkill(t, cfg, "next", afterFooterID)), 0o644))
+		beforeFooterID := "synthetic-user-modified-before-footer-command"
+		beforeFooterSkill := commandSkillPath(root, cfg, beforeFooterID)
+		require.NoError(t, os.MkdirAll(filepath.Dir(beforeFooterSkill), 0o755))
+		require.NoError(t, os.WriteFile(
+			beforeFooterSkill,
+			[]byte(userModifiedRetiredCommandSkillBeforeFooter(t, cfg, "new", beforeFooterID)),
+			0o644,
+		))
+		shapePreservingID := "synthetic-user-modified-shape-command"
+		shapePreservingSkill := commandSkillPath(root, cfg, shapePreservingID)
+		require.NoError(t, os.MkdirAll(filepath.Dir(shapePreservingSkill), 0o755))
+		require.NoError(t, os.WriteFile(
+			shapePreservingSkill,
+			[]byte(userModifiedRetiredCommandSkillBullet(t, cfg, "next", shapePreservingID)),
+			0o644,
+		))
+
+		require.NoError(t, Generate(root, []string{cfg.ID}, true))
+
+		got, err := os.ReadFile(afterFooterSkill)
+		require.NoError(t, err, "refresh must preserve user-modified generated-shape content under retired command names")
+		assert.Contains(t, string(got), "local operator notes")
+		got, err = os.ReadFile(beforeFooterSkill)
+		require.NoError(t, err, "refresh must preserve user-modified generated-shape content before the footer")
+		assert.Contains(t, string(got), "local operator notes")
+		got, err = os.ReadFile(shapePreservingSkill)
+		require.NoError(t, err, "refresh must preserve shape-preserving user-modified generated content")
+		assert.Contains(t, string(got), "local operator override")
+	})
+
+	t.Run("manifest absent user modified realistic legacy stats sample is preserved", func(t *testing.T) {
+		for _, cfg := range commandSkillHostConfigs(t) {
+			t.Run(cfg.ID, func(t *testing.T) {
+				root := t.TempDir()
+
+				require.NoError(t, Generate(root, []string{cfg.ID}, true))
+
+				id := "stats"
+				skillPath := commandSkillPath(root, cfg, id)
+				require.NoError(t, os.MkdirAll(filepath.Dir(skillPath), 0o755))
+				sample := realisticLegacyRetiredCommandSkillForTest(t, cfg, id)
+				footer := commandSkillFooter(id)
+				require.Contains(t, sample, footer)
+				modified := replaceOnceForTest(
+					t,
+					sample,
+					"Show repo-wide governance freshness and workflow statistics across every change.",
+					"Show repo-wide governance freshness and local operator notes across every change.",
+				)
+				require.Contains(t, modified, footer)
+				require.NoError(t, os.WriteFile(skillPath, []byte(modified), 0o644))
+
+				require.NoError(t, Generate(root, []string{cfg.ID}, true))
+
+				got, err := os.ReadFile(skillPath)
+				require.NoError(t, err, "%s refresh must preserve user-modified realistic legacy stats content", cfg.ID)
+				assert.Equal(t, modified, string(got))
+			})
+		}
+	})
+
+	t.Run("manifest tracked user modified generated shape refuses deletion", func(t *testing.T) {
+		root := t.TempDir()
+		cfg := toolRegistry["codex"]
+
+		require.NoError(t, Generate(root, []string{cfg.ID}, true))
+
+		id := "synthetic-manifest-tracked-user-modified-command"
+		skillPath := commandSkillPath(root, cfg, id)
+		require.NoError(t, os.MkdirAll(filepath.Dir(skillPath), 0o755))
+		require.NoError(t, os.WriteFile(skillPath, []byte(generatedRetiredCommandSkill(t, cfg, "next", id)), 0o644))
+		addOwnershipManifestFiles(t, root, cfg, skillPath)
+		require.NoError(t, os.WriteFile(skillPath, []byte(userModifiedRetiredCommandSkill(t, cfg, "next", id)), 0o644))
+
+		err := Generate(root, []string{cfg.ID}, true)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "managed-modified")
+
+		got, readErr := os.ReadFile(skillPath)
+		require.NoError(t, readErr)
+		assert.Contains(t, string(got), "local operator notes")
+	})
+}
+
+func commandSkillHostConfigs(t *testing.T) []ToolConfig {
+	t.Helper()
+
+	var out []ToolConfig
+	for _, cfg := range Registry() {
+		if cfg.CommandSkillSurface {
+			out = append(out, cfg)
+		}
+	}
+	require.NotEmpty(t, out)
+	return out
+}
+
+func commandSkillPath(root string, cfg ToolConfig, id string) string {
+	return filepath.Join(root, SkillPath(cfg, id))
+}
+
+func assertNoOrphanCommandSkills(t *testing.T, root string, cfg ToolConfig) {
+	t.Helper()
+
+	skillsRoot := filepath.Join(root, cfg.SkillsDir)
+	err := filepath.WalkDir(skillsRoot, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil || d.IsDir() || d.Name() != "SKILL.md" {
+			return walkErr
+		}
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		fm, _, err := splitSkillFrontmatter(string(raw))
+		if err != nil {
+			return nil
+		}
+		var meta struct {
+			CommandID string `yaml:"command_id"`
+			Surface   string `yaml:"surface"`
+		}
+		if err := yaml.Unmarshal([]byte(fm), &meta); err != nil {
+			return nil
+		}
+		id := strings.TrimSpace(meta.CommandID)
+		if id == "" || strings.TrimSpace(meta.Surface) != "skill" {
+			return nil
+		}
+		if _, ok := commandRegistryMap[id]; !ok {
+			t.Fatalf("%s refresh left orphan command skill %s at %s", cfg.ID, id, path)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+func generatedRetiredCommandSkill(t *testing.T, cfg ToolConfig, sourceID, id string) string {
+	t.Helper()
+
+	content, err := renderCommandSkill(cfg, sourceID)
+	require.NoError(t, err)
+	return rewriteGeneratedCommandSkillIdentityForTest(t, content, cfg, sourceID, id)
+}
+
+func realisticLegacyRetiredCommandSkillForTest(t *testing.T, cfg ToolConfig, id string) string {
+	t.Helper()
+
+	sample := realisticLegacyCodexRetiredCommandSkillForTest(t, id)
+	return replaceOnceForTest(
+		t,
+		sample,
+		fmt.Sprintf("trigger: \"$slipway-%s\"", id),
+		"trigger: \""+commandTrigger(cfg, id)+"\"",
+	)
+}
+
+func realisticLegacyCodexRetiredCommandSkillForTest(t *testing.T, id string) string {
+	t.Helper()
+
+	switch id {
+	case "stats":
+		return legacyRetiredCommandSkillSampleForTest(
+			"---",
+			"name: slipway-stats",
+			"description: \"Show repo-wide governance freshness and workflow statistics\"",
+			"install_profiles:",
+			"  - full",
+			"requires: []",
+			"command_id: \"stats\"",
+			"trigger: \"$slipway-stats\"",
+			"class: \"query\"",
+			"tier: \"diagnostics\"",
+			"surface: \"skill\"",
+			"---",
+			"# Stats",
+			"",
+			"Show repo-wide governance freshness and workflow statistics across every change.",
+			"",
+			"## Invocation",
+			"```bash",
+			"slipway stats --json",
+			"```",
+			"",
+			"## Contract",
+			"- Read-only repo-wide observability: active/archived counts, freshness summaries,",
+			"  and workflow statistics. It is not scoped to a single change — use",
+			"  `slipway status` for the active change.",
+			"",
+			"## Flags",
+			"- `--json`: JSON output",
+			"",
+			"## Arguments",
+			"```text",
+			"[--json]",
+			"```",
+			"",
+			"## Prerequisites",
+			"- `.slipway.yaml` must exist (run `slipway init` first)",
+			"",
+			"Invoke the authoritative `slipway stats` CLI surface directly; do not reimplement Slipway lifecycle semantics.",
+		)
+	case "learn":
+		return legacyRetiredCommandSkillSampleForTest(
+			"---",
+			"name: slipway-learn",
+			"description: \"Preview governance learning proposals from lifecycle evidence\"",
+			"install_profiles:",
+			"  - full",
+			"requires: []",
+			"command_id: \"learn\"",
+			"trigger: \"$slipway-learn\"",
+			"class: \"query\"",
+			"tier: \"diagnostics\"",
+			"surface: \"skill\"",
+			"---",
+			"# Learn",
+			"",
+			"Preview read-only governance learning proposals derived from accumulated",
+			"lifecycle evidence.",
+			"",
+			"## Invocation",
+			"```bash",
+			"slipway learn --preview --json",
+			"```",
+			"",
+			"## Contract",
+			"- Read-only and non-mutating: it surfaces *proposed* governance adjustments for",
+			"  human review; it never applies them. Proposals are advisory only.",
+			"- `--preview` is the default. This is a maintainer/observability surface, not a",
+			"  step in driving a single change.",
+			"",
+			"## Flags",
+			"- `--preview`: generate read-only governance learning proposals (default true)",
+			"- `--json`: JSON output",
+			"",
+			"## Arguments",
+			"```text",
+			"[--preview] [--json]",
+			"```",
+			"",
+			"## Prerequisites",
+			"- `.slipway.yaml` must exist (run `slipway init` first)",
+			"",
+			"Invoke the authoritative `slipway learn` CLI surface directly; do not reimplement Slipway lifecycle semantics.",
+		)
+	case "checkpoint":
+		return legacyRetiredCommandSkillSampleForTest(
+			"---",
+			"name: slipway-checkpoint",
+			"description: \"Set an active checkpoint to pause wave execution and request user input\"",
+			"install_profiles:",
+			"  - full",
+			"requires: []",
+			"command_id: \"checkpoint\"",
+			"trigger: \"$slipway-checkpoint\"",
+			"class: \"mutation\"",
+			"tier: \"situational\"",
+			"surface: \"skill\"",
+			"---",
+			"# Checkpoint",
+			"",
+			"Pause wave execution and request user input for a specific task.",
+			"",
+			"## Invocation",
+			"```bash",
+			"slipway checkpoint --task-id <task_id> [--type <type>] [--allowed-responses <responses>] --json",
+			"```",
+			"",
+			"## Contract",
+			"- Sets an active checkpoint on the current governed change.",
+			"- Only valid during `S2_IMPLEMENT` state.",
+			"- Only one checkpoint can be active at a time.",
+			"- Resume with `slipway run --resume-response \"<response>\"`.",
+			"- After checkpoint resume, a **fresh subagent MUST be spawned** — do NOT continue in the same context.",
+			"",
+			"## When to Use",
+			"- Task encounters a blocker requiring human judgment (architectural decision, ambiguous requirement).",
+			"- Task encounters deviation that requires user decision.",
+			"- Retry budget exhausted — surface failure to user for decision.",
+			"",
+			"## Flags",
+			"- `--task-id <id>`: ID of the paused task (required)",
+			"- `--type <type>`: Checkpoint type — `human_verify` (default), `decision`, `human_action`",
+			"- `--allowed-responses <responses>`: Comma-separated allowed response values (required for `type=decision`)",
+			"- `--json`: JSON output",
+			"- `--change <slug>`: target a specific active change",
+			"",
+			"## Arguments",
+			"```text",
+			"--task-id <id> [--type human_verify|decision|human_action] [--allowed-responses <value> ...] [--json] [--change <slug>]",
+			"```",
+			"",
+			"## Prerequisites",
+			"- `.slipway.yaml` must exist (run `slipway init` first)",
+			"- An active governed change must be in S2_IMPLEMENT with a materialized wave plan (run `slipway repair` if `wave-plan.yaml` is missing).",
+			"",
+			"Invoke the authoritative `slipway checkpoint` CLI surface directly; do not reimplement Slipway lifecycle semantics.",
+		)
+	case "pivot":
+		return legacyRetiredCommandSkillSampleForTest(
+			"---",
+			"name: slipway-pivot",
+			"description: \"Reroute or rescope an active change\"",
+			"command_id: \"pivot\"",
+			"trigger: \"$slipway-pivot\"",
+			"class: \"mutation\"",
+			"tier: \"situational\"",
+			"surface: \"skill\"",
+			"---",
+			"# Pivot",
+			"",
+			"Reroute (re-evaluate the routing/discovery decision) or rescope (reopen intake to",
+			"amend scope) an active change. Both set `needs_discovery=true` and clear",
+			"execution residue.",
+			"",
+			"## Invocation",
+			"```bash",
+			"slipway pivot --reroute",
+			"slipway pivot --rescope",
+			"```",
+			"",
+			"## Contract",
+			"- Show pivot summary with before/after state.",
+			"- Confirm pivot action with user before executing.",
+			"- `--reroute` (the default when no flag is given) is valid in `S1_PLAN`,",
+			"  `S2_EXECUTE`, `S3_REVIEW`, or `S4_VERIFY`; it returns the change to `S1_PLAN`",
+			"  with discovery forced on. An invalid state is blocked (`pivot_state_invalid`).",
+			"- `--rescope` is valid in `S2_EXECUTE`, `S3_REVIEW`, or `S4_VERIFY`; it returns",
+			"  the change to `S0_INTAKE` (intake/clarify) and clears the intent",
+			"  `## Approved Summary` so it must be re-confirmed. Before execution",
+			"  (`S0_INTAKE`/`S1_PLAN`) and terminal states are blocked",
+			"  (`rescope_state_invalid`).",
+			"",
+			"## Flags",
+			"- `--reroute`: Re-evaluate routing/discovery and re-enter `S1_PLAN` (valid in S1_PLAN/S2_EXECUTE/S3_REVIEW/S4_VERIFY).",
+			"- `--rescope`: Reopen intake — return to `S0_INTAKE` to amend scope, clearing the Approved Summary (valid in S2_EXECUTE/S3_REVIEW/S4_VERIFY).",
+			"- `--json`: JSON output",
+			"- `--change <slug>`: target a specific active change",
+			"",
+			"## Arguments",
+			"```text",
+			"[--reroute|--rescope] [--json] [--change <slug>]",
+			"```",
+			"",
+			"## Prerequisites",
+			"- `.slipway.yaml` must exist (run `slipway init` first)",
+			"- an active change must exist, or pass `--change <slug>` when supported.",
+			"",
+			"Invoke the authoritative `slipway pivot` CLI surface directly; do not reimplement Slipway lifecycle semantics.",
+		)
+	default:
+		t.Fatalf("unknown realistic legacy command skill sample %q", id)
+		return ""
+	}
+}
+
+func legacyRetiredCommandSkillSampleForTest(lines ...string) string {
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func rewriteGeneratedCommandSkillIdentityForTest(t *testing.T, content string, cfg ToolConfig, sourceID, id string) string {
+	t.Helper()
+
+	content = normalizeTemplateLineEndings(content)
+	for _, replacement := range []struct {
+		old string
+		new string
+	}{
+		{
+			old: "name: " + adapterSkillName(sourceID) + "\n",
+			new: "name: " + adapterSkillName(id) + "\n",
+		},
+		{
+			old: "command_id: \"" + sourceID + "\"\n",
+			new: "command_id: \"" + id + "\"\n",
+		},
+		{
+			old: "trigger: \"" + commandTrigger(cfg, sourceID) + "\"\n",
+			new: "trigger: \"" + commandTrigger(cfg, id) + "\"\n",
+		},
+		{
+			old: commandSkillFooter(sourceID),
+			new: commandSkillFooter(id),
+		},
+	} {
+		require.Equal(t, 1, strings.Count(content, replacement.old), "test fixture should contain one generated identity marker %q", replacement.old)
+		content = strings.Replace(content, replacement.old, replacement.new, 1)
+	}
+	return content
+}
+
+func userModifiedRetiredCommandSkill(t *testing.T, cfg ToolConfig, sourceID, id string) string {
+	t.Helper()
+
+	return generatedRetiredCommandSkill(t, cfg, sourceID, id) + "\nlocal operator notes\n"
+}
+
+func userModifiedRetiredCommandSkillBeforeFooter(t *testing.T, cfg ToolConfig, sourceID, id string) string {
+	t.Helper()
+
+	footer := commandSkillFooter(id)
+	return replaceOnceForTest(t, generatedRetiredCommandSkill(t, cfg, sourceID, id), "\n"+footer, "\nlocal operator notes\n\n"+footer)
+}
+
+func userModifiedRetiredCommandSkillBullet(t *testing.T, cfg ToolConfig, sourceID, id string) string {
+	t.Helper()
+
+	return replaceOnceForTest(
+		t,
+		generatedRetiredCommandSkill(t, cfg, sourceID, id),
+		"- `next_skill.name` is the authoritative governed-host handoff.",
+		"- `next_skill.name` is a local operator override.",
+	)
+}
+
+func replaceOnceForTest(t *testing.T, content, old, new string) string {
+	t.Helper()
+
+	require.Equal(t, 1, strings.Count(content, old), "test fixture should contain one copy of %q", old)
+	return strings.Replace(content, old, new, 1)
+}
+
 func TestGenerateRefreshDoesNotPruneSkillDirsWithoutGeneratedAdapterMarker(t *testing.T) {
 	root := t.TempDir()
 


### PR DESCRIPTION
## Summary

Fixes stale generated command-skill directories left behind after a command is retired from the live Slipway command registry.

## What Changed

- Adds refresh cleanup for retired generated command-skill directories under every command-skill host adapter.
- Keeps deletion fail-closed:
  - manifest-tracked residue still goes through the ownership-manifest policy and refuses `managed-modified` content,
  - manifestless residue is removed only when it exactly matches generated command-skill content,
  - user-owned or user-modified retired-named skills are preserved.
- Adds a non-tautological generated command-skill contract test that resolves parsed `command_id` values against `newRootCmd().Commands()`.
- Archives the governed Slipway change bundle after `slipway done`.

## Root Cause

`cleanupStaleSkillDirs` only pruned stale generated skill directories when their names were still represented in the current generated skill directory set. Fully retired commands disappear from that set, so old `slipway-<command>` skill directories could remain discoverable after refresh.

## Validation

- `go test ./...`
- `golangci-lint run ./...`
- `go run ./internal/toolgen/cmd/gen-surface-manifest --check`
- `git diff --check`
- Fresh S3 review evidence:
  - `spec-compliance-review`: pass
  - `code-quality-review`: pass
  - `independent-review`: pass
  - `ship-verification`: pass
- `go run . done --json`
