### PR TITLE
feat(docs): surface Design Philosophy & Governed Workflow deep-dives in sidebar

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -49,7 +49,9 @@ export default defineConfig({
 					label: 'Explanation',
 					items: [
 						{ label: 'Design', slug: 'explanation/design' },
+						{ label: 'Design Philosophy (deep dive)', slug: 'design' },
 						{ label: 'Workflow', slug: 'explanation/workflow' },
+						{ label: 'Governed Workflow (deep dive)', slug: 'workflow' },
 					],
 				},
 			],


### PR DESCRIPTION
Re-applies the sidebar change that was dropped from the #333 squash-merge (it was pushed to the branch after merge). The legacy deep-dive pages `/design/` and `/workflow/` are built but were hidden from the sidebar; this lists them under Explanation alongside the short summaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)