### PR TITLE
perf(state): complete state read fast paths

### DIFF
--- a/artifacts/changes/archived/complete-state-read-fast-paths/assurance.md
+++ b/artifacts/changes/archived/complete-state-read-fast-paths/assurance.md
@@ -1,0 +1,73 @@
+# Assurance
+
+## Scope Summary
+
+This change completes `opt.md` state-read performance items 4.2, 4.3, and 4.4
+in one governed implementation:
+
+- `next` and `validate` now reuse command-scoped verification inventory through
+  `stateReadContext` when evaluating governance readiness, matching the existing
+  `status` path.
+- successful explicit `--change <slug>` paths for `status`, `next`, and
+  `validate` are regression-tested against an unrelated orphaned active bundle
+  that would fail a broad active-change scan.
+- default status timeline rendering is regression-tested as a bounded tail read
+  while full lifecycle log integrity remains fail-closed.
+
+No persistent index, cross-command cache, compatibility layer, schema migration,
+or unrelated lifecycle repair was added.
+
+## Verification Verdict
+
+Implementation verification passed. Targeted command/state/progression tests and
+the full repository test suite completed successfully.
+
+## Evidence Index
+
+- `artifacts/changes/complete-state-read-fast-paths/verification/implementation-verification.md`
+- `artifacts/changes/complete-state-read-fast-paths/verification/wave-orchestration-notes.md`
+- Runtime task evidence:
+  - `.git/slipway/runtime/changes/complete-state-read-fast-paths/evidence/tasks/t-01.json`
+  - `.git/slipway/runtime/changes/complete-state-read-fast-paths/evidence/tasks/t-02.json`
+  - `.git/slipway/runtime/changes/complete-state-read-fast-paths/evidence/tasks/t-03.json`
+  - `.git/slipway/runtime/changes/complete-state-read-fast-paths/evidence/tasks/t-04.json`
+- Commands:
+  - `go test ./cmd ./internal/engine/progression -count=1`
+  - `go test ./cmd -run 'Test(ResolveExplicitChange|ValidateChangeFlag|ExplicitChangeCommandsUseFastPathWhenOtherBundleIsOrphaned|BuildGovernedStatusView|StatusDirectExecutionView)' -count=1`
+  - `go test ./cmd ./internal/state -run 'Test(StatusExplicitChangeUsesBoundedTimelineTail|ReadLifecycleEventTail|ReadLifecycleEvents|StatusViewIncludesLifecycleTimeline|StatusTimeline)' -count=1`
+  - `go test ./cmd ./internal/state ./internal/engine/progression -count=1`
+  - `go test ./... -count=1`
+
+## Requirement Coverage
+
+- REQ-001: covered by `cmd/next.go`, `cmd/validate.go`, existing
+  `cmd/status_view_build.go`, and targeted command/progression tests.
+- REQ-002: covered by
+  `TestExplicitChangeCommandsUseFastPathWhenOtherBundleIsOrphaned` plus the
+  existing explicit missing/archived resolver tests.
+- REQ-003: covered by `TestStatusExplicitChangeUsesBoundedTimelineTail` and
+  existing lifecycle event tail tests in `internal/state`.
+- REQ-004: covered by existing bound-worktree, archived, missing, no-active, and
+  multi-active resolver/status tests included in the targeted package suite.
+
+## Residual Risks and Exceptions
+
+No residual blocker is accepted. The primary residual risk is performance
+coverage granularity: this change proves narrow read paths through behavioral
+regression tests rather than adding a persistent benchmark gate. That is
+intentional because the selected approach avoids persistent caches and keeps
+state authority fresh per command invocation.
+
+## Rollback Readiness
+
+Rollback is a normal git revert of this implementation and artifact commit. No
+data migration, persistent cache, index, or cleanup step is required. Re-run
+`go test ./cmd ./internal/state ./internal/engine/progression -count=1` and
+`go test ./... -count=1` after rollback if needed.
+
+## Archive Decision
+
+Archive readiness is pending S3 review convergence and terminal
+ship-verification. Active `validate --json` currently proves the implementation
+is in `S3_REVIEW` with `G_plan` and `G_scope` approved; final active validation
+must be captured again immediately before `done`.

--- a/artifacts/changes/archived/complete-state-read-fast-paths/change.yaml
+++ b/artifacts/changes/archived/complete-state-read-fast-paths/change.yaml
@@ -1,0 +1,60 @@
+version: 1
+slug: complete-state-read-fast-paths
+description: complete state read fast paths
+status: done
+current_state: DONE
+needs_discovery: true
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-06-27T13:41:25.278979Z
+quality_mode: standard
+workflow_profile: code
+workflow_preset: standard
+worktree_branch: feat/complete-state-read-fast-paths
+artifact_schema: expanded
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: 97607c561cedc9d102ce61bc3b1cefb5513dab5204704fad3e28071c210ab28f
+        updated_at: 2026-06-27T14:06:18.31274765Z
+    decision:
+        id: decision
+        path: decision.md
+        state: frozen
+        content_hash: e335a0d70477650f6530d205f8cd7472f59dfcbea430c4c3144ecbf6f8d94d99
+        updated_at: 2026-06-27T13:46:17.370945152Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: 86987bd0493dc1154ac3a2be0807df5a47125cdfa88d52dde672dc7c29631a27
+        updated_at: 2026-06-27T13:42:46.41663667Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: ba8e7c301d0602d0c62207df441c111a7744ecd1a5071f80ff147225ee6d8183
+        updated_at: 2026-06-27T13:46:17.370526695Z
+    research:
+        id: research
+        path: research.md
+        state: frozen
+        content_hash: 8c579a66ac05f7d3dac4a0215b8812ea033f4f74537b68ccc9de8861be90b13a
+        updated_at: 2026-06-27T13:45:06.977406508Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: 33c698ebfef061b7016c5289bb9b8da7147a04e47af06d0151721a1deebd3cd1
+        updated_at: 2026-06-27T14:05:34.926546641Z
+evidence_refs:
+    code-quality-review: .worktrees/complete-state-read-fast-paths/artifacts/changes/complete-state-read-fast-paths/verification/code-quality-review.yaml
+    independent-review: .worktrees/complete-state-read-fast-paths/artifacts/changes/complete-state-read-fast-paths/verification/independent-review.yaml
+    intake-clarification: .worktrees/complete-state-read-fast-paths/artifacts/changes/complete-state-read-fast-paths/verification/intake-clarification.yaml
+    plan-audit: .worktrees/complete-state-read-fast-paths/artifacts/changes/complete-state-read-fast-paths/verification/plan-audit.yaml
+    research-orchestration: .worktrees/complete-state-read-fast-paths/artifacts/changes/complete-state-read-fast-paths/verification/research-orchestration.yaml
+    ship-verification: .worktrees/complete-state-read-fast-paths/artifacts/changes/complete-state-read-fast-paths/verification/ship-verification.yaml
+    spec-compliance-review: .worktrees/complete-state-read-fast-paths/artifacts/changes/complete-state-read-fast-paths/verification/spec-compliance-review.yaml
+    wave-orchestration: .worktrees/complete-state-read-fast-paths/artifacts/changes/complete-state-read-fast-paths/verification/wave-orchestration.yaml

--- a/artifacts/changes/archived/complete-state-read-fast-paths/decision.md
+++ b/artifacts/changes/archived/complete-state-read-fast-paths/decision.md
@@ -1,0 +1,61 @@
+# Decision
+
+## Alternatives Considered
+
+1. Complete the existing invocation-local read context.
+   - Pros: small blast radius, matches current code structure, preserves
+     `internal/state` as the read layer, and avoids cross-command authority.
+   - Cons: requires focused seams/tests to prove successful explicit paths avoid
+     global scans.
+2. Add a persistent workspace index.
+   - Pros: could improve repeated command latency across invocations.
+   - Cons: introduces stale authority risk, cache invalidation complexity, and
+     violates the scope constraint against persistent caches.
+3. Optimize only `status`.
+   - Pros: fastest path to visible timeline and status latency improvements.
+   - Cons: fails the requirement that `status`, `next`, and `validate` share
+     read-context improvements.
+
+## Selected Approach
+
+Select option 1. Extend the existing `stateReadContext` and direct state helper
+usage only where required to complete `opt.md` 4.2, 4.3, and 4.4. Do not retain
+compatibility wrappers for replaced behavior, and do not introduce persistent
+indexes or cross-command caches.
+
+## Interfaces and Data Flow
+
+- `cmd/state_read_context.go` remains the command-scoped read reuse boundary.
+- `cmd/status.go`, `cmd/next.go`, `cmd/validate.go`, and shared command
+  resolvers should pass the same read context through one command invocation.
+- `internal/state/store.go` continues to own `LoadChangeFast`, bundle
+  discovery, and fail-closed state authority.
+- `internal/state/verification.go` continues to own verification inventory
+  parsing, with resolved-change reads preferred after authority is known.
+- `internal/state/lifecycle_event.go` continues to own bounded lifecycle tail
+  decoding for display surfaces and full-log decoding for integrity surfaces.
+
+## Rollout and Rollback
+
+Rollout is source-only and covered by tests. Rollback is a normal git revert of
+the implementation commit; because no persistent cache or schema migration is
+introduced, rollback has no data cleanup step.
+
+Verification command for rollback safety:
+
+```bash
+go test ./cmd ./internal/state ./internal/engine/progression -count=1
+go test ./... -count=1
+```
+
+## Risk
+
+- Risk: over-caching within a command could serve stale data after a mutating
+  operation. Mitigation: keep the context command-scoped and invalidate dependent
+  caches on explicit reload.
+- Risk: fast paths could skip archived or hidden sibling checks. Mitigation:
+  preserve existing explicit resolver fallback behavior and add regression
+  tests for missing/archived semantics.
+- Risk: tail timeline reads could hide malformed older entries. Mitigation:
+  use tail reads only for bounded display and keep full-log validation on
+  integrity/health surfaces.

--- a/artifacts/changes/archived/complete-state-read-fast-paths/intent.md
+++ b/artifacts/changes/archived/complete-state-read-fast-paths/intent.md
@@ -1,0 +1,78 @@
+# Intent
+
+## Summary
+Complete the remaining required state-read performance work from `opt.md` by
+implementing a single-invocation read context, explicit `--change` fast paths,
+and tail-oriented status timeline reads.
+
+## Complexity Assessment
+complex
+
+Rationale: this touches public lifecycle read paths used by `status`, `next`,
+and `validate`, and must preserve bound worktree, archived change, missing slug,
+multi-active, and no-active fail-closed semantics while reducing redundant reads.
+
+## Guardrail Domains
+<!-- none detected -->
+
+## In Scope
+- Implement a command-scoped state/read context for `status`, `next`, and
+  `validate` that reuses facts discovered during the current invocation only.
+- Reuse git root/common-dir/workspace discovery, worktree list parsing,
+  invocation route, loaded `change.yaml`, resolved change paths, verification
+  records, lifecycle event path, and status timeline reads within one command.
+- Add an explicit `--change <slug>` fast path so successful explicit reads avoid
+  scanning all change bundles unless fallback or diagnostics require it.
+- Add a tail-oriented lifecycle timeline read for `status` so rendering the last
+  N events does not require decoding the full lifecycle log.
+- Add targeted tests and performance-sensitive regression coverage for the above
+  without changing lifecycle authority semantics.
+
+## Out of Scope
+- Persistent cross-command caches or durable indexes.
+- Compatibility layers for retired read paths or legacy route contracts.
+- Release/supply-chain hardening from `opt.md` section 2.
+- P0 lifecycle route/freshness/action/capability semantic repairs from
+  `opt.md` section 1, except where preserving current semantics is required.
+- Lifecycle append crash-safety, fsync, compaction, or JSONL rewrite semantics.
+
+## Constraints
+- Current worktree Slipway behavior is the authority; do not substitute
+  remembered workflows or source-derived guesses for CLI output.
+- No compatibility layer should be retained for removed or replaced
+  implementations.
+- Cache lifetime must be a single CLI invocation and must fail closed to fresh
+  reads rather than serving stale lifecycle authority.
+- Preserve unrelated dirty and ignored files.
+
+## Acceptance Signals
+- `status`, `next`, and `validate` share a single invocation route/read context
+  in the successful bound-worktree paths.
+- `status/next/validate --change <slug>` no longer scan all 300+ change bundles
+  for the ordinary successful explicit-slug path.
+- Missing explicit slug still fails closed with `change_not_found` semantics.
+- Archived, bound elsewhere, no-active, and multi-active behavior do not regress.
+- `status` timeline tail rendering reads only the required tail for normal
+  bounded display while malformed logs still fail closed.
+- Targeted tests and `go test ./... -count=1` pass.
+
+## Open Questions
+<!-- Track real unknowns as a checklist. An unchecked `- [ ]` item is unresolved
+     and routes intake to S0_INTAKE/research; mark `- [x]` once resolved. Leave the
+     section empty (or write `None`) when there are none. Prose here is
+     documentation, not a blocker — a genuine open question must be a `- [ ]`. -->
+None
+
+## Deferred Ideas
+- Persistent workspace index or daemon-backed cache.
+- Lifecycle log compaction or append durability redesign.
+- Broader public-surface coverage gate changes beyond tests required for this
+  state-read optimization.
+
+## Approved Summary
+Approved in-session by the user's standing confirmation on 2026-06-27:
+implement the remaining `opt.md` state-read performance items 4.2, 4.3, and
+4.4 as one coherent change. The change will add command-scoped read-context
+reuse, explicit `--change` fast paths, and status timeline tail reads while
+preserving fail-closed lifecycle semantics. It will not add compatibility
+layers, persistent caches, release hardening, or unrelated P0 lifecycle repairs.

--- a/artifacts/changes/archived/complete-state-read-fast-paths/requirements.md
+++ b/artifacts/changes/archived/complete-state-read-fast-paths/requirements.md
@@ -1,0 +1,64 @@
+# Requirements
+
+## Requirements
+
+### Requirement: Invocation-scoped read context reuse
+REQ-001: The system MUST reuse state-read facts discovered during one
+`status`, `next`, or `validate` invocation for that invocation only, including
+loaded change authority, resolved change paths, verification inventory, and
+display timeline reads.
+
+#### Scenario: Reuse within one command
+GIVEN a command has already loaded a governed change and resolved its paths
+WHEN the same command builds downstream status, next, or validate views for that change
+THEN the command reuses the invocation-scoped read context instead of repeating equivalent state discovery.
+
+#### Scenario: No cross-command cache
+GIVEN a command has completed
+WHEN a later command reads the same change
+THEN it starts from fresh state authority and does not reuse a prior command's cached facts.
+
+### Requirement: Explicit change fast path
+REQ-002: The system MUST use a narrow authority-known fast path for successful
+`--change <slug>` reads and MUST avoid scanning all change bundles on the
+ordinary successful explicit-slug path.
+
+#### Scenario: Successful explicit slug
+GIVEN a valid active change slug is passed to `status`, `next`, or `validate`
+WHEN the command can load the change from invocation-local or bound authority
+THEN the command completes without enumerating every active change bundle.
+
+#### Scenario: Missing explicit slug
+GIVEN an explicit slug that does not name an active or archived change
+WHEN `status`, `next`, or `validate` resolves that slug
+THEN the command fails closed with stable `change_not_found` semantics and exit code 3.
+
+### Requirement: Tail-oriented status timeline read
+REQ-003: The system MUST use a bounded tail read for status timeline display
+and MUST preserve fail-closed malformed-log behavior for retained lines and
+full-log integrity surfaces.
+
+#### Scenario: Status displays recent events
+GIVEN a lifecycle event log with many historical entries
+WHEN `status` renders the default bounded timeline
+THEN it reads and decodes only the bounded tail plus required predecessor transition context.
+
+#### Scenario: Malformed retained line
+GIVEN the retained timeline tail or required predecessor context contains malformed JSON
+WHEN `status` builds its timeline
+THEN the command returns a lifecycle event log read error instead of silently skipping the malformed line.
+
+### Requirement: Existing lifecycle semantics preserved
+REQ-004: The system MUST preserve existing bound-worktree, archived-change,
+missing explicit slug, no-active, and multi-active fail-closed semantics while
+optimizing reads.
+
+#### Scenario: Archived local worktree
+GIVEN an invocation runs from an archived change worktree
+WHEN status, next, or validate resolves lifecycle authority
+THEN archived-local behavior remains preferred over unrelated active changes.
+
+#### Scenario: Multi-active root
+GIVEN the root workspace has multiple active changes
+WHEN an unscoped command needs lifecycle authority
+THEN the command continues to report the existing multi-active remediation rather than selecting one implicitly.

--- a/artifacts/changes/archived/complete-state-read-fast-paths/research.md
+++ b/artifacts/changes/archived/complete-state-read-fast-paths/research.md
@@ -1,0 +1,109 @@
+# Research
+
+## Alternatives Considered
+
+### Architecture
+- Affected modules: `cmd/state_read_context.go`, `cmd/status.go`,
+  `cmd/next.go`, `cmd/validate.go`, `cmd/common.go`,
+  `internal/state/store.go`, `internal/state/verification.go`, and
+  `internal/state/lifecycle_event.go`.
+- Dependency chains: CLI commands call `stateReadContext`, which delegates to
+  `internal/state` for authoritative reads; governance readiness still calls
+  `internal/engine/progression`, which reads verification data through
+  `internal/state`.
+- Blast radius: limited to read assembly and state read helpers. Mutation
+  paths, lifecycle append semantics, and durable authority stay unchanged.
+- Constraints: `internal/state` must remain below `internal/engine`; the read
+  context must not become a persistent cache; missing explicit slug and archived
+  semantics must continue to fail closed.
+
+### Patterns
+- Existing conventions: current code already uses `stateReadContext` for
+  `loadChange`, `reloadChange`, `resolvedPaths`, `verificationRecords`, and
+  `loadExecution`.
+- Reusable abstractions: `state.LoadChangeFast` already prioritizes
+  invocation-local/bound authority before falling back to full workspace scans;
+  `state.ListVerificationsForChange` avoids slug-based rediscovery after a
+  change is resolved; `state.ReadLifecycleEventTailWithPredecessorTransition`
+  provides status-display tail reads.
+- Convention deviations: some readiness code still calls `progression` directly
+  and therefore cannot reuse command-local verification inventory without an
+  additional option or adapter. That should be handled as a focused extension,
+  not by making `internal/state` depend on engine types.
+
+### Risks
+- Technical risks:
+  - medium: caching route or verification data can mask malformed or stale
+    authority if reused after a mutation inside the same command.
+  - medium: explicit `--change` fast paths can accidentally skip hidden sibling
+    or archived checks that currently fail closed.
+  - low: status tail reads can under-report malformed old log lines if used in
+    health/repair surfaces. The current tail helper should remain display-only.
+- Guardrail domains: no sensitive auth, financial, credentials, or schema
+  migration domain is touched.
+- Reversibility: changes are localized and reversible by removing read-context
+  reuse and falling back to existing direct state reads.
+
+### Test Strategy
+- Existing coverage: `cmd/state_read_context_test.go` covers change/path cache
+  behavior; `internal/state/lifecycle_event_test.go` covers tail reads and
+  malformed retained lines; `cmd/common_test.go` and
+  `cmd/resolve_explicit_change_authority_test.go` cover explicit missing and
+  archived semantics.
+- Infrastructure needs: add small instrumentation seams or test-only counters
+  around state-read context operations rather than broad benchmark-only tests.
+- Verification approach: targeted tests should prove explicit successful
+  `--change` paths avoid global scans, read context reuses loaded change/paths/
+  verification data within a command, and status timeline reads use bounded tail
+  behavior while preserving malformed retained-line failures.
+
+### Options
+- Option 1: Incrementally complete the existing invocation read context.
+  - Design: extend the existing `stateReadContext` and nearby state helpers just
+    enough to cover route/worktree-list reuse, explicit-slug fast path tests,
+    verification reuse, and status timeline tail behavior.
+  - Tradeoffs: smallest blast radius and best fit with current code; may leave
+    deeper `progression` readiness reuse for a separate focused seam if it would
+    require broad engine API churn.
+- Option 2: Build a persistent workspace index.
+  - Design: write an index of worktrees, bundles, verification inventory, and
+    timeline metadata that commands can reuse across invocations.
+  - Tradeoffs: could improve repeated command latency, but violates this
+    change's constraint against cross-command authority caches and introduces
+    staleness/invalidation risk.
+- Option 3: Optimize only status display.
+  - Design: stop after tail timeline reads and explicit status fast path.
+  - Tradeoffs: low risk, but fails `opt.md` because `next` and `validate` would
+    continue to duplicate reads and explicit `--change` behavior would remain
+    under-proven.
+- Selected: Option 1. It completes the required 4.2/4.3/4.4 state-read scope
+  without adding compatibility layers or persistent authority.
+
+## Unknowns
+- Resolved: whether tail lifecycle reads already exist -> yes,
+  `internal/state/lifecycle_event.go` provides bounded tail helpers and tests.
+- Resolved: whether explicit `--change` has a fast load primitive -> yes,
+  `state.LoadChangeFast` exists and is used by `stateReadContext.loadChange`.
+- Remaining: exact implementation gap will be finalized in plan audit after
+  measuring which paths still call global scans in successful explicit cases.
+
+## Assumptions
+- The current codebase map is relevant to this scope because it names the exact
+  state-read hot paths and tests for this change.
+- `opt.md` remains the authoritative scope source for 4.2, 4.3, and 4.4.
+- Existing P0 lifecycle semantics are load-bearing and must be preserved rather
+  than redefined in this performance change.
+
+## Canonical References
+- `opt.md`
+- `artifacts/codebase/ARCHITECTURE.md`
+- `artifacts/codebase/TESTING.md`
+- `artifacts/codebase/CONCERNS.md`
+- `cmd/state_read_context.go`
+- `cmd/status.go`
+- `cmd/next.go`
+- `cmd/validate.go`
+- `cmd/common.go`
+- `internal/state/store.go`
+- `internal/state/verification.go`
+- `internal/state/lifecycle_event.go`

--- a/artifacts/changes/archived/complete-state-read-fast-paths/tasks.md
+++ b/artifacts/changes/archived/complete-state-read-fast-paths/tasks.md
@@ -1,0 +1,56 @@
+# Tasks
+
+## Task List
+
+- [x] `t-01` Complete invocation-scoped read context reuse in command read paths.
+  - depends_on: []
+  - target_files: [`cmd/state_read_context.go`, `cmd/status.go`, `cmd/next.go`, `cmd/validate.go`, `cmd/common.go`]
+  - task_kind: code
+  - covers: [REQ-001, REQ-004]
+  - acceptance:
+    - `status`, `next`, and `validate` pass one invocation-scoped read context through downstream lifecycle authority, path, verification, and display reads.
+    - A completed command does not persist or reuse read-context facts across later command invocations.
+    - Existing bound-worktree, archived-local, no-active, and multi-active authority semantics remain unchanged.
+  - evidence:
+    - Targeted tests in `cmd/state_read_context_test.go` demonstrate in-command reuse and no cross-command cache.
+    - Targeted command tests continue to pass for bound, archived, missing, no-active, and multi-active lifecycle authority cases.
+
+- [x] `t-02` Add explicit `--change` fast-path coverage and preserve missing/archived semantics.
+  - depends_on: [`t-01`]
+  - target_files: [`cmd/state_read_context_test.go`, `cmd/common_test.go`, `cmd/status_context_repair_test.go`, `cmd/resolve_explicit_change_authority_test.go`]
+  - task_kind: test
+  - covers: [REQ-002, REQ-004]
+  - acceptance:
+    - Successful explicit `--change <slug>` reads for `status`, `next`, and `validate` avoid enumerating every active change bundle.
+    - Missing explicit slugs still return stable `change_not_found` semantics and exit code 3.
+    - Archived explicit and archived-local resolution behavior stays preferred over unrelated active changes.
+  - evidence:
+    - Targeted tests use instrumentation or focused fixtures to prove the successful explicit-slug path does not call the broad active-change scan.
+    - Existing and new resolver tests pass in `cmd/common_test.go`, `cmd/status_context_repair_test.go`, and `cmd/resolve_explicit_change_authority_test.go`.
+
+- [x] `t-03` Verify and complete tail-oriented status timeline reads.
+  - depends_on: [`t-01`]
+  - target_files: [`cmd/status_view_build.go`, `cmd/status_context_repair_test.go`, `internal/state/lifecycle_event.go`, `internal/state/lifecycle_event_test.go`]
+  - task_kind: code
+  - covers: [REQ-003, REQ-004]
+  - acceptance:
+    - Default `status` timeline display uses a bounded lifecycle-event tail read plus required predecessor transition context.
+    - Malformed JSON in the retained tail or predecessor context still fails closed with a lifecycle event log read error.
+    - Full-log integrity readers remain available for health, repair, or verification surfaces and are not replaced by display-only tail reads.
+  - evidence:
+    - `internal/state/lifecycle_event_test.go` covers bounded tail reads and malformed retained-line failures.
+    - `cmd/status_context_repair_test.go` or an equivalent command-level test proves the status display path uses the bounded timeline read.
+
+- [x] `t-04` Run targeted and full verification, including performance-sensitive state-read checks.
+  - depends_on: [`t-01`, `t-02`, `t-03`]
+  - target_files: [`artifacts/changes/complete-state-read-fast-paths/verification/implementation-verification.md`]
+  - task_kind: verification
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004]
+  - acceptance:
+    - Targeted command/state/progression packages pass after implementation.
+    - Full repository tests pass or any failure is documented as unrelated with a targeted rerun showing this change is not the cause.
+    - Verification notes record commands, outcomes, and any residual risk.
+  - evidence:
+    - `go test ./cmd ./internal/state ./internal/engine/progression -count=1`
+    - `go test ./... -count=1`
+    - `artifacts/changes/complete-state-read-fast-paths/verification/implementation-verification.md`

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -218,6 +218,57 @@ func TestValidateChangeFlagRejectsArchivedSlugWithConcreteDiagnostic(t *testing.
 	assert.NotContains(t, out.String(), "no active change or ambiguous")
 }
 
+func TestExplicitChangeCommandsUseFastPathWhenOtherBundleIsOrphaned(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	ensureTestGitRepo(t, root)
+	initTestWorkspace(t, root)
+
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "explicit fast path target")
+	orphanDir := filepath.Join(root, "artifacts", "changes", "orphaned-active-bundle")
+	require.NoError(t, os.MkdirAll(orphanDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(orphanDir, "notes.md"), []byte("orphaned\n"), 0o644))
+
+	t.Run("status", func(t *testing.T) {
+		cmd := commandForRoot(t, root, makeStatusCmd())
+		cmd.SetArgs([]string{"--json", "--change", slug})
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+
+		require.NoError(t, cmd.Execute())
+
+		var view statusView
+		require.NoError(t, json.Unmarshal(out.Bytes(), &view))
+		assert.Equal(t, slug, view.Slug)
+	})
+
+	t.Run("next", func(t *testing.T) {
+		cmd := commandForRoot(t, root, makeNextCmd())
+		cmd.SetArgs([]string{"--json", "--change", slug})
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+
+		require.NoError(t, cmd.Execute())
+
+		var view nextView
+		require.NoError(t, json.Unmarshal(out.Bytes(), &view))
+		assert.Equal(t, slug, view.Slug)
+	})
+
+	t.Run("validate", func(t *testing.T) {
+		cmd := commandForRoot(t, root, makeValidateCmd())
+		cmd.SetArgs([]string{"--json", "--change", slug})
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+
+		require.NoError(t, cmd.Execute())
+
+		var view validateView
+		require.NoError(t, json.Unmarshal(out.Bytes(), &view))
+		assert.Equal(t, slug, view.Slug)
+	})
+}
+
 func TestResolveExplicitChangeSurfacesCorruptState(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()

--- a/cmd/next.go
+++ b/cmd/next.go
@@ -510,6 +510,10 @@ func buildNextViewForCommandWithReadContext(readCtx *stateReadContext, ref chang
 		view.PresetUpgradeReasons = presetFields.PresetUpgradeReasons
 		view.GovernanceForecast = presetFields.GovernanceForecast
 
+		verificationRecords, err := readCtx.verificationRecords(*governedChange)
+		if err != nil {
+			return nextView{}, wrapGovernanceReadinessError("evaluate next skill evidence", ref.Slug, err)
+		}
 		readiness, err := progression.EvaluateGovernanceReadiness(
 			root,
 			*governedChange,
@@ -518,6 +522,7 @@ func buildNextViewForCommandWithReadContext(readCtx *stateReadContext, ref chang
 				// Next needs projected artifact context for rendering, but keeps the
 				// reconcile read-only by requesting only the in-memory projection.
 				IncludeArtifactProjection: true,
+				VerificationRecords:       verificationRecords,
 			},
 		)
 		if err != nil {

--- a/cmd/status_context_repair_test.go
+++ b/cmd/status_context_repair_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -371,6 +372,56 @@ func TestBuildGovernedStatusViewPlanAuditKeepsNextAction(t *testing.T) {
 	view, err := buildStatusViewFromChange(root, change)
 	require.NoError(t, err)
 	assert.Contains(t, view.NextReadyActions, "next")
+}
+
+func TestStatusExplicitChangeUsesBoundedTimelineTail(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	ensureTestGitRepo(t, root)
+	initTestWorkspace(t, root)
+
+	change := model.NewChange("status-bounded-tail")
+	change.CurrentState = model.StateS1Plan
+	change.PlanSubStep = model.PlanSubStepAudit
+	require.NoError(t, state.SaveChange(root, change))
+
+	logPath, err := state.LifecycleEventLogPath(root, change)
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(logPath), 0o755))
+	payload := []byte("{not-json}\n")
+	for i := 0; i < 450; i++ {
+		line, err := json.Marshal(state.LifecycleEvent{
+			Version:     1,
+			EventID:     fmt.Sprintf("tail-event-%03d", i),
+			ChangeSlug:  change.Slug,
+			OccurredAt:  time.Date(2026, 6, 27, 12, 0, i%60, 0, time.UTC),
+			Command:     "run",
+			EventType:   "skill.evidence_recorded",
+			Result:      "recorded",
+			BeforeState: model.StateS1Plan,
+			AfterState:  model.StateS1Plan,
+		})
+		require.NoError(t, err)
+		payload = append(payload, line...)
+		payload = append(payload, '\n')
+	}
+	require.NoError(t, os.WriteFile(logPath, payload, 0o644))
+
+	cmd := commandForRoot(t, root, makeStatusCmd())
+	cmd.SetArgs([]string{"--json", "--change", change.Slug})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	require.NoError(t, cmd.Execute())
+
+	var view statusView
+	require.NoError(t, json.Unmarshal(out.Bytes(), &view))
+	require.Len(t, view.Timeline, 20)
+	assert.Equal(t, "tail-event-430", view.Timeline[0].EventID)
+	assert.Equal(t, "tail-event-449", view.Timeline[19].EventID)
+
+	_, err = state.ReadLifecycleEvents(root, change)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "line 1")
 }
 
 func TestStatusDirectExecutionView(t *testing.T) {

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -279,13 +279,19 @@ func buildValidateViewForSlugWithReadContext(readCtx *stateReadContext, slug str
 
 	// Validate remains read-only, but includes artifact projection so JSON callers
 	// can distinguish stable artifacts from projected auto-amendments.
+	verificationRecords, err := readCtx.verificationRecords(change)
+	if err != nil {
+		return validateView{}, wrapGovernanceReadinessError("validate readiness", change.Slug, err)
+	}
 	readiness, err := progression.EvaluateGovernanceReadiness(root, change, progression.GovernanceReadinessOptions{
 		IncludeGateEvaluations:    true,
 		IncludeArtifactProjection: true,
+		VerificationRecords:       verificationRecords,
 	})
 	if err != nil && errors.Is(err, fs.ErrPermission) {
 		readiness, err = progression.EvaluateGovernanceReadiness(root, change, progression.GovernanceReadinessOptions{
 			IncludeGateEvaluations: true,
+			VerificationRecords:    verificationRecords,
 		})
 	}
 	if err != nil {


### PR DESCRIPTION
## Summary
- reuse invocation-scoped verification records in next and validate readiness paths
- add explicit --change fast-path regression coverage for status, next, and validate
- add command-level bounded status timeline coverage while preserving full-log fail-closed behavior
- archive governed change complete-state-read-fast-paths

## Verification
- go test ./cmd ./internal/engine/progression -count=1
- go test ./cmd -run 'Test(ResolveExplicitChange|ValidateChangeFlag|ExplicitChangeCommandsUseFastPathWhenOtherBundleIsOrphaned|BuildGovernedStatusView|StatusDirectExecutionView)' -count=1
- go test ./cmd ./internal/state -run 'Test(StatusExplicitChangeUsesBoundedTimelineTail|ReadLifecycleEventTail|ReadLifecycleEvents|StatusViewIncludesLifecycleTimeline|StatusTimeline)' -count=1
- go test ./cmd ./internal/state ./internal/engine/progression -count=1
- go test ./... -count=1
- golangci-lint run ./... --timeout=5m
- go run ./internal/testlint/cmd/testlint ./...
- git diff --check