### PR TITLE
fix(validate): fail closed for missing explicit change

### DIFF
--- a/artifacts/changes/archived/fail-closed-missing-change/assurance.md
+++ b/artifacts/changes/archived/fail-closed-missing-change/assurance.md
@@ -1,0 +1,167 @@
+# Assurance
+
+## Scope Summary
+This change implements opt.md section 1.2 for the governed change
+`fail-closed-missing-change`: an explicit missing target passed to
+`validate --change <slug>` now fails closed with a typed `change_not_found`
+precondition error instead of being softened into the unscoped no-active
+diagnostic view.
+
+The delivered scope is intentionally narrow:
+
+- `cmd/common.go` updates the shared explicit-change resolver so a true missing
+  explicit slug returns `change_not_found` with exit code 3 and `slipway status`
+  remediation.
+- `cmd/common.go` preserves archived explicit slug handling before the missing
+  slug branch, so archived targets still fail closed as
+  `archived_change_not_validatable`.
+- `cmd/validate.go` is not changed; it continues to enter diagnostics fallback
+  only for `no_active_change` and `active_context_ambiguous`.
+- `cmd/validate_readonly_test.go`, `cmd/common_test.go`, and
+  `cmd/resolve_explicit_change_authority_test.go` pin the command-level and
+  resolver-level behavior for the missing explicit slug, archived explicit slug,
+  unscoped no-active diagnostics, and adjacent corrupted-authority paths.
+
+The current governed run is `run_summary_version: 1`. `tasks.md` marks t-01 and
+t-02 complete, and `verification/execution-summary.yaml` records
+`overall_verdict: pass` for both tasks.
+
+## Verification Verdict
+Verdict: pass for REQ-001 at `run_summary_version: 1`, subject to the terminal
+`ship-verification` stamp and the final active validation recheck before
+`done`.
+
+Fresh active validation proof before `done` has been captured in S3 review with:
+
+```text
+go run . validate --json
+```
+
+After the selected peer reviews were stamped, that active worktree validation
+exited 0 and reported:
+
+- `evidence_freshness: fresh`
+- `scope_contract.status: pass`
+- selected S3 peer reviews ready/pass for `spec-compliance-review`,
+  `code-quality-review`, and `independent-review`
+- valid requirements, tasks, and decision contracts
+- `G_plan: approved`
+- `G_scope: approved`
+- `G_ship: blocked` only because this assurance artifact and terminal
+  `ship-verification` evidence/attestations had not yet been recorded
+
+The current selected S3 peer review set has passed at `run_version: 1`:
+
+- `spec-compliance-review.yaml`: `verdict: pass`, `blockers: []`,
+  `layer:R0=pass`, `scope_contract:pass`, `negative_path:pass`, and
+  `context_origin:stage=review=019f0382-257e-7b83-b5bb-87d2d7a0df66`
+- `code-quality-review.yaml`: `verdict: pass`, `blockers: []`,
+  `layer:IR1=pass`, and
+  `context_origin:stage=review=019f0382-6a57-7f82-b697-06d04c2d6340`
+- `independent-review.yaml`: `verdict: pass`, `blockers: []`, and
+  `context_origin:stage=review=019f0382-9d57-7560-8bff-bcde2f7e8365`
+
+The current implementation proof includes:
+
+- `verification/logs/t-02-green.txt`: targeted resolver and validate command
+  tests passed before S3.
+- `verification/logs/t-02-cli-repro.txt`: direct
+  `go run . validate --change definitely-not-a-change --json` proof returned
+  JSON with `error_code: change_not_found`, `exit_code: 3`, and
+  `slug: definitely-not-a-change`.
+- `verification/logs/post-wave-go-test-cmd.txt`: `go test ./cmd -count=1`
+  passed after implementation.
+- `verification/logs/t-02-green-after-review.txt`: targeted resolver and
+  validate command tests passed after the S3 stale-comment repair.
+- `verification/logs/post-review-go-test-cmd.txt`: `go test ./cmd -count=1`
+  passed after the S3 stale-comment repair.
+
+No guardrail domain is set for this change, so no high-risk SAST baseline token
+is required.
+
+## Evidence Index
+- `verification/execution-summary.yaml` records `run_summary_version: 1`,
+  `overall_verdict: pass`, and completed tasks t-01 and t-02.
+- `verification/wave-orchestration.yaml` records passing S2 wave evidence at
+  `run_version: 1`.
+- `verification/wave-orchestration-notes.md` records the RED/GREEN flow, the
+  root cause, the live CLI proof, and the S3 comment repair with post-repair
+  test transcripts.
+- `verification/task-result-t-01.json` records the RED black-box validate test
+  for the missing explicit slug path.
+- `verification/task-result-t-02.json` records the GREEN resolver and live CLI
+  proof for the `change_not_found` contract.
+- `verification/spec-compliance-review.yaml` records the current passing spec
+  review at `run_version: 1`.
+- `verification/code-quality-review.yaml` records the current passing code
+  quality review at `run_version: 1`.
+- `verification/independent-review.yaml` records the current passing
+  independent review at `run_version: 1`.
+- `verification/logs/t-01-red.txt` captures the pre-fix regression failure:
+  validate still returned success diagnostics for the explicit missing slug.
+- `verification/logs/t-02-green.txt` and
+  `verification/logs/t-02-green-after-review.txt` capture targeted passing
+  tests for the final resolver and validate behavior.
+- `verification/logs/t-02-cli-repro.txt` captures the direct missing-slug CLI
+  proof with `change_not_found`.
+- `verification/logs/post-wave-go-test-cmd.txt` and
+  `verification/logs/post-review-go-test-cmd.txt` capture package-level
+  `go test ./cmd -count=1` proof.
+
+## Requirement Coverage
+- REQ-001 missing explicit validate target is covered by
+  `cmd/common.go`, `cmd/validate.go`, `cmd/validate_readonly_test.go`, and
+  `cmd/resolve_explicit_change_authority_test.go`. The command path now returns
+  a typed `change_not_found` precondition error with exit code 3, slug
+  preservation, and `slipway status` remediation.
+- REQ-001 archived explicit validate preservation is covered by
+  `cmd/common.go`, `cmd/common_test.go`, and
+  `cmd/validate_readonly_test.go`. Archived explicit targets remain
+  `archived_change_not_validatable` and remain zero-write.
+- REQ-001 unscoped no-active validation preservation is covered by
+  `cmd/validate.go` and `cmd/validate_readonly_test.go`. Unscoped
+  `validate --json` without an active governed change still emits the existing
+  diagnostics view and remains zero-write.
+- The selected resolver-level decision is covered by `cmd/common.go` and the
+  resolver tests. No validate-only missing-slug branch was added, and no public
+  flags, artifact schemas, runtime layout, or persisted data formats changed.
+- The S3 stale-comment repair is covered by final spec, code-quality, and
+  independent review notes. The comment beside the changed branch now states the
+  current contract instead of the old `no_active_change` softening behavior.
+
+## Residual Risks and Exceptions
+- The broader opt.md InvocationRoute model, freshness split, S3 action contract,
+  host capability model, and supply-chain items are intentionally out of scope
+  for this change and remain for later governed slices.
+- The changed behavior is an intentional fail-closed correction: callers that
+  previously relied on explicit missing slugs being softened into
+  `no_active_change` now receive `change_not_found`. That is the required public
+  contract for this slice.
+- No schema migrations, credential handling changes, external API contract
+  changes, generated binary assets, or irreversible data operations are part of
+  this change.
+
+## Rollback Readiness
+Rollback is a straightforward source and artifact rollback: revert the modified
+Go files and discard the governed artifact bundle for
+`fail-closed-missing-change` if the change is abandoned before archival. There
+are no database migrations, generated binary artifacts, credential changes,
+external service contracts, or irreversible runtime operations. If the S3
+stale-comment repair were rejected independently, rollback would be limited to
+the comment text in `cmd/common.go`; the behavioral resolver fix and tests are
+separable.
+
+## Archive Decision
+Archive readiness decision: ready to proceed to terminal `ship-verification`,
+then to the governed ship-gate recheck for the REQ-001 scope.
+
+This assurance does not bypass the engine. Active worktree proof has been
+captured before `done` with `go run . validate --json`; the current proof shows
+fresh evidence, passing scope contract, and all selected S3 peer reviews
+passing, with the only remaining blockers being this assurance contract and
+terminal `ship-verification` evidence/attestations. `ship-verification` must
+record the authoritative full-suite proof, evidence-freshness proof,
+reviewer-independence attestation, and assurance-completeness attestation. After
+the terminal stamp, the coordinator must run active validation again and advance
+only if the current worktree reports the ship gate as approved or done-ready.
+Archived bundles are frozen records and are not used as active validation input.

--- a/artifacts/changes/archived/fail-closed-missing-change/change.yaml
+++ b/artifacts/changes/archived/fail-closed-missing-change/change.yaml
@@ -1,0 +1,60 @@
+version: 1
+slug: fail-closed-missing-change
+description: fail closed missing change
+status: done
+current_state: DONE
+needs_discovery: true
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-06-26T10:03:19.113161Z
+quality_mode: standard
+workflow_profile: code
+workflow_preset: standard
+worktree_branch: feat/fail-closed-missing-change
+artifact_schema: expanded
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: 614d619a53d0d162b159ba6aeacf4367df33f052628c6e3c1f0c15fc4937463e
+        updated_at: 2026-06-26T10:50:23.206706441Z
+    decision:
+        id: decision
+        path: decision.md
+        state: frozen
+        content_hash: 420a7d02f4850763fde252ab47714f4e6573cf64ce391c45e96dfb6852b72e8b
+        updated_at: 2026-06-26T10:07:40.318978602Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: 1de9a0350775a71fdf7c1b1ea00ffd0249675ddbf5e23ebe2abcb6ba3105e5fb
+        updated_at: 2026-06-26T10:04:23.878184666Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: 65ad88f329565db778b07efc51cb248eae3f4f44d85d3b514ca1791c2e9dcf0f
+        updated_at: 2026-06-26T10:07:40.318043559Z
+    research:
+        id: research
+        path: research.md
+        state: frozen
+        content_hash: a3ca0d8930073493d2c3fdfcaed21208c2a7ed05650819678ec504195772ffdb
+        updated_at: 2026-06-26T10:06:31.095629723Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: 556d059bd3d2a0b3d7f5b57bab7af915d60b9f6b523d55d72646c73919ec042c
+        updated_at: 2026-06-26T10:23:08.016705907Z
+evidence_refs:
+    code-quality-review: .worktrees/fail-closed-missing-change/artifacts/changes/fail-closed-missing-change/verification/code-quality-review.yaml
+    independent-review: .worktrees/fail-closed-missing-change/artifacts/changes/fail-closed-missing-change/verification/independent-review.yaml
+    intake-clarification: .worktrees/fail-closed-missing-change/artifacts/changes/fail-closed-missing-change/verification/intake-clarification.yaml
+    plan-audit: .worktrees/fail-closed-missing-change/artifacts/changes/fail-closed-missing-change/verification/plan-audit.yaml
+    research-orchestration: .worktrees/fail-closed-missing-change/artifacts/changes/fail-closed-missing-change/verification/research-orchestration.yaml
+    ship-verification: .worktrees/fail-closed-missing-change/artifacts/changes/fail-closed-missing-change/verification/ship-verification.yaml
+    spec-compliance-review: .worktrees/fail-closed-missing-change/artifacts/changes/fail-closed-missing-change/verification/spec-compliance-review.yaml
+    wave-orchestration: .worktrees/fail-closed-missing-change/artifacts/changes/fail-closed-missing-change/verification/wave-orchestration.yaml

--- a/artifacts/changes/archived/fail-closed-missing-change/decision.md
+++ b/artifacts/changes/archived/fail-closed-missing-change/decision.md
@@ -1,0 +1,51 @@
+# Decision
+
+## Alternatives Considered
+- Resolver-level fix: change `resolveExplicitChange` so a true missing explicit
+  slug returns `change_not_found` instead of `no_active_change`. This keeps the
+  explicit resolver contract shared and avoids validate-specific branching.
+- Validate-only fix: make `validate` suppress diagnostics fallback when
+  `--change` is present. This is smaller at the command boundary, but it leaves
+  the shared explicit resolver with misleading semantics for other callers.
+- Full route-model fix: implement the broader `InvocationRoute` model from
+  opt.md section 1.1. This is the strategic direction, but it is too broad for
+  the section 1.2 fail-closed bug.
+
+## Selected Approach
+Use the resolver-level fix. `resolveExplicitChange` is already the single path
+for explicit `--change` active-governance targets, and `loadChangeBySlug`
+already uses `change_not_found` for the same missing-slug concept. Updating the
+explicit resolver keeps `validate` aligned with the shared command contract
+without adding a validate-only exception.
+
+## Interfaces and Data Flow
+- CLI input: `validate --change <slug> --json`.
+- Data flow before the change: `validate` calls `resolveActiveChangeRef`, which
+  calls `resolveExplicitChange`; missing active and archived authority returns
+  `no_active_change`; validate's diagnostics fallback converts that to a
+  successful diagnostics view.
+- Data flow after the change: the same path returns a `change_not_found`
+  precondition error for true missing explicit slugs. Validate no longer enters
+  the no-active diagnostics fallback because the error code is not
+  `no_active_change`.
+- No public flags, artifact schemas, runtime state layout, or persisted data
+  formats change.
+
+## Rollout and Rollback
+Rollout is a normal source change with tests. Rollback is a straightforward git
+revert of the resolver and tests. Verification command:
+
+```text
+go test ./cmd -run 'Validate.*(Missing|Archived|NoActive)|ResolveExplicitChange' -count=1
+```
+
+## Risk
+- Regression risk: archived explicit slug handling could accidentally change;
+  this is covered by a validate command test and existing explicit resolver
+  tests.
+- Regression risk: unscoped no-active validate could stop using diagnostics;
+  this is covered by the zero-write no-active validate test.
+- Compatibility risk: callers that depended on explicit missing slugs being
+  softened to `no_active_change` will now receive the more precise
+  `change_not_found` precondition error. This is intentional and matches the
+  fail-closed requirement.

--- a/artifacts/changes/archived/fail-closed-missing-change/intent.md
+++ b/artifacts/changes/archived/fail-closed-missing-change/intent.md
@@ -1,0 +1,65 @@
+# Intent
+
+## Summary
+Make `validate --change <slug>` fail closed when the explicit slug does not
+resolve to an active or archived governed change.
+
+## Complexity Assessment
+simple
+
+The reproduction is a public CLI contract defect with a narrow behavioral
+surface. It needs black-box command tests and a small resolver-path repair, not
+new architecture or discovery.
+
+## Guardrail Domains
+None.
+
+## In Scope
+- `validate --change <missing> --json` must return a typed
+  `change_not_found` error with exit code 3 instead of falling through to
+  generic diagnostics.
+- Explicit archived slug behavior for `validate --change <archived> --json`
+  must remain fail-closed and documented by tests.
+- Unscoped no-active `validate --json` semantics must be fixed in tests so the
+  product contract is explicit.
+- The fix may touch the active-change resolver and validate command boundary
+  only as needed to align `validate` with the existing `status`, `next`,
+  `done`, and `evidence` resolver behavior.
+
+## Out of Scope
+- Full `InvocationRoute` consolidation from opt.md section 1.1.
+- Freshness field splitting from opt.md section 1.3.
+- S3 action-contract alignment from opt.md section 1.4.
+- Host capability/delegation reporting from opt.md section 1.5.
+- Any release, supply-chain, or branch-protection work from opt.md section 2.
+
+## Constraints
+- Preserve unrelated dirty files in the root checkout (`.gemini/`,
+  `coverage.out`, and `opt.md`).
+- Use the bound worktree
+  `.worktrees/fail-closed-missing-change` as the active change authority.
+- Keep remediation output executable and stable for agents.
+
+## Acceptance Signals
+- `go run . validate --change definitely-not-a-change --json` exits 3 and
+  returns `error_code: change_not_found`, `exit_code: 3`, and executable
+  remediation.
+- A black-box test covers explicit missing slug behavior.
+- A black-box test covers explicit archived slug behavior.
+- A black-box test fixes unscoped no-active `validate --json` behavior.
+- Targeted tests for the changed command/resolver surface pass.
+
+## Open Questions
+None.
+
+## Deferred Ideas
+- General route model extraction remains deferred to opt.md section 1.1.
+- Freshness/action contract cleanup remains deferred to opt.md sections 1.3
+  and 1.4.
+
+## Approved Summary
+Approved under the user's standing auto-permit instruction for the opt.md
+execution loop on 2026-06-26. This change is limited to making explicit missing
+`validate --change <slug>` requests fail closed with `change_not_found` and exit
+3, while locking explicit archived and unscoped no-active validation semantics
+with tests.

--- a/artifacts/changes/archived/fail-closed-missing-change/requirements.md
+++ b/artifacts/changes/archived/fail-closed-missing-change/requirements.md
@@ -1,0 +1,30 @@
+# Requirements
+
+## Requirements
+
+### Requirement: Explicit missing validate target fails closed
+REQ-001: The system MUST return a typed fail-closed precondition error when
+`validate --change <slug>` names a change slug that does not exist, and it MUST
+preserve existing explicit archived and unscoped no-active validation semantics.
+
+#### Scenario: Missing explicit validate target
+GIVEN a Slipway workspace with no active or archived change named
+`definitely-not-a-change`
+WHEN an operator runs `slipway validate --change definitely-not-a-change --json`
+THEN the command exits with code 3
+AND the JSON error has `error_code: change_not_found`
+AND the JSON error has `exit_code: 3`
+AND the remediation tells the operator how to check or choose a valid change
+
+#### Scenario: Archived explicit validate target remains fail closed
+GIVEN a governed change has been archived as done
+WHEN an operator runs `slipway validate --change <archived-slug> --json`
+THEN the command exits with code 3
+AND the JSON error remains `archived_change_not_validatable`
+AND the remediation points at archived evidence or choosing an active change
+
+#### Scenario: Unscoped no-active validate remains diagnostic
+GIVEN a Slipway workspace has no active governed change
+WHEN an operator runs `slipway validate --json` without `--change`
+THEN the command emits the existing diagnostics view
+AND the command does not write governed state

--- a/artifacts/changes/archived/fail-closed-missing-change/research.md
+++ b/artifacts/changes/archived/fail-closed-missing-change/research.md
@@ -1,0 +1,94 @@
+# Research
+
+## Alternatives Considered
+
+### Architecture
+- Affected modules: `cmd/common.go` for active/explicit change resolution and
+  `cmd/validate.go` for validate's read-only command boundary.
+- Dependency chains: `validate` calls `resolveActiveChangeRef`; explicit
+  `--change` dispatches to `resolveExplicitChange`; that in turn loads active
+  bundle state through `internal/state` and returns CLI errors consumed by the
+  command wrapper.
+- Blast radius: low. The desired behavior is constrained to explicit missing
+  slugs and should not alter active worktree resolution, archived slug handling,
+  or broader status/next/done semantics.
+- Constraints: explicit archived slug must continue to return
+  `archived_change_not_validatable`; malformed or orphaned active authority
+  must remain fail-closed to state-integrity/recovery errors; unscoped no-active
+  validate semantics must stay documented by tests.
+
+### Patterns
+- Existing conventions: command boundaries use typed `CLIError` values with
+  stable `error_code`, `exit_code`, remediation, and optional `slug` details.
+  Existing `loadChangeBySlug` already maps `os.ErrNotExist` to
+  `change_not_found`.
+- Reusable abstractions: `newPreconditionError` and existing explicit resolver
+  tests in `cmd/resolve_explicit_change_authority_test.go` are the right
+  pattern for fail-closed CLI errors.
+- Convention deviations: none needed. The fix should prefer changing the
+  explicit resolver's missing-slug error over adding validate-specific
+  string handling.
+
+### Risks
+- Technical risks: low. The main regression risk is accidentally changing
+  unscoped `validate --json` diagnostics or archived slug handling.
+- Guardrail domains: none. No auth, credentials, external API, schema,
+  irreversible operation, or financial/PII surface is touched.
+- Reversibility: straightforward source rollback in `cmd/common.go` and test
+  files.
+
+### Test Strategy
+- Existing coverage: `cmd/validate_readonly_test.go` already covers no-active
+  zero-write behavior, explicit archived slug zero-write behavior, malformed
+  verification recovery, and orphan active bundle zero-write behavior.
+  `cmd/resolve_explicit_change_authority_test.go` covers archived fallback,
+  missing-authority fail-closed behavior, and malformed authority.
+- Infrastructure needs: no new helpers are required. Existing command tests can
+  use `commandForRoot`, `makeValidateCmd`, `createGovernedRequest`,
+  `state.ArchiveChange`, and `asCLIError`.
+- Verification approach: add failing tests first for explicit missing
+  `validate --change`, explicit archived `validate --change`, and unscoped
+  no-active validate behavior; then update the resolver behavior and run
+  targeted `cmd` tests.
+
+### Options
+- Option A: Change `resolveExplicitChange` so a true missing explicit slug
+  returns `change_not_found` instead of `no_active_change`. Tradeoff: this
+  aligns all callers of explicit resolution, not only validate; this is the
+  selected behavior because explicit slugs are user-specified identities and
+  should not be softened into ambient no-active diagnostics.
+- Option B: Keep `resolveExplicitChange` as-is and make
+  `shouldFallbackValidateDiagnostics` detect whether `--change` was supplied.
+  Tradeoff: narrower code diff, but validate would diverge from the shared
+  resolver contract and other callers could keep receiving the misleading
+  `no_active_change` code.
+- Option C: Introduce a larger route model now and migrate validate onto it.
+  Tradeoff: aligns with opt.md section 1.1, but it is larger than the section
+  1.2 bug and would delay the fail-closed fix.
+- Selected: Option A, with tests in the validate command boundary and explicit
+  resolver area.
+
+## Unknowns
+None.
+
+## Assumptions
+- The current product bug is reproduced on main: `go run . validate --change
+  definitely-not-a-change --json` exits 0 with generic diagnostics rather than
+  a typed missing-change error. Evidence: live command run before change
+  creation.
+- The relevant public contract is a typed precondition error, not a diagnostics
+  view, for explicit missing identities. Evidence: `loadChangeBySlug` already
+  uses `change_not_found` for missing explicit slug loads in `cmd/common.go`.
+- The existing codebase map is semantically stale for most of this change
+  because it was authored for handoff work, but its active-change-resolution
+  note correctly identifies `resolveActiveChangeRef` as the command-entry seam.
+  Evidence: `artifacts/codebase/ARCHITECTURE.md`.
+
+## Canonical References
+- `cmd/common.go`
+- `cmd/validate.go`
+- `cmd/validate_readonly_test.go`
+- `cmd/resolve_explicit_change_authority_test.go`
+- `cmd/active_change_resolution_test.go`
+- `artifacts/changes/fail-closed-missing-change/intent.md`
+- `artifacts/codebase/ARCHITECTURE.md`

--- a/artifacts/changes/archived/fail-closed-missing-change/tasks.md
+++ b/artifacts/changes/archived/fail-closed-missing-change/tasks.md
@@ -1,0 +1,18 @@
+# Tasks
+
+## Task List
+
+- [x] `t-01` Add black-box validate command tests for explicit missing,
+  explicit archived, and unscoped no-active behavior.
+  - depends_on: []
+  - target_files: [cmd/validate_readonly_test.go]
+  - task_kind: test
+  - covers: [REQ-001]
+
+- [x] `t-02` Update explicit change resolution so true missing explicit slugs
+  return `change_not_found` while preserving archived and corrupted-authority
+  fail-closed behavior.
+  - depends_on: [t-01]
+  - target_files: [cmd/common.go, cmd/common_test.go, cmd/resolve_explicit_change_authority_test.go]
+  - task_kind: code
+  - covers: [REQ-001]

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -439,15 +439,15 @@ func resolveExplicitChange(root string, slug string) (changeRef, error) {
 				)
 			}
 			// No archived record was found. Only os.ErrNotExist (no bundle at all)
-			// softens to no_active_change. A missing-authority error without an
-			// archive is genuine active-bundle corruption and must fall through to
-			// fail closed on change_state_load_failed.
+			// is a true missing explicit slug. A missing-authority error without
+			// an archive is genuine active-bundle corruption and must fall through
+			// to fail closed on change_state_load_failed.
 			if errors.Is(err, os.ErrNotExist) {
 				if recoveryErr := deleteRecoveryError(root, slug); recoveryErr != nil {
 					return changeRef{}, recoveryErr
 				}
 				return changeRef{}, newPreconditionError(
-					"no_active_change",
+					"change_not_found",
 					fmt.Sprintf("no change found for slug %q", slug),
 					"Check the slug with `slipway status`.",
 					slug,

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -130,7 +130,7 @@ func TestResolveExplicitChangeRejectsUnknownSlug(t *testing.T) {
 	_, err := resolveExplicitChange(root, "slug-missing")
 	cliErr := asCLIError(err)
 	require.NotNil(t, cliErr)
-	assert.Equal(t, "no_active_change", cliErr.ErrorCode)
+	assert.Equal(t, "change_not_found", cliErr.ErrorCode)
 	assert.Equal(t, categoryPrecondition, cliErr.Category)
 	assert.Equal(t, exitCodePrecondition, cliErr.ExitCode)
 	assert.Equal(t, "slug-missing", cliErr.Slug)

--- a/cmd/resolve_explicit_change_authority_test.go
+++ b/cmd/resolve_explicit_change_authority_test.go
@@ -58,6 +58,22 @@ func TestResolveExplicitChangeFallsBackToArchivedWhenActiveBundleAuthorityMissin
 	assert.NotEqual(t, "change_state_load_failed", cliErr.ErrorCode)
 }
 
+func TestResolveExplicitChangeMissingSlugFailsClosed(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	ensureTestGitRepo(t, root)
+	initTestWorkspace(t, root)
+
+	_, resolveErr := resolveExplicitChange(root, "definitely-not-a-change")
+	cliErr := asCLIError(resolveErr)
+	require.NotNil(t, cliErr)
+	assert.Equal(t, "change_not_found", cliErr.ErrorCode)
+	assert.Equal(t, categoryPrecondition, cliErr.Category)
+	assert.Equal(t, exitCodePrecondition, cliErr.ExitCode)
+	assert.Equal(t, "definitely-not-a-change", cliErr.Slug)
+	assert.Contains(t, cliErr.Remediation, "slipway status")
+}
+
 // TestResolveExplicitChangeMissingAuthorityWithoutArchiveFailsClosed pins the
 // fail-closed nuance: broadening the archived-fallback trigger must NOT soften a
 // genuine missing-authority error into no_active_change when there is no archived

--- a/cmd/validate_readonly_test.go
+++ b/cmd/validate_readonly_test.go
@@ -68,6 +68,31 @@ func TestValidateNoActiveDiagnosticIsZeroWrite(t *testing.T) {
 	assert.Contains(t, out.String(), "no active change or ambiguous")
 }
 
+func TestValidateMissingExplicitSlugFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	ensureTestGitRepo(t, root)
+	initTestWorkspace(t, root)
+
+	before := snapshotNonGitTree(t, root)
+
+	cmd := commandForRoot(t, root, makeValidateCmd())
+	cmd.SetArgs([]string{"--json", "--change", "definitely-not-a-change"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	err := cmd.Execute()
+
+	cliErr := asCLIError(err)
+	require.NotNil(t, cliErr)
+	assert.Equal(t, "change_not_found", cliErr.ErrorCode)
+	assert.Equal(t, categoryPrecondition, cliErr.Category)
+	assert.Equal(t, exitCodePrecondition, cliErr.ExitCode)
+	assert.Equal(t, "definitely-not-a-change", cliErr.Slug)
+	assert.Contains(t, cliErr.Remediation, "slipway status")
+	assert.Equal(t, before, snapshotNonGitTree(t, root))
+}
+
 func TestValidateArchivedExplicitSlugIsZeroWrite(t *testing.T) {
 	t.Parallel()
 
@@ -92,6 +117,9 @@ func TestValidateArchivedExplicitSlugIsZeroWrite(t *testing.T) {
 	cliErr := asCLIError(err)
 	require.NotNil(t, cliErr)
 	assert.Equal(t, "archived_change_not_validatable", cliErr.ErrorCode)
+	assert.Equal(t, categoryPrecondition, cliErr.Category)
+	assert.Equal(t, exitCodePrecondition, cliErr.ExitCode)
+	assert.Equal(t, slug, cliErr.Slug)
 	assert.Equal(t, before, snapshotNonGitTree(t, root))
 }
 


### PR DESCRIPTION
## Summary
- return change_not_found for true missing explicit --change slugs in the shared resolver
- preserve archived explicit validation and unscoped no-active diagnostics semantics
- add command-level and resolver-level regression coverage plus archived/no-active assertions
- archive governed change fail-closed-missing-change after approved ship-verification

## Verification
- go test ./cmd -run 'TestValidate(NoActiveDiagnosticIsZeroWrite|MissingExplicitSlugFailsClosed|ArchivedExplicitSlugIsZeroWrite)|TestResolveExplicitChange(MissingSlugFailsClosed|RejectsUnknownSlug|FallsBackToArchivedWhenActiveBundleAuthorityMissing|MissingAuthorityWithoutArchiveFailsClosed|MalformedActiveAuthorityFailsClosed)' -count=1
- go test ./cmd -count=1
- go test ./... -count=1
- golangci-lint run ./...
- go run . validate --change definitely-not-a-change --json
- go run . validate --json
