### PR TITLE
fix(lifecycle): repair public command contracts

### DIFF
--- a/artifacts/changes/archived/repair-public-lifecycle-contract/assurance.md
+++ b/artifacts/changes/archived/repair-public-lifecycle-contract/assurance.md
@@ -1,0 +1,127 @@
+# Assurance
+
+## Scope Summary
+
+This change repairs the public lifecycle contract for `opt.md` section 1.1
+through 1.5 as one cohesive code change. The delivered scope adds a shared
+invocation route/actionability projection, stable explicit `--change` error
+taxonomy, readiness-safe freshness fields, shared current-action projection, and
+host capability visibility with fail-closed behavior for selected delegated
+actions.
+
+The implementation changes command and model surfaces only:
+`cmd/common.go`, `cmd/freshness_diagnostics.go`, `cmd/status.go`,
+`cmd/status_view_build.go`, `cmd/validate.go`, `cmd/next.go`,
+`cmd/next_handoff.go`, `internal/engine/capability/resolver.go`,
+`internal/model/reason_code.go`, and `internal/model/recovery.go`, with focused
+regression coverage in the planned command/model/capability test files. The
+codebase-map edits under `artifacts/codebase/` are context refreshes and are
+reported as scope-contract exempt context files.
+
+## Verification Verdict
+
+Current verdict: pass for implementation and selected S3 peer review, pending
+the terminal `ship-verification` evidence record. `go test ./cmd -count=1`,
+`go test ./... -count=1`, and `golangci-lint run ./...` passed after the S3
+repair batch. The active `validate --json` run after S3 review evidence reported
+`scope_contract.status=pass`, fresh execution evidence, passing selected peer
+reviews, and only the expected pre-ship blockers for this assurance file and
+`ship-verification`.
+
+Selected S3 peer evidence is recorded and passing for:
+
+- `spec-compliance-review`
+- `code-quality-review`
+- `independent-review`
+- `security-review`
+
+The S3 repair batch was performed by fresh-context repair subagent
+`019f0400-0b39-75c0-9597-791072c7eadf`. The final selected review evidence was
+recorded from distinct fresh reviewer handles:
+
+- spec compliance: `019f0418-9ea0-7731-a3af-921230085f28`
+- code quality: `019f0418-a641-7fe3-a576-d1cde9f91dcb`
+- independent review: `019f0418-ac2c-77d0-aa2f-0afa5a721d29`
+- security review: `019f0418-b202-7091-aa8e-290c7b29ada8`
+
+## Evidence Index
+
+- `verification/execution-summary.yaml`: run version 1, overall verdict pass,
+  four task waves passed.
+- `verification/wave-orchestration.yaml`: wave orchestration pass with command
+  evidence for `go test ./cmd -count=1`, `go test ./internal/engine/capability
+  -count=1`, `go test ./internal/model -count=1`, `go test ./... -count=1`,
+  and `golangci-lint run ./...`.
+- `verification/spec-compliance-review.yaml`: pass with `layer:R0=pass`,
+  `scope_contract:pass`, `negative_path:pass`, and
+  `decision_fidelity:pass`.
+- `verification/code-quality-review.yaml`: pass with `layer:IR1=pass` and
+  quality references for route matrix, host capability fallback behavior, and
+  inspect-only done/archived route remediation.
+- `verification/independent-review.yaml`: pass with distinct fresh review
+  context and repair context references.
+- `verification/security-review.yaml`: pass with distinct fresh review context
+  and repair context references.
+- Active `validate --json` after selected review evidence: `skills_ready`
+  reports pass for spec, code-quality, independent, and security reviews;
+  `scope_contract.status=pass`; `execution_evidence_freshness=fresh`;
+  remaining blockers are `assurance_contract_missing` and ship-verification
+  requirements, which this closeout sequence is addressing.
+
+## Requirement Coverage
+
+- REQ-001 is covered by the shared `invocationRouteView` and command wiring,
+  plus `TestBoundWorktreeCommandsExposeConsistentLocalInvocationRoute`, root
+  bound-elsewhere tests, and run/status route tests. The route matrix exercises
+  `status --json`, `next --json`, and `validate --json` from the bound worktree.
+- REQ-002 is covered by explicit missing-change handling returning
+  `change_not_found`, archived explicit command fail-closed behavior, and
+  zero-write validate tests for invalid or archived explicit changes.
+- REQ-003 is covered by additive `execution_evidence_freshness`,
+  `governance_evidence_freshness`, and `overall_readiness_freshness` fields,
+  while preserving legacy `evidence_freshness` as execution evidence freshness.
+- REQ-004 is covered by the shared current-action projection and S3 review-batch
+  tests across `next`, `status`, `validate`, and `run --diagnostics`.
+- REQ-005 is covered by `internal/engine/capability` resolver behavior,
+  canonical `host_capability_unavailable` reason/recovery text, and command
+  tests proving unknown/unavailable host capability fails closed unless explicit
+  `manual_independent_review` fallback is selected.
+
+## Residual Risks and Exceptions
+
+- `SLIPWAY_HOST_CAPABILITIES` is an environment-declared host capability signal.
+  The implementation intentionally treats missing or empty declaration as
+  `unknown`, then fails closed for required independent-review subagent
+  capability unless an explicit fallback is selected.
+- `cmd/test_main_test.go` sets deterministic package-test defaults so existing
+  review-batch tests model a capable test host. The explicit fail-closed test
+  unsets and overrides that environment to prove production behavior for
+  unknown, empty, unavailable, and fallback states.
+- `tasks.md` was amended during S3 repair to include the test harness target.
+  Current `validate --json --focus spec-trace` reports the S3 task-plan
+  amendment diagnostic and keeps the change in S3 review rather than reopening
+  S2, which is the intended in-place review convergence behavior.
+- No compatibility exception, security bypass, or deferred product requirement
+  remains for REQ-001 through REQ-005.
+
+## Rollback Readiness
+
+Rollback is a normal git revert of the source/test/artifact changes in this
+branch before merge. There is no data migration, external API contract change,
+credential format change, network integration, or persistent runtime state
+change outside the governed evidence/artifact files. If rollback is needed after
+merge, revert the merge commit or the feature commit and rerun the command test
+suite because command JSON fields added here are public additive surfaces.
+
+## Archive Decision
+
+Archive readiness decision: ready to archive after terminal ship verification
+passes and `slipway run` advances the change to done-ready. Active
+`validate --json` proof was captured before `done` and showed the active change
+was still in S3 with fresh execution evidence, passing selected peer reviews,
+and only assurance/ship-verification blockers remaining. This assurance file is
+the closeout artifact required before ship verification records
+`closeout:assurance_complete=pass`.
+
+Archived bundles must be treated as frozen records after `slipway done`; they
+are not revalidated through the active `validate --json` gate after archive.

--- a/artifacts/changes/archived/repair-public-lifecycle-contract/change.yaml
+++ b/artifacts/changes/archived/repair-public-lifecycle-contract/change.yaml
@@ -1,0 +1,61 @@
+version: 1
+slug: repair-public-lifecycle-contract
+description: repair public lifecycle contract
+status: done
+current_state: DONE
+needs_discovery: true
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-06-26T11:36:27.889647Z
+quality_mode: full
+workflow_profile: code
+workflow_preset: standard
+worktree_branch: feat/repair-public-lifecycle-contract
+artifact_schema: expanded
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: 38a361ec37cc823447538aec659a4dfc86360988cf265f40deb5873e405f4017
+        updated_at: 2026-06-26T13:37:19.861279333Z
+    decision:
+        id: decision
+        path: decision.md
+        state: frozen
+        content_hash: b3f85442710bf9038a34539ae7ffdbb42cdbe6fcc4f98bbfb260c6cccf39d972
+        updated_at: 2026-06-26T11:47:45.153998244Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: c16c522e56a4186104eccdff5076835042f80e20b07b57ae4262dab82b2818f2
+        updated_at: 2026-06-26T11:37:27.777760637Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: 99169fe575605dae434c475d3c964fe6d0c993bcba3331cccbf2a74f9334421a
+        updated_at: 2026-06-26T11:44:51.731183868Z
+    research:
+        id: research
+        path: research.md
+        state: frozen
+        content_hash: 63617537538319ccf672e392f3f7ff41bf9ceead4f2326dd1e172c36f6426048
+        updated_at: 2026-06-26T11:43:15.722973678Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: 586cce73ef4e42f3e1169ef4ee4261d487b8e5f4c39eee409cc514af1f6fe308
+        updated_at: 2026-06-26T13:11:34.857490782Z
+evidence_refs:
+    code-quality-review: .worktrees/repair-public-lifecycle-contract/artifacts/changes/repair-public-lifecycle-contract/verification/code-quality-review.yaml
+    independent-review: .worktrees/repair-public-lifecycle-contract/artifacts/changes/repair-public-lifecycle-contract/verification/independent-review.yaml
+    intake-clarification: .worktrees/repair-public-lifecycle-contract/artifacts/changes/repair-public-lifecycle-contract/verification/intake-clarification.yaml
+    plan-audit: .worktrees/repair-public-lifecycle-contract/artifacts/changes/repair-public-lifecycle-contract/verification/plan-audit.yaml
+    research-orchestration: .worktrees/repair-public-lifecycle-contract/artifacts/changes/repair-public-lifecycle-contract/verification/research-orchestration.yaml
+    security-review: .worktrees/repair-public-lifecycle-contract/artifacts/changes/repair-public-lifecycle-contract/verification/security-review.yaml
+    ship-verification: .worktrees/repair-public-lifecycle-contract/artifacts/changes/repair-public-lifecycle-contract/verification/ship-verification.yaml
+    spec-compliance-review: .worktrees/repair-public-lifecycle-contract/artifacts/changes/repair-public-lifecycle-contract/verification/spec-compliance-review.yaml
+    wave-orchestration: .worktrees/repair-public-lifecycle-contract/artifacts/changes/repair-public-lifecycle-contract/verification/wave-orchestration.yaml

--- a/artifacts/changes/archived/repair-public-lifecycle-contract/decision.md
+++ b/artifacts/changes/archived/repair-public-lifecycle-contract/decision.md
@@ -1,0 +1,171 @@
+# Decision
+
+## Alternatives Considered
+
+### Option A: Patch the root `status` path only
+
+This would make `status --json` from the root checkout fail when the only active
+change is bound to another worktree. It is small and would fix the most visible
+bad output, but it would leave the rest of the public contract inconsistent:
+`validate --change <missing>` would still return diagnostics with exit 0,
+freshness would still conflate execution evidence with readiness, and `status`
+and `validate` would still have their own action wording instead of matching
+`next`.
+
+### Option B: Shared route/actionability projection with additive public fields
+
+This introduces one shared command-side projection for lifecycle invocation:
+which workspace invoked the command, which change authority was selected,
+whether the selected change is bound locally, whether local lifecycle execution
+is allowed, and which remediation or command is executable next. `status`,
+`next`, and `validate` expose that projection in JSON; mutation commands keep
+using the same resolver so failures remain fail-closed. The same change adds
+readiness-safe freshness fields and a shared action kind projection so `status`
+and `validate` cannot disagree with `next`.
+
+### Option C: Move route, readiness, and host capability into a new engine
+service
+
+This would be a cleaner architectural endpoint, but it would mix the lifecycle
+contract repair with a larger internal refactor. It would also pull in parts of
+`opt.md` section 3, which this change intentionally defers.
+
+Selected: Option B. It is broad enough to repair `opt.md` section 1 as a single
+contract, while keeping the implementation in the existing command/view
+boundaries.
+
+## Selected Approach
+
+Implement a command-side invocation route/actionability contract and thread it
+through the public lifecycle surfaces that currently diverge.
+
+The route contract classifies at least these cases:
+- locally bound active change
+- active change bound to another worktree
+- explicit missing change
+- explicit archived/non-active change
+- no active change
+- ambiguous multiple active changes
+
+For a locally bound active change, `status`, `next`, and `validate` report the
+same route kind, invocation workspace, bound workspace, change authority path,
+local executable flag, and executable next action/remediation.
+
+For a root invocation against a unique active change bound elsewhere, public
+commands must not advertise locally executable lifecycle actions. The acceptable
+contract is either the existing fail-closed `change_bound_to_other_worktree`
+precondition or a diagnostics view whose route fields clearly say local
+execution is not allowed and name `cd <bound-worktree>` or `--change <slug>` as
+the remediation.
+
+For explicit missing changes, active lifecycle commands use `change_not_found`
+with exit 3. `validate --change <missing> --json` stops returning successful
+diagnostics.
+
+Freshness output keeps the legacy `evidence_freshness` field as execution
+evidence freshness, then adds explicit readiness-oriented fields:
+- `execution_evidence_freshness`
+- `governance_evidence_freshness`
+- `overall_readiness_freshness`
+
+`overall_readiness_freshness` is not allowed to be `fresh` when a required
+governance gate is blocked by missing or stale skill evidence.
+
+Action output adds a shared action kind projection derived from the same logic
+as `next`. S3 review-batch pending states report `review_batch` through
+`next --json --diagnostics`, `status --json`, and `validate --json`.
+
+Host capability output is additive and narrow. It is attached only when the
+selected host action actually requires delegation, subagent execution, or a
+fresh independent review context. If that capability is unavailable and no
+explicit fallback was selected, the contract fails closed instead of claiming
+that prior authorization is sufficient. If a manual fallback is selected, the
+view names the degraded mode and the evidence required to proceed.
+
+## Interfaces and Data Flow
+
+### Public JSON additions
+
+`status`, `next`, and `validate` gain an additive `invocation_route` object with
+fields equivalent to:
+- `kind`
+- `change_slug`
+- `invocation_workspace_path`
+- `bound_workspace_path`
+- `change_authority_path`
+- `local_lifecycle_execution_allowed`
+- `remediation`
+- `next_command`
+
+`status` and `validate` gain additive action fields equivalent to:
+- `current_action_kind`
+- `current_action_command`
+
+`status` and `validate` gain additive freshness fields:
+- `execution_evidence_freshness`
+- `governance_evidence_freshness`
+- `overall_readiness_freshness`
+
+`next`, `status`, and `validate` gain additive host capability information when
+the selected action needs it:
+- required capability
+- availability
+- fallback mode, when explicitly selected or supported
+- evidence requirement for manual fallback
+
+### Internal flow
+
+Command entry points continue to resolve root and flags in `cmd`. The shared
+route helper uses existing state functions and `resolveActiveChangeRef`
+ingredients rather than introducing a separate state loader. Mutating commands
+still fail before writes when the route is not locally executable.
+
+`status` stops bypassing the resolver in the bound-elsewhere case. It either
+returns the same fail-closed error as other commands or returns a diagnostics
+view that removes locally unexecutable ready actions and carries explicit route
+remediation.
+
+`validate` stops swallowing explicit missing-change resolution errors into the
+generic no-active diagnostics path. It only falls back to diagnostics for true
+unscoped no-active or ambiguous contexts.
+
+Freshness projection preserves the existing execution summary calculation, then
+adds a readiness projection based on governance readiness blockers and required
+skill evidence state.
+
+Action projection reuses the next-view confirmation/action derivation where
+possible and exposes the resulting action kind to `status` and `validate`.
+
+## Rollout and Rollback
+
+Rollout is a normal governed code change:
+1. Add failing tests for the current public divergences.
+2. Implement the shared route/actionability projection and route JSON.
+3. Add readiness freshness and action kind fields.
+4. Add narrow host capability fail-closed projection.
+5. Run focused tests, `go test ./cmd -count=1`, `go test ./... -count=1`, and
+   `golangci-lint run ./...`.
+6. Finish the governed S3 review/final closeout flow before opening the PR.
+
+Rollback is a git revert of the implementation commit or PR merge commit. The
+verification command after rollback is `go test ./cmd -count=1`, followed by
+`go test ./... -count=1` if the revert crosses package boundaries.
+
+## Risk
+
+The main behavioral risk is regressing archived-local status handling from
+#283. The implementation keeps archived-local as a distinct route and adds a
+regression assertion before changing route selection.
+
+The second risk is overblocking normal auto-mode skill handoffs. Capability
+fail-closed behavior is therefore limited to selected actions that actually
+require unavailable delegation or independent-review capability; ordinary
+non-sensitive handoffs keep the existing auto behavior.
+
+The third risk is confusing existing JSON consumers by changing the meaning of
+`evidence_freshness`. The implementation leaves that legacy field execution
+oriented and adds clearly named readiness fields beside it.
+
+The fourth risk is introducing another status-only projection. Tests will assert
+that `status`, `next`, and `validate` expose the same route/action contract for
+the same change state.

--- a/artifacts/changes/archived/repair-public-lifecycle-contract/intent.md
+++ b/artifacts/changes/archived/repair-public-lifecycle-contract/intent.md
@@ -1,0 +1,97 @@
+# Intent
+
+## Summary
+Repair the public lifecycle action contract described by `opt.md` section 1 as
+one cohesive change. The goal is that `status`, `validate`, `next`, `run`,
+`done`, and `evidence` route the same invocation consistently, report freshness
+without overstating readiness, expose the same next-action contract, and fail
+closed when host capabilities are insufficient.
+
+## Complexity Assessment
+complex
+Rationale: this crosses multiple CLI public surfaces, shared change routing,
+freshness/readiness semantics, generated/skill-facing copy, and black-box CLI
+test fixtures. The surface is intentionally broader than a single resolver bug
+because the user rejected the prior small-scope split and the failures are
+coupled through the same action-contract model.
+
+## Guardrail Domains
+No sensitive-data, credential, financial, schema-migration, or external API
+contract guardrail is in scope. This is public CLI lifecycle correctness and
+agent-action safety.
+
+## In Scope
+- `opt.md` section 1.1 through 1.5 as a single lifecycle public-surface repair.
+- Introduce a shared invocation route/actionability model, or an equivalent
+  existing-pattern implementation, used by `status`, `validate`, `next`, `run`,
+  `done`, and `evidence`.
+- Route fields must identify invocation workspace, change authority path, bound
+  workspace path, route kind, whether local lifecycle execution is allowed, and
+  the effective remediation or next command.
+- Align explicit missing `--change` handling across public commands, including
+  `validate --change <missing>` returning `change_not_found` with exit 3.
+- Split or supplement freshness/readiness JSON so execution evidence freshness
+  cannot be mistaken for overall governance readiness.
+- Align `status` and `validate` with `next` for the current action kind,
+  especially S3 review-batch pending states.
+- Add CLI-visible host-capability/delegation fail-closed behavior for the #339
+  class of dead end, including fallback modes where supported.
+- Preserve archived-local fallback behavior from #283.
+- Add focused black-box tests and package tests for the route fields,
+  `next_ready_actions`, remediation text, missing/archived/no-active cases,
+  freshness combinations, review-batch action consistency, and host-capability
+  permutations.
+
+## Out of Scope
+- `opt.md` section 2 release and supply-chain hardening.
+- `opt.md` section 3 architecture dependency and coverage-gate hardening unless
+  directly required by the lifecycle contract implementation.
+- `opt.md` section 4 state-read performance baseline/indexing work.
+- Reintroducing the reverted archive-only PR flow or splitting this change into
+  narrow one-bug PRs.
+- Cleaning unrelated existing worktrees or user dirt beyond the already reset
+  and deleted abandoned changes.
+
+## Constraints
+- Use the current bound worktree as lifecycle authority.
+- Preserve unrelated root untracked files: `.gemini/`, `coverage.out`, and
+  `opt.md`.
+- Keep changes scoped to public lifecycle/action-contract behavior and tests.
+- Prefer existing command and view-building patterns over a new parallel
+  framework.
+- Work in auto-mode: the user's latest instruction authorizes best-judgment
+  choices and blocker resolution without stopping for clarification.
+
+## Acceptance Signals
+- Root unscoped commands against a unique active change bound elsewhere do not
+  advertise locally unexecutable `next/run/done` actions; they either fail with
+  `change_bound_to_other_worktree` or provide executable remediation.
+- Bound-worktree `status`, `next`, and `validate` expose consistent route fields.
+- `validate --change definitely-not-a-change --json` exits 3 with
+  `change_not_found`.
+- Archived-local worktree status remains archived-local and does not regress
+  #283.
+- Freshness fields distinguish execution evidence, skill/governance evidence,
+  and overall readiness so blocked ship gates cannot look completion-ready.
+- S3 review-batch pending fixtures report the same action kind through `next`,
+  `status`, and `validate`.
+- Host capability/delegation unavailable states fail closed or expose an
+  explicit supported fallback.
+- Focused tests, `go test ./cmd -count=1`, `go test ./... -count=1`, and
+  `golangci-lint run ./...` pass before ship.
+
+## Open Questions
+None.
+
+## Deferred Ideas
+- Release/ruleset/security hardening from `opt.md` section 2.
+- Architecture dependency and coverage-gate work from `opt.md` section 3.
+- State-read performance baseline/indexing work from `opt.md` section 4.
+
+## Approved Summary
+Approved via user auto-mode instruction on 2026-06-26 after resetting the
+previous too-small attempt. This change repairs `opt.md` section 1 as a single
+public lifecycle contract slice: shared route/actionability, explicit missing
+change fail-closed handling, readiness-safe freshness fields, `status`/`validate`
+alignment with `next`, and host-capability fail-closed behavior. Sections 2-4 of
+`opt.md` are intentionally deferred to later changes.

--- a/artifacts/changes/archived/repair-public-lifecycle-contract/requirements.md
+++ b/artifacts/changes/archived/repair-public-lifecycle-contract/requirements.md
@@ -1,0 +1,104 @@
+# Requirements
+
+## Requirements
+
+### Requirement: Shared Invocation Route
+
+REQ-001: The system MUST classify lifecycle command invocation through one
+shared route/actionability contract for `status`, `validate`, `next`, `run`,
+`done`, and `evidence`.
+
+#### Scenario: Root invocation sees a bound active change elsewhere
+
+GIVEN a single active governed change whose bound worktree is not the current
+invocation workspace
+WHEN an operator runs an unscoped lifecycle command from the root checkout
+THEN the command MUST either fail with `change_bound_to_other_worktree`, exit 3,
+or return a diagnostics/status view whose route fields say local lifecycle
+execution is not allowed and whose remediation names `cd <bound-worktree>` or
+`--change <slug>`.
+
+#### Scenario: Bound worktree invocation is locally executable
+
+GIVEN a governed change bound to the current worktree
+WHEN an operator runs `status`, `next`, or `validate`
+THEN each JSON view MUST identify the same route kind, invocation workspace,
+change authority path, bound workspace path, local actionability, and effective
+next remediation/action.
+
+### Requirement: Stable Missing and Archived Explicit Changes
+
+REQ-002: The system MUST use stable explicit `--change` error taxonomy across
+public lifecycle commands.
+
+#### Scenario: Missing explicit change
+
+GIVEN no active or archived change exists for `definitely-not-a-change`
+WHEN an operator runs `validate --change definitely-not-a-change --json`
+THEN the command MUST fail closed with `error_code: change_not_found`, exit 3,
+and executable remediation.
+
+#### Scenario: Archived explicit change
+
+GIVEN a change has been archived
+WHEN an operator runs active lifecycle commands with `--change <archived-slug>`
+THEN the commands MUST fail closed as archived/non-active active-command usage,
+without writing new evidence or active lifecycle state.
+
+### Requirement: Readiness-Safe Freshness
+
+REQ-003: The system MUST distinguish execution-evidence freshness from
+governance/skill evidence freshness and overall readiness freshness.
+
+#### Scenario: Execution fresh but governance skill missing
+
+GIVEN execution evidence is fresh but required skill evidence is missing or
+stale
+WHEN an operator reads `status --json` or `validate --json`
+THEN the JSON and human-facing contract MUST NOT imply that the whole change is
+fresh or completion-ready.
+
+#### Scenario: Ship gate blocked
+
+GIVEN `G_ship` is blocked
+WHEN an operator reads status or validation output
+THEN overall readiness freshness MUST be stale, blocked, or equivalent and MUST
+not be collapsed into a single fresh evidence field.
+
+### Requirement: Status and Validate Follow Next Action Contract
+
+REQ-004: The system MUST align `status` and `validate` with `next` for the
+current machine-action kind.
+
+#### Scenario: Review batch pending
+
+GIVEN an S3 review batch is pending
+WHEN an operator compares `next --json --diagnostics`, `status --json`, and
+`validate --json`
+THEN all three surfaces MUST expose `review_batch` as the current action kind,
+and recovery/remediation prose MUST NOT override it with a different primary
+automation path.
+
+### Requirement: Host Capability Fail-Closed Contract
+
+REQ-005: The system MUST make selected-skill host capability prerequisites
+visible in the CLI contract and fail closed when a required capability is
+unavailable without an explicit supported fallback.
+
+#### Scenario: Delegation capability unavailable
+
+GIVEN a selected skill requires subagent/delegation or independent-review
+capability
+WHEN the current host capability is unavailable and no fallback has been
+selected
+THEN `run`, `next`, and `validate` MUST NOT report
+`prior_authorization_sufficient=true` for that action and MUST surface a
+fail-closed blocker or explicit remediation.
+
+#### Scenario: Manual fallback selected
+
+GIVEN delegation is unavailable but the selected skill supports manual
+independent reviewer evidence
+WHEN the operator explicitly chooses that fallback
+THEN the CLI contract MUST name the degraded mode and the evidence requirement
+needed to proceed.

--- a/artifacts/changes/archived/repair-public-lifecycle-contract/research.md
+++ b/artifacts/changes/archived/repair-public-lifecycle-contract/research.md
@@ -1,0 +1,195 @@
+# Research
+
+## Alternatives Considered
+
+### Architecture
+- Affected modules:
+  - `cmd/common.go`: active/explicit change resolution, bound-elsewhere errors,
+    archived fallback, next-ready action helpers, execution freshness projection.
+  - `cmd/status.go` and `cmd/status_view_build.go`: status-only route selection,
+    status view shape, `next_ready_actions`, diagnostics/archived views.
+  - `cmd/validate.go`: validate resolver fallback, readiness/freshness view,
+    actionable next skill projection.
+  - `cmd/next.go`, `cmd/run.go`, `cmd/done.go`, `cmd/evidence.go`: lifecycle
+    command entry points that already use `resolveActiveChangeRef`.
+  - `cmd/next_skill_view.go` and `internal/engine/capability`: host/technique
+    hint generation, currently advisory rather than fail-closed capability state.
+- Dependency chains:
+  - `cmd/* command` -> route/active-change resolver -> `internal/state`
+    worktree binding/archive loaders -> command-specific view/action logic.
+  - `status` -> `resolveStatusRouteForRoot` -> `buildStatusViewFromChange` ->
+    `projectNextReadyActionsWithPrimary` and `projectFreshnessForExecMode`.
+  - `next/run` -> `resolveActiveChangeRef` -> `buildNextViewForCommand` ->
+    `deriveConfirmationRequirement`.
+  - `validate` -> `resolveActiveChangeRef` -> `buildValidateViewForSlug` ->
+    `progression.EvaluateGovernanceReadiness`.
+- Blast radius: public CLI JSON/prose for `status`, `next`, `validate`, `run`,
+  `done`, and `evidence`; tests in `cmd`; additive model fields may touch
+  generated skill/template assertions only if host capability output is added to
+  command surfaces.
+- Constraints:
+  - Preserve archived-local #283 behavior.
+  - Preserve zero-write/read-only behavior for status/validate/next probes.
+  - Preserve `projectFreshnessForExecMode` as execution-evidence freshness; add
+    readiness/governance freshness instead of redefining it in place.
+  - Do not mix release/security hardening or performance work into this change.
+
+### Patterns
+- Existing conventions:
+  - Commands resolve change identity before acquiring locks or loading detailed
+    views.
+  - `CLIError` precondition errors carry stable `error_code`, exit code 3, and
+    remediation.
+  - View-layer structs use additive JSON fields for richer machine contracts.
+  - Tests prefer command-level black-box assertions through `commandForRoot` or
+    `runRootCommandIn` when public CLI behavior matters.
+- Reusable abstractions:
+  - `resolveActiveChangeRef`, `wrapResolutionError`, archived worktree fallback,
+    and `state.FindActiveChangeForWorktree` are the right raw ingredients for a
+    shared invocation route.
+  - `deriveConfirmationRequirement` already owns authoritative next action kind
+    for `next`; `status` and `validate` should reuse or mirror that projection
+    through a shared action-contract helper rather than inventing separate prose.
+  - Existing capability registry bindings can seed host capability metadata, but
+    availability/fallback state needs a new CLI-visible projection.
+- Convention deviations:
+  - `status` currently has a deliberately distinct diagnostics path; the shared
+    route should not remove diagnostics mode, but it must prevent a normal
+    governed detail view when the invocation workspace cannot execute lifecycle
+    actions locally.
+
+### Risks
+- High: route unification can accidentally break archived-local reporting. Keep
+  archived-local as an explicit route kind with tests.
+- High: capability fail-closed can block legitimate auto-mode flows if it treats
+  all skills as requiring delegation. Only skills/contexts that actually require
+  external delegation or fresh independent context should report that
+  capability requirement.
+- Medium: adding freshness fields can confuse clients if names overlap. Use
+  explicit names such as `execution_evidence_freshness`,
+  `governance_evidence_freshness`, and `overall_readiness_freshness`, while
+  leaving existing `evidence_freshness` as legacy execution freshness until
+  later migration.
+- Medium: `status` failing closed from root may be less convenient than a
+  diagnostics view. A diagnostics view is acceptable if it does not expose local
+  lifecycle actions and carries `cd <bound-worktree>` or `--change <slug>`.
+- Low: broader scope increases test count and implementation size, but the
+  failures are coupled through the same public action contract.
+- Guardrail domains: none beyond lifecycle correctness; no credentials, PII,
+  financial data, schema migration, or external API contract.
+- Reversibility: additive fields and route/action helper changes are reversible.
+  Error-code corrections for explicit missing slugs intentionally remove the
+  old misleading behavior.
+
+### Test Strategy
+- Existing coverage:
+  - Helper-level bound-worktree resolution exists in
+    `cmd/active_change_resolution_test.go`.
+  - Validate zero-write and archived explicit cases exist in
+    `cmd/validate_readonly_test.go`.
+  - S3 next/validate/run consistency exists in `cmd/progression_next_test.go`,
+    but status action-kind consistency is missing.
+  - Execution freshness behavior is pinned in `cmd/common_test.go`.
+- New infrastructure needs:
+  - A small test helper that creates an active change bound to another git
+    worktree, then runs root-unscoped `status`, `next`, `validate`, `done`, and
+    `evidence` as public commands.
+  - JSON assertions for route kind, invocation workspace, bound path,
+    local-executable flag, remediation, and absence of locally unexecutable
+    `next/run/done` ready actions.
+  - Freshness fixtures that combine execution-fresh/stale with skill/governance
+    fresh/stale/blocked.
+  - Host capability fixtures for available delegation, unavailable delegation
+    with explicit fallback, and unavailable/no fallback.
+- Verification approach:
+  - First add failing tests for the current divergences.
+  - Implement the shared route/action/freshness/capability projections.
+  - Run focused route/action/freshness tests, then `go test ./cmd -count=1`,
+    `go test ./... -count=1`, and `golangci-lint run ./...`.
+
+### Options
+- Option A: Patch `status` only.
+  - Design: make root unscoped status call `resolveActiveChangeRef` and fail on
+    `change_bound_to_other_worktree`.
+  - Tradeoffs: fixes the loudest reproduction, but leaves explicit missing slug
+    drift, freshness overclaim, action-contract drift, and #339 capability
+    dead-end unsolved. This repeats the too-small scope problem.
+- Option B: Shared route/actionability projection plus additive action,
+  freshness, and capability fields.
+  - Design: introduce an internal `InvocationRoute`/equivalent projection that
+    all public lifecycle commands can consult. Add additive route fields to
+    status/next/validate where useful; use the route to gate local actions;
+    add readiness freshness and action-kind projections; add capability
+    requirement/availability/fallback metadata and fail-closed blockers where
+    unavailable.
+  - Tradeoffs: medium-sized change, but it matches the coupled failure mode and
+    gives tests one contract to pin.
+- Option C: Move lifecycle routing into a larger engine-level state/action
+  service.
+  - Design: refactor command routing, readiness, and capability into a deeper
+    engine package before touching views.
+  - Tradeoffs: cleaner long term but too large for this change and risks mixing
+    `opt.md` section 3 architecture work into the P0 lifecycle contract.
+- Selected: Option B. It is the smallest approach that addresses `opt.md`
+  section 1 as one coherent scope without dragging in release/security,
+  architecture-boundary, or performance work.
+
+## Unknowns
+
+- Resolved: Is the current root-status bound-worktree behavior actually
+  divergent? -> Yes. A live probe from repo root with the active change bound to
+  `.worktrees/repair-public-lifecycle-contract` returned a normal governed
+  `status --json` view with `next_ready_actions: ["next","cancel"]`, while
+  root `next`, `validate`, `done`, and `evidence` all failed closed with
+  `change_bound_to_other_worktree`, exit 3.
+- Resolved: Is explicit missing `--change` already aligned? -> No. A live probe
+  showed `status --change definitely-not-a-change --json` returns
+  `change_not_found`, `validate --change definitely-not-a-change --json`
+  returns diagnostics with exit 0, and `next --change definitely-not-a-change
+  --json` returns `no_active_change`, exit 3.
+- Resolved: Should this change cover `opt.md` section 2-4? -> No. Intake scope
+  explicitly defers release/security, architecture/coverage, and performance
+  hardening to later changes.
+- Remaining: None.
+
+## Assumptions
+
+- Adding new JSON fields is acceptable when the old fields are ambiguous, as long
+  as unsafe old values such as locally unexecutable ready actions are corrected.
+  Evidence: existing view structs already use many additive JSON fields across
+  status/validate/next.
+- Existing `evidence_freshness` should remain execution-oriented for now, with
+  new readiness freshness fields added beside it. Evidence:
+  `cmd/common_test.go:560-580` asserts required-skill blockers do not make
+  `projectFreshnessForExecMode` stale.
+- Capability fail-closed should be tied to selected skills and host requirements,
+  not all skill handoffs. Evidence: auto-mode tests intentionally allow
+  non-guardrail review batches and skill handoffs to soften, while security
+  review remains hard-stop.
+
+## Canonical References
+
+- `opt.md` section 1.1-1.5
+- `cmd/common.go:339-390`
+- `cmd/common.go:405-483`
+- `cmd/common.go:909-934`
+- `cmd/common.go:994-1034`
+- `cmd/status.go:17-66`
+- `cmd/status.go:299-378`
+- `cmd/status.go:400-416`
+- `cmd/status_view_build.go:17-180`
+- `cmd/validate.go:17-52`
+- `cmd/validate.go:140-184`
+- `cmd/validate.go:262-318`
+- `cmd/next.go:14-75`
+- `cmd/next.go:703-883`
+- `cmd/next_skill_view.go:894-925`
+- `internal/engine/capability/resolver.go:48-70`
+- `internal/engine/progression/confirmation_boundaries.go:139-152`
+- `cmd/active_change_resolution_test.go:17-95`
+- `cmd/active_change_resolution_test.go:98-175`
+- `cmd/validate_readonly_test.go:52-96`
+- `cmd/progression_next_test.go:1065-1183`
+- `cmd/common_test.go:496-580`
+- `cmd/auto_mode_test.go:173-205`
+- `cmd/auto_mode_test.go:263-280`

--- a/artifacts/changes/archived/repair-public-lifecycle-contract/tasks.md
+++ b/artifacts/changes/archived/repair-public-lifecycle-contract/tasks.md
@@ -1,0 +1,47 @@
+# Tasks
+
+## Task List
+
+- [x] `t-01` Implement shared invocation route and explicit change error taxonomy.
+  - depends_on: []
+  - target_files: [cmd/common.go, cmd/freshness_diagnostics.go, cmd/status.go, cmd/validate.go, cmd/next.go, cmd/next_handoff.go, cmd/done.go, cmd/evidence.go]
+  - task_kind: code
+  - covers: [REQ-001, REQ-002]
+  - acceptance:
+    - `status`, `next`, and `validate` expose the same additive invocation route fields for a locally bound active change.
+    - Root or wrong-worktree invocation cannot advertise locally executable lifecycle actions for a change bound elsewhere.
+    - `validate --change definitely-not-a-change --json` returns `change_not_found` with exit 3, and archived explicit active-command usage remains fail-closed without writes.
+    - Existing archived-local status behavior from #283 remains covered and unchanged.
+
+- [x] `t-02` Add readiness-safe freshness fields and shared current action projection.
+  - depends_on: [t-01]
+  - target_files: [cmd/common.go, cmd/status.go, cmd/status_view_build.go, cmd/validate.go, cmd/next.go]
+  - task_kind: code
+  - covers: [REQ-003, REQ-004]
+  - acceptance:
+    - `status --json` and `validate --json` include `execution_evidence_freshness`, `governance_evidence_freshness`, and `overall_readiness_freshness`.
+    - Missing or stale required skill evidence prevents `overall_readiness_freshness` from being reported as `fresh`.
+    - The legacy `evidence_freshness` execution-evidence contract remains compatible with existing tests.
+    - S3 review-batch pending states expose `review_batch` as the current action kind through `next`, `status`, and `validate`.
+
+- [x] `t-03` Add host capability visibility and fail-closed fallback contract for selected delegated actions.
+  - depends_on: [t-02]
+  - target_files: [cmd/next.go, cmd/next_handoff.go, cmd/next_skill_view.go, cmd/run.go, cmd/validate.go, internal/engine/capability/resolver.go, internal/engine/progression/confirmation_boundaries.go, internal/model/reason_code.go, internal/model/recovery.go]
+  - task_kind: code
+  - covers: [REQ-005]
+  - acceptance:
+    - Selected actions that require unavailable delegation, subagent, or independent-review capability do not report `prior_authorization_sufficient=true`.
+    - `next`, `run`, and `validate` surface the same fail-closed capability blocker or explicit remediation for unavailable required capability.
+    - Manual fallback, when selected or supported, names the degraded mode and the evidence requirement needed to proceed.
+    - Ordinary non-sensitive skill handoffs that do not require unavailable host capability keep the existing auto-mode behavior.
+
+- [x] `t-04` Add public CLI regression coverage for route, freshness, action, and capability contracts.
+  - depends_on: [t-01, t-02, t-03]
+  - target_files: [cmd/active_change_resolution_test.go, cmd/validate_readonly_test.go, cmd/status_view_build_test.go, cmd/progression_next_test.go, cmd/auto_mode_test.go, cmd/common_test.go, cmd/run_contract_test.go, cmd/next_skill_capability_hints_test.go, cmd/test_main_test.go, internal/engine/capability/resolver_test.go, internal/engine/capability/routes_test.go, internal/model/reason_code_contract_test.go]
+  - task_kind: test
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004, REQ-005]
+  - acceptance:
+    - Focused command tests fail on the current root/wrong-worktree actionability drift and pass after the route contract is implemented.
+    - Tests cover explicit missing `--change`, archived explicit active-command usage, archived-local status, readiness-safe freshness, review-batch action kind consistency, and host capability fail-closed behavior.
+    - Package tests for changed capability resolver behavior are added when resolver behavior changes; otherwise command-level tests explicitly prove no resolver package change was needed.
+    - `go test ./cmd -count=1`, `go test ./... -count=1`, and `golangci-lint run ./...` are the required implementation verification commands before S3 closeout.

--- a/artifacts/codebase/ARCHITECTURE.md
+++ b/artifacts/codebase/ARCHITECTURE.md
@@ -1,30 +1,42 @@
 # Architecture
 
-- Question: What seams must this change touch to add an engine-owned per-change
-  handoff command without creating a second lifecycle authority?
-- Runtime location: per-change runtime state lives under the git-common Slipway
-  namespace. `state.ChangeHandoffPath(root, slug)` already defines the advisory
-  handoff path as `ChangeDir(root, slug)/handoff.md`, so the new writer should
-  reuse that path rather than introducing a parallel location. Evidence:
-  `internal/state/local_runtime_paths.go:361-369`.
-- Active-change resolution: command and hook entrypoints should reuse
-  `resolveActiveChangeRef`, which resolves explicit `--change` first and then
-  prefers the invoking git worktree's active binding through
-  `state.FindActiveChangeForWorktree`. Evidence: `cmd/common.go:312-364`.
-- CLI command surface: root command registration is in `cmd/root.go`, while new
-  command implementation belongs in a focused `cmd/handoff.go` with companion
-  command tests. The command must remain advisory and must not participate in
-  gate/evidence/freshness evaluation.
-- Hook surface: `slipway hook session-start` is implemented in
-  `cmd/session_start_hook.go` and already emits an authoritative `next` block
-  plus a bounded handoff presence/path summary. `slipway hook context-pressure`
-  is implemented in `cmd/context_pressure_hook.go` and currently emits a generic
-  workflow handoff nudge. Evidence: `cmd/session_start_hook.go:34-68`,
-  `cmd/session_start_hook.go:131-142`, `cmd/context_pressure_hook.go:430-449`.
-- Tool generation surface: adapter metadata, command registration, command-skill
-  rendering, hook settings merging, and human invocation summaries are centralized
-  in `internal/toolgen/toolgen.go`. Codex currently uses command skills and has
-  no configured hook settings path, which makes generated `.codex/config.toml`
-  support a new toolgen surface rather than a hook-only patch. Evidence:
-  `internal/toolgen/toolgen.go:25-46`, `internal/toolgen/toolgen.go:87-102`,
-  `internal/toolgen/toolgen.go:2454-2463`.
+- Question: Which seams must change so every public lifecycle command reports
+  the same invocation route, actionability, freshness/readiness, and host
+  capability contract?
+- Active command resolution currently centers on `resolveActiveChangeRef` in
+  `cmd/common.go:339-390`. It resolves explicit `--change` first, then current
+  git worktree binding, then a global active fallback. Most lifecycle commands
+  (`next`, `run`, `done`, `evidence`) call this resolver before acting.
+- Explicit slug resolution is in `resolveExplicitChange` at
+  `cmd/common.go:405-483`. Missing active bundles currently become
+  `no_active_change`, archived slugs become `archived_change_not_validatable`,
+  and corrupted active bundles fail closed as `change_state_load_failed`.
+- Bound-elsewhere error construction is in `wrapResolutionError` at
+  `cmd/common.go:909-934`. It already carries `change_bound_to_other_worktree`,
+  bound slug/path details, and executable remediation.
+- `status` has a separate route path in `cmd/status.go:299-378`.
+  `resolveStatusRouteForRoot` only consults `resolveActiveChangeRef` for
+  multi-active cases, so a single active change bound to another worktree can be
+  rendered as a normal governed status view from the root checkout.
+- Archived-local precedence is explicitly protected by
+  `statusArchivedChangeForCurrentWorktree` in `cmd/status.go:400-416` and by
+  resolver archived fallback in `cmd/common.go:353-364` and `cmd/common.go:370-379`.
+  Any shared route must preserve this #283 invariant.
+- `statusView`, `validateView`, and `nextView` carry separate action/freshness
+  shapes: `statusView` exposes `next_ready_actions` and `evidence_freshness`
+  (`cmd/status.go:17-66`), `validateView` exposes `actionable_next_skill` and
+  `evidence_freshness` (`cmd/validate.go:17-52`), and `nextView` exposes
+  `confirmation_requirement` (`cmd/next.go:14-75`).
+- `status` currently derives ready actions through
+  `projectNextReadyActionsWithPrimary` (`cmd/common.go:994-1018`) and does not
+  know whether the invocation workspace is locally executable. This is the root
+  of the misleading root-status behavior.
+- Execution freshness is projected by `projectFreshnessForExecMode` at
+  `cmd/common.go:1020-1034`. The helper intentionally ignores non-freshness
+  blockers such as `required_skill_missing`, so a broader readiness freshness
+  field must be added instead of changing execution freshness semantics in place.
+- Host capability data is currently advisory. `appendCatalogHints` resolves
+  support hints from the capability registry (`cmd/next_skill_view.go:894-925`),
+  and the registry resolver produces supports/hydrate references
+  (`internal/engine/capability/resolver.go:48-70`). There is no CLI-visible
+  field for required host capabilities, availability, or fail-closed fallback.

--- a/artifacts/codebase/CONCERNS.md
+++ b/artifacts/codebase/CONCERNS.md
@@ -1,27 +1,34 @@
 # Concerns
 
-- Second-authority risk: handoff content must never become lifecycle authority.
-  Machine header and `show --brief` output must omit lifecycle state/substep and
-  next_skill/next_command, and must point resumers to `slipway status` and
-  `slipway next` instead.
-- Context pollution risk: SessionStart can fire from the repo root or when
-  multiple changes exist. The hook must emit bounded slugs/paths or a count in
-  ambiguous contexts and never inject full handoff bodies or focus prose.
-- Hook portability risk: Claude and Codex payloads differ. Shared hook handlers
-  must fail silent, preserve existing Claude behavior, accept Codex SessionStart
-  and UserPromptSubmit payloads, and use Codex-compatible output only where
-  Codex expects it.
-- Trust risk: generating `.codex/config.toml` is not the same as enabling hooks.
-  The README and setup output must state that repo trust and hook trust are
-  user-granted and that Slipway never edits global Codex trust config.
-- Worktree placement risk: Slipway-provisioned worktrees may not be where Codex
-  reads project hooks. Toolgen must write Codex hook config where Codex actually
-  reads it for the root checkout while keeping governed code edits in the bound
-  worktree.
-- Generated-surface drift risk: adding a command must keep command registry,
-  command skills, surface manifest expectations, README command contracts, and
-  generated workflow guidance aligned. Stale negative tests that currently assert
-  no `.codex/config.toml` must be updated intentionally.
-- Advisory invariant risk: a stale, missing, or hand-edited handoff must not
-  affect lifecycle gates, evidence freshness, readiness, or bypass/force-close
-  paths. A dedicated invariant test should guard this.
+- Route divergence risk: `status` currently succeeds from the root checkout for
+  a single active change bound elsewhere, while `next`, `validate`, `done`, and
+  `evidence` fail closed through `resolveActiveChangeRef`. A partial fix in one
+  command would preserve misleading agent guidance.
+- Local actionability risk: `next_ready_actions` currently describes lifecycle
+  actions by state only (`cmd/common.go:994-1018`). It can therefore advertise
+  `next`, `run`, or `done` in a workspace that cannot execute those actions
+  locally.
+- Archived-local regression risk: #283 behavior intentionally prefers an
+  archived change in the current archived worktree over an unrelated active
+  change elsewhere. A shared route abstraction must encode this as a first-class
+  route kind instead of treating it as an afterthought.
+- Error taxonomy drift risk: explicit missing slugs currently vary by command
+  (`status --change` returns `change_not_found`, `validate --change` falls back
+  to diagnostics, and `next --change` reports `no_active_change`). The shared
+  route must pin stable error codes and exit code 3.
+- Freshness overclaim risk: execution evidence freshness is not the same as
+  governance readiness. Existing tests intentionally allow `required_skill_missing`
+  while execution freshness remains `fresh`, so adding new readiness fields is
+  safer than changing the execution-freshness helper semantics.
+- Action-contract drift risk: `next` owns `confirmation_requirement` and action
+  kinds, while `status` and `validate` expose separate recovery/action fields.
+  `status`/`validate` must not let `recovery.primary_action` override or
+  contradict the current `next` action kind.
+- Capability dead-end risk: technique hints and generated skill prose can tell a
+  host to spawn or delegate, but the CLI does not currently report whether that
+  capability exists. Auto-mode must not report prior authorization sufficient
+  when the selected skill requires an unavailable host capability and no explicit
+  fallback is selected.
+- Compatibility risk: new JSON fields should be additive where possible, while
+  erroneous existing values that cause unsafe action claims should be corrected
+  even if tests need updates.

--- a/artifacts/codebase/TESTING.md
+++ b/artifacts/codebase/TESTING.md
@@ -1,31 +1,38 @@
 # Testing
 
-- Question: What proof is needed for an advisory per-change handoff command,
-  hook surfacing, and generated Codex hook config?
-- Handoff artifact tests should cover creation, refresh, monotonic generation,
-  narrative preservation, section updates, staleness derived from lifecycle-event
-  timestamps, and absence of lifecycle state/substep or next_skill/next_command
-  in the machine header and `--brief` descriptor. Planned targets:
-  `internal/state/handoff_test.go`, `cmd/handoff_test.go`.
-- Resolver and no-op behavior should be command-tested: slug-free active
-  worktree resolution, explicit `--change`, and graceful no-op when no active
-  change is bound. Planned target: `cmd/handoff_test.go`.
-- Hook tests should assert the existing context-pressure hook points to
-  `slipway handoff write`, SessionStart emits only a bounded pointer after the
-  authoritative next block, ambiguous/root contexts never dump handoff bodies or
-  focus text, and Codex-compatible hook output uses
-  `hookSpecificOutput.additionalContext`. Planned targets:
-  `cmd/context_pressure_hook_test.go`, `cmd/session_start_hook_test.go`.
-- Toolgen tests should update command registry counts and generated command-skill
-  expectations for `handoff`, assert `.codex/config.toml` hook generation uses
-  Codex's `[[hooks.<Event>]]` shape, assert refresh/idempotence behavior, and
-  update the current negative Codex config tests. Planned target:
-  `internal/toolgen/toolgen_test.go`.
-- Documentation/contract tests should keep README command contracts and init
-  output honest, including the trust caveat that generated Codex hooks are inert
-  until repo and hook trust are granted. Planned targets: `README.md`,
-  `cmd/init_test.go`, `internal/toolgen/toolgen_test.go`.
-- Minimum final verification remains `go build ./...`, `go vet ./...`,
-  `gofmt -s -l`, and `go test ./...`; package-focused tests should be run
-  earlier around `internal/state`, `cmd`, and `internal/toolgen` while the waves
-  are implemented.
+- Question: What tests prove the public lifecycle contract is consistent without
+  only testing private helper behavior?
+- Existing resolver tests in `cmd/active_change_resolution_test.go:17-95`
+  cover helper-level bound-elsewhere behavior for `resolveActiveChangeRef`,
+  `next --change`, and root `run`, but they do not cover root unscoped
+  `status`, root unscoped `validate`, `done`, or `evidence` as a shared
+  contract matrix.
+- Existing archived-local regression tests in
+  `cmd/active_change_resolution_test.go:98-175` and `cmd/status.go:400-416`
+  should be preserved and extended only as needed; this behavior must not be
+  rewritten away while introducing shared routing.
+- Existing validate zero-write tests in `cmd/validate_readonly_test.go:52-96`
+  cover no-active diagnostics and archived explicit slugs. They should be
+  extended so explicit missing slugs fail closed with `change_not_found` instead
+  of returning diagnostics.
+- Existing review-action consistency tests in
+  `cmd/progression_next_test.go:1065-1183` compare `next`, `validate`, and
+  `run` for S3 review-batch state. They do not assert `status` exposes the same
+  action kind, so this change should add a status-side action contract assertion.
+- Freshness tests in `cmd/common_test.go:496-580` prove
+  `projectFreshnessForExecMode` tracks execution evidence and deliberately
+  ignores non-freshness blockers. New tests should keep that behavior while
+  asserting new readiness/governance freshness fields become stale/blocked when
+  required skills or ship gates are missing.
+- Auto-mode tests in `cmd/auto_mode_test.go:173-205` and
+  `cmd/auto_mode_test.go:263-280` show current `prior_authorization_sufficient`
+  softening for review batches and non-sensitive skill handoffs, with security
+  review staying hard-stop. #339 tests should add capability-unavailable cases
+  so prior authorization alone is not reported sufficient when the required host
+  mechanism is absent.
+- Black-box command helpers exist through `runRootCommandIn` in
+  `cmd/error_contract_test.go:267-280`; command-level tests should use these or
+  `commandForRoot` instead of only calling private route helpers.
+- Minimum focused verification before implementation closeout: new route/action
+  matrix tests, freshness field tests, host-capability tests, `go test ./cmd
+  -count=1`, `go test ./... -count=1`, and `golangci-lint run ./...`.

--- a/cmd/active_change_resolution_test.go
+++ b/cmd/active_change_resolution_test.go
@@ -40,6 +40,35 @@ func TestResolveActiveChangeRefReportsBoundElsewhereFromRoot(t *testing.T) {
 	})
 }
 
+func TestStatusFromRootReportsBoundElsewhere(t *testing.T) {
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		initGitRepoForWorktreeTests(t, root)
+
+		worktreePath := filepath.Join(t.TempDir(), "status-bound-worktree")
+		runGit(t, root, "worktree", "add", worktreePath, "-b", "status-bound-worktree")
+		change := model.NewChange("status-bound-change")
+		change.WorktreePath = worktreePath
+		require.NoError(t, state.SaveChange(root, change))
+
+		var out bytes.Buffer
+		cmd := commandForRoot(t, root, makeStatusCmd())
+		cmd.SetArgs([]string{"--json"})
+		cmd.SetOut(&out)
+		err := cmd.Execute()
+
+		cliErr := asCLIError(err)
+		require.NotNil(t, cliErr)
+		normalizedWorktreePath, normalizeErr := state.NormalizePath(worktreePath)
+		require.NoError(t, normalizeErr)
+		assert.Equal(t, "change_bound_to_other_worktree", cliErr.ErrorCode)
+		assert.Contains(t, cliErr.Remediation, "--change status-bound-change")
+		assert.Contains(t, cliErr.Remediation, normalizedWorktreePath)
+		assert.NotContains(t, out.String(), `"slug"`, "unscoped root status must not render a stale action view for a bound worktree")
+	})
+}
+
 func TestNextChangeFlagFromRootTargetsBoundWorktree(t *testing.T) {
 	root := t.TempDir()
 	withWorkspace(t, root, func() {
@@ -66,7 +95,132 @@ func TestNextChangeFlagFromRootTargetsBoundWorktree(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, normalizedWorktreePath, view.InputContext.WorkspaceRoot)
 		assert.Equal(t, "next-bound-change", view.Slug)
+		require.NotNil(t, view.InvocationRoute)
+		assert.Equal(t, "explicit_bound_change", view.InvocationRoute.Kind)
+		assert.Equal(t, "next-bound-change", view.InvocationRoute.ChangeSlug)
+		assert.False(t, view.InvocationRoute.LocalLifecycleExecutionAllowed)
+		assert.True(t, view.InvocationRoute.EffectiveLifecycleExecutionAllowed)
+		assert.Equal(t, "slipway next --change next-bound-change", view.InvocationRoute.NextCommand)
 	})
+}
+
+func TestBoundWorktreeCommandsExposeConsistentLocalInvocationRoute(t *testing.T) {
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		initGitRepoForWorktreeTests(t, root)
+
+		slug := "local-bound-route"
+		branch := state.DefaultWorktreeBranch(slug)
+		worktreePath := filepath.Join(t.TempDir(), slug)
+		runGit(t, root, "worktree", "add", worktreePath, "-b", branch)
+
+		change := model.NewChange(slug)
+		change.Description = "exercise local bound invocation route"
+		change.WorkflowPreset = model.WorkflowPresetStandard
+		change.QualityMode = model.QualityModeStandard
+		change.ComplexityLevel = "simple"
+		change.CurrentState = model.StateS1Plan
+		change.PlanSubStep = model.PlanSubStepBundle
+		change.WorktreePath = worktreePath
+		change.WorktreeBranch = branch
+		require.NoError(t, state.SaveChange(root, change))
+		writeMinimalGovernedBundle(t, worktreePath, change)
+
+		withNestedWorkingDirectory(t, worktreePath, func() {
+			var statusOut bytes.Buffer
+			statusCmd := makeStatusCmd()
+			statusCmd.SetArgs([]string{"--json"})
+			statusCmd.SetOut(&statusOut)
+			require.NoError(t, statusCmd.Execute())
+			var status statusView
+			require.NoError(t, json.Unmarshal(statusOut.Bytes(), &status))
+
+			var nextOut bytes.Buffer
+			nextCmd := makeNextCmd()
+			nextCmd.SetArgs([]string{"--json"})
+			nextCmd.SetOut(&nextOut)
+			require.NoError(t, nextCmd.Execute())
+			var next nextHandoffView
+			require.NoError(t, json.Unmarshal(nextOut.Bytes(), &next))
+
+			var validateOut bytes.Buffer
+			validateCmd := makeValidateCmd()
+			validateCmd.SetArgs([]string{"--json"})
+			validateCmd.SetOut(&validateOut)
+			require.NoError(t, validateCmd.Execute())
+			var validate validateView
+			require.NoError(t, json.Unmarshal(validateOut.Bytes(), &validate))
+
+			routes := map[string]*invocationRouteView{
+				"status":   status.InvocationRoute,
+				"next":     next.InvocationRoute,
+				"validate": validate.InvocationRoute,
+			}
+			for surface, route := range routes {
+				assertLocalInvocationRoute(t, surface, route, slug)
+			}
+			assert.Equal(t, status.InvocationRoute, next.InvocationRoute)
+			assert.Equal(t, status.InvocationRoute, validate.InvocationRoute)
+		})
+	})
+}
+
+func TestInvocationRouteWithoutNextCommandUsesInspectOnlyRemediation(t *testing.T) {
+	root := t.TempDir()
+	worktreePath := filepath.Join(root, ".worktrees", "archived-local-route")
+	change := model.NewChange("archived-local-route")
+	change.Status = model.ChangeStatusDone
+	change.CurrentState = model.StateDone
+	change.WorktreePath = worktreePath
+
+	route := buildInvocationRouteView(root, change, root, false)
+	require.NotNil(t, route)
+	assert.Equal(t, "archived", route.Kind)
+	assert.False(t, route.LocalLifecycleExecutionAllowed)
+	assert.False(t, route.EffectiveLifecycleExecutionAllowed)
+	assert.Empty(t, route.NextCommand)
+	assert.NotEmpty(t, route.Remediation)
+	assert.Contains(t, route.Remediation, "to inspect the change")
+	assert.NotContains(t, route.Remediation, "or run")
+	assert.NotContains(t, route.Remediation, "``")
+}
+
+func assertLocalInvocationRoute(t *testing.T, surface string, route *invocationRouteView, slug string) {
+	t.Helper()
+
+	require.NotNil(t, route, "%s invocation_route", surface)
+	assert.Equal(t, "local_active", route.Kind, surface)
+	assert.Equal(t, slug, route.ChangeSlug, surface)
+	assert.True(t, route.LocalLifecycleExecutionAllowed, surface)
+	assert.True(t, route.EffectiveLifecycleExecutionAllowed, surface)
+	assert.NotEmpty(t, route.InvocationWorkspacePath, surface)
+	assert.NotEmpty(t, route.BoundWorkspacePath, surface)
+	assert.NotEmpty(t, route.ChangeAuthorityPath, surface)
+	assert.Equal(t, "slipway next", route.NextCommand, surface)
+	assert.Empty(t, route.Remediation, surface)
+}
+
+func TestValidateChangeFlagRejectsMissingSlugWithoutWritingState(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	ensureTestGitRepo(t, root)
+	initTestWorkspace(t, root)
+
+	cmd := commandForRoot(t, root, makeValidateCmd())
+	cmd.SetArgs([]string{"--json", "--change", "missing-explicit-change"})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	err := cmd.Execute()
+
+	cliErr := asCLIError(err)
+	require.NotNil(t, cliErr)
+	assert.Equal(t, "change_not_found", cliErr.ErrorCode)
+	assert.Equal(t, "missing-explicit-change", cliErr.Slug)
+	assert.NotContains(t, out.String(), "no active change or ambiguous")
+	_, statErr := os.Stat(state.BundleChangeFilePath(root, "missing-explicit-change"))
+	assert.True(t, os.IsNotExist(statErr), "validate must not create state for a missing explicit change")
 }
 
 func TestRunFromRootReportsBoundElsewhere(t *testing.T) {

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -29,6 +29,18 @@ type changeRef struct {
 
 const governedExecutionMode = string(ctxpack.ExecutionModeGoverned)
 
+type invocationRouteView struct {
+	Kind                               string `json:"kind"`
+	ChangeSlug                         string `json:"change_slug,omitempty"`
+	InvocationWorkspacePath            string `json:"invocation_workspace_path,omitempty"`
+	BoundWorkspacePath                 string `json:"bound_workspace_path,omitempty"`
+	ChangeAuthorityPath                string `json:"change_authority_path,omitempty"`
+	LocalLifecycleExecutionAllowed     bool   `json:"local_lifecycle_execution_allowed"`
+	EffectiveLifecycleExecutionAllowed bool   `json:"effective_lifecycle_execution_allowed"`
+	Remediation                        string `json:"remediation,omitempty"`
+	NextCommand                        string `json:"next_command,omitempty"`
+}
+
 type projectRootContextKey struct{}
 
 func projectRootFromCommand(cmd *cobra.Command) (string, error) {
@@ -447,7 +459,7 @@ func resolveExplicitChange(root string, slug string) (changeRef, error) {
 					return changeRef{}, recoveryErr
 				}
 				return changeRef{}, newPreconditionError(
-					"no_active_change",
+					"change_not_found",
 					fmt.Sprintf("no change found for slug %q", slug),
 					"Check the slug with `slipway status`.",
 					slug,
@@ -1015,6 +1027,85 @@ func projectNextReadyActionsWithPrimary(currentState model.WorkflowState, primar
 	}
 	actions = append(actions, "cancel")
 	return actions
+}
+
+func buildInvocationRouteView(
+	root string,
+	change model.Change,
+	invocationWorkspace string,
+	explicitChange bool,
+) *invocationRouteView {
+	slug := strings.TrimSpace(change.Slug)
+	if slug == "" {
+		return nil
+	}
+	route := &invocationRouteView{
+		ChangeSlug: slug,
+	}
+	if strings.TrimSpace(invocationWorkspace) != "" {
+		route.InvocationWorkspacePath = state.DisplayPath(root, invocationWorkspace)
+	}
+	if paths, err := state.ResolveChangePaths(root, change); err == nil {
+		route.BoundWorkspacePath = state.DisplayPath(root, paths.WorkspaceRoot)
+		route.ChangeAuthorityPath = state.DisplayPath(root, filepath.Join(paths.GovernedBundleDir, "change.yaml"))
+	}
+
+	localAllowed := invocationWorkspaceMatchesChange(root, change, invocationWorkspace)
+	route.LocalLifecycleExecutionAllowed = localAllowed
+	route.EffectiveLifecycleExecutionAllowed = localAllowed || explicitChange
+	switch {
+	case change.Status != model.ChangeStatusActive:
+		route.Kind = "archived"
+		route.EffectiveLifecycleExecutionAllowed = false
+	case strings.TrimSpace(change.WorktreePath) == "":
+		route.Kind = "unbound_active"
+		route.LocalLifecycleExecutionAllowed = true
+		route.EffectiveLifecycleExecutionAllowed = true
+	case localAllowed:
+		route.Kind = "local_active"
+	case explicitChange:
+		route.Kind = "explicit_bound_change"
+	default:
+		route.Kind = "bound_elsewhere"
+	}
+
+	action := invocationRouteAction(change.CurrentState)
+	if action != "" {
+		route.NextCommand = "slipway " + action
+		if explicitChange || !route.LocalLifecycleExecutionAllowed {
+			route.NextCommand += " --change " + slug
+		}
+	}
+	if !route.LocalLifecycleExecutionAllowed && strings.TrimSpace(route.BoundWorkspacePath) != "" {
+		if strings.TrimSpace(route.NextCommand) != "" {
+			route.Remediation = fmt.Sprintf("cd %s or run `%s` from this workspace.", route.BoundWorkspacePath, route.NextCommand)
+		} else {
+			route.Remediation = fmt.Sprintf("cd %s to inspect the change.", route.BoundWorkspacePath)
+		}
+	}
+	return route
+}
+
+func invocationWorkspaceMatchesChange(root string, change model.Change, invocationWorkspace string) bool {
+	if strings.TrimSpace(change.WorktreePath) == "" {
+		normalizedRoot, rootErr := state.NormalizePath(root)
+		normalizedInvocation, invocationErr := state.NormalizePath(invocationWorkspace)
+		return rootErr == nil && invocationErr == nil && normalizedRoot == normalizedInvocation
+	}
+	normalizedBound, boundErr := state.NormalizePath(change.WorktreePath)
+	normalizedInvocation, invocationErr := state.NormalizePath(invocationWorkspace)
+	return boundErr == nil && invocationErr == nil && normalizedBound == normalizedInvocation
+}
+
+func invocationRouteAction(currentState model.WorkflowState) string {
+	switch currentState {
+	case model.StateDone:
+		return ""
+	case model.StateS2Implement:
+		return "run"
+	default:
+		return "next"
+	}
 }
 
 func projectFreshnessForExecMode(

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -130,7 +130,7 @@ func TestResolveExplicitChangeRejectsUnknownSlug(t *testing.T) {
 	_, err := resolveExplicitChange(root, "slug-missing")
 	cliErr := asCLIError(err)
 	require.NotNil(t, cliErr)
-	assert.Equal(t, "no_active_change", cliErr.ErrorCode)
+	assert.Equal(t, "change_not_found", cliErr.ErrorCode)
 	assert.Equal(t, categoryPrecondition, cliErr.Category)
 	assert.Equal(t, exitCodePrecondition, cliErr.ExitCode)
 	assert.Equal(t, "slug-missing", cliErr.Slug)

--- a/cmd/freshness_diagnostics.go
+++ b/cmd/freshness_diagnostics.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"strings"
 
+	"github.com/signalridge/slipway/internal/model"
 	"github.com/signalridge/slipway/internal/state"
 	"github.com/spf13/cobra"
 )
@@ -25,6 +26,14 @@ func applyNextInvocationWorkspacePath(cmd *cobra.Command, root string, view *nex
 	applyCommandInvocationWorkspacePath(cmd, root, view.FreshnessDiagnostics)
 }
 
+func applyNextInvocationRoute(cmd *cobra.Command, root string, change model.Change, explicitChange bool, view *nextView) {
+	if view == nil {
+		return
+	}
+	workspace := invocationWorkspaceRootFromCommand(cmd, root)
+	view.InvocationRoute = buildInvocationRouteView(root, change, workspace, explicitChange)
+}
+
 func applyValidateInvocationWorkspacePath(cmd *cobra.Command, root string, view *validateView) {
 	if view == nil {
 		return
@@ -32,11 +41,27 @@ func applyValidateInvocationWorkspacePath(cmd *cobra.Command, root string, view 
 	applyCommandInvocationWorkspacePath(cmd, root, view.FreshnessDiagnostics)
 }
 
+func applyValidateInvocationRoute(cmd *cobra.Command, root string, change model.Change, explicitChange bool, view *validateView) {
+	if view == nil {
+		return
+	}
+	workspace := invocationWorkspaceRootFromCommand(cmd, root)
+	view.InvocationRoute = buildInvocationRouteView(root, change, workspace, explicitChange)
+}
+
 func applyStatusInvocationWorkspacePath(cmd *cobra.Command, root string, view *statusView) {
 	if view == nil {
 		return
 	}
 	applyCommandInvocationWorkspacePath(cmd, root, view.FreshnessDiagnostics)
+}
+
+func applyStatusInvocationRoute(cmd *cobra.Command, root string, change model.Change, explicitChange bool, view *statusView) {
+	if view == nil {
+		return
+	}
+	workspace := invocationWorkspaceRootFromCommand(cmd, root)
+	view.InvocationRoute = buildInvocationRouteView(root, change, workspace, explicitChange)
 }
 
 func attachFreshnessDiagnostics(diagnostics state.ExecutionFreshnessDiagnostics) *state.ExecutionFreshnessDiagnostics {

--- a/cmd/next.go
+++ b/cmd/next.go
@@ -2,9 +2,11 @@ package cmd
 
 import (
 	"io"
+	"os"
 	"strings"
 
 	"github.com/signalridge/slipway/internal/engine/artifact"
+	"github.com/signalridge/slipway/internal/engine/capability"
 	"github.com/signalridge/slipway/internal/engine/progression"
 	"github.com/signalridge/slipway/internal/model"
 	"github.com/signalridge/slipway/internal/state"
@@ -33,6 +35,10 @@ type nextView struct {
 	PlanSubStep               model.PlanSubStep                    `json:"plan_substep,omitempty"`
 	PlanningNote              string                               `json:"planning_note,omitempty"`
 	LifecycleStatus           string                               `json:"lifecycle_status"`
+	InvocationRoute           *invocationRouteView                 `json:"invocation_route,omitempty"`
+	CurrentActionKind         string                               `json:"current_action_kind,omitempty"`
+	CurrentActionCommand      string                               `json:"current_action_command,omitempty"`
+	HostCapabilities          []hostCapabilityView                 `json:"host_capabilities,omitempty"`
 	Advanced                  *progression.AdvanceSummary          `json:"advanced,omitempty"`
 	AutoTransitions           []progression.AdvanceSummary         `json:"auto_transitions,omitempty"`
 	NextSkill                 *nextSkillView                       `json:"next_skill"`
@@ -72,6 +78,17 @@ type confirmationRequirement struct {
 	NextAction                   string `json:"next_action,omitempty"`
 	NextActionKind               string `json:"next_action_kind,omitempty"`
 	NextCommand                  string `json:"next_command,omitempty"`
+}
+
+type hostCapabilityView struct {
+	SkillName           string `json:"skill_name"`
+	Capability          string `json:"capability"`
+	Required            bool   `json:"required"`
+	Availability        string `json:"availability"`
+	FallbackSelected    bool   `json:"fallback_selected,omitempty"`
+	FallbackMode        string `json:"fallback_mode,omitempty"`
+	EvidenceRequirement string `json:"evidence_requirement,omitempty"`
+	Remediation         string `json:"remediation,omitempty"`
 }
 
 type skillEvidenceEntry struct {
@@ -341,6 +358,9 @@ Environment variables:
 						return err
 					}
 					applyNextInvocationWorkspacePath(cmd, root, &view)
+					if change, loadErr := state.LoadChange(root, ref.Slug); loadErr == nil {
+						applyNextInvocationRoute(cmd, root, change, strings.TrimSpace(changeSlug) != "", &view)
+					}
 					return encodeJSONResponse(cmd, buildNextHandoffView(view))
 				}
 
@@ -356,6 +376,9 @@ Environment variables:
 					return err
 				}
 				applyNextInvocationWorkspacePath(cmd, root, &view)
+				if change, loadErr := state.LoadChange(root, ref.Slug); loadErr == nil {
+					applyNextInvocationRoute(cmd, root, change, strings.TrimSpace(changeSlug) != "", &view)
+				}
 
 				if contextGuard {
 					return writeContextGuardHookMessages(cmd.OutOrStdout(), view)
@@ -452,7 +475,10 @@ func buildNextViewForCommand(root string, ref changeRef, opts nextViewOptions) (
 	}
 	finalize := func() (nextView, error) {
 		applyReadyAdvanceDiagnostics(root, governedChange, &view)
+		applyHostCapabilityContractToNext(&view)
 		view.ConfirmationRequirement = deriveConfirmationRequirement(view)
+		view.CurrentActionKind = view.ConfirmationRequirement.NextActionKind
+		view.CurrentActionCommand = view.ConfirmationRequirement.NextCommand
 		view.Recovery = model.BuildRecovery(view.Blockers)
 		return view, nil
 	}
@@ -820,6 +846,131 @@ func nextSkillHandoffName(skill *nextSkillView) string {
 		return name
 	}
 	return strings.TrimSpace(skill.Name)
+}
+
+func applyHostCapabilityContractToNext(view *nextView) {
+	if view == nil {
+		return
+	}
+	view.HostCapabilities = hostCapabilityViewsForSkills(selectedHostCapabilitySkillNamesForNext(*view))
+	for _, req := range view.HostCapabilities {
+		if hostCapabilityBlocks(req) {
+			view.Blockers = appendReasonCodes(
+				view.Blockers,
+				[]model.ReasonCode{model.NewReasonCode("host_capability_unavailable", req.SkillName+":"+req.Capability)},
+			)
+		}
+	}
+}
+
+func applyHostCapabilityContractToValidate(view *validateView, skills []string) {
+	if view == nil {
+		return
+	}
+	view.HostCapabilities = hostCapabilityViewsForSkills(skills)
+	for _, req := range view.HostCapabilities {
+		if hostCapabilityBlocks(req) {
+			view.Blockers = model.NormalizeReasonCodes(append(
+				view.Blockers,
+				model.NewReasonCode("host_capability_unavailable", req.SkillName+":"+req.Capability),
+			))
+		}
+	}
+	view.CanAdvance = len(view.Blockers) == 0
+}
+
+func hostCapabilityBlocks(req hostCapabilityView) bool {
+	return req.Required && req.Availability != "available" && !req.FallbackSelected
+}
+
+func selectedHostCapabilitySkillNamesForNext(view nextView) []string {
+	var names []string
+	if view.ReviewBatch != nil {
+		for _, skill := range view.ReviewBatch.Skills {
+			names = append(names, skill.Name)
+		}
+	}
+	if view.NextSkill != nil {
+		names = append(names, nextSkillHandoffName(view.NextSkill))
+	}
+	return names
+}
+
+func selectedHostCapabilitySkillNamesForValidate(
+	change model.Change,
+	readiness progression.GovernanceReadiness,
+	actionable *actionableNextSkillView,
+) []string {
+	if change.CurrentState == model.StateS3Review {
+		if pending := pendingSelectedReviewSkills(change, readiness); len(pending) > 0 {
+			return pending
+		}
+	}
+	if actionable == nil {
+		return nil
+	}
+	if name := strings.TrimSpace(actionable.BlockingName); name != "" {
+		return []string{name}
+	}
+	return []string{strings.TrimSpace(actionable.Name)}
+}
+
+func hostCapabilityViewsForSkills(skillNames []string) []hostCapabilityView {
+	if len(skillNames) == 0 {
+		return nil
+	}
+	hostCapabilities := splitCapabilityEnv(os.Getenv("SLIPWAY_HOST_CAPABILITIES"))
+	fallbacks := splitCapabilityEnv(os.Getenv("SLIPWAY_HOST_CAPABILITY_FALLBACKS"))
+	seen := map[string]bool{}
+	var views []hostCapabilityView
+	for _, skillName := range skillNames {
+		skillName = strings.TrimSpace(skillName)
+		if skillName == "" || seen[skillName] {
+			continue
+		}
+		seen[skillName] = true
+		req := capability.ResolveHostCapabilityRequirement(skillName, capability.Signals{
+			HostCapabilities: hostCapabilities,
+			Fallbacks:        fallbacks,
+		})
+		if req == nil {
+			continue
+		}
+		views = append(views, hostCapabilityView{
+			SkillName:           req.SkillID,
+			Capability:          req.Capability,
+			Required:            req.Required,
+			Availability:        req.Availability,
+			FallbackSelected:    req.FallbackSelected,
+			FallbackMode:        req.FallbackMode,
+			EvidenceRequirement: req.EvidenceRequirement,
+			Remediation:         req.Remediation,
+		})
+	}
+	return views
+}
+
+func splitCapabilityEnv(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	parts := strings.FieldsFunc(raw, func(r rune) bool {
+		switch r {
+		case ',', ';', ' ', '\t', '\n', '\r':
+			return true
+		default:
+			return false
+		}
+	})
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
 }
 
 func confirmationHardStop(reason string) confirmationRequirement {

--- a/cmd/next_handoff.go
+++ b/cmd/next_handoff.go
@@ -18,6 +18,8 @@ type nextHandoffView struct {
 	ExecutionMode    string                  `json:"execution_mode,omitempty"`
 	CurrentState     model.WorkflowState     `json:"current_state"`
 	LifecycleStatus  string                  `json:"lifecycle_status,omitempty"`
+	InvocationRoute  *invocationRouteView    `json:"invocation_route,omitempty"`
+	HostCapabilities []hostCapabilityView    `json:"host_capabilities,omitempty"`
 	NextSkill        *nextSkillHandoff       `json:"next_skill"`
 	ReviewBatch      *reviewBatchView        `json:"review_batch,omitempty"`
 	ContextBudget    *contextBudgetHandoff   `json:"context_budget,omitempty"`
@@ -97,6 +99,7 @@ func buildNextHandoffSourceView(root string, ref changeRef, preview bool, autoSk
 		view.GuardrailDomain = strings.TrimSpace(governedChange.GuardrailDomain)
 	}
 	finalize := func() (nextView, error) {
+		applyHostCapabilityContractToNext(&view)
 		view.ConfirmationRequirement = deriveConfirmationRequirement(view)
 		return view, nil
 	}
@@ -236,9 +239,14 @@ func buildNextHandoffView(view nextView) nextHandoffView {
 		ExecutionMode:   view.ExecutionMode,
 		CurrentState:    view.CurrentState,
 		LifecycleStatus: view.LifecycleStatus,
-		NextSkill:       nextSkill,
-		ReviewBatch:     cloneReviewBatch(view.ReviewBatch),
-		ContextBudget:   budget,
+		InvocationRoute: view.InvocationRoute,
+		HostCapabilities: append(
+			[]hostCapabilityView(nil),
+			view.HostCapabilities...,
+		),
+		NextSkill:     nextSkill,
+		ReviewBatch:   cloneReviewBatch(view.ReviewBatch),
+		ContextBudget: budget,
 		InputContext: nextHandoffContext{
 			WorkspaceRoot:        view.InputContext.WorkspaceRoot,
 			ArtifactBundle:       view.InputContext.ArtifactBundle,

--- a/cmd/progression_next_test.go
+++ b/cmd/progression_next_test.go
@@ -1142,6 +1142,7 @@ func TestReviewStateActionableNextSkillConsistentAcrossCommandSurfaces(t *testin
 			progression.SkillSecurityReview,
 		}, reviewBatchSkillNames(nextDiag.ReviewBatch))
 		assert.Equal(t, "review_batch", nextDiag.ConfirmationRequirement.Reason)
+		assert.Equal(t, "review_batch", nextDiag.CurrentActionKind)
 
 		validateCmd := commandForRoot(t, root, makeValidateCmd())
 		validateCmd.SetArgs([]string{"--json", "--change", slug})
@@ -1159,6 +1160,24 @@ func TestReviewStateActionableNextSkillConsistentAcrossCommandSurfaces(t *testin
 		assert.Contains(t, validate.ActionableNextSkill.RequiredTokens, "layer:IR3=pass")
 		assert.NotContains(t, validate.ActionableNextSkill.RequiredTokens, "layer:R0=pass")
 		assert.NotContains(t, validate.ActionableNextSkill.RequiredTokens, "layer:R3=pass")
+		assert.Equal(t, "review_batch", validate.CurrentActionKind)
+		assert.Equal(t, "slipway run", validate.CurrentActionCommand)
+		assert.Equal(t, "fresh", validate.ExecutionEvidenceFreshness)
+		assert.Equal(t, "stale", validate.GovernanceEvidenceFreshness)
+		assert.Equal(t, "blocked", validate.OverallReadinessFreshness)
+
+		statusCmd := commandForRoot(t, root, makeStatusCmd())
+		statusCmd.SetArgs([]string{"--json", "--change", slug})
+		var statusOut bytes.Buffer
+		statusCmd.SetOut(&statusOut)
+		require.NoError(t, statusCmd.Execute())
+		var status statusView
+		require.NoError(t, json.Unmarshal(statusOut.Bytes(), &status))
+		assert.Equal(t, "review_batch", status.CurrentActionKind)
+		assert.Equal(t, "slipway run", status.CurrentActionCommand)
+		assert.Equal(t, "fresh", status.ExecutionEvidenceFreshness)
+		assert.Equal(t, "stale", status.GovernanceEvidenceFreshness)
+		assert.Equal(t, "blocked", status.OverallReadinessFreshness)
 
 		runCmd := commandForRoot(t, root, makeRunCmd())
 		runCmd.SetArgs([]string{"--json", "--diagnostics", "--change", slug})
@@ -1180,7 +1199,163 @@ func TestReviewStateActionableNextSkillConsistentAcrossCommandSurfaces(t *testin
 			progression.SkillSecurityReview,
 		}, reviewBatchSkillNames(runView.ReviewBatch))
 		assert.Equal(t, "review_batch", runView.ConfirmationRequirement.Reason)
+		assert.Equal(t, "review_batch", runView.CurrentActionKind)
 	})
+}
+
+func TestReviewBatchHostCapabilityUnavailableFailsClosedUnlessFallbackSelected(t *testing.T) {
+	root, slug := prepareReviewBatchHostCapabilityFixture(t)
+
+	originalCapabilities, hadCapabilities := os.LookupEnv("SLIPWAY_HOST_CAPABILITIES")
+	originalFallbacks, hadFallbacks := os.LookupEnv("SLIPWAY_HOST_CAPABILITY_FALLBACKS")
+	t.Cleanup(func() {
+		if hadCapabilities {
+			require.NoError(t, os.Setenv("SLIPWAY_HOST_CAPABILITIES", originalCapabilities))
+		} else {
+			require.NoError(t, os.Unsetenv("SLIPWAY_HOST_CAPABILITIES"))
+		}
+		if hadFallbacks {
+			require.NoError(t, os.Setenv("SLIPWAY_HOST_CAPABILITY_FALLBACKS", originalFallbacks))
+		} else {
+			require.NoError(t, os.Unsetenv("SLIPWAY_HOST_CAPABILITY_FALLBACKS"))
+		}
+	})
+
+	require.NoError(t, os.Unsetenv("SLIPWAY_HOST_CAPABILITIES"))
+	require.NoError(t, os.Unsetenv("SLIPWAY_HOST_CAPABILITY_FALLBACKS"))
+
+	unsetCmd := commandForRoot(t, root, makeNextCmd())
+	unsetCmd.SetArgs([]string{"--json", "--change", slug})
+	var unsetOut bytes.Buffer
+	unsetCmd.SetOut(&unsetOut)
+	require.NoError(t, unsetCmd.Execute())
+	var unsetHandoff nextHandoffView
+	require.NoError(t, json.Unmarshal(unsetOut.Bytes(), &unsetHandoff))
+	unsetCapability := requireIndependentReviewHostCapability(t, unsetHandoff.HostCapabilities)
+	assert.Equal(t, "unknown", unsetCapability.Availability)
+	assert.False(t, unsetCapability.FallbackSelected)
+	assert.Contains(t, model.ReasonSpecs(unsetHandoff.Blockers), "host_capability_unavailable:independent-review:subagent")
+	assert.Equal(t, "blocked_by_governance", unsetHandoff.Confirmation.Reason)
+
+	t.Setenv("SLIPWAY_HOST_CAPABILITIES", "")
+	t.Setenv("SLIPWAY_HOST_CAPABILITY_FALLBACKS", "")
+
+	nextCmd := commandForRoot(t, root, makeNextCmd())
+	nextCmd.SetArgs([]string{"--json", "--change", slug})
+	var nextOut bytes.Buffer
+	nextCmd.SetOut(&nextOut)
+	require.NoError(t, nextCmd.Execute())
+	var handoff nextHandoffView
+	require.NoError(t, json.Unmarshal(nextOut.Bytes(), &handoff))
+	nextCapability := requireIndependentReviewHostCapability(t, handoff.HostCapabilities)
+	assert.Equal(t, "unknown", nextCapability.Availability)
+	assert.False(t, nextCapability.FallbackSelected)
+	assert.Contains(t, model.ReasonSpecs(handoff.Blockers), "host_capability_unavailable:independent-review:subagent")
+	assert.Equal(t, "blocked_by_governance", handoff.Confirmation.Reason)
+	assert.Equal(t, "blocker_resolution", handoff.Confirmation.NextActionKind)
+
+	validateCmd := commandForRoot(t, root, makeValidateCmd())
+	validateCmd.SetArgs([]string{"--json", "--change", slug})
+	var validateOut bytes.Buffer
+	validateCmd.SetOut(&validateOut)
+	require.NoError(t, validateCmd.Execute())
+	var validate validateView
+	require.NoError(t, json.Unmarshal(validateOut.Bytes(), &validate))
+	validateCapability := requireIndependentReviewHostCapability(t, validate.HostCapabilities)
+	assert.Equal(t, "unknown", validateCapability.Availability)
+	assert.False(t, validateCapability.FallbackSelected)
+	assert.Contains(t, model.ReasonSpecs(validate.Blockers), "host_capability_unavailable:independent-review:subagent")
+	assert.False(t, validate.CanAdvance)
+
+	runCmd := commandForRoot(t, root, makeRunCmd())
+	runCmd.SetArgs([]string{"--json", "--diagnostics", "--change", slug})
+	var runOut bytes.Buffer
+	runCmd.SetOut(&runOut)
+	require.NoError(t, runCmd.Execute())
+	var runView nextView
+	require.NoError(t, json.Unmarshal(runOut.Bytes(), &runView))
+	runCapability := requireIndependentReviewHostCapability(t, runView.HostCapabilities)
+	assert.Equal(t, "unknown", runCapability.Availability)
+	assert.False(t, runCapability.FallbackSelected)
+	assert.Contains(t, model.ReasonSpecs(runView.Blockers), "host_capability_unavailable:independent-review:subagent")
+	assert.Equal(t, "blocked_by_governance", runView.ConfirmationRequirement.Reason)
+
+	t.Setenv("SLIPWAY_HOST_CAPABILITIES", "none")
+
+	unavailableCmd := commandForRoot(t, root, makeNextCmd())
+	unavailableCmd.SetArgs([]string{"--json", "--diagnostics", "--change", slug})
+	var unavailableOut bytes.Buffer
+	unavailableCmd.SetOut(&unavailableOut)
+	require.NoError(t, unavailableCmd.Execute())
+	var unavailableView nextView
+	require.NoError(t, json.Unmarshal(unavailableOut.Bytes(), &unavailableView))
+	unavailableCapability := requireIndependentReviewHostCapability(t, unavailableView.HostCapabilities)
+	assert.Equal(t, "unavailable", unavailableCapability.Availability)
+	assert.False(t, unavailableCapability.FallbackSelected)
+	assert.Contains(t, model.ReasonSpecs(unavailableView.Blockers), "host_capability_unavailable:independent-review:subagent")
+
+	t.Setenv("SLIPWAY_HOST_CAPABILITY_FALLBACKS", "manual_independent_review")
+
+	fallbackCmd := commandForRoot(t, root, makeNextCmd())
+	fallbackCmd.SetArgs([]string{"--json", "--diagnostics", "--change", slug})
+	var fallbackOut bytes.Buffer
+	fallbackCmd.SetOut(&fallbackOut)
+	require.NoError(t, fallbackCmd.Execute())
+	var fallbackView nextView
+	require.NoError(t, json.Unmarshal(fallbackOut.Bytes(), &fallbackView))
+	fallbackCapability := requireIndependentReviewHostCapability(t, fallbackView.HostCapabilities)
+	assert.Equal(t, "unavailable", fallbackCapability.Availability)
+	assert.True(t, fallbackCapability.FallbackSelected)
+	assert.Equal(t, "manual_independent_review", fallbackCapability.FallbackMode)
+	assert.NotContains(t, model.ReasonSpecs(fallbackView.Blockers), "host_capability_unavailable:independent-review:subagent")
+	assert.Equal(t, "review_batch", fallbackView.ConfirmationRequirement.Reason)
+}
+
+func prepareReviewBatchHostCapabilityFixture(t *testing.T) (string, string) {
+	t.Helper()
+
+	root := t.TempDir()
+	ensureTestGitRepo(t, root)
+	initTestWorkspace(t, root)
+
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "review host capability contract")
+	change, err := state.LoadChange(root, slug)
+	require.NoError(t, err)
+	change.CurrentState = model.StateS3Review
+	change.PlanSubStep = model.PlanSubStepNone
+	change.GuardrailDomain = "external_api_contracts"
+	require.NoError(t, state.SaveChange(root, change))
+	writePassingExecutionSummary(t, root, slug, 1, "t-01")
+	writePassingWaveEvidence(t, root, slug, 1)
+	writeSkillVerification(t, root, slug, progression.SkillSpecComplianceReview, model.VerificationRecord{
+		Verdict:    model.VerificationVerdictPass,
+		Blockers:   []model.ReasonCode{},
+		Timestamp:  time.Now().UTC(),
+		RunVersion: 1,
+		References: []string{
+			"layer:R0=pass",
+			"layer:R3=pass",
+			"layer:IR1=pass",
+			"layer:IR3=pass",
+		},
+	})
+	return root, slug
+}
+
+func requireIndependentReviewHostCapability(t *testing.T, capabilities []hostCapabilityView) hostCapabilityView {
+	t.Helper()
+
+	for _, capabilityView := range capabilities {
+		if capabilityView.SkillName == progression.SkillIndependentReview {
+			assert.Equal(t, "subagent", capabilityView.Capability)
+			assert.True(t, capabilityView.Required)
+			assert.NotEmpty(t, capabilityView.EvidenceRequirement)
+			assert.NotEmpty(t, capabilityView.Remediation)
+			return capabilityView
+		}
+	}
+	require.Fail(t, "missing independent-review host capability", "capabilities: %#v", capabilities)
+	return hostCapabilityView{}
 }
 
 func TestReviewStateDocsProfileSkipsCodeQualityAcrossCommandSurfaces(t *testing.T) {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -15,50 +15,56 @@ import (
 )
 
 type statusView struct {
-	ExecutionMode             string                               `json:"execution_mode"`
-	Mode                      string                               `json:"mode,omitempty"`
-	HydrateReferences         []string                             `json:"hydrate_references,omitempty"`
-	Slug                      string                               `json:"slug,omitempty"`
-	QualityMode               string                               `json:"quality_mode,omitempty"`
-	WorkflowProfile           string                               `json:"workflow_profile,omitempty"`
-	WorkflowPreset            string                               `json:"workflow_preset,omitempty"`
-	SuggestedWorkflowPreset   string                               `json:"suggested_workflow_preset,omitempty"`
-	EffectiveWorkflowPreset   string                               `json:"effective_workflow_preset,omitempty"`
-	PresetConfirmationPending bool                                 `json:"preset_confirmation_pending,omitempty"`
-	PresetUpgradeReasons      []string                             `json:"preset_upgrade_reasons,omitempty"`
-	GovernanceForecast        *governanceForecastView              `json:"governance_forecast,omitempty"`
-	AutoPassedStates          []model.AutoPassedState              `json:"auto_passed_states,omitempty"`
-	NeedsDiscovery            bool                                 `json:"needs_discovery,omitempty"`
-	Phase                     model.UserPhase                      `json:"phase,omitempty"`
-	LifecycleStatus           string                               `json:"lifecycle_status,omitempty"`
-	DoneReady                 bool                                 `json:"done_ready,omitempty"`
-	Archived                  bool                                 `json:"archived,omitempty"`
-	ArchivePath               string                               `json:"archive_path,omitempty"`
-	CurrentState              model.WorkflowState                  `json:"current_state,omitempty"`
-	IntakeSubStep             model.IntakeSubStep                  `json:"intake_substep,omitempty"`
-	PlanSubStep               model.PlanSubStep                    `json:"plan_substep,omitempty"`
-	PlanningNote              string                               `json:"planning_note,omitempty"`
-	InterruptedExecutionAt    string                               `json:"interrupted_execution_at,omitempty"`
-	Narrative                 string                               `json:"narrative,omitempty"`
-	NextReadyActions          []string                             `json:"next_ready_actions,omitempty"`
-	SummaryBlockers           []model.ReasonCode                   `json:"summary_blockers,omitempty"`
-	Blockers                  []model.ReasonCode                   `json:"blockers,omitempty"`
-	Recovery                  *model.RecoverySummary               `json:"recovery,omitempty"`
-	GateStatus                map[string]model.GateRecord          `json:"gate_status,omitempty"`
-	ContextDependencies       *model.ContextDependencies           `json:"context_dependencies,omitempty"`
-	SelectedPriorContext      []selectedPriorContextView           `json:"selected_prior_context,omitempty"`
-	UnresolvedDependencies    []unresolvedDependencyView           `json:"unresolved_dependencies,omitempty"`
-	Progress                  *statusProgress                      `json:"progress,omitempty"`
-	ArtifactDAG               []artifactDAGNode                    `json:"artifact_dag,omitempty"`
-	ArtifactAmendments        []artifact.AmendmentEvent            `json:"artifact_amendments,omitempty"`
-	EvidencePointers          statusEvidencePointers               `json:"evidence_pointers,omitempty"`
-	EvidenceFreshness         string                               `json:"evidence_freshness"`
-	FreshnessDiagnostics      *state.ExecutionFreshnessDiagnostics `json:"freshness_diagnostics,omitempty"`
-	SelectedReviewSkills      []string                             `json:"selected_review_skills,omitempty"`
-	ScopeContract             *scopeContractView                   `json:"scope_contract,omitempty"`
-	SourceStateFile           string                               `json:"source_state_file,omitempty"`
-	Timeline                  []statusTimelineEvent                `json:"timeline,omitempty"`
-	Diagnostics               []string                             `json:"diagnostics,omitempty"`
+	ExecutionMode               string                               `json:"execution_mode"`
+	Mode                        string                               `json:"mode,omitempty"`
+	HydrateReferences           []string                             `json:"hydrate_references,omitempty"`
+	Slug                        string                               `json:"slug,omitempty"`
+	QualityMode                 string                               `json:"quality_mode,omitempty"`
+	WorkflowProfile             string                               `json:"workflow_profile,omitempty"`
+	WorkflowPreset              string                               `json:"workflow_preset,omitempty"`
+	SuggestedWorkflowPreset     string                               `json:"suggested_workflow_preset,omitempty"`
+	EffectiveWorkflowPreset     string                               `json:"effective_workflow_preset,omitempty"`
+	PresetConfirmationPending   bool                                 `json:"preset_confirmation_pending,omitempty"`
+	PresetUpgradeReasons        []string                             `json:"preset_upgrade_reasons,omitempty"`
+	GovernanceForecast          *governanceForecastView              `json:"governance_forecast,omitempty"`
+	AutoPassedStates            []model.AutoPassedState              `json:"auto_passed_states,omitempty"`
+	NeedsDiscovery              bool                                 `json:"needs_discovery,omitempty"`
+	Phase                       model.UserPhase                      `json:"phase,omitempty"`
+	LifecycleStatus             string                               `json:"lifecycle_status,omitempty"`
+	DoneReady                   bool                                 `json:"done_ready,omitempty"`
+	Archived                    bool                                 `json:"archived,omitempty"`
+	ArchivePath                 string                               `json:"archive_path,omitempty"`
+	CurrentState                model.WorkflowState                  `json:"current_state,omitempty"`
+	IntakeSubStep               model.IntakeSubStep                  `json:"intake_substep,omitempty"`
+	PlanSubStep                 model.PlanSubStep                    `json:"plan_substep,omitempty"`
+	PlanningNote                string                               `json:"planning_note,omitempty"`
+	InterruptedExecutionAt      string                               `json:"interrupted_execution_at,omitempty"`
+	Narrative                   string                               `json:"narrative,omitempty"`
+	InvocationRoute             *invocationRouteView                 `json:"invocation_route,omitempty"`
+	NextReadyActions            []string                             `json:"next_ready_actions,omitempty"`
+	SummaryBlockers             []model.ReasonCode                   `json:"summary_blockers,omitempty"`
+	Blockers                    []model.ReasonCode                   `json:"blockers,omitempty"`
+	Recovery                    *model.RecoverySummary               `json:"recovery,omitempty"`
+	GateStatus                  map[string]model.GateRecord          `json:"gate_status,omitempty"`
+	ContextDependencies         *model.ContextDependencies           `json:"context_dependencies,omitempty"`
+	SelectedPriorContext        []selectedPriorContextView           `json:"selected_prior_context,omitempty"`
+	UnresolvedDependencies      []unresolvedDependencyView           `json:"unresolved_dependencies,omitempty"`
+	Progress                    *statusProgress                      `json:"progress,omitempty"`
+	ArtifactDAG                 []artifactDAGNode                    `json:"artifact_dag,omitempty"`
+	ArtifactAmendments          []artifact.AmendmentEvent            `json:"artifact_amendments,omitempty"`
+	EvidencePointers            statusEvidencePointers               `json:"evidence_pointers,omitempty"`
+	EvidenceFreshness           string                               `json:"evidence_freshness"`
+	ExecutionEvidenceFreshness  string                               `json:"execution_evidence_freshness,omitempty"`
+	GovernanceEvidenceFreshness string                               `json:"governance_evidence_freshness,omitempty"`
+	OverallReadinessFreshness   string                               `json:"overall_readiness_freshness,omitempty"`
+	FreshnessDiagnostics        *state.ExecutionFreshnessDiagnostics `json:"freshness_diagnostics,omitempty"`
+	CurrentActionKind           string                               `json:"current_action_kind,omitempty"`
+	CurrentActionCommand        string                               `json:"current_action_command,omitempty"`
+	SelectedReviewSkills        []string                             `json:"selected_review_skills,omitempty"`
+	ScopeContract               *scopeContractView                   `json:"scope_contract,omitempty"`
+	SourceStateFile             string                               `json:"source_state_file,omitempty"`
+	Timeline                    []statusTimelineEvent                `json:"timeline,omitempty"`
+	Diagnostics                 []string                             `json:"diagnostics,omitempty"`
 	// Governance (derived from governance_snapshot.yaml)
 	GovernanceSignals *governanceSignalView   `json:"governance_signals,omitempty"`
 	ActiveControls    []governanceControlView `json:"active_controls,omitempty"`
@@ -240,7 +246,7 @@ func makeStatusCmd() *cobra.Command {
 				if archived {
 					return showArchivedStatusForChange(cmd, root, change, outputFormat, effectiveView, hydrateKeys, hydrate)
 				}
-				return showStatusForChange(cmd, root, change, outputFormat, effectiveView, hydrateKeys, hydrate)
+				return showStatusForChange(cmd, root, change, outputFormat, effectiveView, hydrateKeys, hydrate, true)
 			}
 
 			if change, ok, err := statusChangeFromCurrentWorktreeBinding(root); err != nil {
@@ -254,7 +260,7 @@ func makeStatusCmd() *cobra.Command {
 						return err
 					}
 				}
-				return showStatusForChange(cmd, root, change, outputFormat, effectiveView, hydrateKeys, hydrate)
+				return showStatusForChange(cmd, root, change, outputFormat, effectiveView, hydrateKeys, hydrate, false)
 			}
 
 			// When the invocation worktree hosts a local archived change, prefer it
@@ -327,7 +333,7 @@ func makeStatusCmd() *cobra.Command {
 					return err
 				}
 			}
-			return showStatusForChange(cmd, root, *route.change, outputFormat, effectiveView, hydrateKeys, hydrate)
+			return showStatusForChange(cmd, root, *route.change, outputFormat, effectiveView, hydrateKeys, hydrate, false)
 		},
 	}
 	cmd.Flags().BoolVar(&jsonFlag, "json", false, "JSON output (shorthand for --format json)")
@@ -358,6 +364,20 @@ func resolveStatusRoute(active []model.Change) statusRoute {
 
 func resolveStatusRouteForRoot(root string, active []model.Change) (statusRoute, error) {
 	route := resolveStatusRoute(active)
+	if route.change != nil {
+		ref, err := resolveActiveChangeRef(root, "")
+		if err != nil {
+			return statusRoute{}, err
+		}
+		if ref.Slug == route.change.Slug {
+			return route, nil
+		}
+		change, err := loadChangeBySlug(root, ref.Slug)
+		if err != nil {
+			return statusRoute{}, err
+		}
+		return statusRoute{change: &change}, nil
+	}
 	if !route.multiChange {
 		return route, nil
 	}
@@ -491,7 +511,7 @@ func deleteRecoveryStatusViewForSlug(root, slug string) *statusView {
 	return view
 }
 
-func showStatusForChange(cmd *cobra.Command, root string, change model.Change, outputFormat string, requestedView string, hydrateKeys []string, hydrate bool) error {
+func showStatusForChange(cmd *cobra.Command, root string, change model.Change, outputFormat string, requestedView string, hydrateKeys []string, hydrate bool, explicitChange bool) error {
 	return withChangeStateLock(root, change.Slug, "status", func() error {
 		latest, err := state.LoadChange(root, change.Slug)
 		if err != nil {
@@ -502,6 +522,7 @@ func showStatusForChange(cmd *cobra.Command, root string, change model.Change, o
 			return err
 		}
 		applyStatusInvocationWorkspacePath(cmd, root, &view)
+		applyStatusInvocationRoute(cmd, root, latest, explicitChange, &view)
 		view.Mode = requestedView
 		view.HydrateReferences = hydrateKeys
 		return printStatusView(cmd, root, view, outputFormat, hydrate)
@@ -510,6 +531,7 @@ func showStatusForChange(cmd *cobra.Command, root string, change model.Change, o
 
 func showArchivedStatusForChange(cmd *cobra.Command, root string, change model.Change, outputFormat string, requestedView string, hydrateKeys []string, hydrate bool) error {
 	view := buildArchivedStatusView(root, change)
+	applyStatusInvocationRoute(cmd, root, change, true, &view)
 	view.Mode = requestedView
 	view.HydrateReferences = hydrateKeys
 	return printStatusView(cmd, root, view, outputFormat, hydrate)

--- a/cmd/status_view_build.go
+++ b/cmd/status_view_build.go
@@ -130,6 +130,8 @@ func buildGovernedStatusView(root string, change model.Change) (statusView, erro
 	view.Blockers = model.NormalizeReasonCodes(append(view.Blockers, waveBlockers...))
 	applyDoneReadyProjection(change, readiness.GateEvaluations, &view)
 	view.Recovery = model.BuildRecovery(view.Blockers)
+	applyReadinessFreshnessToStatus(&view, readiness)
+	view.CurrentActionKind, view.CurrentActionCommand = projectCurrentActionContract(change, readiness)
 	view.FreshnessDiagnostics = attachFreshnessDiagnostics(readiness.FreshnessDiagnostics)
 	view.Diagnostics = append([]string(nil), projection.Diagnostics...)
 	view.Diagnostics = append(view.Diagnostics, waveDiagnostics...)
@@ -178,6 +180,82 @@ func buildStatusViewBase(
 	}
 	view.Narrative = buildStatusNarrative(view)
 	return view
+}
+
+func applyReadinessFreshnessToStatus(view *statusView, readiness progression.GovernanceReadiness) {
+	if view == nil {
+		return
+	}
+	view.ExecutionEvidenceFreshness = view.EvidenceFreshness
+	view.GovernanceEvidenceFreshness = projectGovernanceEvidenceFreshness(readiness)
+	view.OverallReadinessFreshness = projectOverallReadinessFreshness(
+		view.ExecutionEvidenceFreshness,
+		view.GovernanceEvidenceFreshness,
+		view.Blockers,
+	)
+}
+
+func applyReadinessFreshnessToValidate(view *validateView, readiness progression.GovernanceReadiness) {
+	if view == nil {
+		return
+	}
+	view.ExecutionEvidenceFreshness = view.EvidenceFreshness
+	view.GovernanceEvidenceFreshness = projectGovernanceEvidenceFreshness(readiness)
+	view.OverallReadinessFreshness = projectOverallReadinessFreshness(
+		view.ExecutionEvidenceFreshness,
+		view.GovernanceEvidenceFreshness,
+		view.Blockers,
+	)
+}
+
+func projectGovernanceEvidenceFreshness(readiness progression.GovernanceReadiness) string {
+	if len(readiness.SkillBlockers) > 0 {
+		return "stale"
+	}
+	return "fresh"
+}
+
+func projectOverallReadinessFreshness(executionFreshness, governanceFreshness string, blockers []model.ReasonCode) string {
+	if len(model.NormalizeReasonCodes(blockers)) > 0 {
+		return "blocked"
+	}
+	if executionFreshness == "stale" || governanceFreshness == "stale" {
+		return "stale"
+	}
+	if executionFreshness == "" || executionFreshness == "unknown" || governanceFreshness == "" || governanceFreshness == "unknown" {
+		return "unknown"
+	}
+	return "fresh"
+}
+
+func projectCurrentActionContract(change model.Change, readiness progression.GovernanceReadiness) (string, string) {
+	if change.CurrentState == model.StateS3Review {
+		pending := pendingSelectedReviewSkills(change, readiness)
+		if len(pending) > 1 {
+			return "review_batch", "slipway run"
+		}
+		if len(pending) == 1 {
+			return "skill_handoff", "slipway run"
+		}
+	}
+	if skill := buildActionableNextSkillView(change, readiness); skill != nil {
+		return "skill_handoff", "slipway run"
+	}
+	if change.CurrentState == model.StateDone {
+		return "", ""
+	}
+	return "command_required", "slipway " + invocationRouteAction(change.CurrentState)
+}
+
+func pendingSelectedReviewSkills(change model.Change, readiness progression.GovernanceReadiness) []string {
+	selected := selectedReviewSkillsFromReadiness(readiness, change.EffectiveWorkflowProfile())
+	pending := make([]string, 0, len(selected))
+	for _, name := range selected {
+		if !skillHasPassingEvidence(readiness.PassingSkills, name) {
+			pending = append(pending, name)
+		}
+	}
+	return pending
 }
 
 func statusPrimaryAction(root string, change model.Change, execCtx executionContext) (string, []model.ReasonCode, []string) {

--- a/cmd/test_main_test.go
+++ b/cmd/test_main_test.go
@@ -10,5 +10,7 @@ func TestMain(m *testing.M) {
 	commandLockWaitUnit = 10 * time.Millisecond
 	commandCancelGraceUnit = 10 * time.Millisecond
 	processPreemptionPollInterval = time.Millisecond
+	_ = os.Setenv("SLIPWAY_HOST_CAPABILITIES", "subagent")
+	_ = os.Setenv("SLIPWAY_HOST_CAPABILITY_FALLBACKS", "")
 	os.Exit(m.Run())
 }

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"io/fs"
+	"strings"
 
 	"github.com/signalridge/slipway/internal/engine/artifact"
 	"github.com/signalridge/slipway/internal/engine/progression"
@@ -15,40 +16,47 @@ import (
 )
 
 type validateView struct {
-	Slug                      string                               `json:"slug"`
-	QualityMode               string                               `json:"quality_mode,omitempty"`
-	WorkflowPreset            string                               `json:"workflow_preset,omitempty"`
-	SuggestedWorkflowPreset   string                               `json:"suggested_workflow_preset,omitempty"`
-	EffectiveWorkflowPreset   string                               `json:"effective_workflow_preset,omitempty"`
-	PresetConfirmationPending bool                                 `json:"preset_confirmation_pending,omitempty"`
-	PresetUpgradeReasons      []string                             `json:"preset_upgrade_reasons,omitempty"`
-	GovernanceForecast        *governanceForecastView              `json:"governance_forecast,omitempty"`
-	NeedsDiscovery            bool                                 `json:"needs_discovery,omitempty"`
-	Phase                     model.UserPhase                      `json:"phase,omitempty"`
-	ExecutionMode             string                               `json:"execution_mode"`
-	CurrentState              model.WorkflowState                  `json:"current_state"`
-	IntakeSubStep             model.IntakeSubStep                  `json:"intake_substep,omitempty"`
-	PlanSubStep               model.PlanSubStep                    `json:"plan_substep,omitempty"`
-	PlanningNote              string                               `json:"planning_note,omitempty"`
-	SkillsReady               map[string]string                    `json:"skills_ready"`
-	Blockers                  []model.ReasonCode                   `json:"blockers"`
-	Recovery                  *model.RecoverySummary               `json:"recovery,omitempty"`
-	CanAdvance                bool                                 `json:"can_advance"`
-	GateStatus                map[string]string                    `json:"gate_status,omitempty"`
-	GateDetails               map[string]model.GateRecord          `json:"gate_details,omitempty"`
-	EvidenceFreshness         string                               `json:"evidence_freshness"`
-	FreshnessDiagnostics      *state.ExecutionFreshnessDiagnostics `json:"freshness_diagnostics,omitempty"`
-	ActionableNextSkill       *actionableNextSkillView             `json:"actionable_next_skill,omitempty"`
-	SelectedReviewSkills      []string                             `json:"selected_review_skills,omitempty"`
-	RequirementsContract      *artifactContractView                `json:"requirements_contract,omitempty"`
-	TasksContract             *artifactContractView                `json:"tasks_contract,omitempty"`
-	DecisionContract          *artifactContractView                `json:"decision_contract,omitempty"`
-	ScopeContract             *scopeContractView                   `json:"scope_contract,omitempty"`
-	Diagnostics               []string                             `json:"diagnostics,omitempty"`
-	Mode                      string                               `json:"mode,omitempty"`
-	HydrateReferences         []string                             `json:"hydrate_references,omitempty"`
-	ArtifactAmendments        []artifact.AmendmentEvent            `json:"artifact_amendments,omitempty"`
-	RequiredActions           []governanceActionView               `json:"required_actions,omitempty"`
+	Slug                        string                               `json:"slug"`
+	QualityMode                 string                               `json:"quality_mode,omitempty"`
+	WorkflowPreset              string                               `json:"workflow_preset,omitempty"`
+	SuggestedWorkflowPreset     string                               `json:"suggested_workflow_preset,omitempty"`
+	EffectiveWorkflowPreset     string                               `json:"effective_workflow_preset,omitempty"`
+	PresetConfirmationPending   bool                                 `json:"preset_confirmation_pending,omitempty"`
+	PresetUpgradeReasons        []string                             `json:"preset_upgrade_reasons,omitempty"`
+	GovernanceForecast          *governanceForecastView              `json:"governance_forecast,omitempty"`
+	NeedsDiscovery              bool                                 `json:"needs_discovery,omitempty"`
+	Phase                       model.UserPhase                      `json:"phase,omitempty"`
+	ExecutionMode               string                               `json:"execution_mode"`
+	CurrentState                model.WorkflowState                  `json:"current_state"`
+	IntakeSubStep               model.IntakeSubStep                  `json:"intake_substep,omitempty"`
+	PlanSubStep                 model.PlanSubStep                    `json:"plan_substep,omitempty"`
+	PlanningNote                string                               `json:"planning_note,omitempty"`
+	InvocationRoute             *invocationRouteView                 `json:"invocation_route,omitempty"`
+	SkillsReady                 map[string]string                    `json:"skills_ready"`
+	Blockers                    []model.ReasonCode                   `json:"blockers"`
+	Recovery                    *model.RecoverySummary               `json:"recovery,omitempty"`
+	CanAdvance                  bool                                 `json:"can_advance"`
+	GateStatus                  map[string]string                    `json:"gate_status,omitempty"`
+	GateDetails                 map[string]model.GateRecord          `json:"gate_details,omitempty"`
+	EvidenceFreshness           string                               `json:"evidence_freshness"`
+	ExecutionEvidenceFreshness  string                               `json:"execution_evidence_freshness,omitempty"`
+	GovernanceEvidenceFreshness string                               `json:"governance_evidence_freshness,omitempty"`
+	OverallReadinessFreshness   string                               `json:"overall_readiness_freshness,omitempty"`
+	FreshnessDiagnostics        *state.ExecutionFreshnessDiagnostics `json:"freshness_diagnostics,omitempty"`
+	CurrentActionKind           string                               `json:"current_action_kind,omitempty"`
+	CurrentActionCommand        string                               `json:"current_action_command,omitempty"`
+	HostCapabilities            []hostCapabilityView                 `json:"host_capabilities,omitempty"`
+	ActionableNextSkill         *actionableNextSkillView             `json:"actionable_next_skill,omitempty"`
+	SelectedReviewSkills        []string                             `json:"selected_review_skills,omitempty"`
+	RequirementsContract        *artifactContractView                `json:"requirements_contract,omitempty"`
+	TasksContract               *artifactContractView                `json:"tasks_contract,omitempty"`
+	DecisionContract            *artifactContractView                `json:"decision_contract,omitempty"`
+	ScopeContract               *scopeContractView                   `json:"scope_contract,omitempty"`
+	Diagnostics                 []string                             `json:"diagnostics,omitempty"`
+	Mode                        string                               `json:"mode,omitempty"`
+	HydrateReferences           []string                             `json:"hydrate_references,omitempty"`
+	ArtifactAmendments          []artifact.AmendmentEvent            `json:"artifact_amendments,omitempty"`
+	RequiredActions             []governanceActionView               `json:"required_actions,omitempty"`
 }
 
 type actionableNextSkillView struct {
@@ -164,7 +172,7 @@ func makeValidateCmd() *cobra.Command {
 
 			ref, err := resolveActiveChangeRef(root, changeSlug)
 			if err != nil {
-				if shouldFallbackValidateDiagnostics(err) {
+				if strings.TrimSpace(changeSlug) == "" && shouldFallbackValidateDiagnostics(err) {
 					view := diagnosticValidateView("no active change or ambiguous; use `--change <slug>` or run `slipway repair`")
 					view.Mode = effectiveMode
 					view.HydrateReferences = normalizeHydrateKeys(resolveEffectiveFocusHydrate("validate", focus))
@@ -178,6 +186,9 @@ func makeValidateCmd() *cobra.Command {
 				return err
 			}
 			applyValidateInvocationWorkspacePath(cmd, root, &view)
+			if change, loadErr := state.LoadChange(root, ref.Slug); loadErr == nil {
+				applyValidateInvocationRoute(cmd, root, change, strings.TrimSpace(changeSlug) != "", &view)
+			}
 			view.Mode = effectiveMode
 			view.HydrateReferences = normalizeHydrateKeys(resolveEffectiveFocusHydrate("validate", focus))
 			return encodeJSONResponse(cmd, view)
@@ -303,6 +314,10 @@ func buildValidateViewForSlug(root, slug string) (validateView, error) {
 		view.SelectedReviewSkills = selectedReviewSkillsFromReadiness(readiness, change.EffectiveWorkflowProfile())
 	}
 	view.ActionableNextSkill = buildActionableNextSkillView(change, readiness)
+	applyHostCapabilityContractToValidate(
+		&view,
+		selectedHostCapabilitySkillNamesForValidate(change, readiness, view.ActionableNextSkill),
+	)
 	applyGovernanceSurfaceToValidate(readiness, &view)
 	gateDetails := gateStatusFromEvaluations(readiness.GateEvaluations)
 	gateStatus := map[string]string{}
@@ -312,6 +327,8 @@ func buildValidateViewForSlug(root, slug string) (validateView, error) {
 	view.GateStatus = gateStatus
 	view.GateDetails = gateDetails
 	view.Recovery = buildValidateRecovery(view.Blockers, gateDetails)
+	applyReadinessFreshnessToValidate(&view, readiness)
+	view.CurrentActionKind, view.CurrentActionCommand = projectCurrentActionContract(change, readiness)
 	if readiness.ArtifactProjection != nil && len(readiness.ArtifactProjection.Amendments) > 0 {
 		view.ArtifactAmendments = append([]artifact.AmendmentEvent(nil), readiness.ArtifactProjection.Amendments...)
 	}

--- a/internal/engine/capability/resolver.go
+++ b/internal/engine/capability/resolver.go
@@ -33,6 +33,19 @@ type Resolution struct {
 	HydrateReferences []string
 }
 
+// HostCapabilityRequirement describes a host/runtime capability a selected
+// skill needs outside the Slipway kernel itself.
+type HostCapabilityRequirement struct {
+	SkillID             string
+	Capability          string
+	Required            bool
+	Availability        string
+	FallbackSelected    bool
+	FallbackMode        string
+	EvidenceRequirement string
+	Remediation         string
+}
+
 // Signals carries the context inputs for capability resolution.
 type Signals struct {
 	Command      string
@@ -40,6 +53,12 @@ type Signals struct {
 	Blockers     []string
 	ChangedFiles []string
 	Paths        []string
+	// HostCapabilities names capabilities the current host explicitly reports,
+	// e.g. "subagent". The token "none" means the host explicitly reports no
+	// delegated-execution capability. Empty means unknown, not unavailable.
+	HostCapabilities []string
+	// Fallbacks names explicit host/operator-selected fallback modes.
+	Fallbacks []string
 	// Focus names an explicit `--focus <alias>` selection resolved through
 	// surface policy. Empty means no explicit focus was requested.
 	Focus string
@@ -68,6 +87,65 @@ func Resolve(reg *Registry, sig Signals) Resolution {
 	resolution.HydrateReferences = collectHydrateReferences(reg, sig, resolution)
 
 	return resolution
+}
+
+func ResolveHostCapabilityRequirement(skillID string, sig Signals) *HostCapabilityRequirement {
+	skillID = strings.TrimSpace(skillID)
+	if skillID != "independent-review" {
+		return nil
+	}
+	req := &HostCapabilityRequirement{
+		SkillID:             skillID,
+		Capability:          "subagent",
+		Required:            true,
+		Availability:        hostCapabilityAvailability(sig.HostCapabilities, "subagent"),
+		EvidenceRequirement: "record independent-review evidence from a fresh independent reviewer context",
+		Remediation:         "Run independent-review in a host with subagent capability, or explicitly select manual_independent_review fallback and record fresh independent reviewer evidence.",
+	}
+	if fallbackSelected(sig.Fallbacks, "manual_independent_review") {
+		req.FallbackSelected = true
+		req.FallbackMode = "manual_independent_review"
+	}
+	return req
+}
+
+func hostCapabilityAvailability(tokens []string, capabilityName string) string {
+	capabilityName = strings.TrimSpace(capabilityName)
+	if capabilityName == "" {
+		return "unknown"
+	}
+	declared := false
+	for _, token := range tokens {
+		token = strings.TrimSpace(strings.ToLower(token))
+		switch token {
+		case "":
+			continue
+		case "none", "unavailable":
+			declared = true
+		default:
+			declared = true
+			if token == capabilityName || token == "delegation" {
+				return "available"
+			}
+		}
+	}
+	if declared {
+		return "unavailable"
+	}
+	return "unknown"
+}
+
+func fallbackSelected(tokens []string, fallbackName string) bool {
+	fallbackName = strings.TrimSpace(fallbackName)
+	if fallbackName == "" {
+		return false
+	}
+	for _, token := range tokens {
+		if strings.TrimSpace(token) == fallbackName {
+			return true
+		}
+	}
+	return false
 }
 
 // resolveRoute applies the surface-policy-based route contract. It returns

--- a/internal/engine/capability/resolver_test.go
+++ b/internal/engine/capability/resolver_test.go
@@ -89,6 +89,79 @@ func TestResolveNoMatchReturnsEmpty(t *testing.T) {
 	assert.Empty(t, res.Supports)
 }
 
+func TestResolveHostCapabilityRequirement(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unknown skill has no host capability contract", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Nil(t, ResolveHostCapabilityRequirement("code-quality-review", Signals{}))
+	})
+
+	tests := []struct {
+		name             string
+		signals          Signals
+		wantAvailability string
+		wantFallback     bool
+		wantFallbackMode string
+	}{
+		{
+			name:             "undeclared host capability remains unknown",
+			signals:          Signals{},
+			wantAvailability: "unknown",
+		},
+		{
+			name: "explicit subagent capability is available",
+			signals: Signals{
+				HostCapabilities: []string{"subagent"},
+			},
+			wantAvailability: "available",
+		},
+		{
+			name: "delegation alias satisfies subagent",
+			signals: Signals{
+				HostCapabilities: []string{"delegation"},
+			},
+			wantAvailability: "available",
+		},
+		{
+			name: "explicit none is unavailable",
+			signals: Signals{
+				HostCapabilities: []string{"none"},
+			},
+			wantAvailability: "unavailable",
+		},
+		{
+			name: "manual independent review fallback is explicit",
+			signals: Signals{
+				HostCapabilities: []string{"none"},
+				Fallbacks:        []string{"manual_independent_review"},
+			},
+			wantAvailability: "unavailable",
+			wantFallback:     true,
+			wantFallbackMode: "manual_independent_review",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := ResolveHostCapabilityRequirement("independent-review", tt.signals)
+			require.NotNil(t, req)
+			assert.Equal(t, "independent-review", req.SkillID)
+			assert.Equal(t, "subagent", req.Capability)
+			assert.True(t, req.Required)
+			assert.Equal(t, tt.wantAvailability, req.Availability)
+			assert.Equal(t, tt.wantFallback, req.FallbackSelected)
+			assert.Equal(t, tt.wantFallbackMode, req.FallbackMode)
+			assert.NotEmpty(t, req.EvidenceRequirement)
+			assert.NotEmpty(t, req.Remediation)
+		})
+	}
+}
+
 func TestResolveReviewHostDoesNotAttachPromotedReviewHosts(t *testing.T) {
 	t.Parallel()
 	reg := DefaultRegistry()

--- a/internal/model/reason_code.go
+++ b/internal/model/reason_code.go
@@ -198,6 +198,10 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 		Severity: ReasonSeverityError,
 		Message:  "A required high-risk safety check is missing",
 	},
+	"host_capability_unavailable": {
+		Severity: ReasonSeverityError,
+		Message:  "A selected governance skill requires a host capability that is unavailable",
+	},
 	"incomplete_execution_task": {
 		Severity: ReasonSeverityError,
 		Message:  "A planned execution task has no recorded passing evidence",

--- a/internal/model/reason_code_contract_test.go
+++ b/internal/model/reason_code_contract_test.go
@@ -82,6 +82,7 @@ func canonicalReasonCodeSnapshot() []string {
 		"governed_bundle_path_invalid",
 		"high_risk_check_failed",
 		"high_risk_check_missing",
+		"host_capability_unavailable",
 		"incomplete_execution_task",
 		"intake_clarification_incomplete",
 		"intake_confirmation_incomplete",

--- a/internal/model/recovery.go
+++ b/internal/model/recovery.go
@@ -253,6 +253,12 @@ var blockerRemediations = map[string]blockerRemediation{
 		CommandTemplate: "slipway validate --focus sast",
 		Class:           RecoveryClassSatisfyControl,
 	},
+	"host_capability_unavailable": {
+		Remediation:     "Run the selected governance skill in a host that provides {detail}, or explicitly select the documented fallback for {subject} and record fresh evidence.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassSatisfyControl,
+		SplitDetail:     true,
+	},
 	"incomplete_execution_task": {
 		Remediation:     "Execute task {subject} and record its evidence with `slipway evidence task`, or update tasks.md if the task no longer belongs, then continue wave-orchestration.",
 		CommandTemplate: "slipway run",


### PR DESCRIPTION
## Summary
- add a shared invocation route/actionability projection for status, next, validate, and related lifecycle surfaces
- split execution/governance/overall readiness freshness and align current-action projection with next
- add host capability visibility with fail-closed independent-review subagent behavior and explicit manual fallback support
- archive the governed change after S3 peer reviews and terminal ship verification

## Root Cause
The public lifecycle surfaces had drifted: root or wrong-worktree command output could imply local actionability, validate could collapse explicit missing changes into generic diagnostics, readiness freshness could be read as fresh while governance evidence was missing, and delegated review capability was not represented as a fail-closed prerequisite.

## Validation
- go test ./cmd -count=1
- go test ./... -count=1
- golangci-lint run ./...
- S3 selected reviews recorded: spec-compliance, code-quality, independent, security
- ship-verification recorded with fresh full-suite, lint, stub scan, scope contract, assurance, and reviewer-independence evidence