### PR TITLE
feat(perf): add state-read baseline

### DIFF
--- a/artifacts/changes/archived/add-state-read-performance-baseline/assurance.md
+++ b/artifacts/changes/archived/add-state-read-performance-baseline/assurance.md
@@ -1,0 +1,73 @@
+# Assurance
+
+## Scope Summary
+Delivered a focused state-read performance baseline for the `opt.md` 4.1
+requirement. The change adds:
+
+- `internal/perfbaseline` JSON baseline and threshold comparison logic;
+- `internal/perfbaseline/cmd/state-read-baseline`, a repo-native tool that
+  builds or accepts a `slipway` binary, prepares a synthetic state-read fixture,
+  warms each required lifecycle command, records the fastest timed sample,
+  and checks regressions across bounded independent attempts without letting
+  check mode overwrite the committed baseline by default;
+- `state-read-performance-baseline.json`, the initial built-binary baseline
+  artifact;
+- operator documentation for refresh and check commands.
+
+No lifecycle route, freshness, action-contract, release, GitHub settings, or
+persistent cache behavior was changed.
+
+## Verification Verdict
+Implementation verification passed:
+
+- targeted package tests passed;
+- baseline refresh passed and wrote `state-read-performance-baseline.json`;
+- baseline check passed against the committed baseline with a 30% budget;
+- full repository `go test ./... -count=1` passed.
+
+## Evidence Index
+- `artifacts/changes/add-state-read-performance-baseline/verification/implementation-tests.txt`
+- `artifacts/changes/add-state-read-performance-baseline/verification/state-read-current.json`
+- `artifacts/changes/add-state-read-performance-baseline/verification/full-suite.txt`
+- `.git/slipway/runtime/changes/add-state-read-performance-baseline/evidence/tasks/t-01.json`
+- `.git/slipway/runtime/changes/add-state-read-performance-baseline/evidence/tasks/t-02.json`
+- `.git/slipway/runtime/changes/add-state-read-performance-baseline/evidence/tasks/t-03.json`
+- `.git/slipway/runtime/changes/add-state-read-performance-baseline/evidence/tasks/t-04.json`
+- `artifacts/changes/add-state-read-performance-baseline/verification/wave-orchestration.yaml`
+
+## Requirement Coverage
+- REQ-001: Covered by `state-read-baseline` refresh mode and
+  `state-read-performance-baseline.json`, which records root status, bound
+  status, bound next diagnostics, bound validate, and explicit `--change`
+  status measurements.
+- REQ-002: Covered by the committed baseline artifact, including
+  `real_ms`/`user_ms`/`system_ms`, fixture worktree/change/verification counts,
+  Go version, git commit, binary path, warmup/sample/check-attempt counts, and
+  repeat commands.
+- REQ-003: Covered by `perfbaseline.Compare` tests and `state-read-baseline
+  -mode check`, which reports command-specific threshold regressions.
+- REQ-004: Covered by targeted `go test ./internal/perfbaseline
+  ./internal/perfbaseline/cmd/state-read-baseline -count=1` and full
+  `go test ./... -count=1`.
+
+## Residual Risks and Exceptions
+- Local timing measurements remain host-sensitive. The tool reduces incidental
+  noise with one warmup, the fastest of seven timed samples, and up to three
+  independent check attempts. The 30% threshold is still a guardrail for
+  interactive regressions rather than a statistically rigorous benchmark claim.
+- The committed baseline includes the local temporary fixture and binary paths
+  from the measurement run. They are audit metadata for that run; repeatability
+  comes from the recorded refresh command and fixture generator.
+- Generated fixtures are intentionally temporary by default. Use
+  `-keep-fixture` only for local diagnosis.
+
+## Rollback Readiness
+Rollback is straightforward: remove `internal/perfbaseline`, remove
+`state-read-performance-baseline.json`, and revert the operator-guide section.
+No persisted runtime schema or lifecycle authority format changes are involved.
+
+## Archive Decision
+Archive after current-worktree review and ship-verification gates pass. Capture
+active `validate --json` freshness/readiness proof before `done`; archived
+bundles are frozen records and are not revalidated through the active validate
+gate.

--- a/artifacts/changes/archived/add-state-read-performance-baseline/change.yaml
+++ b/artifacts/changes/archived/add-state-read-performance-baseline/change.yaml
@@ -1,0 +1,45 @@
+version: 1
+slug: add-state-read-performance-baseline
+description: add state read performance baseline
+status: done
+current_state: DONE
+complexity_level: simple
+base_ref: HEAD
+created_at: 2026-06-27T10:19:56.288585Z
+quality_mode: standard
+workflow_preset: standard
+worktree_branch: feat/add-state-read-performance-baseline
+artifact_schema: core
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: ef7b7b5e67248af33f09a08bdb03edcec8268c2153443149eca94f35a9a3bc80
+        updated_at: 2026-06-27T11:44:40.650007292Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: 4bf759ec22d12d3d84b1b136dd1f254bd05773bf8040b45ff0b0d88498c213c4
+        updated_at: 2026-06-27T10:20:51.837166355Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: 32e84299b5a0064ec74c2bd57cdda46977ba23398ffbc936f82546400e1e3462
+        updated_at: 2026-06-27T10:21:50.411314182Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: 10a129dd8617d401a5452b25b487a4e47281c29468e202911a7d55a489db3156
+        updated_at: 2026-06-27T10:57:27.225208573Z
+evidence_refs:
+    code-quality-review: .worktrees/add-state-read-performance-baseline/artifacts/changes/add-state-read-performance-baseline/verification/code-quality-review.yaml
+    independent-review: .worktrees/add-state-read-performance-baseline/artifacts/changes/add-state-read-performance-baseline/verification/independent-review.yaml
+    intake-clarification: .worktrees/add-state-read-performance-baseline/artifacts/changes/add-state-read-performance-baseline/verification/intake-clarification.yaml
+    plan-audit: .worktrees/add-state-read-performance-baseline/artifacts/changes/add-state-read-performance-baseline/verification/plan-audit.yaml
+    ship-verification: .worktrees/add-state-read-performance-baseline/artifacts/changes/add-state-read-performance-baseline/verification/ship-verification.yaml
+    spec-compliance-review: .worktrees/add-state-read-performance-baseline/artifacts/changes/add-state-read-performance-baseline/verification/spec-compliance-review.yaml
+    wave-orchestration: .worktrees/add-state-read-performance-baseline/artifacts/changes/add-state-read-performance-baseline/verification/wave-orchestration.yaml

--- a/artifacts/changes/archived/add-state-read-performance-baseline/intent.md
+++ b/artifacts/changes/archived/add-state-read-performance-baseline/intent.md
@@ -1,0 +1,57 @@
+# Intent
+
+## Summary
+Add a repeatable built-binary performance baseline for state-read-heavy
+lifecycle commands.
+
+## Complexity Assessment
+simple
+The change should add benchmark/fixture tooling and a documented baseline around
+existing public commands. It should not alter lifecycle routing semantics or add
+new caching behavior.
+
+## In Scope
+- Add a repo-native, repeatable way to construct or reuse a synthetic state-read
+  fixture with at least 25 worktrees, 300 `change.yaml` files, and 100
+  verification records.
+- Measure built `slipway` binary timings for root `status --json`, bound
+  `status --json`, bound `next --json --diagnostics`, bound `validate --json`,
+  and explicit `--change <slug>` scenarios.
+- Persist a human-readable baseline artifact that records `real/user/sys`,
+  worktree count, `change.yaml` count, verification record count, command
+  version/commit, and the local repeat command.
+- Add a lightweight regression threshold path, with a default 30% threshold for
+  the measured core commands.
+- Add targeted tests for the fixture/baseline parser or threshold logic.
+
+## Out of Scope
+- No lifecycle route/freshness/action-contract semantic changes.
+- No persistent cross-command index or cache.
+- No release workflow, GitHub settings, third-party action pinning, or API token
+  hardening work.
+- No compatibility layer for retired benchmark formats.
+
+## Constraints
+- Measurements must use a built binary, not `go run`.
+- Tooling must be deterministic enough for local repeat use and CI-adjacent
+  validation, but it should not make every PR run a slow 25-worktree benchmark
+  unless explicitly invoked.
+- Existing ignored runtime evidence/events must stay uncommitted.
+
+## Acceptance Signals
+- A documented command can create or refresh the required fixture and record a
+  baseline artifact.
+- The baseline artifact includes command timings and fixture dimensions for all
+  required scenarios.
+- Threshold checking reports which command regressed beyond the allowed 30%.
+- Targeted tests cover parser/threshold behavior, and final verification runs
+  `go test ./... -count=1`.
+
+## Open Questions
+None.
+
+## Approved Summary
+Approved under standing user auto-authorization on 2026-06-27: implement a
+focused state-read performance baseline and regression threshold path for the
+already-built lifecycle command surfaces. Keep semantic changes, persistent
+indexes, release hardening, and compatibility layers out of scope.

--- a/artifacts/changes/archived/add-state-read-performance-baseline/requirements.md
+++ b/artifacts/changes/archived/add-state-read-performance-baseline/requirements.md
@@ -1,0 +1,57 @@
+# Requirements
+
+## Requirements
+
+### Requirement: Repeatable Built-Binary State-Read Baseline
+REQ-001: The system MUST provide a repo-native way to measure state-read-heavy
+lifecycle command performance with a built `slipway` binary, not `go run`, and
+MUST cover the root `status --json`, bound `status --json`, bound
+`next --json --diagnostics`, bound `validate --json`, and explicit
+`--change <slug>` scenarios.
+
+#### Scenario: Baseline fixture and command coverage
+GIVEN a repository checkout with the state-read baseline tool available
+WHEN an operator runs the documented baseline refresh command
+THEN the tool builds or uses a `slipway` binary and records timings for every
+required lifecycle command scenario.
+
+### Requirement: Fixture Dimensions and Timing Evidence
+REQ-002: The system MUST record enough fixture and timing metadata to make a
+baseline result auditable, including `real/user/sys`, worktree count,
+`change.yaml` count, verification record count, command version or commit, and
+the command lines used.
+
+#### Scenario: Baseline artifact is inspectable
+GIVEN a refreshed state-read performance baseline
+WHEN an operator opens the committed baseline artifact
+THEN it shows the required fixture dimensions and timing values for each
+measured command without requiring access to ignored runtime files.
+
+### Requirement: Regression Threshold Checking
+REQ-003: The system MUST provide a threshold check that compares a new
+measurement to the committed baseline and reports each command whose `real`
+duration regressed beyond the configured allowance, defaulting to 30%.
+
+#### Scenario: A command exceeds the threshold
+GIVEN a committed baseline and a new measurement where one command is more than
+30% slower
+WHEN the threshold check runs
+THEN it fails and names the regressed command, baseline duration, current
+duration, and allowed threshold.
+
+#### Scenario: Measurements stay within threshold
+GIVEN a committed baseline and a new measurement where all commands are within
+the configured threshold
+WHEN the threshold check runs
+THEN it passes and reports that all measured state-read commands are within the
+allowed regression budget.
+
+### Requirement: Local Validation Path
+REQ-004: The system MUST add targeted automated tests for the state-read
+baseline parser, writer, or threshold logic, and final verification MUST include
+`go test ./... -count=1`.
+
+#### Scenario: Threshold logic is tested
+GIVEN the state-read baseline package test suite
+WHEN `go test` runs for that package
+THEN it covers both passing and failing threshold comparisons.

--- a/artifacts/changes/archived/add-state-read-performance-baseline/tasks.md
+++ b/artifacts/changes/archived/add-state-read-performance-baseline/tasks.md
@@ -1,0 +1,31 @@
+# Tasks
+
+## Task List
+
+- [x] `t-01` Add the state-read baseline data model, JSON encoding, and regression threshold comparison logic.
+  - depends_on: []
+  - target_files: [internal/perfbaseline/baseline.go, internal/perfbaseline/baseline_test.go]
+  - task_kind: code
+  - covers: [REQ-002, REQ-003, REQ-004]
+  - acceptance: `go test ./internal/perfbaseline -count=1` covers JSON round-trip, passing threshold comparisons, and failing threshold comparisons with command-specific diagnostics.
+
+- [x] `t-02` Add the state-read baseline CLI that builds or accepts a binary, prepares the required synthetic fixture, measures required lifecycle command scenarios, and writes measurements.
+  - depends_on: [t-01]
+  - target_files: [internal/perfbaseline/cmd/state-read-baseline/main.go, internal/perfbaseline/cmd/state-read-baseline/main_test.go]
+  - task_kind: code
+  - covers: [REQ-001, REQ-002, REQ-003]
+  - acceptance: A local run of `go run ./internal/perfbaseline/cmd/state-read-baseline -mode refresh -out state-read-performance-baseline.json` uses a built binary and writes measurements for root status, bound status, bound next, bound validate, and explicit `--change` scenarios.
+
+- [x] `t-03` Commit an initial state-read baseline artifact and document the repeat/check commands.
+  - depends_on: [t-02]
+  - target_files: [state-read-performance-baseline.json, docs/operator-guide.md]
+  - task_kind: doc
+  - covers: [REQ-001, REQ-002, REQ-003]
+  - acceptance: `state-read-performance-baseline.json` records fixture dimensions, command metadata, `real/user/sys` timings, and documented refresh/check commands; `docs/operator-guide.md` names the same commands.
+
+- [x] `t-04` Run targeted tests and final repository verification.
+  - depends_on: [t-01, t-02, t-03]
+  - target_files: [artifacts/changes/add-state-read-performance-baseline/verification/implementation-tests.txt, artifacts/changes/add-state-read-performance-baseline/verification/full-suite.txt]
+  - task_kind: verification
+  - covers: [REQ-004]
+  - acceptance: Verification evidence records targeted `go test ./internal/perfbaseline -count=1`, the baseline refresh/check commands, and final `go test ./... -count=1`.

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -164,6 +164,50 @@ Run the docs build (Astro Starlight) only when Node dependencies are available
 locally; run `cd website && npm install` first. CI runs the same docs build for
 verification.
 
+## State-Read Performance Baseline
+
+State-read-heavy lifecycle commands have a repeatable built-binary baseline in
+`state-read-performance-baseline.json`. Refresh it after intentional state-read
+performance work:
+
+```bash
+go run ./internal/perfbaseline/cmd/state-read-baseline \
+  -mode refresh \
+  -out state-read-performance-baseline.json
+```
+
+The tool builds a temporary `slipway` binary unless `-binary <path>` is passed,
+creates a synthetic fixture by default, warms each command once, and records the
+fastest of seven timed samples for:
+
+- root worktree `status --json`;
+- bound worktree `status --json`;
+- bound worktree `next --json --diagnostics`;
+- bound worktree `validate --json`;
+- root worktree `status --json --change <slug>`.
+
+The default fixture includes at least 25 Git worktrees, 300 `change.yaml` files,
+and 100 verification records. Temporary fixture directories are removed after
+the run unless `-keep-fixture` is set.
+
+Check a new local measurement against the committed baseline with the default
+30% real-time regression budget. Check mode requires an explicit `-out` path so
+it cannot overwrite the committed baseline by accident:
+
+```bash
+go run ./internal/perfbaseline/cmd/state-read-baseline \
+  -mode check \
+  -baseline state-read-performance-baseline.json \
+  -out /tmp/slipway-state-read-current.json
+```
+
+The check reports the specific command whose `real_ms` exceeds the allowed
+threshold. By default it runs up to three independent measurement attempts and
+passes as soon as one attempt stays within the 30% budget; persistent
+regressions must exceed the budget on every attempt. Write the output
+measurement to a temporary path or to the active change's ignored
+`verification/` directory when keeping local governed evidence.
+
 ## Adapter Refresh
 
 Refresh generated AI-tool surfaces after changing templates or command contracts:

--- a/internal/perfbaseline/baseline.go
+++ b/internal/perfbaseline/baseline.go
@@ -1,0 +1,244 @@
+package perfbaseline
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	SchemaVersion           = 1
+	DefaultRegressionBudget = 0.30
+)
+
+type Baseline struct {
+	SchemaVersion    int              `json:"schema_version"`
+	GeneratedAt      time.Time        `json:"generated_at"`
+	GitCommit        string           `json:"git_commit"`
+	GoVersion        string           `json:"go_version"`
+	SlipwayBinary    string           `json:"slipway_binary"`
+	RegressionBudget float64          `json:"regression_budget"`
+	WarmupCount      int              `json:"warmup_count"`
+	SampleCount      int              `json:"sample_count"`
+	SampleStatistic  string           `json:"sample_statistic"`
+	CheckAttempts    int              `json:"check_attempts"`
+	Fixture          Fixture          `json:"fixture"`
+	Commands         []CommandMeasure `json:"commands"`
+	RefreshCommand   string           `json:"refresh_command"`
+	CheckCommand     string           `json:"check_command"`
+}
+
+type Fixture struct {
+	Root                 string `json:"root"`
+	WorktreeCount        int    `json:"worktree_count"`
+	ChangeYAMLCount      int    `json:"change_yaml_count"`
+	VerificationCount    int    `json:"verification_count"`
+	BoundChangeSlug      string `json:"bound_change_slug"`
+	ExplicitChangeSlug   string `json:"explicit_change_slug"`
+	FixtureGenerationRef string `json:"fixture_generation_ref,omitempty"`
+}
+
+type CommandMeasure struct {
+	ID          string   `json:"id"`
+	Description string   `json:"description"`
+	CWD         string   `json:"cwd"`
+	Args        []string `json:"args"`
+	RealMS      float64  `json:"real_ms"`
+	UserMS      float64  `json:"user_ms"`
+	SystemMS    float64  `json:"system_ms"`
+	ExitCode    int      `json:"exit_code"`
+}
+
+type Regression struct {
+	CommandID    string
+	BaselineMS   float64
+	CurrentMS    float64
+	AllowedMS    float64
+	ThresholdPct float64
+}
+
+func NewBaseline() Baseline {
+	return Baseline{
+		SchemaVersion:    SchemaVersion,
+		GeneratedAt:      time.Now().UTC(),
+		RegressionBudget: DefaultRegressionBudget,
+		Commands:         []CommandMeasure{},
+	}
+}
+
+func Read(r io.Reader) (Baseline, error) {
+	var b Baseline
+	dec := json.NewDecoder(r)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&b); err != nil {
+		return Baseline{}, fmt.Errorf("decode state-read baseline: %w", err)
+	}
+	if err := b.Validate(); err != nil {
+		return Baseline{}, err
+	}
+	return b, nil
+}
+
+func Write(w io.Writer, b Baseline) error {
+	if err := b.Validate(); err != nil {
+		return err
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(b); err != nil {
+		return fmt.Errorf("encode state-read baseline: %w", err)
+	}
+	return nil
+}
+
+func (b Baseline) Validate() error {
+	if b.SchemaVersion != SchemaVersion {
+		return fmt.Errorf("unsupported state-read baseline schema_version %d", b.SchemaVersion)
+	}
+	if b.RegressionBudget <= 0 {
+		return fmt.Errorf("regression_budget must be positive")
+	}
+	if b.WarmupCount < 0 {
+		return fmt.Errorf("warmup_count must be non-negative")
+	}
+	if b.SampleCount <= 0 {
+		return fmt.Errorf("sample_count must be positive")
+	}
+	if strings.TrimSpace(b.SampleStatistic) == "" {
+		return fmt.Errorf("sample_statistic is required")
+	}
+	if b.CheckAttempts <= 0 {
+		return fmt.Errorf("check_attempts must be positive")
+	}
+	if b.Fixture.WorktreeCount <= 0 {
+		return fmt.Errorf("fixture.worktree_count must be positive")
+	}
+	if b.Fixture.ChangeYAMLCount <= 0 {
+		return fmt.Errorf("fixture.change_yaml_count must be positive")
+	}
+	if b.Fixture.VerificationCount <= 0 {
+		return fmt.Errorf("fixture.verification_count must be positive")
+	}
+	if len(b.Commands) == 0 {
+		return fmt.Errorf("commands must not be empty")
+	}
+	seen := map[string]struct{}{}
+	for i, cmd := range b.Commands {
+		if err := cmd.Validate(); err != nil {
+			return fmt.Errorf("commands[%d]: %w", i, err)
+		}
+		if _, ok := seen[cmd.ID]; ok {
+			return fmt.Errorf("duplicate command id %q", cmd.ID)
+		}
+		seen[cmd.ID] = struct{}{}
+	}
+	return nil
+}
+
+func (m CommandMeasure) Validate() error {
+	if strings.TrimSpace(m.ID) == "" {
+		return fmt.Errorf("id is required")
+	}
+	if len(m.Args) == 0 {
+		return fmt.Errorf("args must not be empty")
+	}
+	if math.IsNaN(m.RealMS) || m.RealMS <= 0 {
+		return fmt.Errorf("real_ms must be positive")
+	}
+	if math.IsNaN(m.UserMS) || m.UserMS < 0 {
+		return fmt.Errorf("user_ms must be non-negative")
+	}
+	if math.IsNaN(m.SystemMS) || m.SystemMS < 0 {
+		return fmt.Errorf("system_ms must be non-negative")
+	}
+	return nil
+}
+
+func Compare(baseline, current Baseline, threshold float64) ([]Regression, error) {
+	if threshold <= 0 {
+		threshold = baseline.RegressionBudget
+	}
+	if threshold <= 0 {
+		threshold = DefaultRegressionBudget
+	}
+	if err := baseline.Validate(); err != nil {
+		return nil, fmt.Errorf("baseline invalid: %w", err)
+	}
+	if err := current.Validate(); err != nil {
+		return nil, fmt.Errorf("current measurement invalid: %w", err)
+	}
+
+	currentByID := make(map[string]CommandMeasure, len(current.Commands))
+	for _, cmd := range current.Commands {
+		currentByID[cmd.ID] = cmd
+	}
+
+	var regressions []Regression
+	for _, base := range baseline.Commands {
+		cur, ok := currentByID[base.ID]
+		if !ok {
+			return nil, fmt.Errorf("current measurement missing command %q", base.ID)
+		}
+		allowed := base.RealMS * (1 + threshold)
+		if cur.RealMS > allowed {
+			regressions = append(regressions, Regression{
+				CommandID:    base.ID,
+				BaselineMS:   base.RealMS,
+				CurrentMS:    cur.RealMS,
+				AllowedMS:    allowed,
+				ThresholdPct: threshold * 100,
+			})
+		}
+	}
+	sort.Slice(regressions, func(i, j int) bool {
+		return regressions[i].CommandID < regressions[j].CommandID
+	})
+	return regressions, nil
+}
+
+func RequiredCommandIDs() []string {
+	return []string{
+		"root-status-json",
+		"bound-status-json",
+		"bound-next-json-diagnostics",
+		"bound-validate-json",
+		"explicit-change-status-json",
+	}
+}
+
+func MissingRequiredCommands(b Baseline) []string {
+	present := map[string]struct{}{}
+	for _, cmd := range b.Commands {
+		present[cmd.ID] = struct{}{}
+	}
+	var missing []string
+	for _, id := range RequiredCommandIDs() {
+		if _, ok := present[id]; !ok {
+			missing = append(missing, id)
+		}
+	}
+	return missing
+}
+
+func SortCommands(commands []CommandMeasure) {
+	order := RequiredCommandIDs()
+	slices.SortFunc(commands, func(a, b CommandMeasure) int {
+		ai := slices.Index(order, a.ID)
+		bi := slices.Index(order, b.ID)
+		if ai == -1 {
+			ai = len(order)
+		}
+		if bi == -1 {
+			bi = len(order)
+		}
+		if ai != bi {
+			return ai - bi
+		}
+		return strings.Compare(a.ID, b.ID)
+	})
+}

--- a/internal/perfbaseline/baseline_test.go
+++ b/internal/perfbaseline/baseline_test.go
@@ -1,0 +1,205 @@
+package perfbaseline
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBaselineRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	b := sampleBaseline()
+	var buf bytes.Buffer
+	require.NoError(t, Write(&buf, b))
+
+	got, err := Read(&buf)
+	require.NoError(t, err)
+	assert.Equal(t, b.SchemaVersion, got.SchemaVersion)
+	assert.Equal(t, b.Fixture.WorktreeCount, got.Fixture.WorktreeCount)
+	assert.Equal(t, RequiredCommandIDs(), commandIDs(got.Commands))
+}
+
+func TestComparePassesWithinThreshold(t *testing.T) {
+	t.Parallel()
+
+	baseline := sampleBaseline()
+	current := sampleBaseline()
+	current.Commands[0].RealMS = 129
+
+	regressions, err := Compare(baseline, current, 0.30)
+	require.NoError(t, err)
+	assert.Empty(t, regressions)
+}
+
+func TestCompareReportsCommandSpecificRegression(t *testing.T) {
+	t.Parallel()
+
+	baseline := sampleBaseline()
+	current := sampleBaseline()
+	current.Commands[0].RealMS = 131
+	current.Commands[2].RealMS = 92
+
+	regressions, err := Compare(baseline, current, 0.30)
+	require.NoError(t, err)
+	require.Len(t, regressions, 2)
+	assert.Equal(t, "bound-next-json-diagnostics", regressions[0].CommandID)
+	assert.Equal(t, "root-status-json", regressions[1].CommandID)
+	assert.InDelta(t, 130, regressions[1].AllowedMS, 0.001)
+}
+
+func TestCompareRejectsMissingCurrentCommand(t *testing.T) {
+	t.Parallel()
+
+	baseline := sampleBaseline()
+	current := sampleBaseline()
+	current.Commands = current.Commands[:len(current.Commands)-1]
+
+	_, err := Compare(baseline, current, 0.30)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "current measurement missing command")
+}
+
+func TestReadRejectsUnknownFields(t *testing.T) {
+	t.Parallel()
+
+	_, err := Read(strings.NewReader(`{
+		"schema_version": 1,
+		"generated_at": "2026-06-27T00:00:00Z",
+		"git_commit": "abc",
+		"go_version": "go1.26",
+		"slipway_binary": "./slipway",
+		"regression_budget": 0.3,
+		"fixture": {
+			"root": "/tmp/fixture",
+			"worktree_count": 25,
+			"change_yaml_count": 300,
+			"verification_count": 100,
+			"bound_change_slug": "bound",
+			"explicit_change_slug": "explicit"
+		},
+		"commands": [
+			{
+				"id": "root-status-json",
+				"description": "root status",
+				"cwd": "/tmp/fixture",
+				"args": ["status", "--json"],
+				"real_ms": 100,
+				"user_ms": 20,
+				"system_ms": 10,
+				"exit_code": 0
+			}
+		],
+		"unexpected": true
+	}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown field")
+}
+
+func TestValidateRequiresSampleMetadata(t *testing.T) {
+	t.Parallel()
+
+	b := sampleBaseline()
+	b.WarmupCount = -1
+	assert.ErrorContains(t, b.Validate(), "warmup_count must be non-negative")
+
+	b = sampleBaseline()
+	b.SampleCount = 0
+	assert.ErrorContains(t, b.Validate(), "sample_count must be positive")
+
+	b = sampleBaseline()
+	b.SampleStatistic = ""
+	assert.ErrorContains(t, b.Validate(), "sample_statistic is required")
+
+	b = sampleBaseline()
+	b.CheckAttempts = 0
+	assert.ErrorContains(t, b.Validate(), "check_attempts must be positive")
+}
+
+func TestMissingRequiredCommands(t *testing.T) {
+	t.Parallel()
+
+	b := sampleBaseline()
+	b.Commands = b.Commands[:2]
+	assert.Equal(t, RequiredCommandIDs()[2:], MissingRequiredCommands(b))
+}
+
+func sampleBaseline() Baseline {
+	b := NewBaseline()
+	b.GeneratedAt = time.Date(2026, 6, 27, 0, 0, 0, 0, time.UTC)
+	b.GitCommit = "abc123"
+	b.GoVersion = "go1.26.4"
+	b.SlipwayBinary = "/tmp/slipway"
+	b.WarmupCount = 1
+	b.SampleCount = 7
+	b.SampleStatistic = "fastest"
+	b.CheckAttempts = 3
+	b.Fixture = Fixture{
+		Root:               "/tmp/fixture",
+		WorktreeCount:      25,
+		ChangeYAMLCount:    300,
+		VerificationCount:  100,
+		BoundChangeSlug:    "bound-change",
+		ExplicitChangeSlug: "explicit-change",
+	}
+	b.Commands = []CommandMeasure{
+		{
+			ID:          "root-status-json",
+			Description: "root status",
+			CWD:         "/tmp/fixture",
+			Args:        []string{"status", "--json"},
+			RealMS:      100,
+			UserMS:      20,
+			SystemMS:    10,
+		},
+		{
+			ID:          "bound-status-json",
+			Description: "bound status",
+			CWD:         "/tmp/fixture/.worktrees/bound-change",
+			Args:        []string{"status", "--json"},
+			RealMS:      80,
+			UserMS:      18,
+			SystemMS:    9,
+		},
+		{
+			ID:          "bound-next-json-diagnostics",
+			Description: "bound next",
+			CWD:         "/tmp/fixture/.worktrees/bound-change",
+			Args:        []string{"next", "--json", "--diagnostics"},
+			RealMS:      70,
+			UserMS:      17,
+			SystemMS:    8,
+		},
+		{
+			ID:          "bound-validate-json",
+			Description: "bound validate",
+			CWD:         "/tmp/fixture/.worktrees/bound-change",
+			Args:        []string{"validate", "--json"},
+			RealMS:      60,
+			UserMS:      16,
+			SystemMS:    7,
+		},
+		{
+			ID:          "explicit-change-status-json",
+			Description: "explicit status",
+			CWD:         "/tmp/fixture",
+			Args:        []string{"status", "--json", "--change", "explicit-change"},
+			RealMS:      50,
+			UserMS:      15,
+			SystemMS:    6,
+		},
+	}
+	return b
+}
+
+func commandIDs(commands []CommandMeasure) []string {
+	ids := make([]string, 0, len(commands))
+	for _, cmd := range commands {
+		ids = append(ids, cmd.ID)
+	}
+	return ids
+}

--- a/internal/perfbaseline/cmd/state-read-baseline/main.go
+++ b/internal/perfbaseline/cmd/state-read-baseline/main.go
@@ -1,0 +1,581 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/signalridge/slipway/internal/model"
+	"github.com/signalridge/slipway/internal/perfbaseline"
+	"github.com/signalridge/slipway/internal/state"
+)
+
+const (
+	defaultWorktrees     = 25
+	defaultChanges       = 300
+	defaultVerifications = 100
+)
+
+type options struct {
+	mode          string
+	out           string
+	baseline      string
+	binary        string
+	fixtureRoot   string
+	keepFixture   bool
+	threshold     float64
+	worktrees     int
+	changes       int
+	verifications int
+	warmups       int
+	samples       int
+	checkAttempts int
+	stdout        io.Writer
+	stderr        io.Writer
+}
+
+type fixtureInfo struct {
+	root               string
+	boundWorktree      string
+	boundChangeSlug    string
+	explicitChangeSlug string
+}
+
+type generatedChange struct {
+	slug      string
+	bundleDir string
+}
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout, os.Stderr); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, stdout, stderr io.Writer) error {
+	opts, err := parseOptions(args, stdout, stderr)
+	if err != nil {
+		return err
+	}
+	switch opts.mode {
+	case "refresh":
+		return refresh(opts)
+	case "check":
+		return check(opts)
+	default:
+		return fmt.Errorf("unsupported -mode %q (expected refresh or check)", opts.mode)
+	}
+}
+
+func parseOptions(args []string, stdout, stderr io.Writer) (options, error) {
+	opts := options{
+		mode:          "refresh",
+		out:           "state-read-performance-baseline.json",
+		baseline:      "state-read-performance-baseline.json",
+		threshold:     perfbaseline.DefaultRegressionBudget,
+		worktrees:     defaultWorktrees,
+		changes:       defaultChanges,
+		verifications: defaultVerifications,
+		warmups:       1,
+		samples:       7,
+		checkAttempts: 3,
+		stdout:        stdout,
+		stderr:        stderr,
+	}
+	fs := flag.NewFlagSet("state-read-baseline", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.StringVar(&opts.mode, "mode", opts.mode, "mode: refresh or check")
+	fs.StringVar(&opts.out, "out", opts.out, "output path for refresh or current measurement path for check")
+	fs.StringVar(&opts.baseline, "baseline", opts.baseline, "baseline path used by check")
+	fs.StringVar(&opts.binary, "binary", "", "existing slipway binary to measure; defaults to building a temporary binary")
+	fs.StringVar(&opts.fixtureRoot, "fixture-root", "", "existing or new fixture root; defaults to a temporary directory")
+	fs.BoolVar(&opts.keepFixture, "keep-fixture", false, "keep generated temporary fixture after the command exits")
+	fs.Float64Var(&opts.threshold, "threshold", opts.threshold, "allowed real-time regression ratio")
+	fs.IntVar(&opts.worktrees, "worktrees", opts.worktrees, "minimum fixture worktree count")
+	fs.IntVar(&opts.changes, "changes", opts.changes, "minimum fixture change.yaml count")
+	fs.IntVar(&opts.verifications, "verifications", opts.verifications, "minimum fixture verification record count")
+	fs.IntVar(&opts.warmups, "warmups", opts.warmups, "warmup executions per measured command")
+	fs.IntVar(&opts.samples, "samples", opts.samples, "timed sample executions per measured command; the fastest sample is recorded")
+	fs.IntVar(&opts.checkAttempts, "check-attempts", opts.checkAttempts, "independent measurement attempts for check mode; any passing attempt satisfies the threshold")
+	if err := fs.Parse(args); err != nil {
+		return options{}, err
+	}
+	outProvided := flagProvided(fs, "out")
+	if opts.worktrees < 1 {
+		return options{}, errors.New("-worktrees must be positive")
+	}
+	if opts.changes < 2 {
+		return options{}, errors.New("-changes must be at least 2 to cover bound and explicit change scenarios")
+	}
+	if opts.verifications < 1 {
+		return options{}, errors.New("-verifications must be positive")
+	}
+	if opts.warmups < 0 {
+		return options{}, errors.New("-warmups must be non-negative")
+	}
+	if opts.samples < 1 {
+		return options{}, errors.New("-samples must be positive")
+	}
+	if opts.checkAttempts < 1 {
+		return options{}, errors.New("-check-attempts must be positive")
+	}
+	if opts.mode == "check" && !outProvided {
+		return options{}, errors.New("-out is required in check mode to avoid overwriting the committed baseline")
+	}
+	return opts, nil
+}
+
+func flagProvided(fs *flag.FlagSet, name string) bool {
+	provided := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == name {
+			provided = true
+		}
+	})
+	return provided
+}
+
+func refresh(opts options) error {
+	b, cleanup, err := measure(opts)
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if err != nil {
+		return err
+	}
+
+	var buf bytes.Buffer
+	if err := perfbaseline.Write(&buf, b); err != nil {
+		return err
+	}
+	if err := os.WriteFile(opts.out, buf.Bytes(), 0o600); err != nil {
+		return fmt.Errorf("write baseline %s: %w", opts.out, err)
+	}
+	fmt.Fprintf(opts.stdout, "wrote %s\n", opts.out)
+	return nil
+}
+
+func check(opts options) error {
+	baselineFile, err := os.Open(opts.baseline)
+	if err != nil {
+		return fmt.Errorf("open baseline %s: %w", opts.baseline, err)
+	}
+	defer func() { _ = baselineFile.Close() }()
+
+	baseline, err := perfbaseline.Read(baselineFile)
+	if err != nil {
+		return err
+	}
+
+	var lastRegressions []perfbaseline.Regression
+	for attempt := 1; attempt <= opts.checkAttempts; attempt++ {
+		current, cleanup, err := measure(opts)
+		if cleanup != nil {
+			cleanup()
+		}
+		if err != nil {
+			return err
+		}
+		regressions, err := perfbaseline.Compare(baseline, current, opts.threshold)
+		if err != nil {
+			return err
+		}
+		if len(regressions) == 0 {
+			return writeCheckResult(opts, current, attempt)
+		}
+		lastRegressions = regressions
+	}
+
+	for _, r := range lastRegressions {
+		fmt.Fprintf(
+			opts.stderr,
+			"%s regressed: baseline %.2fms, current %.2fms, allowed %.2fms (%.0f%%)\n",
+			r.CommandID,
+			r.BaselineMS,
+			r.CurrentMS,
+			r.AllowedMS,
+			r.ThresholdPct,
+		)
+	}
+	return fmt.Errorf("%d state-read command(s) exceeded regression threshold after %d attempt(s)", len(lastRegressions), opts.checkAttempts)
+}
+
+func writeCheckResult(opts options, current perfbaseline.Baseline, attempt int) error {
+	var buf bytes.Buffer
+	if err := perfbaseline.Write(&buf, current); err != nil {
+		return err
+	}
+	if err := os.WriteFile(opts.out, buf.Bytes(), 0o600); err != nil {
+		return fmt.Errorf("write current measurement %s: %w", opts.out, err)
+	}
+	fmt.Fprintf(opts.stdout, "state-read baseline check passed on attempt %d; wrote %s\n", attempt, opts.out)
+	return nil
+}
+
+func measure(opts options) (perfbaseline.Baseline, func(), error) {
+	binary, binaryCleanup, err := ensureBinary(opts)
+	if err != nil {
+		return perfbaseline.Baseline{}, nil, err
+	}
+
+	fixture, fixtureCleanup, err := ensureFixture(opts, binary)
+	if err != nil {
+		if binaryCleanup != nil {
+			binaryCleanup()
+		}
+		return perfbaseline.Baseline{}, nil, err
+	}
+	cleanup := func() {
+		if fixtureCleanup != nil {
+			fixtureCleanup()
+		}
+		if binaryCleanup != nil {
+			binaryCleanup()
+		}
+	}
+
+	commands := []perfbaseline.CommandMeasure{
+		{
+			ID:          "root-status-json",
+			Description: "root worktree: slipway status --json",
+			CWD:         fixture.root,
+			Args:        []string{"status", "--json"},
+		},
+		{
+			ID:          "bound-status-json",
+			Description: "bound worktree: slipway status --json",
+			CWD:         fixture.boundWorktree,
+			Args:        []string{"status", "--json"},
+		},
+		{
+			ID:          "bound-next-json-diagnostics",
+			Description: "bound worktree: slipway next --json --diagnostics",
+			CWD:         fixture.boundWorktree,
+			Args:        []string{"next", "--json", "--diagnostics"},
+		},
+		{
+			ID:          "bound-validate-json",
+			Description: "bound worktree: slipway validate --json",
+			CWD:         fixture.boundWorktree,
+			Args:        []string{"validate", "--json"},
+		},
+		{
+			ID:          "explicit-change-status-json",
+			Description: "root worktree: slipway status --json --change <slug>",
+			CWD:         fixture.root,
+			Args:        []string{"status", "--json", "--change", fixture.explicitChangeSlug},
+		},
+	}
+
+	for i := range commands {
+		measured, err := runMeasured(binary, commands[i], opts.warmups, opts.samples)
+		if err != nil {
+			cleanup()
+			return perfbaseline.Baseline{}, nil, err
+		}
+		commands[i] = measured
+	}
+	perfbaseline.SortCommands(commands)
+
+	b := perfbaseline.NewBaseline()
+	b.GitCommit = gitCommit()
+	b.GoVersion = runtime.Version()
+	b.SlipwayBinary = binary
+	b.RegressionBudget = opts.threshold
+	b.WarmupCount = opts.warmups
+	b.SampleCount = opts.samples
+	b.SampleStatistic = "fastest"
+	b.CheckAttempts = opts.checkAttempts
+	b.Fixture = perfbaseline.Fixture{
+		Root:                 fixture.root,
+		WorktreeCount:        opts.worktrees,
+		ChangeYAMLCount:      opts.changes,
+		VerificationCount:    opts.verifications,
+		BoundChangeSlug:      fixture.boundChangeSlug,
+		ExplicitChangeSlug:   fixture.explicitChangeSlug,
+		FixtureGenerationRef: "internal/perfbaseline/cmd/state-read-baseline",
+	}
+	b.Commands = commands
+	b.RefreshCommand = "go run ./internal/perfbaseline/cmd/state-read-baseline -mode refresh -out state-read-performance-baseline.json"
+	b.CheckCommand = "go run ./internal/perfbaseline/cmd/state-read-baseline -mode check -baseline state-read-performance-baseline.json -out /tmp/slipway-state-read-current.json"
+	if missing := perfbaseline.MissingRequiredCommands(b); len(missing) > 0 {
+		cleanup()
+		return perfbaseline.Baseline{}, nil, fmt.Errorf("missing required command measurements: %s", strings.Join(missing, ", "))
+	}
+	return b, cleanup, nil
+}
+
+func ensureBinary(opts options) (string, func(), error) {
+	if strings.TrimSpace(opts.binary) != "" {
+		abs, err := filepath.Abs(opts.binary)
+		if err != nil {
+			return "", nil, fmt.Errorf("resolve binary: %w", err)
+		}
+		return abs, nil, nil
+	}
+	dir, err := os.MkdirTemp("", "slipway-state-read-bin-*")
+	if err != nil {
+		return "", nil, fmt.Errorf("create binary tempdir: %w", err)
+	}
+	binary := filepath.Join(dir, binaryName())
+	cmd := exec.Command("go", "build", "-o", binary, ".") // #nosec G204 -- fixed go build invocation for the current trusted repository.
+	cmd.Stdout = opts.stdout
+	cmd.Stderr = opts.stderr
+	if err := cmd.Run(); err != nil {
+		_ = os.RemoveAll(dir)
+		return "", nil, fmt.Errorf("build slipway binary: %w", err)
+	}
+	return binary, func() { _ = os.RemoveAll(dir) }, nil
+}
+
+func ensureFixture(opts options, binary string) (fixtureInfo, func(), error) {
+	root := strings.TrimSpace(opts.fixtureRoot)
+	var cleanup func()
+	if root == "" {
+		dir, err := os.MkdirTemp("", "slipway-state-read-fixture-*")
+		if err != nil {
+			return fixtureInfo{}, nil, fmt.Errorf("create fixture tempdir: %w", err)
+		}
+		root = dir
+		if !opts.keepFixture {
+			cleanup = func() { _ = os.RemoveAll(dir) }
+		}
+	}
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		if cleanup != nil {
+			cleanup()
+		}
+		return fixtureInfo{}, nil, fmt.Errorf("resolve fixture root: %w", err)
+	}
+	if err := prepareFixture(abs, binary, opts); err != nil {
+		if cleanup != nil {
+			cleanup()
+		}
+		return fixtureInfo{}, nil, err
+	}
+	return fixtureInfo{
+		root:               abs,
+		boundWorktree:      filepath.Join(abs, ".worktrees", "perf-bound-change"),
+		boundChangeSlug:    "perf-bound-change",
+		explicitChangeSlug: "perf-explicit-change",
+	}, cleanup, nil
+}
+
+func prepareFixture(root, binary string, opts options) error {
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return fmt.Errorf("create fixture root: %w", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".git")); err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("stat fixture git dir: %w", err)
+		}
+		if err := runCommand(root, "git", "init"); err != nil {
+			return err
+		}
+		if err := runCommand(root, "git", "config", "user.email", "fixture@example.invalid"); err != nil {
+			return err
+		}
+		if err := runCommand(root, "git", "config", "user.name", "Slipway Fixture"); err != nil {
+			return err
+		}
+		if err := os.WriteFile(filepath.Join(root, "README.md"), []byte("state-read fixture\n"), 0o600); err != nil {
+			return fmt.Errorf("write fixture README: %w", err)
+		}
+		if err := runCommand(root, "git", "add", "README.md"); err != nil {
+			return err
+		}
+		if err := runCommand(root, "git", "commit", "-m", "fixture baseline"); err != nil {
+			return err
+		}
+	}
+	if err := model.SaveConfig(state.ConfigPath(root), model.DefaultConfig()); err != nil {
+		return fmt.Errorf("write fixture config: %w", err)
+	}
+	if err := ensureWorktrees(root, opts.worktrees); err != nil {
+		return err
+	}
+	changes, err := ensureChanges(root, opts)
+	if err != nil {
+		return err
+	}
+	if err := ensureVerificationRecords(changes, opts.verifications); err != nil {
+		return err
+	}
+	if _, err := os.Stat(binary); err != nil { // #nosec G703 -- binary is a local path explicitly selected by the operator or built in a private tempdir.
+		return fmt.Errorf("stat slipway binary %s: %w", binary, err)
+	}
+	return nil
+}
+
+func ensureWorktrees(root string, count int) error {
+	if count <= 1 {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Join(root, ".worktrees"), 0o700); err != nil {
+		return fmt.Errorf("create worktrees dir: %w", err)
+	}
+	for i := 1; i < count; i++ {
+		name := fmt.Sprintf("perf-wt-%02d", i)
+		path := filepath.Join(root, ".worktrees", name)
+		if _, err := os.Stat(path); err == nil {
+			continue
+		}
+		branch := "perf/" + name
+		if err := runCommand(root, "git", "worktree", "add", "-b", branch, path, "HEAD"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func ensureChanges(root string, opts options) ([]generatedChange, error) {
+	changes := make([]generatedChange, 0, opts.changes)
+	for i := 0; i < opts.changes; i++ {
+		slug := fmt.Sprintf("perf-change-%03d", i)
+		switch i {
+		case 0:
+			slug = "perf-bound-change"
+		case 1:
+			slug = "perf-explicit-change"
+		}
+		change := model.NewChange(slug)
+		change.Description = "state read fixture " + strconv.Itoa(i)
+		change.ArtifactSchema = model.ArtifactSchemaCore
+		change.WorkflowProfile = model.WorkflowProfileCode
+		change.WorkflowPreset = model.WorkflowPresetStandard
+		change.QualityMode = model.QualityModeStandard
+		change.CurrentState = model.StateS2Implement
+		if slug == "perf-bound-change" {
+			change.WorktreePath = filepath.Join(root, ".worktrees", slug)
+			if _, err := os.Stat(change.WorktreePath); os.IsNotExist(err) {
+				if err := runCommand(root, "git", "worktree", "add", "-b", "feat/"+slug, change.WorktreePath, "HEAD"); err != nil {
+					return nil, err
+				}
+			}
+		}
+		if err := state.SaveChange(root, change); err != nil {
+			return nil, fmt.Errorf("save fixture change %s: %w", slug, err)
+		}
+		bundleDir, err := state.GovernedBundleDir(root, change)
+		if err != nil {
+			return nil, fmt.Errorf("resolve fixture bundle %s: %w", slug, err)
+		}
+		changes = append(changes, generatedChange{
+			slug:      slug,
+			bundleDir: bundleDir,
+		})
+	}
+	return changes, nil
+}
+
+func ensureVerificationRecords(changes []generatedChange, count int) error {
+	if len(changes) == 0 {
+		return errors.New("verification records require at least one generated change slug")
+	}
+	for i := 0; i < count; i++ {
+		change := changes[i%len(changes)]
+		path := filepath.Join(change.bundleDir, "verification", fmt.Sprintf("skill-%03d.yaml", i))
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			return fmt.Errorf("create verification dir: %w", err)
+		}
+		raw := []byte(strings.Join([]string{
+			"verdict: pass",
+			"blockers: []",
+			"timestamp: 2026-01-01T00:00:00Z",
+			"run_version: 1",
+			"references:",
+			"  - fixture:state-read-baseline",
+			"notes: fixture verification record",
+			"",
+		}, "\n"))
+		if err := os.WriteFile(path, raw, 0o600); err != nil {
+			return fmt.Errorf("write verification %s: %w", path, err)
+		}
+	}
+	return nil
+}
+
+func runMeasured(binary string, measure perfbaseline.CommandMeasure, warmups, samples int) (perfbaseline.CommandMeasure, error) {
+	for i := 0; i < warmups; i++ {
+		if _, err := runSingleMeasurement(binary, measure); err != nil {
+			return measure, err
+		}
+	}
+	measurements := make([]perfbaseline.CommandMeasure, 0, samples)
+	for i := 0; i < samples; i++ {
+		measured, err := runSingleMeasurement(binary, measure)
+		if err != nil {
+			return measure, err
+		}
+		measurements = append(measurements, measured)
+	}
+	return fastestMeasurement(measurements), nil
+}
+
+func fastestMeasurement(measurements []perfbaseline.CommandMeasure) perfbaseline.CommandMeasure {
+	sort.Slice(measurements, func(i, j int) bool {
+		return measurements[i].RealMS < measurements[j].RealMS
+	})
+	return measurements[0]
+}
+
+func runSingleMeasurement(binary string, measure perfbaseline.CommandMeasure) (perfbaseline.CommandMeasure, error) {
+	cmd := exec.Command(binary, measure.Args...) // #nosec G204 G702 -- benchmark intentionally executes the selected local slipway binary with fixed scenario args.
+	cmd.Dir = measure.CWD
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	start := time.Now()
+	err := cmd.Run()
+	elapsed := time.Since(start)
+
+	measure.RealMS = float64(elapsed.Microseconds()) / 1000
+	if state := cmd.ProcessState; state != nil {
+		measure.ExitCode = state.ExitCode()
+		if userMS, systemMS, ok := processTimesMS(state); ok {
+			measure.UserMS = userMS
+			measure.SystemMS = systemMS
+		}
+	}
+	if err != nil {
+		return measure, fmt.Errorf("%s failed: %w: %s", measure.ID, err, strings.TrimSpace(stderr.String()))
+	}
+	return measure, nil
+}
+
+func runCommand(dir, name string, args ...string) error {
+	cmd := exec.Command(name, args...) // #nosec G204 -- caller supplies fixed git subcommands from this file's fixture builder.
+	cmd.Dir = dir
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%s %s failed: %w: %s", name, strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
+	}
+	return nil
+}
+
+func gitCommit() string {
+	out, err := exec.Command("git", "rev-parse", "HEAD").Output()
+	if err != nil {
+		return "unknown"
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func binaryName() string {
+	if runtime.GOOS == "windows" {
+		return "slipway.exe"
+	}
+	return "slipway"
+}

--- a/internal/perfbaseline/cmd/state-read-baseline/main_test.go
+++ b/internal/perfbaseline/cmd/state-read-baseline/main_test.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/signalridge/slipway/internal/perfbaseline"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrepareFixtureDoesNotCreateOrphanChangeBundles(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	binary := filepath.Join(root, binaryName())
+	require.NoError(t, os.WriteFile(binary, []byte("test binary"), 0o755))
+
+	opts := options{
+		worktrees:     2,
+		changes:       3,
+		verifications: 8,
+	}
+	require.NoError(t, prepareFixture(root, binary, opts))
+
+	changeDirs, err := os.ReadDir(filepath.Join(root, "artifacts", "changes"))
+	require.NoError(t, err)
+	for _, entry := range changeDirs {
+		if !entry.IsDir() || entry.Name() == "archived" {
+			continue
+		}
+		assert.FileExists(t, filepath.Join(root, "artifacts", "changes", entry.Name(), "change.yaml"))
+	}
+	assert.FileExists(t, filepath.Join(
+		root,
+		"artifacts",
+		"changes",
+		"perf-explicit-change",
+		"verification",
+		"skill-001.yaml",
+	))
+	assert.FileExists(t, filepath.Join(
+		root,
+		".worktrees",
+		"perf-bound-change",
+		"artifacts",
+		"changes",
+		"perf-bound-change",
+		"verification",
+		"skill-000.yaml",
+	))
+	assert.NoDirExists(t, filepath.Join(root, "artifacts", "changes", "perf-bound-change"))
+	assert.NoDirExists(t, filepath.Join(root, "artifacts", "changes", "perf-change-001"))
+}
+
+func TestEnsureVerificationRecordsRequiresGeneratedSlugs(t *testing.T) {
+	t.Parallel()
+
+	err := ensureVerificationRecords(nil, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one generated change slug")
+}
+
+func TestParseOptionsRequiresExplicitChangeCapacity(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseOptions([]string{"-changes", "1"}, io.Discard, io.Discard)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least 2")
+}
+
+func TestParseOptionsRequiresPositiveCheckAttempts(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseOptions([]string{"-check-attempts", "0"}, io.Discard, io.Discard)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "check-attempts")
+}
+
+func TestParseOptionsRequiresCheckOutput(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseOptions([]string{"-mode", "check"}, io.Discard, io.Discard)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "-out is required in check mode")
+}
+
+func TestRunMeasuredRecordsFastestSample(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	countFile := filepath.Join(root, "count")
+	measured, err := runMeasured(os.Args[0], commandMeasureForTest(root, countFile), 0, 3)
+	require.NoError(t, err)
+	assert.Greater(t, measured.RealMS, 0.0)
+
+	raw, err := os.ReadFile(countFile)
+	require.NoError(t, err)
+	assert.Equal(t, "3", string(raw))
+}
+
+func TestFastestMeasurementSelectsLowestRealTime(t *testing.T) {
+	t.Parallel()
+
+	fastest := fastestMeasurement([]perfbaseline.CommandMeasure{
+		{ID: "slow", RealMS: 150},
+		{ID: "fast", RealMS: 10},
+		{ID: "middle", RealMS: 50},
+	})
+
+	assert.Equal(t, "fast", fastest.ID)
+}
+
+func commandMeasureForTest(root, countFile string) perfbaseline.CommandMeasure {
+	return perfbaseline.CommandMeasure{
+		ID:   "test-measure",
+		CWD:  root,
+		Args: []string{"-test.run=TestMeasureHelperProcess", "--", countFile},
+	}
+}
+
+func TestMeasureHelperProcess(t *testing.T) {
+	separator := -1
+	for i, arg := range os.Args {
+		if arg == "--" {
+			separator = i
+			break
+		}
+	}
+	if separator == -1 || separator+1 >= len(os.Args) {
+		return
+	}
+
+	countFile := os.Args[separator+1]
+	count := 0
+	if raw, err := os.ReadFile(countFile); err == nil {
+		parsed, err := strconv.Atoi(string(raw))
+		if err == nil {
+			count = parsed
+		}
+	}
+	count++
+	if err := os.WriteFile(countFile, []byte(strconv.Itoa(count)), 0o600); err != nil {
+		os.Exit(1)
+	}
+	if count == 1 {
+		time.Sleep(150 * time.Millisecond)
+	} else {
+		time.Sleep(10 * time.Millisecond)
+	}
+	os.Exit(0)
+}

--- a/internal/perfbaseline/cmd/state-read-baseline/process_times_unix.go
+++ b/internal/perfbaseline/cmd/state-read-baseline/process_times_unix.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+func processTimesMS(state *os.ProcessState) (float64, float64, bool) {
+	usage, ok := state.SysUsage().(*syscall.Rusage)
+	if !ok {
+		return 0, 0, false
+	}
+	return durationMS(usage.Utime), durationMS(usage.Stime), true
+}
+
+func durationMS(tv syscall.Timeval) float64 {
+	return float64(tv.Sec)*1000 + float64(tv.Usec)/1000
+}

--- a/internal/perfbaseline/cmd/state-read-baseline/process_times_windows.go
+++ b/internal/perfbaseline/cmd/state-read-baseline/process_times_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package main
+
+import "os"
+
+func processTimesMS(state *os.ProcessState) (float64, float64, bool) {
+	return 0, 0, false
+}

--- a/state-read-performance-baseline.json
+++ b/state-read-performance-baseline.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-06-27T11:28:41.344586Z",
+  "git_commit": "b52a20732df75e378dc7526a9487b125bbf70453",
+  "go_version": "go1.26.4",
+  "slipway_binary": "/var/folders/k4/9ckhh39j3vv7d666qp4w7m880000gn/T/slipway-state-read-bin-3357840184/slipway",
+  "regression_budget": 0.3,
+  "warmup_count": 1,
+  "sample_count": 7,
+  "sample_statistic": "fastest",
+  "check_attempts": 3,
+  "fixture": {
+    "root": "/var/folders/k4/9ckhh39j3vv7d666qp4w7m880000gn/T/slipway-state-read-fixture-502104490",
+    "worktree_count": 25,
+    "change_yaml_count": 300,
+    "verification_count": 100,
+    "bound_change_slug": "perf-bound-change",
+    "explicit_change_slug": "perf-explicit-change",
+    "fixture_generation_ref": "internal/perfbaseline/cmd/state-read-baseline"
+  },
+  "commands": [
+    {
+      "id": "root-status-json",
+      "description": "root worktree: slipway status --json",
+      "cwd": "/var/folders/k4/9ckhh39j3vv7d666qp4w7m880000gn/T/slipway-state-read-fixture-502104490",
+      "args": [
+        "status",
+        "--json"
+      ],
+      "real_ms": 1424.889,
+      "user_ms": 379.118,
+      "system_ms": 1020.776,
+      "exit_code": 0
+    },
+    {
+      "id": "bound-status-json",
+      "description": "bound worktree: slipway status --json",
+      "cwd": "/var/folders/k4/9ckhh39j3vv7d666qp4w7m880000gn/T/slipway-state-read-fixture-502104490/.worktrees/perf-bound-change",
+      "args": [
+        "status",
+        "--json"
+      ],
+      "real_ms": 108.496,
+      "user_ms": 35.732,
+      "system_ms": 62.071,
+      "exit_code": 0
+    },
+    {
+      "id": "bound-next-json-diagnostics",
+      "description": "bound worktree: slipway next --json --diagnostics",
+      "cwd": "/var/folders/k4/9ckhh39j3vv7d666qp4w7m880000gn/T/slipway-state-read-fixture-502104490/.worktrees/perf-bound-change",
+      "args": [
+        "next",
+        "--json",
+        "--diagnostics"
+      ],
+      "real_ms": 112.91,
+      "user_ms": 39.508,
+      "system_ms": 61.995,
+      "exit_code": 0
+    },
+    {
+      "id": "bound-validate-json",
+      "description": "bound worktree: slipway validate --json",
+      "cwd": "/var/folders/k4/9ckhh39j3vv7d666qp4w7m880000gn/T/slipway-state-read-fixture-502104490/.worktrees/perf-bound-change",
+      "args": [
+        "validate",
+        "--json"
+      ],
+      "real_ms": 94.032,
+      "user_ms": 35.992,
+      "system_ms": 55.291,
+      "exit_code": 0
+    },
+    {
+      "id": "explicit-change-status-json",
+      "description": "root worktree: slipway status --json --change \u003cslug\u003e",
+      "cwd": "/var/folders/k4/9ckhh39j3vv7d666qp4w7m880000gn/T/slipway-state-read-fixture-502104490",
+      "args": [
+        "status",
+        "--json",
+        "--change",
+        "perf-explicit-change"
+      ],
+      "real_ms": 90.746,
+      "user_ms": 30.032,
+      "system_ms": 50.589,
+      "exit_code": 0
+    }
+  ],
+  "refresh_command": "go run ./internal/perfbaseline/cmd/state-read-baseline -mode refresh -out state-read-performance-baseline.json",
+  "check_command": "go run ./internal/perfbaseline/cmd/state-read-baseline -mode check -baseline state-read-performance-baseline.json -out /tmp/slipway-state-read-current.json"
+}


### PR DESCRIPTION
## Summary
- add an internal state-read performance baseline model and CLI
- commit an initial baseline artifact for key lifecycle read paths
- document refresh/check workflow, including explicit check output safety
- archive governed change add-state-read-performance-baseline

## Verification
- go test ./internal/perfbaseline ./internal/perfbaseline/cmd/state-read-baseline -count=1
- go test ./... -count=1
- go run ./internal/perfbaseline/cmd/state-read-baseline -mode check (expected failure without -out)
- go run ./internal/perfbaseline/cmd/state-read-baseline -mode check -baseline state-read-performance-baseline.json -out artifacts/changes/add-state-read-performance-baseline/verification/ship-state-read-current.json
- slipway validate --json: G_ship approved before done

Ignored local verification/events artifacts were not committed.