### PR TITLE
chore(governance): archive evidence recovery UX change

### DIFF
--- a/artifacts/changes/archived/fix-evidence-and-recovery-ux/assurance.md
+++ b/artifacts/changes/archived/fix-evidence-and-recovery-ux/assurance.md
@@ -1,0 +1,163 @@
+# Assurance
+
+## Scope Summary
+This change delivers the public evidence and recovery UX fixes for GitHub issues
+#310 and #311, including the #310.1 wave-plan freshness repair. The governed
+scope is complete for five requirements:
+
+- REQ-001 rejects duplicate non-empty task result `session_id` values during
+  `slipway evidence task --result-file` import before invalid task evidence is
+  persisted.
+- REQ-002 keeps malformed engine-owned `verification/<skill>.yaml` records
+  fail-closed while explaining the verification-record boundary and the
+  `--notes-file` recovery path.
+- REQ-003 makes ready no-skill lifecycle states report advancement guidance
+  instead of governance-blocked wording.
+- REQ-004 distinguishes archived same-slug active-state residue from the
+  archived delivered record and avoids primary `--worktree` remediation text.
+- REQ-005 excludes lifecycle bookkeeping from the `wave-orchestration`
+  wave-plan freshness digest so freshly stamped evidence does not immediately
+  stale itself after equivalent wave-plan rematerialization, while genuine
+  task-plan structural, scope, or semantic changes still stale the evidence.
+
+The current governed run is `run_summary_version: 2`. `tasks.md` marks t-01
+through t-05 complete, and `verification/execution-summary.yaml` records
+`overall_verdict: pass` for all five tasks.
+
+## Verification Verdict
+Verdict: pass for the delivered AC-1 through AC-5 scope at
+`run_summary_version: 2`, subject to the engine-owned final-closeout stamp and
+ship-gate recheck.
+
+The latest active validation proof before `done` was captured in S3 review by
+the independent final-closeout verifier with:
+
+```text
+go run . validate --json
+```
+
+That active worktree validation exited 0 and reported:
+
+- `evidence_freshness: fresh`
+- `scope_contract.status: pass`
+- selected S3 skills ready/pass for `spec-compliance-review`,
+  `code-quality-review`, `independent-review`, `goal-verification`, and
+  `security-review`
+- valid requirements and tasks contracts
+- `G_plan: approved`
+- `G_ship: blocked` only because `final-closeout` evidence and the
+  final-closeout assurance and reviewer-independence attestations had not yet
+  been recorded
+
+The full-suite proof for this run is
+`verification/logs/goal-verification-go-test-all-count1-rv2.txt`, which records
+`go test ./... -count=1`, `started_at: 2026-06-26T09:21:01Z`,
+`finished_at: 2026-06-26T09:24:24Z`, and `exit_code: 0`. The current
+`verification/suite-result.yaml` binds that proof to `run_summary_version: 2`
+with digest
+`sha256:c7f21d24903a6f958595d3e18bf696c6703ecc087362d6304513715389587c4c`.
+
+The selected S3 review set has passed at `run_version: 2`:
+
+- `spec-compliance-review.yaml`: `verdict: pass`, `blockers: []`,
+  `run_version: 2`
+- `code-quality-review.yaml`: `verdict: pass`, `blockers: []`,
+  `run_version: 2`
+- `independent-review.yaml`: `verdict: pass`, `blockers: []`,
+  `run_version: 2`
+- `goal-verification.yaml`: `verdict: pass`, `blockers: []`,
+  `run_version: 2`
+- `security-review.yaml`: `verdict: pass`, `blockers: []`,
+  `run_version: 2`
+
+No guardrail domain is set for this change, so no high-risk SAST baseline token
+is required.
+
+## Evidence Index
+- `verification/execution-summary.yaml` records
+  `run_summary_version: 2`, `overall_verdict: pass`, and completed tasks
+  t-01 through t-05.
+- `verification/wave-orchestration.yaml` records the passing wave evidence for
+  all five tasks at `run_version: 2`, including the repair executor handle for
+  t-05.
+- `verification/suite-result.yaml` records the current full-suite digest for
+  `run_summary_version: 2`.
+- `verification/logs/goal-verification-go-test-all-count1-rv2.txt` captures the
+  current full-suite proof, `go test ./... -count=1`, exit 0.
+- `verification/logs/t-05-focused.txt` captures the focused REQ-005 regression
+  proof, exit 0.
+- `verification/task-result-t-01.json` through
+  `verification/task-result-t-05.json` record task-level proof for REQ-001
+  through REQ-005.
+- `verification/spec-compliance-review.yaml` records the current passing spec
+  review at `run_version: 2`.
+- `verification/code-quality-review.yaml` records the current passing code
+  quality review at `run_version: 2`.
+- `verification/independent-review.yaml` records the current passing independent
+  review at `run_version: 2`.
+- `verification/goal-verification.yaml` records the current passing goal
+  verification at `run_version: 2`.
+- `verification/security-review.yaml` records the current passing security
+  review at `run_version: 2`.
+- `verification/final-closeout-notes.md` records the independent final-closeout
+  verifier's pre-stamp validation, proof-reuse judgment, and the assurance
+  repair required before final-closeout evidence can be stamped.
+
+## Requirement Coverage
+- REQ-001 is covered by `cmd/evidence.go` and regression tests in
+  `cmd/evidence_task_test.go`, including duplicate sessions in one import batch
+  and duplicate sessions against existing active-run task evidence.
+- REQ-002 is covered by `internal/state/verification.go`,
+  `internal/state/verification_test.go`, `cmd/validate_readonly_test.go`, and
+  generated `wave-orchestration` skill guidance; malformed verification YAML
+  remains invalid and now carries actionable notes-file recovery guidance.
+- REQ-003 is covered by `cmd/next.go` and `cmd/progression_next_test.go`;
+  ready no-skill states now surface the `slipway run` command boundary instead
+  of `blocked_by_governance` wording.
+- REQ-004 is covered by `cmd/common.go`, `cmd/status.go`,
+  `internal/model/recovery.go`, `cmd/orphaned_bundle_unmanaged_worktree_test.go`,
+  and `internal/model/recovery_test.go`; archived same-slug active residue now
+  targets only incomplete active-state residue and omits `--worktree` from the
+  primary remediation.
+- REQ-005 is covered by
+  `internal/engine/progression/evidence_digests.go` and
+  `internal/engine/progression/evidence_digests_test.go`; the wave-plan digest
+  excludes run-summary version, per-wave parallel flag, and generated-at
+  timestamp bookkeeping while preserving staleness for genuine task-plan scope
+  changes.
+
+## Residual Risks and Exceptions
+- There is no remaining assurance exception for #310.1; it is covered by
+  REQ-005 and t-05.
+- The REQ-005 digest exclusion is intentionally limited to known lifecycle
+  bookkeeping fields. Future wave-plan bookkeeping fields should be evaluated
+  before they are added to the freshness digest input.
+- The selected S3 reviewers and goal-verification have passed at the current
+  run version. The only remaining ship-gate work is the engine-owned
+  `final-closeout` evidence stamp, followed by active validation and governed
+  lifecycle advancement.
+- This change does not include schema migrations, credential handling changes,
+  external API contract changes, generated binary assets, or irreversible data
+  operations.
+
+## Rollback Readiness
+Rollback is straightforward source and artifact rollback: revert the modified Go
+files and discard the governed artifact bundle for
+`fix-evidence-and-recovery-ux` if the change is abandoned. There are no schema
+migrations, external API contracts, credential changes, generated binary assets,
+or irreversible data operations. If only the t-05 repair were rejected, rollback
+would be limited to the REQ-005 digest change, its regression test, and the
+associated governed task and assurance artifacts.
+
+## Archive Decision
+Archive readiness decision: ready to proceed to the governed final-closeout
+stamp and ship-gate recheck for the full REQ-001 through REQ-005 scope.
+
+This assurance does not bypass the engine. Before any `done` command, active
+worktree proof has been captured with `go run . validate --json`, and the
+engine must accept a passing `final-closeout` record containing the required
+freshness, proof-reuse, reviewer-independence, and assurance-completeness
+attestations. After the final-closeout stamp, the coordinator must run active
+validation again and advance only if the current worktree reports the ship gate
+as approved or done-ready. Archived bundles are frozen records and are not used
+as active validation input.

--- a/artifacts/changes/archived/fix-evidence-and-recovery-ux/change.yaml
+++ b/artifacts/changes/archived/fix-evidence-and-recovery-ux/change.yaml
@@ -1,0 +1,48 @@
+version: 1
+slug: fix-evidence-and-recovery-ux
+description: fix evidence and recovery UX
+status: done
+current_state: DONE
+complexity_level: simple
+base_ref: HEAD
+created_at: 2026-06-23T09:19:28.852942Z
+quality_mode: standard
+workflow_profile: code
+workflow_preset: standard
+worktree_branch: feat/fix-evidence-and-recovery-ux
+artifact_schema: core
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: 743e7235f77e85baa1bae469fc4ed6dfab3ab065ae5ba44a8c434356077c4996
+        updated_at: 2026-06-23T10:28:18.536232735Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: 1a5b069cbadb30a10afe72778b2bb19a90e976af2334c6a13979242a97c2a3c8
+        updated_at: 2026-06-23T11:48:01.990395023Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: 6c78d1b9da600c0233e7e015076943faaf6cacecf21ad5b0137702417f292e01
+        updated_at: 2026-06-23T11:48:41.276742255Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: 6b025215253be54c3dff0b038c66bf12bbf149def98b4c350471a918a406044f
+        updated_at: 2026-06-23T11:49:10.573210979Z
+evidence_refs:
+    code-quality-review: .worktrees/fix-evidence-and-recovery-ux/artifacts/changes/fix-evidence-and-recovery-ux/verification/code-quality-review.yaml
+    final-closeout: .worktrees/fix-evidence-and-recovery-ux/artifacts/changes/fix-evidence-and-recovery-ux/verification/final-closeout.yaml
+    goal-verification: .worktrees/fix-evidence-and-recovery-ux/artifacts/changes/fix-evidence-and-recovery-ux/verification/goal-verification.yaml
+    independent-review: .worktrees/fix-evidence-and-recovery-ux/artifacts/changes/fix-evidence-and-recovery-ux/verification/independent-review.yaml
+    intake-clarification: .worktrees/fix-evidence-and-recovery-ux/artifacts/changes/fix-evidence-and-recovery-ux/verification/intake-clarification.yaml
+    plan-audit: .worktrees/fix-evidence-and-recovery-ux/artifacts/changes/fix-evidence-and-recovery-ux/verification/plan-audit.yaml
+    security-review: .worktrees/fix-evidence-and-recovery-ux/artifacts/changes/fix-evidence-and-recovery-ux/verification/security-review.yaml
+    spec-compliance-review: .worktrees/fix-evidence-and-recovery-ux/artifacts/changes/fix-evidence-and-recovery-ux/verification/spec-compliance-review.yaml
+    wave-orchestration: .worktrees/fix-evidence-and-recovery-ux/artifacts/changes/fix-evidence-and-recovery-ux/verification/wave-orchestration.yaml

--- a/artifacts/changes/archived/fix-evidence-and-recovery-ux/intent.md
+++ b/artifacts/changes/archived/fix-evidence-and-recovery-ux/intent.md
@@ -1,0 +1,77 @@
+# Intent
+
+## Summary
+Fix the confirmed #310/#311 evidence-recording and recovery UX defects that
+cause Slipway to accept unusable task evidence, present ready states as blocked,
+or recommend ambiguous deletion for archived-change residue.
+## Complexity Assessment
+simple
+Rationale: the change is limited to CLI/governance recovery surfaces and focused
+regression coverage. It does not introduce a new workflow stage, external API, or
+guardrail-domain behavior.
+
+## In Scope
+- Fail fast during `slipway evidence task --result-file` import when duplicate
+  non-empty `session_id` values in the active run would later invalidate
+  `wave-orchestration` evidence.
+- Improve malformed engine-owned `verification/<skill>.yaml` diagnostics so
+  users are directed to move free-form notes to
+  `verification/<skill>-notes.md` and rerun `slipway evidence skill --notes-file`.
+- Adjust `slipway next --json --diagnostics` ready/no-skill-required output so
+  it does not use `blocked_by_governance` or "resolve governance blockers"
+  wording when the lifecycle can advance.
+- Improve orphaned active bundle residue recovery for slugs that also have an
+  archived change record, so the delete target is explicitly active residue and
+  the archive/source commits are not implied as deletion targets.
+- Exclude lifecycle bookkeeping (run-summary version, per-wave parallel flag,
+  generated-at timestamp) from the `wave-orchestration` wave-plan freshness
+  digest so a freshly recorded `slipway evidence skill --skill wave-orchestration`
+  pass does not immediately stale itself when the wave plan re-materializes at a
+  different run version (#310.1, reproduced on current `main`).
+- State the engine-owned `verification/<skill>.yaml` boundary preventively in the
+  generated `wave-orchestration` skill guidance, not only in the malformed-record
+  error path.
+- Add regression tests for each confirmed behavior.
+
+## Out of Scope
+- Do not broaden the `wave-orchestration` wave-plan digest change beyond excluding
+  the named bookkeeping fields; structural, scope, and semantic task-plan hashes
+  MUST still stale the evidence when the plan genuinely changes.
+- Do not change `slipway delete` destructive semantics beyond safer recovery
+  classification and wording.
+- Do not modify archived change records or user worktrees as part of the fix.
+
+## Constraints
+- Keep compatibility with existing reason-code taxonomy where possible.
+- Preserve fail-closed behavior for malformed engine-owned verification records.
+- Keep recovery commands explicit and non-destructive by default when archive or
+  worktree safety context is ambiguous.
+
+## Acceptance Signals
+- Focused regression tests show duplicate result-file `session_id` imports are
+  rejected before task evidence is persisted.
+- Focused regression tests show malformed `verification/<skill>.yaml` errors
+  mention the engine-owned boundary and `--notes-file` recovery path.
+- Focused regression tests show ready/no-skill-required `next --json
+  --diagnostics` output avoids governance-blocked wording.
+- Focused regression tests show archived same-slug orphaned active residue
+  recovery names active residue explicitly and does not recommend `--worktree`.
+- A focused regression test shows a freshly stamped `wave-orchestration` pass
+  stays fresh after the wave plan re-materializes at a new run version, while a
+  real task-plan scope change still stales the evidence.
+- `go test ./cmd ./internal/model ./internal/state ./internal/engine/progression`
+  passes, or any narrower test scope is justified by the final evidence.
+
+## Open Questions
+None.
+
+## Approved Summary
+User requested a complete governed repair after reproducing the open issues, then
+directed that the #310.1 wave-plan digest-stale path also be reproduced and fixed.
+That path was reproduced on current `main` (a freshly stamped
+`wave-orchestration` evidence immediately re-stales itself when the wave plan
+re-materializes at a different run version), so the approved scope now covers the
+confirmed #310/#311 defects plus the #310.1 wave-plan freshness-digest fix and the
+preventive generated-skill boundary guidance, each with focused regression
+coverage. The user chose to land this through a governed re-walk rather than a
+direct patch.

--- a/artifacts/changes/archived/fix-evidence-and-recovery-ux/requirements.md
+++ b/artifacts/changes/archived/fix-evidence-and-recovery-ux/requirements.md
@@ -1,0 +1,79 @@
+# Requirements
+
+### Requirement: Reject invalid shared task sessions early
+REQ-001: `slipway evidence task --result-file` MUST reject duplicate non-empty
+`session_id` values within the active task-evidence run when those values would
+later produce `session_isolation_warning` for wave orchestration.
+
+#### Scenario: Duplicate session IDs are rejected before persistence
+GIVEN two result-file imports for different planned tasks in the same active run
+AND both result files declare the same non-empty `session_id`
+WHEN `slipway evidence task --result-file <a> --result-file <b> --json` runs
+THEN the command fails with an actionable diagnostic
+AND no task evidence from the invalid batch is persisted.
+
+### Requirement: Explain malformed engine-owned verification records
+REQ-002: Slipway MUST keep malformed `verification/<skill>.yaml` records
+fail-closed while explaining that these YAML files are engine-owned verification
+records and free-form notes belong in a separate notes file passed through
+`slipway evidence skill --notes-file`. The same engine-owned boundary MUST be
+stated preventively in the generated `wave-orchestration` skill guidance, not
+only in the post-failure error path.
+
+#### Scenario: Free-form notes in verification YAML receive recovery guidance
+GIVEN `verification/wave-orchestration.yaml` contains free-form text rather than
+a `VerificationRecord`
+WHEN a command loads governed verification evidence
+THEN the error explains the engine-owned file boundary
+AND the remediation names `verification/wave-orchestration-notes.md` plus
+`slipway evidence skill --skill wave-orchestration --notes-file`.
+
+#### Scenario: Generated wave-orchestration guidance states the engine-owned boundary
+GIVEN the generated `wave-orchestration` skill guidance
+WHEN an author reads it before recording evidence
+THEN it reserves `verification/<skill>.yaml` as an engine-owned VerificationRecord
+written only by `slipway evidence skill`
+AND it directs free-form notes to `verification/<skill>-notes.md` via `--notes-file`.
+
+### Requirement: Show ready lifecycle states as ready
+REQ-003: `slipway next --json --diagnostics` MUST NOT present
+`blocked_by_governance` or "resolve governance blockers" wording when the
+current lifecycle state can advance and no skill is required.
+
+#### Scenario: Ready S2 output points to advancement
+GIVEN a governed S2 change has passing fresh `wave-orchestration` evidence
+AND `slipway validate --json` reports `can_advance=true`
+WHEN `slipway next --json --diagnostics` runs
+THEN the confirmation or recovery wording identifies the state as ready to
+advance
+AND it does not instruct the user to resolve governance blockers.
+
+### Requirement: Disambiguate archived same-slug active residue
+REQ-004: Orphaned active bundle residue recovery MUST distinguish stale active
+state from an archived/delivered change when the same slug also has an archived
+record.
+
+#### Scenario: Archived same-slug residue avoids destructive worktree wording
+GIVEN `artifacts/changes/<slug>/` exists without `change.yaml`
+AND `artifacts/changes/archived/<slug>/change.yaml` exists
+WHEN status or validation surfaces orphaned active bundle residue recovery
+THEN the recovery text names the target as incomplete active-state residue
+AND it says the archived record and source commits are not the target
+AND it does not recommend `--worktree` as part of the primary remediation.
+
+### Requirement: Keep freshly stamped wave-orchestration evidence fresh
+REQ-005: A successful `slipway evidence skill --skill wave-orchestration` MUST NOT
+leave its own freshly stamped evidence immediately stale. The wave-plan freshness
+digest MUST exclude lifecycle bookkeeping (run-summary version, per-wave parallel
+flag, generated-at timestamp) so that re-materializing a structurally identical
+wave plan at a different run version does not flip the just-recorded evidence to
+`required_skill_stale`, while genuine task-plan structural, scope, or semantic
+changes MUST still stale it.
+
+#### Scenario: Re-materialized wave plan keeps fresh evidence fresh
+GIVEN a recorded passing `wave-orchestration` verification for the active run
+WHEN the wave plan re-materializes at a different run-summary version with the
+same task structure
+THEN `slipway validate --json` does not report
+`required_skill_stale:wave-orchestration:wave-plan.yaml`
+AND a real change to a task's target files in the plan still stales the evidence.

--- a/artifacts/changes/archived/fix-evidence-and-recovery-ux/tasks.md
+++ b/artifacts/changes/archived/fix-evidence-and-recovery-ux/tasks.md
@@ -1,0 +1,33 @@
+# Tasks
+
+## Task List
+
+- [x] `t-01` Reject duplicate task-result session IDs during batch import
+  - depends_on: []
+  - target_files: ["cmd/evidence.go", "cmd/evidence_task_test.go"]
+  - task_kind: code
+  - covers: [REQ-001]
+
+- [x] `t-02` Add recovery guidance and preventive generated-skill boundary for engine-owned verification YAML
+  - depends_on: []
+  - target_files: ["internal/state/verification.go", "internal/state/verification_test.go", "cmd/validate_readonly_test.go", "internal/tmpl/templates/skills/wave-orchestration/SKILL.md.tmpl"]
+  - task_kind: code
+  - covers: [REQ-002]
+
+- [x] `t-03` Make ready next diagnostics use advancement wording
+  - depends_on: []
+  - target_files: ["cmd/next.go", "cmd/progression_next_test.go"]
+  - task_kind: code
+  - covers: [REQ-003]
+
+- [x] `t-04` Preserve archived same-slug residue recovery context
+  - depends_on: []
+  - target_files: ["internal/model/recovery.go", "internal/model/reason_code.go", "internal/model/recovery_test.go", "cmd/status.go", "cmd/common.go", "cmd/orphaned_bundle_unmanaged_worktree_test.go"]
+  - task_kind: code
+  - covers: [REQ-004]
+
+- [x] `t-05` Exclude lifecycle bookkeeping from the wave-orchestration wave-plan freshness digest
+  - depends_on: []
+  - target_files: ["internal/engine/progression/evidence_digests.go", "internal/engine/progression/evidence_digests_test.go"]
+  - task_kind: code
+  - covers: [REQ-005]


### PR DESCRIPTION
## Summary

- archive the completed governed change `fix-evidence-and-recovery-ux` after `slipway done`
- add the frozen assurance, change, intent, requirements, and task artifacts for the terminal record

## Context

The implementation PR #314 was already merged. This follow-up PR carries only the archive commit required by `archive_commit_required: true` from `slipway done --json`.

## Verification

- `go run . done --json` completed with `status: done`, `archived: true`, and `archive_commit_required: true`
- before archive, `go run . validate --json` reported `G_ship: approved`, `can_advance: true`, `evidence_freshness: fresh`, and no blockers
- full-suite proof for the governed change: `go test ./... -count=1`, exit 0, recorded in `verification/logs/goal-verification-go-test-all-count1-rv2.txt`
- follow-up branch diff against `origin/main` is archive-only: 5 files, 400 insertions