### PR TITLE
chore(release): harden release supply chain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: Lint YAML
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Install yamllint
         run: pip install yamllint
       - name: Run yamllint
@@ -20,16 +20,16 @@ jobs:
     name: Lint Actions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Run actionlint
-        uses: raven-actions/actionlint@v2
+        uses: raven-actions/actionlint@205b530c5d9fa8f44ae9ed59f341a0db994aa6f8 # v2
   lint-markdown:
     name: Lint Markdown
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Run markdownlint
-        uses: DavidAnson/markdownlint-cli2-action@v23
+        uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd # v23
         with:
           config: .markdownlint.yaml
           globs: |
@@ -44,14 +44,14 @@ jobs:
     name: Lint Go
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: go.mod
           cache: true
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9
         with:
           version: v2.12.2
           args: --timeout=5m
@@ -65,13 +65,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         env:
           GIT_CONFIG_COUNT: "1"
           GIT_CONFIG_KEY_0: core.longpaths
           GIT_CONFIG_VALUE_0: "true"
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: go.mod
           cache: true
@@ -83,9 +83,9 @@ jobs:
     name: Race Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: go.mod
           cache: true
@@ -95,9 +95,9 @@ jobs:
     name: Kernel Coverage Gate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: go.mod
           cache: true
@@ -113,14 +113,42 @@ jobs:
             -coverprofile=tmp/coverage-kernel.out
       - name: Enforce kernel coverage baseline (fails closed on regression)
         run: go run ./internal/coverage/cmd/covergate -check -profile tmp/coverage-kernel.out
+  release-config:
+    name: Release Config
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Check GoReleaser config
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7
+        with:
+          distribution: goreleaser
+          version: v2.16.0
+          args: check
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+      - name: Install syft
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0
+      - name: Snapshot release dry run
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7
+        with:
+          distribution: goreleaser
+          version: v2.16.0
+          args: release --snapshot --clean --skip=publish,sign
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [lint-go, test]
+    needs: [lint-go, test, release-config]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: go.mod
           cache: true
@@ -162,9 +190,9 @@ jobs:
           - goos: windows
             goarch: amd64
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
           REF_NAME: ${{ github.ref }}
         run: |
           if [ "$REF_NAME" != "refs/heads/main" ]; then
-            echo "deploy=false" >> "$GITHUB_OUTPUT"
+            printf 'deploy=false\n' >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -46,7 +46,7 @@ jobs:
             push|workflow_dispatch)
               ;;
             *)
-              echo "deploy=false" >> "$GITHUB_OUTPUT"
+              printf 'deploy=false\n' >> "$GITHUB_OUTPUT"
               exit 0
               ;;
           esac
@@ -58,13 +58,13 @@ jobs:
             "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pages")
 
           if [ "$status" = "200" ]; then
-            echo "deploy=true" >> "$GITHUB_OUTPUT"
+            printf 'deploy=true\n' >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           if [ "$status" = "404" ]; then
             echo "::notice::GitHub Pages is not enabled; docs were built but deployment was skipped."
-            echo "deploy=false" >> "$GITHUB_OUTPUT"
+            printf 'deploy=false\n' >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -79,9 +79,9 @@ jobs:
       run:
         working-directory: website
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Set up Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "22"
           cache: npm
@@ -92,7 +92,7 @@ jobs:
         run: npm run build
       - name: Upload Pages artifact
         if: needs.pages-status.outputs.deploy == 'true'
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: website/dist
   deploy:
@@ -109,4 +109,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/flake-lock-update.yaml
+++ b/.github/workflows/flake-lock-update.yaml
@@ -18,16 +18,16 @@ jobs:
     name: Update flake.lock
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: DeterminateSystems/nix-installer-action@a7ad9c4f0c65208097f4d34f3cfa1913b80cce5c # main
+      - uses: DeterminateSystems/magic-nix-cache-action@76aaf8814cdb385b86597c32b8c51b66b69b0839 # main
         with:
           use-flakehub: false
           use-gha-cache: true
       - name: Update lock file
         run: nix flake update
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           branch: chore/update-flake-lock
           delete-branch: true

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -27,9 +27,9 @@ jobs:
     name: Flake Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: DeterminateSystems/nix-installer-action@a7ad9c4f0c65208097f4d34f3cfa1913b80cce5c # main
+      - uses: DeterminateSystems/magic-nix-cache-action@76aaf8814cdb385b86597c32b8c51b66b69b0839 # main
         with:
           use-flakehub: false
           use-gha-cache: true
@@ -40,9 +40,9 @@ jobs:
     name: Nix Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: DeterminateSystems/nix-installer-action@a7ad9c4f0c65208097f4d34f3cfa1913b80cce5c # main
+      - uses: DeterminateSystems/magic-nix-cache-action@76aaf8814cdb385b86597c32b8c51b66b69b0839 # main
         with:
           use-flakehub: false
           use-gha-cache: true
@@ -57,9 +57,9 @@ jobs:
     name: Dev Shell
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: DeterminateSystems/nix-installer-action@a7ad9c4f0c65208097f4d34f3cfa1913b80cce5c # main
+      - uses: DeterminateSystems/magic-nix-cache-action@76aaf8814cdb385b86597c32b8c51b66b69b0839 # main
         with:
           use-flakehub: false
           use-gha-cache: true

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check Conventional Commit format
-        uses: amannn/action-semantic-pull-request@v6
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Release Please
-        uses: googleapis/release-please-action@v5
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,38 +12,60 @@ on:
         type: string
 
 permissions:
-  contents: write
-  packages: write
-  id-token: write
-  attestations: write
-  actions: read
-  security-events: write
+  contents: read
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: signalridge/slipway
 
 jobs:
+  validate-tag:
+    name: Validate Release Tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      tag_name: ${{ steps.tag.outputs.tag_name }}
+    steps:
+      - name: Validate release tag
+        id: tag
+        shell: bash
+        env:
+          INPUT_TAG: ${{ inputs.tag || '' }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          tag="${INPUT_TAG:-$REF_NAME}"
+          if [[ "$tag" == *[[:cntrl:]]* ]]; then
+            printf '::error::Invalid release tag contains control characters.\n'
+            exit 1
+          fi
+          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            printf '::error::Invalid release tag %q. ' "$tag"
+            printf 'Expected vMAJOR.MINOR.PATCH or vMAJOR.MINOR.PATCH-prerelease.\n'
+            exit 1
+          fi
+          printf 'tag_name=%s\n' "$tag" >> "$GITHUB_OUTPUT"
+
   test:
     name: Test
     runs-on: ubuntu-latest
+    needs: [validate-tag]
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
-          ref: ${{ inputs.tag || github.ref }}
+          ref: ${{ needs.validate-tag.outputs.tag_name }}
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: go.mod
           cache: true
-      - name: Resolve release tag
-        id: tag
-        run: echo "tag_name=${{ inputs.tag || github.ref_name }}" >> "$GITHUB_OUTPUT"
       - name: Run tests
         run: go test -timeout=20m ./... -race -count=1
       - name: Build and verify release metadata
         env:
-          TAG_NAME: ${{ steps.tag.outputs.tag_name }}
+          TAG_NAME: ${{ needs.validate-tag.outputs.tag_name }}
         run: |
           VERSION="${TAG_NAME#v}"
           mkdir -p bin
@@ -59,20 +81,29 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [test]
+    needs: [validate-tag, test]
+    environment: release-publish
+    permissions:
+      actions: read
+      attestations: write
+      contents: write
+      id-token: write
+      packages: write
     outputs:
       version: ${{ steps.version.outputs.version }}
       hashes: ${{ steps.hash.outputs.hashes }}
-      tag_name: ${{ steps.tag.outputs.tag_name }}
+      tag_name: ${{ needs.validate-tag.outputs.tag_name }}
       gh_pat_available: ${{ steps.optional-secrets.outputs.gh_pat_available }}
+      aur_key_available: ${{ steps.optional-secrets.outputs.aur_key_available }}
+      binary_matrix: ${{ steps.smoke.outputs.binary_matrix }}
+      deb_asset: ${{ steps.smoke.outputs.deb_asset }}
+      rpm_asset: ${{ steps.smoke.outputs.rpm_asset }}
+      apk_asset: ${{ steps.smoke.outputs.apk_asset }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
-          ref: ${{ inputs.tag || github.ref }}
-      - name: Resolve release tag
-        id: tag
-        run: echo "tag_name=${{ inputs.tag || github.ref_name }}" >> "$GITHUB_OUTPUT"
+          ref: ${{ needs.validate-tag.outputs.tag_name }}
       - name: Detect optional publishing secrets
         id: optional-secrets
         env:
@@ -80,34 +111,34 @@ jobs:
           AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
         run: |
           if [ -n "$GH_PAT" ]; then
-            echo "gh_pat_available=true" >> "$GITHUB_OUTPUT"
+            printf 'gh_pat_available=true\n' >> "$GITHUB_OUTPUT"
           else
-            echo "gh_pat_available=false" >> "$GITHUB_OUTPUT"
+            printf 'gh_pat_available=false\n' >> "$GITHUB_OUTPUT"
           fi
           if [ -n "$AUR_SSH_PRIVATE_KEY" ]; then
-            echo "aur_key_available=true" >> "$GITHUB_OUTPUT"
+            printf 'aur_key_available=true\n' >> "$GITHUB_OUTPUT"
           else
-            echo "aur_key_available=false" >> "$GITHUB_OUTPUT"
+            printf 'aur_key_available=false\n' >> "$GITHUB_OUTPUT"
           fi
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: go.mod
           cache: true
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
       - name: Install syft
-        uses: anchore/sbom-action/download-syft@v0
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0
       - name: Setup AUR SSH
-        if: env.AUR_SSH_PRIVATE_KEY != ''
+        if: steps.optional-secrets.outputs.aur_key_available == 'true'
         env:
           AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
         run: |
@@ -122,10 +153,10 @@ jobs:
           EOF
       - name: Run GoReleaser
         id: goreleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7
         with:
           distribution: goreleaser
-          version: "~> v2"
+          version: v2.16.0
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -135,8 +166,9 @@ jobs:
       - name: Extract version
         id: version
         run: |
-          VERSION=$(echo '${{ steps.goreleaser.outputs.metadata }}' | jq -r '.version')
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          metadata='${{ steps.goreleaser.outputs.metadata }}'
+          VERSION=$(printf '%s\n' "$metadata" | jq -r '.version')
+          printf 'version=%s\n' "$VERSION" >> "$GITHUB_OUTPUT"
       - name: Generate release subjects
         id: hash
         run: |
@@ -147,9 +179,48 @@ jobs:
             exit 1
           fi
           hashes=$(printf "%s\n" "$subjects" | base64 -w0)
-          echo "hashes=${hashes}" >> "$GITHUB_OUTPUT"
+          printf 'hashes=%s\n' "$hashes" >> "$GITHUB_OUTPUT"
+      - name: Generate release smoke manifest
+        id: smoke
+        run: |
+          cd dist
+          binary_matrix=$(
+            find . -maxdepth 1 -type f \( \
+              -name "slipway_*_linux_amd64.tar.gz" -o \
+              -name "slipway_*_darwin_arm64.tar.gz" -o \
+              -name "slipway_*_windows_amd64.zip" \
+            \) -printf '%f\n' | sort | jq -R -s -c '
+              split("\n")[:-1] | map(
+                if test("_linux_amd64\\.tar\\.gz$") then
+                  {os:"ubuntu-latest", asset:., command:"./slipway"}
+                elif test("_darwin_arm64\\.tar\\.gz$") then
+                  {os:"macos-latest", asset:., command:"./slipway"}
+                elif test("_windows_amd64\\.zip$") then
+                  {os:"windows-latest", asset:., command:"./slipway.exe"}
+                else empty end
+              )'
+          )
+          if [ "$binary_matrix" = "[]" ]; then
+            echo "::error::No executable archive assets were generated for smoke testing"
+            exit 1
+          fi
+          deb_asset=$(find . -maxdepth 1 -type f -name "slipway_*_linux_amd64.deb" -printf '%f\n' | sort | head -n1)
+          rpm_asset=$(find . -maxdepth 1 -type f -name "slipway_*_linux_amd64.rpm" -printf '%f\n' | sort | head -n1)
+          apk_asset=$(find . -maxdepth 1 -type f -name "slipway_*_linux_amd64.apk" -printf '%f\n' | sort | head -n1)
+          for required in deb_asset rpm_asset apk_asset; do
+            if [ -z "${!required}" ]; then
+              printf '::error::Missing release smoke asset output %s\n' "$required"
+              exit 1
+            fi
+          done
+          {
+            printf 'binary_matrix=%s\n' "$binary_matrix"
+            printf 'deb_asset=%s\n' "$deb_asset"
+            printf 'rpm_asset=%s\n' "$rpm_asset"
+            printf 'apk_asset=%s\n' "$apk_asset"
+          } >> "$GITHUB_OUTPUT"
       - name: Upload SBOM artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: sbom
           path: dist/*.sbom.spdx.json
@@ -162,7 +233,8 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    # yamllint disable-line rule:line-length
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       base64-subjects: ${{ needs.release.outputs.hashes }}
       upload-assets: true
@@ -172,11 +244,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [release]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ needs.release.outputs.tag_name }}
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31
       - name: Build package
         run: nix build .#slipway
       - name: Verify binary
@@ -188,9 +260,13 @@ jobs:
     name: Verify Container
     runs-on: ubuntu-latest
     needs: [release]
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
     steps:
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -209,7 +285,7 @@ jobs:
           VERSION: ${{ needs.release.outputs.tag_name }}
         run: |
           TAG="${VERSION#v}"
-          echo "ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${TAG}" >> "$GITHUB_OUTPUT"
+          printf 'ref=%s\n' "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${TAG}" >> "$GITHUB_OUTPUT"
       - name: Scan container image
         # v0.36.0, pinned by commit SHA after GHSA-69fq-xp46-6x23.
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
@@ -219,7 +295,7 @@ jobs:
           output: trivy-results.sarif
           severity: CRITICAL,HIGH
       - name: Upload Trivy scan results
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         if: always()
         with:
           sarif_file: trivy-results.sarif
@@ -247,10 +323,10 @@ jobs:
       - name: Download and install deb
         env:
           VERSION: ${{ needs.release.outputs.tag_name }}
+          ASSET: ${{ needs.release.outputs.deb_asset }}
         run: |
-          TAG="${VERSION#v}"
-          curl -LO "https://github.com/signalridge/slipway/releases/download/${VERSION}/slipway_${TAG}_linux_amd64.deb"
-          sudo dpkg -i "slipway_${TAG}_linux_amd64.deb"
+          curl -LO "https://github.com/signalridge/slipway/releases/download/${VERSION}/${ASSET}"
+          sudo dpkg -i "${ASSET}"
       - name: Verify installation
         run: |
           slipway --version
@@ -265,10 +341,29 @@ jobs:
       - name: Download and install rpm
         env:
           VERSION: ${{ needs.release.outputs.tag_name }}
+          ASSET: ${{ needs.release.outputs.rpm_asset }}
         run: |
-          TAG="${VERSION#v}"
-          curl -LO "https://github.com/signalridge/slipway/releases/download/${VERSION}/slipway_${TAG}_linux_amd64.rpm"
-          rpm -i "slipway_${TAG}_linux_amd64.rpm"
+          curl -LO "https://github.com/signalridge/slipway/releases/download/${VERSION}/${ASSET}"
+          rpm -i "${ASSET}"
+      - name: Verify installation
+        run: |
+          slipway --version
+          slipway --help
+
+  verify-apk:
+    name: Verify APK Package
+    runs-on: ubuntu-latest
+    needs: [release]
+    container: alpine@sha256:7c8cb692ae09657cbc4a3f3cbd0e8d5a2690ba38386aaaf252dbb060bf5eb2e6
+    steps:
+      - name: Download and install apk
+        env:
+          VERSION: ${{ needs.release.outputs.tag_name }}
+          ASSET: ${{ needs.release.outputs.apk_asset }}
+        run: |
+          apk add --no-cache curl
+          curl -LO "https://github.com/signalridge/slipway/releases/download/${VERSION}/${ASSET}"
+          apk add --allow-untrusted "${ASSET}"
       - name: Verify installation
         run: |
           slipway --version
@@ -281,24 +376,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: ubuntu-latest
-            asset: slipway_VERSION_linux_amd64.tar.gz
-            command: ./slipway
-          - os: macos-latest
-            asset: slipway_VERSION_darwin_arm64.tar.gz
-            command: ./slipway
-          - os: windows-latest
-            asset: slipway_VERSION_windows_amd64.zip
-            command: ./slipway.exe
+        include: ${{ fromJSON(needs.release.outputs.binary_matrix) }}
     steps:
       - name: Download and extract binary
         shell: bash
         env:
           VERSION: ${{ needs.release.outputs.tag_name }}
         run: |
-          TAG="${VERSION#v}"
-          ASSET=$(echo "${{ matrix.asset }}" | sed "s/VERSION/${TAG}/")
+          ASSET="${{ matrix.asset }}"
           curl -LO "https://github.com/signalridge/slipway/releases/download/${VERSION}/${ASSET}"
           case "${ASSET}" in
             *.zip) unzip "${ASSET}" ;;

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -14,14 +14,14 @@ jobs:
     name: Go Vulnerability Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: go.mod
           cache: true
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.5.0
       - name: Run govulncheck
         run: govulncheck -format sarif ./... > govulncheck.sarif
       - name: Normalize govulncheck SARIF
@@ -37,14 +37,14 @@ jobs:
           jq -S "$jq_filter" govulncheck.sarif > govulncheck.normalized.sarif
           mv govulncheck.normalized.sarif govulncheck.sarif
       - name: Upload govulncheck SARIF artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: govulncheck-sarif
           path: govulncheck.sarif
           retention-days: 30
       - name: Upload SARIF report
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         if: always()
         continue-on-error: true
         with:
@@ -54,23 +54,23 @@ jobs:
     name: Gosec SAST
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: go.mod
           cache: true
       - name: Run gosec
         run: go run github.com/securego/gosec/v2/cmd/gosec@v2.27.1 -fmt=sarif -out=gosec.sarif ./...
       - name: Upload gosec SARIF artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: gosec-sarif
           path: gosec.sarif
           retention-days: 30
       - name: Upload gosec SARIF report
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         if: always()
         continue-on-error: true
         with:
@@ -80,25 +80,25 @@ jobs:
     name: CodeQL Go Analysis
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: go.mod
           cache: true
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           languages: go
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           category: "/language:go"
   trivy:
     name: Trivy Filesystem Scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Run Trivy vulnerability scanner
         # v0.36.0, pinned by commit SHA after GHSA-69fq-xp46-6x23.
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
@@ -109,14 +109,14 @@ jobs:
           output: trivy-results.sarif
           severity: CRITICAL,HIGH,MEDIUM
       - name: Upload Trivy SARIF artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: trivy-sarif
           path: trivy-results.sarif
           retention-days: 30
       - name: Upload Trivy SARIF report
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         if: always()
         continue-on-error: true
         with:
@@ -127,15 +127,15 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Install syft
-        uses: anchore/sbom-action/download-syft@v0
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0
       - name: Generate SBOM
         run: |
           syft . -o spdx-json > sbom.spdx.json
           syft . -o cyclonedx-json > sbom.cdx.json
       - name: Upload SBOM artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: sbom
           path: |
@@ -146,14 +146,14 @@ jobs:
     name: License Compliance
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: go.mod
           cache: true
       - name: Install go-licenses
-        run: go install github.com/google/go-licenses@latest
+        run: go install github.com/google/go-licenses@v1.6.0
       - name: Check licenses
         run: |
           go-licenses report ./... 2>&1 | tee licenses.txt
@@ -161,7 +161,7 @@ jobs:
             echo "::warning::Found potentially restrictive licenses"
           fi
       - name: Upload license report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: license-report
           path: licenses.txt

--- a/artifacts/codebase/ARCHITECTURE.md
+++ b/artifacts/codebase/ARCHITECTURE.md
@@ -1,42 +1,32 @@
 # Architecture
 
-- Question: Which seams must change so every public lifecycle command reports
-  the same invocation route, actionability, freshness/readiness, and host
-  capability contract?
-- Active command resolution currently centers on `resolveActiveChangeRef` in
-  `cmd/common.go:339-390`. It resolves explicit `--change` first, then current
-  git worktree binding, then a global active fallback. Most lifecycle commands
-  (`next`, `run`, `done`, `evidence`) call this resolver before acting.
-- Explicit slug resolution is in `resolveExplicitChange` at
-  `cmd/common.go:405-483`. Missing active bundles currently become
-  `no_active_change`, archived slugs become `archived_change_not_validatable`,
-  and corrupted active bundles fail closed as `change_state_load_failed`.
-- Bound-elsewhere error construction is in `wrapResolutionError` at
-  `cmd/common.go:909-934`. It already carries `change_bound_to_other_worktree`,
-  bound slug/path details, and executable remediation.
-- `status` has a separate route path in `cmd/status.go:299-378`.
-  `resolveStatusRouteForRoot` only consults `resolveActiveChangeRef` for
-  multi-active cases, so a single active change bound to another worktree can be
-  rendered as a normal governed status view from the root checkout.
-- Archived-local precedence is explicitly protected by
-  `statusArchivedChangeForCurrentWorktree` in `cmd/status.go:400-416` and by
-  resolver archived fallback in `cmd/common.go:353-364` and `cmd/common.go:370-379`.
-  Any shared route must preserve this #283 invariant.
-- `statusView`, `validateView`, and `nextView` carry separate action/freshness
-  shapes: `statusView` exposes `next_ready_actions` and `evidence_freshness`
-  (`cmd/status.go:17-66`), `validateView` exposes `actionable_next_skill` and
-  `evidence_freshness` (`cmd/validate.go:17-52`), and `nextView` exposes
-  `confirmation_requirement` (`cmd/next.go:14-75`).
-- `status` currently derives ready actions through
-  `projectNextReadyActionsWithPrimary` (`cmd/common.go:994-1018`) and does not
-  know whether the invocation workspace is locally executable. This is the root
-  of the misleading root-status behavior.
-- Execution freshness is projected by `projectFreshnessForExecMode` at
-  `cmd/common.go:1020-1034`. The helper intentionally ignores non-freshness
-  blockers such as `required_skill_missing`, so a broader readiness freshness
-  field must be added instead of changing execution freshness semantics in place.
-- Host capability data is currently advisory. `appendCatalogHints` resolves
-  support hints from the capability registry (`cmd/next_skill_view.go:894-925`),
-  and the registry resolver produces supports/hydrate references
-  (`internal/engine/capability/resolver.go:48-70`). There is no CLI-visible
-  field for required host capabilities, availability, or fail-closed fallback.
+- Question: Which release and supply-chain seams must change so `opt.md`
+  section 2 is actually closed rather than documented?
+- GitHub repository protection is external state, but this change stores the
+  applied request bodies under
+  `artifacts/changes/harden-release-supply-chain/verification/`. The live
+  authority is GitHub API rulesets `18174607` for `main` and `18174614` for
+  `refs/tags/v*`, plus environment `release-publish`.
+- `.github/workflows/release.yaml` owns tag-release and manual-release control
+  flow. The hardened flow is `validate-tag` -> `test` -> `release` -> smoke
+  jobs. `validate-tag` is intentionally no-secret/read-only; `release` is the
+  only job that carries write/package/attestation permissions and publishing
+  secrets.
+- `.github/workflows/ci.yml` owns PR verification. The new `Release Config`
+  job validates the GoReleaser config and runs a snapshot dry run before the
+  normal build job can pass.
+- `.github/workflows/security.yaml`, `.github/workflows/nix.yaml`, and
+  `.github/workflows/flake-lock-update.yaml` are supply-chain entry points for
+  scanner/tool installs and Nix setup. Floating action refs and `go install
+  ...@latest` are not acceptable there.
+- `cmd/tool_github.go` owns token-backed REST/GraphQL helper construction for
+  GitHub tools. `newGitHubHTTPClient` is the shared choke point for
+  `SLIPWAY_GITHUB_API_URL`, token selection, and HTTP client setup.
+- `cmd/release_workflow_contract_test.go` is the static workflow policy test
+  for REQ-002 and REQ-006. It parses `.github/workflows/release.yaml` and
+  asserts the secret-exposure ordering and smoke-manifest wiring.
+- `cmd/tool_test.go` covers GitHub API override and token isolation behavior
+  through TLS test servers and an injected HTTP transport.
+- `internal/state/worktree.go` owns governed default worktree provisioning.
+  `EnsureDefaultWorktreeForChange` now validates `change.BaseRef` before the
+  value is passed to `git worktree add`.

--- a/artifacts/codebase/CONCERNS.md
+++ b/artifacts/codebase/CONCERNS.md
@@ -1,34 +1,33 @@
 # Concerns
 
-- Route divergence risk: `status` currently succeeds from the root checkout for
-  a single active change bound elsewhere, while `next`, `validate`, `done`, and
-  `evidence` fail closed through `resolveActiveChangeRef`. A partial fix in one
-  command would preserve misleading agent guidance.
-- Local actionability risk: `next_ready_actions` currently describes lifecycle
-  actions by state only (`cmd/common.go:994-1018`). It can therefore advertise
-  `next`, `run`, or `done` in a workspace that cannot execute those actions
-  locally.
-- Archived-local regression risk: #283 behavior intentionally prefers an
-  archived change in the current archived worktree over an unrelated active
-  change elsewhere. A shared route abstraction must encode this as a first-class
-  route kind instead of treating it as an afterthought.
-- Error taxonomy drift risk: explicit missing slugs currently vary by command
-  (`status --change` returns `change_not_found`, `validate --change` falls back
-  to diagnostics, and `next --change` reports `no_active_change`). The shared
-  route must pin stable error codes and exit code 3.
-- Freshness overclaim risk: execution evidence freshness is not the same as
-  governance readiness. Existing tests intentionally allow `required_skill_missing`
-  while execution freshness remains `fresh`, so adding new readiness fields is
-  safer than changing the execution-freshness helper semantics.
-- Action-contract drift risk: `next` owns `confirmation_requirement` and action
-  kinds, while `status` and `validate` expose separate recovery/action fields.
-  `status`/`validate` must not let `recovery.primary_action` override or
-  contradict the current `next` action kind.
-- Capability dead-end risk: technique hints and generated skill prose can tell a
-  host to spawn or delegate, but the CLI does not currently report whether that
-  capability exists. Auto-mode must not report prior authorization sufficient
-  when the selected skill requires an unavailable host capability and no explicit
-  fallback is selected.
-- Compatibility risk: new JSON fields should be additive where possible, while
-  erroneous existing values that cause unsafe action claims should be corrected
-  even if tests need updates.
+- Live protection drift: GitHub rulesets and environments can change outside
+  git. This change records request bodies in verification artifacts and must
+  re-query live settings before final closeout.
+- Required check drift: branch rulesets use exact check context names. A future
+  workflow rename can block merges until ruleset `18174607` is updated.
+- Path-filtered check risk: ruleset required checks should avoid jobs that do
+  not always run. This change intentionally requires CI/security/title checks,
+  not docs or Nix path-filtered jobs.
+- Tag lockout risk: a tag ruleset with no bypass can prevent legitimate release
+  tags on a user-owned repo. Ruleset `18174614` keeps an explicit owner-user
+  bypass while restricting arbitrary `v*` tag mutation.
+- Secret exposure risk: release workflow inputs are untrusted. The only
+  acceptable flow is no-secret validation before any job can read `GH_PAT`,
+  `AUR_SSH_PRIVATE_KEY`, package/write/attestation permissions, or the
+  protected release environment.
+- Floating dependency risk: action tags and `@latest` tool installs are mutable
+  supply-chain inputs. Full SHA pins and fixed Go module versions are required
+  in workflows touched by this change.
+- Override token leakage risk: `SLIPWAY_GITHUB_API_URL` can point at a
+  non-public GitHub host. Ambient `GH_TOKEN` and `GITHUB_TOKEN` must not be sent
+  to override hosts; override hosts need exact allowlist plus
+  `SLIPWAY_GITHUB_API_TOKEN`.
+- Git ref confusion risk: `BaseRef` is not shell-interpolated, but option-like
+  values can still be parsed by Git as options. Validate before
+  `git worktree add`.
+- Release smoke drift: hard-coded artifact names rot as GoReleaser config
+  changes. Smoke jobs should consume asset names generated from actual `dist/`
+  outputs.
+- Local evidence gap: this workstation lacks a usable Docker daemon for full
+  container snapshot validation, and local syft runs through aqua. CI must cover
+  Docker/SBOM with explicit setup steps.

--- a/artifacts/codebase/STRUCTURE.md
+++ b/artifacts/codebase/STRUCTURE.md
@@ -1,39 +1,36 @@
 # Structure
 
-- Directory layout: `cmd/` owns CLI commands and hooks; `internal/tmpl/`
-  owns authored templates; `internal/toolgen/` emits adapter surfaces; governed
-  artifacts for this change live under `artifacts/changes/<slug>/`.
-  Evidence: `cmd/root.go:28-90`, `internal/tmpl/templates/skills/workflow/SKILL.md.tmpl:1-114`,
-  `internal/toolgen/toolgen_test.go:631-666`.
-- Entry points: `main.go` delegates process exit behavior to `cmd.Execute`;
-  root help groups include lifecycle, discovery, situational, helper,
-  diagnostics, and setup commands. Evidence: `main.go:10-17`,
-  `cmd/root.go:28-90`.
-- Generated versus handwritten boundaries: edit template sources under
-  `internal/tmpl/templates/...`, not generated `.codex/skills` or `.claude`
-  outputs. Generated-surface contracts are pinned by `internal/tmpl` and
-  `internal/toolgen` tests. Evidence: `internal/tmpl/templates_test.go:586-612`,
-  `internal/toolgen/toolgen_test.go:631-666`.
-- Ownership hints: workflow entry guidance belongs in
-  `internal/tmpl/templates/skills/workflow/SKILL.md.tmpl`; command-specific
-  guidance belongs in `_partials/command-*.tmpl`; shared review checklist
-  guidance belongs in `skills/_shared/references/checklist-quality.md`.
-  Evidence: `internal/tmpl/templates/skills/workflow/SKILL.md.tmpl:72-80`,
-  `internal/tmpl/templates/_partials/command-run-body.tmpl:42-48`,
-  `internal/tmpl/templates/skills/_shared/references/checklist-quality.md:1-6`.
-- Notes: codebase-map docs are advisory and should stay bounded to this
-  change's surfaces.
-- New state helper files for this change should live under `internal/state/`
-  beside other git-runtime path and state helpers. The plan's
-  `internal/state/handoff.go` and `internal/state/handoff_test.go` targets are
-  consistent with the existing `ChangeHandoffPath` runtime-path owner in
-  `internal/state/local_runtime_paths.go`.
-- `cmd/handoff.go` should own Cobra command wiring and presentation for
-  `slipway handoff write/show`; hook handlers should call the command or shared
-  command-owned logic rather than parsing handoff files directly.
-- Codex project hook generation is structurally a toolgen concern. Existing
-  tests currently assert that fresh Codex generation does not create
-  `.codex/config.toml`; this change must update those contracts deliberately
-  rather than leaving stale negative assertions in place. Evidence:
-  `cmd/init_test.go:73-75`, `internal/toolgen/toolgen_test.go:1589-1590`,
-  `internal/toolgen/toolgen_test.go:2018-2026`.
+- `.github/workflows/release.yaml`
+  - `validate-tag`: no-secret, read-only tag validation job.
+  - `test`: checks out `needs.validate-tag.outputs.tag_name` and runs release
+    metadata smoke before any release secret is available.
+  - `release`: protected by `release-publish`, owns write/package/attestation
+    permissions, optional publishing secrets, GoReleaser, and generated smoke
+    outputs.
+  - `verify-*`: post-release smoke jobs consume release job outputs and run
+    `slipway --version` plus `slipway --help`.
+- `.github/workflows/ci.yml`
+  - `Release Config` installs fixed GoReleaser, syft, and Docker Buildx before
+    `goreleaser check` and snapshot dry run.
+  - `Build` depends on `Release Config`, so release-config breakage blocks PR
+    success before merge.
+- `.github/workflows/security.yaml`
+  - `govulncheck` and `go-licenses` install pinned module versions.
+  - security upload actions are full SHA-pinned like other workflows.
+- `.github/workflows/nix.yaml` and
+  `.github/workflows/flake-lock-update.yaml`
+  - DeterminateSystems actions are pinned to full commit SHAs rather than
+    `@main`.
+- `cmd/tool_github.go`
+  - Constants define default public GitHub API URL, allowlist env, override
+    token env, and ambient token env names.
+  - `resolveGitHubAPIConfigFromEnv` normalizes/validates base URL and chooses
+    the correct token class.
+  - `githubHTTPClient` serves both REST and GraphQL helper paths.
+- `cmd/release_workflow_contract_test.go`
+  - Reads the workflow from repo root.
+  - Asserts validation-before-secret behavior and generated smoke outputs.
+- `internal/state/worktree.go`
+  - `validateWorktreeBaseRef` is local to the worktree provisioning boundary.
+  - The helper defaults empty refs to `HEAD`, rejects option-like or malformed
+    refs, and verifies commit-ish resolution through `git rev-parse`.

--- a/artifacts/codebase/TESTING.md
+++ b/artifacts/codebase/TESTING.md
@@ -1,38 +1,35 @@
 # Testing
 
-- Question: What tests prove the public lifecycle contract is consistent without
-  only testing private helper behavior?
-- Existing resolver tests in `cmd/active_change_resolution_test.go:17-95`
-  cover helper-level bound-elsewhere behavior for `resolveActiveChangeRef`,
-  `next --change`, and root `run`, but they do not cover root unscoped
-  `status`, root unscoped `validate`, `done`, or `evidence` as a shared
-  contract matrix.
-- Existing archived-local regression tests in
-  `cmd/active_change_resolution_test.go:98-175` and `cmd/status.go:400-416`
-  should be preserved and extended only as needed; this behavior must not be
-  rewritten away while introducing shared routing.
-- Existing validate zero-write tests in `cmd/validate_readonly_test.go:52-96`
-  cover no-active diagnostics and archived explicit slugs. They should be
-  extended so explicit missing slugs fail closed with `change_not_found` instead
-  of returning diagnostics.
-- Existing review-action consistency tests in
-  `cmd/progression_next_test.go:1065-1183` compare `next`, `validate`, and
-  `run` for S3 review-batch state. They do not assert `status` exposes the same
-  action kind, so this change should add a status-side action contract assertion.
-- Freshness tests in `cmd/common_test.go:496-580` prove
-  `projectFreshnessForExecMode` tracks execution evidence and deliberately
-  ignores non-freshness blockers. New tests should keep that behavior while
-  asserting new readiness/governance freshness fields become stale/blocked when
-  required skills or ship gates are missing.
-- Auto-mode tests in `cmd/auto_mode_test.go:173-205` and
-  `cmd/auto_mode_test.go:263-280` show current `prior_authorization_sufficient`
-  softening for review batches and non-sensitive skill handoffs, with security
-  review staying hard-stop. #339 tests should add capability-unavailable cases
-  so prior authorization alone is not reported sufficient when the required host
-  mechanism is absent.
-- Black-box command helpers exist through `runRootCommandIn` in
-  `cmd/error_contract_test.go:267-280`; command-level tests should use these or
-  `commandForRoot` instead of only calling private route helpers.
-- Minimum focused verification before implementation closeout: new route/action
-  matrix tests, freshness field tests, host-capability tests, `go test ./cmd
-  -count=1`, `go test ./... -count=1`, and `golangci-lint run ./...`.
+- Workflow syntax:
+  - `actionlint .github/workflows/*.yml .github/workflows/*.yaml`
+  - `uvx yamllint -c .yamllint.yaml .github/workflows/release.yaml
+    .github/workflows/ci.yml .github/workflows/security.yaml
+    .github/workflows/nix.yaml .github/workflows/flake-lock-update.yaml
+    .github/workflows/docs.yml .github/workflows/pr-title.yaml
+    .github/workflows/release-please.yaml`
+- Release config:
+  - `go run github.com/goreleaser/goreleaser/v2@v2.16.0 check`
+  - Local bounded dry run:
+    `go run github.com/goreleaser/goreleaser/v2@v2.16.0 release --snapshot
+    --clean --skip=publish,sign,sbom,docker`
+  - CI dry run covers Docker/SBOM because it installs syft and sets up Docker
+    Buildx on a runner with Docker available.
+- Release workflow contract:
+  - `go test ./cmd -run TestReleaseWorkflow -count=1`
+  - The test proves `validate-tag` is no-secret/read-only, release/test jobs
+    consume `needs.validate-tag.outputs.tag_name`, only `release` references
+    `GH_PAT`/`AUR_SSH_PRIVATE_KEY`, and smoke inputs come from generated
+    release outputs.
+- GitHub API override:
+  - `go test ./cmd -run 'TestGitHub(APIOverride|BackendSelection|AutoGitHubBackend|ToolFetchPRChecksUsesTokenHTTP|ToolReplyToThreadConfirm|ToolFetchPRFeedback|ToolFetchReviewRequests)' -count=1`
+  - TLS test servers exercise the override path without allowing production
+    HTTP base URLs.
+- BaseRef validation:
+  - `go test ./internal/state -run 'TestEnsureDefaultWorktreeForChange(Rejects|Accepts|_Provisions)' -count=1`
+  - Tests cover option-like refs, unknown refs, valid tag refs, and default
+    provisioning.
+- Full implementation verification before S3:
+  - `go test ./cmd -count=1`
+  - `go test ./internal/state -count=1`
+  - `go test ./... -count=1`
+  - `golangci-lint run ./...`

--- a/cmd/release_workflow_contract_test.go
+++ b/cmd/release_workflow_contract_test.go
@@ -1,0 +1,289 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestReleaseWorkflowValidatesTagBeforeSecretExposure(t *testing.T) {
+	workflow := readWorkflowYAML(t, ".github/workflows/release.yaml")
+	jobs := workflowMap(t, workflow, "jobs")
+
+	validateJob := workflowMap(t, jobs, "validate-tag")
+	assert.Equal(t, "ubuntu-latest", workflowString(t, validateJob, "runs-on"))
+	assert.Equal(t, "read", workflowString(t, workflowMap(t, validateJob, "permissions"), "contents"))
+	assertNotContainsWorkflowValues(t, validateJob, "secrets.", "validate-tag must not expose secrets")
+
+	validateRun := firstStepRun(t, validateJob, "Validate release tag")
+	assert.Contains(t, validateRun, "^v[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9A-Za-z.-]+)?$")
+	assert.Contains(t, validateRun, "[[:cntrl:]]")
+	assert.NotContains(t, validateRun, "grep")
+	assert.Contains(t, validateRun, "printf 'tag_name=%s\\n'")
+	assert.Contains(t, validateRun, ">> \"$GITHUB_OUTPUT\"")
+
+	testJob := workflowMap(t, jobs, "test")
+	assertWorkflowNeeds(t, testJob, "validate-tag")
+	assert.Equal(t, "read", workflowString(t, workflowMap(t, testJob, "permissions"), "contents"))
+	assert.Equal(
+		t,
+		"${{ needs.validate-tag.outputs.tag_name }}",
+		firstStepWithUses(t, testJob, "actions/checkout@")["with"].(map[string]any)["ref"],
+	)
+	assertNotContainsWorkflowValues(t, testJob, "secrets.", "test must not expose release secrets")
+	assertNotContainsWorkflowValues(t, testJob, "inputs.tag", "test must consume the validated tag output")
+
+	releaseJob := workflowMap(t, jobs, "release")
+	assertWorkflowNeeds(t, releaseJob, "validate-tag", "test")
+	assert.Equal(t, "release-publish", workflowString(t, releaseJob, "environment"))
+	releasePerms := workflowMap(t, releaseJob, "permissions")
+	assert.Equal(t, "write", workflowString(t, releasePerms, "contents"))
+	assert.Equal(t, "write", workflowString(t, releasePerms, "packages"))
+	assert.Equal(t, "write", workflowString(t, releasePerms, "id-token"))
+	assert.Equal(t, "write", workflowString(t, releasePerms, "attestations"))
+	assert.Equal(
+		t,
+		"${{ needs.validate-tag.outputs.tag_name }}",
+		firstStepWithUses(t, releaseJob, "actions/checkout@")["with"].(map[string]any)["ref"],
+	)
+	assert.Contains(t, workflowString(t, workflowMap(t, releaseJob, "outputs"), "tag_name"), "needs.validate-tag.outputs.tag_name")
+	assertNotContainsWorkflowValues(t, releaseJob, "inputs.tag", "release must consume the validated tag output")
+
+	for name, rawJob := range jobs {
+		if name == "release" {
+			continue
+		}
+		assertNotContainsWorkflowValues(t, rawJob, "secrets.GH_PAT", name+" must not expose GH_PAT")
+		assertNotContainsWorkflowValues(t, rawJob, "secrets.AUR_SSH_PRIVATE_KEY", name+" must not expose AUR_SSH_PRIVATE_KEY")
+	}
+}
+
+func TestReleaseWorkflowRejectsOutputInjectionTags(t *testing.T) {
+	workflow := readWorkflowYAML(t, ".github/workflows/release.yaml")
+	validateRun := firstStepRun(t, workflowMap(t, workflowMap(t, workflow, "jobs"), "validate-tag"), "Validate release tag")
+
+	output, stderr, err := runReleaseTagValidationStep(t, validateRun, "v1.2.3", "ignored-ref")
+	require.NoError(t, err, stderr)
+	assert.Equal(t, "tag_name=v1.2.3\n", output)
+
+	tests := []struct {
+		name string
+		tag  string
+	}{
+		{name: "valid line after invalid prefix", tag: "bad-ref\nv1.2.3"},
+		{name: "valid line before injected output", tag: "v1.2.3\ntag_name=v9.9.9"},
+		{name: "carriage return", tag: "v1.2.3\rtag_name=v9.9.9"},
+		{name: "tab control", tag: "v1.2.3\t"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output, stderr, err := runReleaseTagValidationStep(t, validateRun, tt.tag, "v1.2.3")
+			require.Error(t, err, stderr)
+			assert.Empty(t, output, "invalid tags must fail before writing GITHUB_OUTPUT")
+		})
+	}
+}
+
+func TestReleaseWorkflowSmokeInputsComeFromGeneratedManifest(t *testing.T) {
+	workflow := readWorkflowYAML(t, ".github/workflows/release.yaml")
+	jobs := workflowMap(t, workflow, "jobs")
+	releaseJob := workflowMap(t, jobs, "release")
+
+	outputs := workflowMap(t, releaseJob, "outputs")
+	for _, output := range []string{"binary_matrix", "deb_asset", "rpm_asset", "apk_asset"} {
+		assert.Contains(t, workflowString(t, outputs, output), "steps.smoke.outputs."+output)
+	}
+
+	smokeRun := firstStepRun(t, releaseJob, "Generate release smoke manifest")
+	assert.Contains(t, smokeRun, "cd dist")
+	assert.Contains(t, smokeRun, "find . -maxdepth 1 -type f")
+	assert.Contains(t, smokeRun, "binary_matrix=")
+	assert.Contains(t, smokeRun, "deb_asset=")
+	assert.Contains(t, smokeRun, "rpm_asset=")
+	assert.Contains(t, smokeRun, "apk_asset=")
+
+	assert.Equal(
+		t,
+		"${{ needs.release.outputs.deb_asset }}",
+		firstNamedStep(t, workflowMap(t, jobs, "verify-deb"), "Download and install deb")["env"].(map[string]any)["ASSET"],
+	)
+	assert.Equal(
+		t,
+		"${{ needs.release.outputs.rpm_asset }}",
+		firstNamedStep(t, workflowMap(t, jobs, "verify-rpm"), "Download and install rpm")["env"].(map[string]any)["ASSET"],
+	)
+	assert.Equal(
+		t,
+		"${{ needs.release.outputs.apk_asset }}",
+		firstNamedStep(t, workflowMap(t, jobs, "verify-apk"), "Download and install apk")["env"].(map[string]any)["ASSET"],
+	)
+
+	verifyBinary := workflowMap(t, jobs, "verify-binary")
+	strategy := workflowMap(t, verifyBinary, "strategy")
+	matrix := workflowMap(t, strategy, "matrix")
+	assert.Equal(t, "${{ fromJSON(needs.release.outputs.binary_matrix) }}", workflowString(t, matrix, "include"))
+}
+
+func readWorkflowYAML(t *testing.T, rel string) map[string]any {
+	t.Helper()
+	root := findRepoRootForWorkflowTest(t)
+	raw, err := os.ReadFile(filepath.Join(root, rel))
+	require.NoError(t, err)
+	var out map[string]any
+	require.NoError(t, yaml.Unmarshal(raw, &out))
+	return out
+}
+
+func findRepoRootForWorkflowTest(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		require.NotEqual(t, dir, parent, "could not find repo root from %s", dir)
+		dir = parent
+	}
+}
+
+func workflowMap(t *testing.T, raw any, key string) map[string]any {
+	t.Helper()
+	m, ok := raw.(map[string]any)
+	require.Truef(t, ok, "expected map for %q, got %T", key, raw)
+	value, ok := m[key]
+	require.Truef(t, ok, "missing key %q", key)
+	out, ok := value.(map[string]any)
+	require.Truef(t, ok, "expected map at %q, got %T", key, value)
+	return out
+}
+
+func runReleaseTagValidationStep(t *testing.T, run, inputTag, refName string) (string, string, error) {
+	t.Helper()
+	outputPath := filepath.Join(t.TempDir(), "github_output")
+	cmd := exec.Command("bash", "-euo", "pipefail", "-c", run)
+	cmd.Env = append(os.Environ(),
+		"INPUT_TAG="+inputTag,
+		"REF_NAME="+refName,
+		"GITHUB_OUTPUT="+outputPath,
+	)
+	combined, err := cmd.CombinedOutput()
+	rawOutput, readErr := os.ReadFile(outputPath)
+	if readErr != nil && !errors.Is(readErr, os.ErrNotExist) {
+		require.NoError(t, readErr)
+	}
+	return string(rawOutput), string(combined), err
+}
+
+func workflowString(t *testing.T, raw any, key string) string {
+	t.Helper()
+	m, ok := raw.(map[string]any)
+	require.Truef(t, ok, "expected map for %q, got %T", key, raw)
+	value, ok := m[key]
+	require.Truef(t, ok, "missing key %q", key)
+	out, ok := value.(string)
+	require.Truef(t, ok, "expected string at %q, got %T", key, value)
+	return out
+}
+
+func firstStepRun(t *testing.T, job map[string]any, name string) string {
+	t.Helper()
+	step := firstNamedStep(t, job, name)
+	run, ok := step["run"].(string)
+	require.Truef(t, ok, "step %q has no run body", name)
+	return run
+}
+
+func firstStepWithUses(t *testing.T, job map[string]any, usesPrefix string) map[string]any {
+	t.Helper()
+	steps, ok := job["steps"].([]any)
+	require.True(t, ok, "job has no steps")
+	for _, rawStep := range steps {
+		step, ok := rawStep.(map[string]any)
+		require.Truef(t, ok, "expected step map, got %T", rawStep)
+		uses, _ := step["uses"].(string)
+		if strings.HasPrefix(uses, usesPrefix) {
+			return step
+		}
+	}
+	t.Fatalf("missing step with uses prefix %q", usesPrefix)
+	return nil
+}
+
+func firstNamedStep(t *testing.T, job map[string]any, name string) map[string]any {
+	t.Helper()
+	steps, ok := job["steps"].([]any)
+	require.True(t, ok, "job has no steps")
+	for _, rawStep := range steps {
+		step, ok := rawStep.(map[string]any)
+		require.Truef(t, ok, "expected step map, got %T", rawStep)
+		if step["name"] == name {
+			return step
+		}
+	}
+	t.Fatalf("missing step %q", name)
+	return nil
+}
+
+func assertWorkflowNeeds(t *testing.T, job map[string]any, want ...string) {
+	t.Helper()
+	rawNeeds, ok := job["needs"]
+	require.True(t, ok, "job has no needs")
+	got := workflowStringSet(rawNeeds)
+	for _, need := range want {
+		assert.Contains(t, got, need)
+	}
+}
+
+func workflowStringSet(raw any) map[string]struct{} {
+	out := map[string]struct{}{}
+	switch v := raw.(type) {
+	case string:
+		out[v] = struct{}{}
+	case []any:
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				out[s] = struct{}{}
+			}
+		}
+	}
+	return out
+}
+
+func assertNotContainsWorkflowValues(t *testing.T, raw any, needle, msg string) {
+	t.Helper()
+	assert.NotContains(t, workflowScalarDump(raw), needle, msg)
+}
+
+func workflowScalarDump(raw any) string {
+	switch v := raw.(type) {
+	case map[string]any:
+		var b strings.Builder
+		for key, value := range v {
+			b.WriteString(key)
+			b.WriteByte('\n')
+			b.WriteString(workflowScalarDump(value))
+			b.WriteByte('\n')
+		}
+		return b.String()
+	case []any:
+		var b strings.Builder
+		for _, item := range v {
+			b.WriteString(workflowScalarDump(item))
+			b.WriteByte('\n')
+		}
+		return b.String()
+	case string:
+		return v
+	default:
+		return ""
+	}
+}

--- a/cmd/tool_github.go
+++ b/cmd/tool_github.go
@@ -133,9 +133,9 @@ const (
 	githubDefaultAPIBaseURL        = "https://api.github.com"
 	githubAPIURLEnv                = "SLIPWAY_GITHUB_API_URL"
 	githubAPIAllowedBaseURLsEnv    = "SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS"
-	githubAPIOverrideTokenEnv      = "SLIPWAY_GITHUB_API_TOKEN"
-	githubAmbientTokenPrimaryEnv   = "GH_TOKEN"
-	githubAmbientTokenSecondaryEnv = "GITHUB_TOKEN"
+	githubAPIOverrideTokenEnv      = "SLIPWAY_GITHUB_API_TOKEN" // #nosec G101 -- environment variable name, not a credential.
+	githubAmbientTokenPrimaryEnv   = "GH_TOKEN"                 // #nosec G101 -- environment variable name, not a credential.
+	githubAmbientTokenSecondaryEnv = "GITHUB_TOKEN"             // #nosec G101 -- environment variable name, not a credential.
 )
 
 var githubRepoPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`)

--- a/cmd/tool_github.go
+++ b/cmd/tool_github.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path"
 	"regexp"
 	"sort"
 	"strings"
@@ -22,8 +23,16 @@ import (
 const githubBackendEnvHelp = `Environment variables:
   SLIPWAY_GITHUB_API_URL  Override the GitHub REST/GraphQL API base URL used by
                           the --backend api / token-backed HTTP path (default
-                          https://api.github.com). Useful for GitHub Enterprise;
-                          a trailing slash is trimmed. The gh backend ignores it.`
+                          https://api.github.com). Overrides must be HTTPS and
+                          listed in SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS.
+  SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS
+                          Comma/space/semicolon separated HTTPS API base URLs
+                          allowed for SLIPWAY_GITHUB_API_URL.
+  SLIPWAY_GITHUB_API_TOKEN
+                          Token used only for an allowed override URL. Ambient
+                          GH_TOKEN/GITHUB_TOKEN are sent only to
+                          https://api.github.com. The gh backend ignores these
+                          HTTP-only settings.`
 
 func makeFetchPRChecksCmd() *cobra.Command {
 	var backend string
@@ -120,13 +129,21 @@ const (
 	githubBackendGH   = "gh"
 	githubBodyCap     = 16 << 20
 	githubStderrCap   = 64 << 10
+
+	githubDefaultAPIBaseURL        = "https://api.github.com"
+	githubAPIURLEnv                = "SLIPWAY_GITHUB_API_URL"
+	githubAPIAllowedBaseURLsEnv    = "SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS"
+	githubAPIOverrideTokenEnv      = "SLIPWAY_GITHUB_API_TOKEN"
+	githubAmbientTokenPrimaryEnv   = "GH_TOKEN"
+	githubAmbientTokenSecondaryEnv = "GITHUB_TOKEN"
 )
 
 var githubRepoPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`)
 
 var (
-	githubLookPath = exec.LookPath
-	githubRunCLI   = runGitHubCLICommand
+	githubLookPath      = exec.LookPath
+	githubRunCLI        = runGitHubCLICommand
+	githubHTTPTransport http.RoundTripper
 )
 
 type githubBackend interface {
@@ -184,8 +201,9 @@ func newGitHubBackend(ctx context.Context, mode string) (githubBackend, error) {
 }
 
 func githubTokenAvailable() bool {
-	return strings.TrimSpace(os.Getenv("GH_TOKEN")) != "" ||
-		strings.TrimSpace(os.Getenv("GITHUB_TOKEN")) != ""
+	return strings.TrimSpace(os.Getenv(githubAmbientTokenPrimaryEnv)) != "" ||
+		strings.TrimSpace(os.Getenv(githubAmbientTokenSecondaryEnv)) != "" ||
+		strings.TrimSpace(os.Getenv(githubAPIOverrideTokenEnv)) != ""
 }
 
 // autoGitHubBackend implements `--backend auto`. It prefers the gh CLI and
@@ -299,18 +317,158 @@ type githubHTTPClient struct {
 func (c githubHTTPClient) backendName() string { return githubBackendAPI }
 
 func newGitHubHTTPClient() (githubHTTPClient, error) {
-	token := strings.TrimSpace(os.Getenv("GH_TOKEN"))
+	cfg, err := resolveGitHubAPIConfigFromEnv()
+	if err != nil {
+		return githubHTTPClient{}, err
+	}
+	client := &http.Client{Timeout: 30 * time.Second}
+	if githubHTTPTransport != nil {
+		client.Transport = githubHTTPTransport
+	}
+	return githubHTTPClient{baseURL: cfg.baseURL, token: cfg.token, client: client}, nil
+}
+
+type githubAPIConfig struct {
+	baseURL  string
+	token    string
+	override bool
+}
+
+func resolveGitHubAPIConfigFromEnv() (githubAPIConfig, error) {
+	baseURL, err := normalizeGitHubAPIBaseURL(firstNonEmpty(os.Getenv(githubAPIURLEnv), githubDefaultAPIBaseURL))
+	if err != nil {
+		return githubAPIConfig{}, err
+	}
+	override := baseURL != githubDefaultAPIBaseURL
+	if override && !githubAPIBaseURLAllowed(baseURL) {
+		return githubAPIConfig{}, newPreconditionError(
+			"github_api_url_not_allowed",
+			fmt.Sprintf("GitHub API override %q is not allowlisted", baseURL),
+			"Set SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS to the exact HTTPS API base URL before using SLIPWAY_GITHUB_API_URL.",
+			"",
+			map[string]any{"base_url": baseURL},
+		)
+	}
+	token := githubAPITokenForBaseURL(override)
 	if token == "" {
-		token = strings.TrimSpace(os.Getenv("GITHUB_TOKEN"))
+		if override {
+			return githubAPIConfig{}, newPreconditionError(
+				"github_api_override_token_missing",
+				"GitHub API override token missing; ambient GH_TOKEN/GITHUB_TOKEN are not sent to override hosts",
+				"Set SLIPWAY_GITHUB_API_TOKEN for the allowed override host, or remove SLIPWAY_GITHUB_API_URL to use https://api.github.com.",
+				"",
+				map[string]any{"base_url": baseURL},
+			)
+		}
+		return githubAPIConfig{}, newPreconditionError(
+			"github_token_missing",
+			"GitHub token missing; set GH_TOKEN or GITHUB_TOKEN",
+			"Set GH_TOKEN or GITHUB_TOKEN before invoking this helper.",
+			"",
+			nil,
+		)
 	}
+	return githubAPIConfig{baseURL: baseURL, token: token, override: override}, nil
+}
+
+func normalizeGitHubAPIBaseURL(raw string) (string, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		value = githubDefaultAPIBaseURL
+	}
+	parsed, err := url.Parse(value)
+	if err != nil || parsed == nil {
+		return "", newInvalidGitHubAPIURLError(value, "parse URL")
+	}
+	if !strings.EqualFold(parsed.Scheme, "https") {
+		return "", newInvalidGitHubAPIURLError(value, "scheme must be https")
+	}
+	if parsed.User != nil || strings.TrimSpace(parsed.Host) == "" {
+		return "", newInvalidGitHubAPIURLError(value, "URL must not include userinfo and must include a host")
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", newInvalidGitHubAPIURLError(value, "URL must not include query or fragment")
+	}
+	if parsed.RawPath != "" {
+		return "", newInvalidGitHubAPIURLError(value, "encoded path is not accepted")
+	}
+	cleanPath := path.Clean(parsed.Path)
+	switch cleanPath {
+	case ".", "/":
+		parsed.Path = ""
+	default:
+		if cleanPath != parsed.Path {
+			return "", newInvalidGitHubAPIURLError(value, "path must be canonical")
+		}
+		if strings.EqualFold(parsed.Hostname(), "api.github.com") {
+			return "", newInvalidGitHubAPIURLError(value, "public api.github.com override must not include a path")
+		}
+		parsed.Path = cleanPath
+	}
+	parsed.Scheme = "https"
+	parsed.Host = strings.ToLower(parsed.Host)
+	return strings.TrimRight(parsed.String(), "/"), nil
+}
+
+func newInvalidGitHubAPIURLError(value, reason string) error {
+	return newInvalidUsageError(
+		"github_api_url_invalid",
+		fmt.Sprintf("invalid GitHub API base URL %q: %s", value, reason),
+		"Use https://api.github.com, or an exact HTTPS GitHub Enterprise API base URL allowlisted by SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS.",
+		nil,
+	)
+}
+
+func githubAPIBaseURLAllowed(baseURL string) bool {
+	entries, invalid := parseGitHubAPIAllowedBaseURLs(os.Getenv(githubAPIAllowedBaseURLsEnv))
+	if invalid != "" {
+		return false
+	}
+	for _, entry := range entries {
+		if entry == baseURL {
+			return true
+		}
+	}
+	return false
+}
+
+func parseGitHubAPIAllowedBaseURLs(raw string) ([]string, string) {
+	parts := strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ',' || r == ';' || r == '\n' || r == '\t' || r == ' '
+	})
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		value := strings.TrimSpace(part)
+		if value == "" {
+			continue
+		}
+		normalized, err := normalizeGitHubAPIBaseURL(value)
+		if err != nil {
+			return nil, value
+		}
+		out = append(out, normalized)
+	}
+	return out, ""
+}
+
+func githubAPITokenForBaseURL(override bool) string {
+	if override {
+		return strings.TrimSpace(os.Getenv(githubAPIOverrideTokenEnv))
+	}
+	token := strings.TrimSpace(os.Getenv(githubAmbientTokenPrimaryEnv))
 	if token == "" {
-		return githubHTTPClient{}, newPreconditionError("github_token_missing", "GitHub token missing; set GH_TOKEN or GITHUB_TOKEN", "Set GH_TOKEN or GITHUB_TOKEN before invoking this helper.", "", nil)
+		token = strings.TrimSpace(os.Getenv(githubAmbientTokenSecondaryEnv))
 	}
-	baseURL := strings.TrimRight(strings.TrimSpace(os.Getenv("SLIPWAY_GITHUB_API_URL")), "/")
-	if baseURL == "" {
-		baseURL = "https://api.github.com"
+	return token
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
 	}
-	return githubHTTPClient{baseURL: baseURL, token: token, client: &http.Client{Timeout: 30 * time.Second}}, nil
+	return ""
 }
 
 func (c githubHTTPClient) getJSON(path string, out any) error {
@@ -403,7 +561,11 @@ func (c githubHTTPClient) walkPages(path string, handle func(raw []byte) (int, e
 			return err
 		}
 		if linkNext := parseLinkNext(linkHeader); linkNext != "" {
-			next = linkNext
+			authorizedNext, err := c.authorizePaginationURL(linkNext)
+			if err != nil {
+				return err
+			}
+			next = authorizedNext
 			usedLink = true
 			continue
 		}
@@ -426,6 +588,68 @@ func (c githubHTTPClient) firstPageURL(path string) string {
 func (c githubHTTPClient) nextPageURL(path string, page int) string {
 	withPer := addQueryParam(path, "per_page", "100")
 	return c.baseURL + addQueryParam(withPer, "page", fmt.Sprint(page))
+}
+
+func (c githubHTTPClient) authorizePaginationURL(raw string) (string, error) {
+	value := strings.TrimSpace(raw)
+	parsed, err := url.Parse(value)
+	if err != nil || parsed == nil || !parsed.IsAbs() {
+		return "", newUnsafeGitHubPaginationURLError(value, "URL must be absolute")
+	}
+	base, err := url.Parse(c.baseURL)
+	if err != nil || base == nil {
+		return "", newUnsafeGitHubPaginationURLError(value, "configured API base URL is invalid")
+	}
+	if !strings.EqualFold(parsed.Scheme, "https") || !strings.EqualFold(parsed.Scheme, base.Scheme) {
+		return "", newUnsafeGitHubPaginationURLError(value, "scheme must remain https")
+	}
+	if !strings.EqualFold(parsed.Host, base.Host) {
+		return "", newUnsafeGitHubPaginationURLError(value, "host must match the configured API base URL")
+	}
+	if parsed.User != nil {
+		return "", newUnsafeGitHubPaginationURLError(value, "URL must not include userinfo")
+	}
+	if parsed.Fragment != "" {
+		return "", newUnsafeGitHubPaginationURLError(value, "URL must not include a fragment")
+	}
+	if parsed.RawPath != "" {
+		return "", newUnsafeGitHubPaginationURLError(value, "encoded path is not accepted")
+	}
+	if !githubAPIPathWithinBase(parsed.Path, base.Path) {
+		return "", newUnsafeGitHubPaginationURLError(value, "path must stay under the configured API base URL")
+	}
+	parsed.Scheme = "https"
+	parsed.Host = strings.ToLower(parsed.Host)
+	return parsed.String(), nil
+}
+
+func githubAPIPathWithinBase(candidatePath, basePath string) bool {
+	candidate := cleanGitHubAPIPath(candidatePath)
+	base := cleanGitHubAPIPath(basePath)
+	if base == "/" {
+		return strings.HasPrefix(candidate, "/")
+	}
+	return candidate == base || strings.HasPrefix(candidate, base+"/")
+}
+
+func cleanGitHubAPIPath(value string) string {
+	if value == "" {
+		return "/"
+	}
+	if !strings.HasPrefix(value, "/") {
+		value = "/" + value
+	}
+	return path.Clean(value)
+}
+
+func newUnsafeGitHubPaginationURLError(value, reason string) error {
+	return newPreconditionError(
+		"github_api_pagination_url_not_allowed",
+		fmt.Sprintf("unsafe GitHub API pagination URL %q: %s", value, reason),
+		"Retry with a GitHub API endpoint that keeps pagination links on the configured HTTPS API base URL.",
+		"",
+		map[string]any{"url": value},
+	)
 }
 
 func addQueryParam(path, key, value string) string {

--- a/cmd/tool_test.go
+++ b/cmd/tool_test.go
@@ -243,7 +243,7 @@ func TestToolReplyToThreadDryRunDoesNotRequireToken(t *testing.T) {
 
 func TestToolFetchPRChecksUsesTokenHTTP(t *testing.T) {
 	var seenAuth string
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := newGitHubAPITestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		seenAuth = r.Header.Get("Authorization")
 		switch r.URL.Path {
 		case "/repos/owner/repo/pulls/7":
@@ -256,7 +256,6 @@ func TestToolFetchPRChecksUsesTokenHTTP(t *testing.T) {
 			http.NotFound(w, r)
 		}
 	}))
-	defer server.Close()
 
 	t.Setenv("SLIPWAY_GITHUB_API_URL", server.URL)
 	t.Setenv("GH_TOKEN", "test-token")
@@ -422,6 +421,192 @@ func TestGitHubBackendSelection(t *testing.T) {
 	}
 }
 
+func TestGitHubAPIOverrideRejectsUnsafeURLs(t *testing.T) {
+	t.Setenv(githubAmbientTokenPrimaryEnv, "ambient-token")
+	t.Setenv(githubAmbientTokenSecondaryEnv, "")
+	t.Setenv(githubAPIOverrideTokenEnv, "override-token")
+	t.Setenv(githubAPIAllowedBaseURLsEnv, "")
+
+	tests := []struct {
+		name     string
+		baseURL  string
+		wantCode string
+	}{
+		{
+			name:     "http rejected",
+			baseURL:  "http://api.github.com",
+			wantCode: "github_api_url_invalid",
+		},
+		{
+			name:     "unknown https host rejected",
+			baseURL:  "https://api.github.invalid",
+			wantCode: "github_api_url_not_allowed",
+		},
+		{
+			name:     "path-confused public host rejected",
+			baseURL:  "https://api.github.com/evil",
+			wantCode: "github_api_url_invalid",
+		},
+		{
+			name:     "path-confused public host with default port rejected",
+			baseURL:  "https://api.github.com:443/evil",
+			wantCode: "github_api_url_invalid",
+		},
+		{
+			name:     "path-confused mixed-case public host with default port rejected",
+			baseURL:  "https://API.GITHUB.COM:443/evil",
+			wantCode: "github_api_url_invalid",
+		},
+		{
+			name:     "query rejected",
+			baseURL:  "https://api.github.com?x=1",
+			wantCode: "github_api_url_invalid",
+		},
+		{
+			name:     "userinfo rejected",
+			baseURL:  "https://token@api.github.com",
+			wantCode: "github_api_url_invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(githubAPIURLEnv, tt.baseURL)
+			_, err := newGitHubHTTPClient()
+			require.Error(t, err)
+			var cliErr *CLIError
+			require.True(t, errors.As(err, &cliErr), "expected CLIError, got %T", err)
+			assert.Equal(t, tt.wantCode, cliErr.ErrorCode)
+		})
+	}
+}
+
+func TestGitHubAPIOverrideRejectsAllowlistedPublicPathConfusion(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseURL string
+	}{
+		{
+			name:    "path",
+			baseURL: "https://api.github.com/evil",
+		},
+		{
+			name:    "default port path",
+			baseURL: "https://api.github.com:443/evil",
+		},
+		{
+			name:    "mixed-case default port path",
+			baseURL: "https://API.GITHUB.COM:443/evil",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(githubAPIURLEnv, tt.baseURL)
+			t.Setenv(githubAPIAllowedBaseURLsEnv, tt.baseURL)
+			t.Setenv(githubAPIOverrideTokenEnv, "override-token")
+			t.Setenv(githubAmbientTokenPrimaryEnv, "ambient-token")
+			t.Setenv(githubAmbientTokenSecondaryEnv, "")
+
+			_, err := newGitHubHTTPClient()
+			require.Error(t, err)
+			var cliErr *CLIError
+			require.True(t, errors.As(err, &cliErr), "expected CLIError, got %T", err)
+			assert.Equal(t, "github_api_url_invalid", cliErr.ErrorCode)
+		})
+	}
+}
+
+func TestGitHubAPIOverrideRequiresOverrideTokenAndDoesNotUseAmbient(t *testing.T) {
+	var hits int
+	var seenAuth string
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		seenAuth = r.Header.Get("Authorization")
+		_, _ = io.WriteString(w, `{"number":7}`)
+	}))
+	defer server.Close()
+	previousTransport := githubHTTPTransport
+	githubHTTPTransport = server.Client().Transport
+	t.Cleanup(func() { githubHTTPTransport = previousTransport })
+
+	t.Setenv(githubAPIURLEnv, server.URL)
+	t.Setenv(githubAPIAllowedBaseURLsEnv, server.URL)
+	t.Setenv(githubAmbientTokenPrimaryEnv, "ambient-token")
+	t.Setenv(githubAmbientTokenSecondaryEnv, "secondary-ambient-token")
+	t.Setenv(githubAPIOverrideTokenEnv, "")
+
+	_, err := newGitHubHTTPClient()
+	require.Error(t, err)
+	var cliErr *CLIError
+	require.True(t, errors.As(err, &cliErr), "expected CLIError, got %T", err)
+	assert.Equal(t, "github_api_override_token_missing", cliErr.ErrorCode)
+	assert.Equal(t, 0, hits, "ambient tokens must not be sent to override hosts")
+
+	t.Setenv(githubAPIOverrideTokenEnv, "override-token")
+	client, err := newGitHubHTTPClient()
+	require.NoError(t, err)
+	var out struct {
+		Number int `json:"number"`
+	}
+	require.NoError(t, client.getJSON("/repos/o/r/pulls/7", &out))
+	assert.Equal(t, 7, out.Number)
+	assert.Equal(t, "Bearer override-token", seenAuth)
+}
+
+func TestGitHubAPIOverrideRejectsUnsafePaginationLink(t *testing.T) {
+	tests := []struct {
+		name string
+		link string
+	}{
+		{
+			name: "cross host",
+			link: "https://attacker.example/repos/owner/repo/issues?per_page=100&page=2",
+		},
+		{
+			name: "base path escape",
+			link: "https://api.enterprise.example/api/repos/owner/repo/issues?per_page=100&page=2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var requests []*http.Request
+			client := githubHTTPClient{
+				baseURL: "https://api.enterprise.example/api/v3",
+				token:   "override-token",
+				client: &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+					requests = append(requests, req.Clone(req.Context()))
+					resp := &http.Response{
+						StatusCode: http.StatusOK,
+						Status:     "200 OK",
+						Header:     make(http.Header),
+						Body:       io.NopCloser(strings.NewReader(`[]`)),
+						Request:    req,
+					}
+					resp.Header.Set("Link", fmt.Sprintf("<%s>; rel=\"next\"", tt.link))
+					return resp, nil
+				})},
+			}
+
+			_, err := client.getPaginated("/repos/owner/repo/issues")
+			require.Error(t, err)
+			var cliErr *CLIError
+			require.True(t, errors.As(err, &cliErr), "expected CLIError, got %T", err)
+			assert.Equal(t, "github_api_pagination_url_not_allowed", cliErr.ErrorCode)
+			require.Len(t, requests, 1, "unsafe Link target must be rejected before any token-bearing follow-up request")
+			assert.Equal(t, "api.enterprise.example", requests[0].URL.Host)
+			assert.Equal(t, "Bearer override-token", requests[0].Header.Get("Authorization"))
+		})
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
 func TestGitHubCLIBackendUsesGHAPIEndpointArgs(t *testing.T) {
 	originalRunCLI := githubRunCLI
 	t.Cleanup(func() { githubRunCLI = originalRunCLI })
@@ -481,16 +666,32 @@ func readBody(t *testing.T, r *http.Request) string {
 	return string(raw)
 }
 
+func newGitHubAPITestServer(t *testing.T, handler http.Handler) *httptest.Server {
+	t.Helper()
+	server := httptest.NewTLSServer(handler)
+	previousTransport := githubHTTPTransport
+	githubHTTPTransport = server.Client().Transport
+	t.Cleanup(func() {
+		githubHTTPTransport = previousTransport
+		server.Close()
+	})
+	t.Setenv(githubAPIURLEnv, server.URL)
+	t.Setenv(githubAPIAllowedBaseURLsEnv, server.URL)
+	t.Setenv(githubAPIOverrideTokenEnv, "test-token")
+	t.Setenv(githubAmbientTokenPrimaryEnv, "")
+	t.Setenv(githubAmbientTokenSecondaryEnv, "")
+	return server
+}
+
 // --- reply-to-thread --confirm -------------------------------------------------
 
 func TestToolReplyToThreadConfirmSuccessReturnsCommentID(t *testing.T) {
 	var sawAuth string
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := newGitHubAPITestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		sawAuth = r.Header.Get("Authorization")
 		require.Equal(t, "/graphql", r.URL.Path)
 		_, _ = w.Write([]byte(`{"data":{"addPullRequestReviewThreadReply":{"comment":{"id":"IC_123","url":"https://github.com/o/r/pull/1#discussion_r1"}}}}`))
 	}))
-	defer server.Close()
 
 	t.Setenv("SLIPWAY_GITHUB_API_URL", server.URL)
 	t.Setenv("GH_TOKEN", "test-token")
@@ -505,12 +706,11 @@ func TestToolReplyToThreadConfirmSuccessReturnsCommentID(t *testing.T) {
 }
 
 func TestToolReplyToThreadConfirmGraphQLErrorsNotReportedPosted(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	server := newGitHubAPITestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		// HTTP 200 but GraphQL errors array is non-empty.
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"data":null,"errors":[{"message":"Could not resolve to a node with the global id of 'PRRT_bad'"}]}`))
 	}))
-	defer server.Close()
 
 	t.Setenv("SLIPWAY_GITHUB_API_URL", server.URL)
 	t.Setenv("GH_TOKEN", "test-token")
@@ -526,11 +726,10 @@ func TestToolReplyToThreadConfirmGraphQLErrorsNotReportedPosted(t *testing.T) {
 }
 
 func TestToolReplyToThreadConfirmNullPayloadFails(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	server := newGitHubAPITestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		// HTTP 200, no errors, but the mutation payload is null/missing.
 		_, _ = w.Write([]byte(`{"data":{"addPullRequestReviewThreadReply":null}}`))
 	}))
-	defer server.Close()
 
 	t.Setenv("SLIPWAY_GITHUB_API_URL", server.URL)
 	t.Setenv("GH_TOKEN", "test-token")
@@ -546,7 +745,7 @@ func TestToolReplyToThreadConfirmNullPayloadFails(t *testing.T) {
 
 func TestToolReplyToThreadConfirmPartialFailureReportsPostedReply(t *testing.T) {
 	var calls int
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	server := newGitHubAPITestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		calls++
 		if calls == 1 {
 			_, _ = w.Write([]byte(`{"data":{"addPullRequestReviewThreadReply":{"comment":{"id":"IC_1","url":"https://github.com/o/r/pull/1#discussion_r1"}}}}`))
@@ -555,7 +754,6 @@ func TestToolReplyToThreadConfirmPartialFailureReportsPostedReply(t *testing.T) 
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"data":null,"errors":[{"message":"Could not resolve to a node with the global id of 'PRRT_bad'"}]}`))
 	}))
-	defer server.Close()
 
 	t.Setenv("SLIPWAY_GITHUB_API_URL", server.URL)
 	t.Setenv("GH_TOKEN", "test-token")
@@ -593,7 +791,7 @@ func TestToolFetchPRFeedbackCategorizesAndCarriesThreadIDs(t *testing.T) {
       }}}}
     }`
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := newGitHubAPITestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/graphql":
 			body := readBody(t, r)
@@ -624,7 +822,6 @@ func TestToolFetchPRFeedbackCategorizesAndCarriesThreadIDs(t *testing.T) {
 			http.NotFound(w, r)
 		}
 	}))
-	defer server.Close()
 
 	t.Setenv("SLIPWAY_GITHUB_API_URL", server.URL)
 	t.Setenv("GH_TOKEN", "test-token")
@@ -681,8 +878,7 @@ func TestToolFetchPRFeedbackCategorizesAndCarriesThreadIDs(t *testing.T) {
 
 func TestToolFetchReviewRequestsFiltersClosedAndBuildsReasons(t *testing.T) {
 	mux := http.NewServeMux()
-	server := httptest.NewServer(mux)
-	defer server.Close()
+	server := newGitHubAPITestServer(t, mux)
 	base := server.URL
 
 	mux.HandleFunc("/orgs/acme/teams/team-a/members", func(w http.ResponseWriter, r *http.Request) {
@@ -793,7 +989,7 @@ func isPageTwoOrLater(r *http.Request) bool {
 
 func TestToolFetchPRChecksSurfacesFailureSnippetAndPaginates(t *testing.T) {
 	var checkRunPages int
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := newGitHubAPITestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/repos/owner/repo/pulls/7":
 			_, _ = io.WriteString(w, `{"number":7,"html_url":"https://github.com/owner/repo/pull/7","head":{"sha":"abc123","ref":"feature"},"base":{"ref":"main"}}`)
@@ -820,7 +1016,6 @@ func TestToolFetchPRChecksSurfacesFailureSnippetAndPaginates(t *testing.T) {
 			http.NotFound(w, r)
 		}
 	}))
-	defer server.Close()
 
 	t.Setenv("SLIPWAY_GITHUB_API_URL", server.URL)
 	t.Setenv("GH_TOKEN", "test-token")
@@ -863,7 +1058,7 @@ func TestToolFetchPRChecksSurfacesFailureSnippetAndPaginates(t *testing.T) {
 
 func TestToolFetchPRChecksSurfacesFailedCommitStatuses(t *testing.T) {
 	var requestedStatus bool
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := newGitHubAPITestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/repos/owner/repo/pulls/7":
 			_, _ = io.WriteString(w, `{"number":7,"html_url":"https://github.com/owner/repo/pull/7","head":{"sha":"abc123","ref":"feature"},"base":{"ref":"main"}}`)
@@ -876,7 +1071,6 @@ func TestToolFetchPRChecksSurfacesFailedCommitStatuses(t *testing.T) {
 			http.NotFound(w, r)
 		}
 	}))
-	defer server.Close()
 
 	t.Setenv("SLIPWAY_GITHUB_API_URL", server.URL)
 	t.Setenv("GH_TOKEN", "test-token")
@@ -1326,12 +1520,11 @@ func TestAutoGitHubBackendFallsBackToTokenOnGHAuthError(t *testing.T) {
 	}
 
 	var httpHits int
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := newGitHubAPITestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		httpHits++
 		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
 		_, _ = w.Write([]byte(`{"number":7}`))
 	}))
-	defer server.Close()
 
 	t.Setenv("SLIPWAY_GITHUB_API_URL", server.URL)
 	t.Setenv("GH_TOKEN", "test-token")
@@ -1378,11 +1571,10 @@ func TestAutoGitHubBackendDoesNotFallBackOnNonAuthError(t *testing.T) {
 	}
 
 	var httpHits int
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	server := newGitHubAPITestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		httpHits++
 		_, _ = w.Write([]byte(`{"number":7}`))
 	}))
-	defer server.Close()
 
 	t.Setenv("SLIPWAY_GITHUB_API_URL", server.URL)
 	t.Setenv("GH_TOKEN", "test-token")

--- a/internal/state/worktree.go
+++ b/internal/state/worktree.go
@@ -233,9 +233,9 @@ func EnsureDefaultWorktreeForChange(root string, change *model.Change) (DefaultW
 	if gitBranchExists(repoRoot, branch) {
 		args = append(args, normalizedPath, branch)
 	} else {
-		baseRef := strings.TrimSpace(change.BaseRef)
-		if baseRef == "" {
-			baseRef = "HEAD"
+		baseRef, err := validateWorktreeBaseRef(repoRoot, change.BaseRef)
+		if err != nil {
+			return DefaultWorktreeBinding{}, err
 		}
 		args = append(args, "-b", branch, normalizedPath, baseRef)
 	}
@@ -254,6 +254,24 @@ func EnsureDefaultWorktreeForChange(root string, change *model.Change) (DefaultW
 		Branch:  branch,
 		Created: true,
 	}, nil
+}
+
+func validateWorktreeBaseRef(repoRoot, raw string) (string, error) {
+	baseRef := strings.TrimSpace(raw)
+	if baseRef == "" {
+		baseRef = "HEAD"
+	}
+	if strings.HasPrefix(baseRef, "-") {
+		return "", fmt.Errorf("invalid base_ref %q: value must not start with '-' because it would be parsed as a git option; repair the change authority to use HEAD, a branch, a tag, or a commit SHA", baseRef)
+	}
+	if strings.ContainsAny(baseRef, "\x00\r\n") {
+		return "", fmt.Errorf("invalid base_ref %q: value must be a single git ref or commit-ish; repair the change authority to use HEAD, a branch, a tag, or a commit SHA", baseRef)
+	}
+	cmd := exec.Command("git", "-C", repoRoot, "rev-parse", "--verify", "--quiet", baseRef+"^{commit}") // #nosec G204 -- baseRef is validated as data and passed as one argv element without shell interpolation.
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("invalid base_ref %q: git cannot resolve it as a commit; repair the change authority to use HEAD, a branch, a tag, or a commit SHA", baseRef)
+	}
+	return baseRef, nil
 }
 
 func gitBranchExists(repoRoot, branch string) bool {

--- a/internal/state/worktree_test.go
+++ b/internal/state/worktree_test.go
@@ -291,6 +291,76 @@ func TestEnsureDefaultWorktreeForChange_ProvisionsNonDiscoveryByDefault(t *testi
 	assert.NotEmpty(t, change.WorktreePath, "binding metadata must be persisted on the change")
 }
 
+func TestEnsureDefaultWorktreeForChangeRejectsOptionLikeBaseRef(t *testing.T) {
+	root := t.TempDir()
+	initGitRepoAt(t, root)
+
+	change := model.NewChange("my-change")
+	change.BaseRef = "--upload-pack=ssh://evil.example/repo"
+
+	_, err := EnsureDefaultWorktreeForChange(root, &change)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid base_ref")
+	assert.Contains(t, err.Error(), "must not start with '-'")
+	assert.NotContains(t, err.Error(), "git worktree add failed")
+	assert.NoDirExists(t, filepath.Join(root, ".worktrees", "my-change"))
+}
+
+func TestEnsureDefaultWorktreeForChangeRejectsInvalidBaseRefControlChars(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		baseRef string
+	}{
+		{name: "nul", baseRef: "main\x00refs/heads/main"},
+		{name: "carriage return", baseRef: "main\rrefs/heads/main"},
+		{name: "line feed", baseRef: "main\nrefs/heads/main"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			initGitRepoAt(t, root)
+
+			change := model.NewChange("my-change")
+			change.BaseRef = tt.baseRef
+
+			_, err := EnsureDefaultWorktreeForChange(root, &change)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid base_ref")
+			assert.Contains(t, err.Error(), "value must be a single git ref")
+			assert.NotContains(t, err.Error(), "git worktree add failed")
+			assert.NoDirExists(t, filepath.Join(root, ".worktrees", "my-change"))
+		})
+	}
+}
+
+func TestEnsureDefaultWorktreeForChangeRejectsUnknownBaseRefBeforeWorktreeAdd(t *testing.T) {
+	root := t.TempDir()
+	initGitRepoAt(t, root)
+
+	change := model.NewChange("my-change")
+	change.BaseRef = "definitely-not-a-ref"
+
+	_, err := EnsureDefaultWorktreeForChange(root, &change)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid base_ref")
+	assert.Contains(t, err.Error(), "repair the change authority")
+	assert.NotContains(t, err.Error(), "git worktree add failed")
+	assert.NoDirExists(t, filepath.Join(root, ".worktrees", "my-change"))
+}
+
+func TestEnsureDefaultWorktreeForChangeAcceptsTagBaseRef(t *testing.T) {
+	root := t.TempDir()
+	initGitRepoAt(t, root)
+	runGit(t, root, "tag", "v0.1.0")
+
+	change := model.NewChange("my-change")
+	change.BaseRef = "v0.1.0"
+
+	binding, err := EnsureDefaultWorktreeForChange(root, &change)
+	require.NoError(t, err)
+	assert.True(t, binding.Created)
+	assert.Contains(t, filepath.ToSlash(binding.Path), ".worktrees/my-change")
+}
+
 func TestEnsureDefaultWorktreeForChange_DisabledByConfig(t *testing.T) {
 	root := t.TempDir()
 	initGitRepoAt(t, root)


### PR DESCRIPTION
## Summary

- Harden release and security workflows with pinned action/runtime setup, dry-run release validation, and supply-chain checks.
- Add release workflow contract coverage and GitHub tool/worktree support needed by the hardened release path.
- Refresh codebase map docs that describe the changed release and testing surfaces.

## Correction From PR #349

PR #349 was merged with archived governed-change files committed under
`artifacts/changes/archived/harden-release-supply-chain/`. This PR replays the
release hardening work without that governed change bundle. The branch and main
were reset, the feature branch was rebuilt, and the new PR is the review/merge
surface.

## Verification

- `git ls-tree -r --name-only origin/main artifacts/changes/archived/harden-release-supply-chain` produced no output.
- `git ls-tree -r --name-only origin/feat/harden-release-supply-chain artifacts/changes/archived/harden-release-supply-chain` produced no output.
- `git ls-files -c -i --exclude-standard` produced no output in the local worktree.
- `git diff --check -- . ':!dist'` passed.
- `actionlint` passed.
- `go test ./... -count=1` passed before the final bundle-removal replay; the final replay removes only governed archive artifacts from the previous attempt and preserves the code/workflow changes.
