### PR TITLE
fix(lifecycle): expose route on mutating surfaces

### DIFF
--- a/artifacts/changes/archived/repair-lifecycle-surface-contracts/assurance.md
+++ b/artifacts/changes/archived/repair-lifecycle-surface-contracts/assurance.md
@@ -1,0 +1,70 @@
+# Assurance
+
+## Scope Summary
+This change completes the remaining `opt.md` section 1 lifecycle route-surface gap by adding the existing invocation route contract to successful single-change mutating JSON surfaces:
+
+- `done --json`
+- `evidence skill --json`
+- `evidence task --json`
+- `evidence task --result-file ... --result-file ... --json` batch output
+
+The implementation reuses the existing `invocationRouteView` and command-local `stateReadContext`. It does not add compatibility shims for the previous missing-route output.
+
+## Verification Verdict
+Verdict: PASS.
+
+Fresh ship-verification evidence for `run_summary_version: 1` was gathered after the selected S3 peer reviews converged. The terminal proof shows:
+
+- Targeted mutating route/fail-closed tests passed, including root unscoped `done --json` against a change bound to another worktree.
+- Existing P0 route, freshness, action, and host capability regression tests passed.
+- `go test ./cmd -count=1` passed.
+- `go test ./... -count=1` passed.
+- `golangci-lint run ./... --timeout=5m` passed.
+- `git diff --check` passed.
+- Placeholder/stub scan found no hits in the touched command and test files.
+
+## Evidence Index
+- `verification/intake-clarification.yaml`
+- `verification/research-orchestration.yaml`
+- `verification/plan-audit.yaml`
+- Runtime task evidence for `t-01` and `t-02`
+- `verification/wave-orchestration.yaml`
+- `verification/spec-compliance-review.yaml`
+- `verification/code-quality-review.yaml`
+- `verification/independent-review.yaml`
+- `verification/lifecycle-surface-route-tests.md`
+- `verification/logs/00-status-json.txt`
+- `verification/logs/01-validate-json.txt`
+- `verification/logs/02-go-test-cmd-mutating-routes.txt`
+- `verification/logs/03-go-test-cmd-existing-route-regressions.txt`
+- `verification/logs/04-go-test-cmd-full.txt`
+- `verification/logs/05-go-test-all.txt`
+- `verification/logs/06-golangci-lint.txt`
+- `verification/logs/07-git-diff-check.txt`
+- `verification/logs/08-placeholder-scan.txt`
+
+## Requirement Coverage
+- REQ-001: Covered by route fields added to `doneView`, `evidenceSkillView`, `evidenceTaskView`, and `evidenceTaskBatchView`, plus targeted route-output tests.
+- REQ-002: Covered by explicit missing slug, root bound-elsewhere, archived target, no-active, and wrong-state fail-closed regression tests.
+- REQ-003: Covered by direct top-level `invocation_route` fields; no compatibility envelope or legacy adapter was introduced.
+- REQ-004: Covered by targeted command tests, existing P0 contract tests, `go test ./cmd -count=1`, `go test ./... -count=1`, lint, diff check, and placeholder scan.
+
+## Residual Risks and Exceptions
+- The legacy top-level `evidence_freshness` field remains because earlier changes already introduced split freshness fields without removing legacy output. This change does not add a new compatibility layer.
+- The new `invocation_route.next_command` for successful `done` reflects pre-archive target context. Consumers should treat it as route context, not a post-archive action recommendation.
+- Verification logs under `verification/logs/` are runtime proof and are intentionally not part of the final committed source/archive surface.
+
+## Rollback Readiness
+Rollback is a normal source revert of the command/view/test changes plus rerunning:
+
+```bash
+go test ./cmd -count=1
+go test ./... -count=1
+```
+
+No schema migration, credential, irreversible state mutation, or external API contract change is introduced.
+
+## Archive Decision
+Ready to archive after recording ship-verification evidence and capturing a final active `validate --json --change repair-lifecycle-surface-contracts` proof.
+
+Rationale: selected S3 peer reviews passed, fresh terminal verification passed, scope contract is pass, and no blocking residual risk remains.

--- a/artifacts/changes/archived/repair-lifecycle-surface-contracts/change.yaml
+++ b/artifacts/changes/archived/repair-lifecycle-surface-contracts/change.yaml
@@ -1,0 +1,60 @@
+version: 1
+slug: repair-lifecycle-surface-contracts
+description: repair lifecycle surface contracts
+status: done
+current_state: DONE
+needs_discovery: true
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-06-27T14:46:33.825622Z
+quality_mode: standard
+workflow_profile: code
+workflow_preset: standard
+worktree_branch: feat/repair-lifecycle-surface-contracts
+artifact_schema: expanded
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: effbf8afb15de032edef32c03701e16709ca9ec73ea1eca5c4474073883648d0
+        updated_at: 2026-06-27T15:42:27.470123517Z
+    decision:
+        id: decision
+        path: decision.md
+        state: frozen
+        content_hash: 440e0c53d584729c7d81aabb4c934b161af8bff3eb24e582040a641789a83317
+        updated_at: 2026-06-27T14:51:14.811212058Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: b6ea4ec900d7a2ad2d868e684eef5e5cba5ff9c43d058cc5ac3a4ef83cd47bd0
+        updated_at: 2026-06-27T14:47:41.2607373Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: 8dd94ff632b363fd98bc79602334866f8c2d62fdc99211f490d371fb0fe82cdb
+        updated_at: 2026-06-27T14:51:14.810639311Z
+    research:
+        id: research
+        path: research.md
+        state: frozen
+        content_hash: 1fd90879d792fc8246bf3df5d5f2bdf2bc6fb3327bd379d9b8ab692b7fcbaa94
+        updated_at: 2026-06-27T14:50:08.209984295Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: 4a6c3e742b9dd45ded6fb511c5fd86f14a13fc630a185f7ab2226cb89754b6ac
+        updated_at: 2026-06-27T15:04:39.648164966Z
+evidence_refs:
+    code-quality-review: .worktrees/repair-lifecycle-surface-contracts/artifacts/changes/repair-lifecycle-surface-contracts/verification/code-quality-review.yaml
+    independent-review: .worktrees/repair-lifecycle-surface-contracts/artifacts/changes/repair-lifecycle-surface-contracts/verification/independent-review.yaml
+    intake-clarification: .worktrees/repair-lifecycle-surface-contracts/artifacts/changes/repair-lifecycle-surface-contracts/verification/intake-clarification.yaml
+    plan-audit: .worktrees/repair-lifecycle-surface-contracts/artifacts/changes/repair-lifecycle-surface-contracts/verification/plan-audit.yaml
+    research-orchestration: .worktrees/repair-lifecycle-surface-contracts/artifacts/changes/repair-lifecycle-surface-contracts/verification/research-orchestration.yaml
+    ship-verification: .worktrees/repair-lifecycle-surface-contracts/artifacts/changes/repair-lifecycle-surface-contracts/verification/ship-verification.yaml
+    spec-compliance-review: .worktrees/repair-lifecycle-surface-contracts/artifacts/changes/repair-lifecycle-surface-contracts/verification/spec-compliance-review.yaml
+    wave-orchestration: .worktrees/repair-lifecycle-surface-contracts/artifacts/changes/repair-lifecycle-surface-contracts/verification/wave-orchestration.yaml

--- a/artifacts/changes/archived/repair-lifecycle-surface-contracts/decision.md
+++ b/artifacts/changes/archived/repair-lifecycle-surface-contracts/decision.md
@@ -1,0 +1,43 @@
+# Decision
+
+## Alternatives Considered
+- Minimal route-completion patch: extend the existing `invocationRouteView` projection to `done` and `evidence`, switch their target resolution to the current per-command read context where useful, and add focused command tests.
+- New lifecycle contract package: move route, action, freshness, and capability projections out of `cmd` into a shared package and make every command consume it.
+- Generic lifecycle JSON envelope: wrap all public lifecycle command responses in one common top-level envelope.
+
+The selected direction is the minimal route-completion patch. The other options increase blast radius without improving the concrete missing behavior found during research.
+
+## Selected Approach
+Use the route/action/freshness/capability foundations already present on main and close the remaining gap in mutating command surfaces:
+
+- Add `InvocationRoute *invocationRouteView` to `doneView`, `evidenceSkillView`, `evidenceTaskView`, and `evidenceTaskBatchView`.
+- Use `newStateReadContext(root)` in `done`, `evidence skill`, and `evidence task` target resolution paths so target resolution and loaded change facts share the current command's read context.
+- Compute route information from the active target change before any mutating operation that can archive or rewrite authority, especially `done`.
+- Populate `invocation_route` on successful JSON outputs for single-change `done` and evidence commands.
+- Add black-box command tests proving route output and explicit missing slug fail-closed behavior.
+
+This avoids a compatibility layer and does not preserve the old missing-route contract. The public JSON response directly gains the correct route field.
+
+## Interfaces and Data Flow
+- Public JSON additions:
+  - `done --json`: add `invocation_route`.
+  - `evidence skill --json`: add `invocation_route`.
+  - `evidence task --json`: add `invocation_route`.
+  - evidence task batch result-file JSON: add `invocation_route` at the batch level if it records against one target change.
+- Internal flow:
+  - Command root resolution creates one `stateReadContext`.
+  - Active target slug is resolved via `resolveActiveChangeRefWithReadContext`.
+  - The active `model.Change` used for command validation also feeds `buildInvocationRouteView` through an apply helper.
+  - Mutating command logic continues to own archiving, evidence stamping, lifecycle event append, and execution summary synchronization.
+
+## Rollout and Rollback
+- Rollout is a normal code/test PR. Existing callers that ignore unknown JSON fields continue unaffected, but the implementation is not a compatibility shim; it directly changes the public contract by adding route data.
+- Rollback is reverting the commit and rerunning:
+  - `go test ./cmd -run 'Test.*(InvocationRoute|ChangeFlag|HostCapability|ReviewBatch|Freshness|Evidence|Done)' -count=1`
+  - `go test ./... -count=1`
+
+## Risk
+- `done` archives the change, so route projection must use the pre-archive active change. If route projection reloads after archive, it can incorrectly report archived or missing active authority.
+- Evidence commands validate stage/actionability before writing records. Route projection must not bypass `validateEvidenceSkillActionable`, `validateEvidenceTaskRunSummaryVersion`, or execution-summary synchronization.
+- The route helper's `NextCommand` may describe the pre-mutation next command; for successful `done`, that is execution context rather than post-archive next action. Tests should assert the route fields needed by `opt.md` without treating `NextCommand` as a post-mutation recommendation.
+- Existing split freshness, review batch action, and host capability behavior must not be rewritten as part of this change. Reuse the current tested code.

--- a/artifacts/changes/archived/repair-lifecycle-surface-contracts/intent.md
+++ b/artifacts/changes/archived/repair-lifecycle-surface-contracts/intent.md
@@ -1,0 +1,54 @@
+# Intent
+
+## Summary
+Repair the P0 public lifecycle surface contracts described in `opt.md` section 1 so `status`, `validate`, `next`, `run`, `done`, and `evidence` report consistent route, action, freshness, and capability semantics for the same governed change.
+
+## Complexity Assessment
+complex
+This touches multiple CLI public surfaces, lifecycle readiness/action reporting, governed evidence freshness semantics, and host capability fail-closed behavior. The work must be planned and verified as one coherent lifecycle surface repair because the `opt.md` acceptance criteria explicitly require the contracts to agree across commands.
+
+## Guardrail Domains
+Lifecycle governance, public CLI contract, and agent workflow safety. No credential, auth, schema migration, or financial domain is in scope.
+
+## In Scope
+- Implement a shared `InvocationRoute` or equivalent route model across `status`, `validate`, `next`, `done`, and `evidence`, including invocation workspace, change authority path, bound workspace path, route kind, local/effective lifecycle execution allowance, next command, and remediation.
+- Make explicit `--change <slug>` missing behavior fail closed as `change_not_found` with exit code 3 for `validate`, aligned with `status`, `next`, `done`, and `evidence`.
+- Split or supplement freshness reporting so execution evidence freshness, governance/skill evidence freshness, and overall readiness freshness cannot be confused.
+- Align `status` and `validate` with `next` for current action kind, especially S3 review batch pending behavior.
+- Expose host capability/delegation prerequisites for selected skills in CLI-visible output and fail closed or present explicit fallback when unavailable, covering the #339 dead-end class.
+- Add black-box CLI and targeted tests for the route, missing explicit slug, freshness, action contract, and capability cases required by `opt.md` 1.1-1.5.
+
+## Out of Scope
+- Release and supply-chain hardening from `opt.md` section 2.
+- Architecture boundary and coverage gate work from `opt.md` section 3, except when a minimal test is required to protect this change's touched surface.
+- State-read performance work from `opt.md` section 4, already handled by prior performance changes.
+- Backward compatibility layers for retired behavior. Per user instruction, implementations should replace incorrect contracts directly rather than preserve legacy compatibility shims.
+- Broad docs polish, persistent indexes, lifecycle append rewriting, or unrelated CLI refactors.
+
+## Constraints
+- Current worktree CLI behavior is authority; do not infer lifecycle state from memory or root checkout state.
+- Preserve unrelated dirty files in the root checkout, including `opt.md`, `.gemini/`, and `coverage.out`.
+- Do not commit ignored runtime artifacts such as `.serena/`, lifecycle `events/`, or `verification/` contents unless they are explicitly non-ignored governed artifacts.
+- No compatibility layer should be added for the retired or misleading behavior being removed.
+
+## Acceptance Signals
+- Root and bound worktree black-box `status`, `next`, and `validate` route/action contract behavior is consistent and tested.
+- `validate --change definitely-not-a-change --json` exits 3 and returns stable `error_code: change_not_found`.
+- Execution-fresh plus governance-stale cases report overall readiness as blocked/stale and do not present a single misleading freshness field.
+- S3 review batch pending fixtures show `next`, `status`, and `validate` agree on the action kind.
+- Host capability unavailable cases do not report prior authorization as sufficient when the selected skill cannot actually run; they fail closed or expose an explicit fallback.
+- Targeted tests pass, then `go test ./... -count=1` passes before final review/ship.
+
+## Open Questions
+<!-- Track real unknowns as a checklist. An unchecked `- [ ]` item is unresolved
+     and routes intake to S0_INTAKE/research; mark `- [x]` once resolved. Leave the
+     section empty (or write `None`) when there are none. Prose here is
+     documentation, not a blocker — a genuine open question must be a `- [ ]`. -->
+None
+
+## Deferred Ideas
+- Release workflow, branch protection, and supply-chain security hardening remain separate governed changes.
+- Wider public-surface coverage gate expansion remains separate unless needed for this change's touched files.
+
+## Approved Summary
+Confirmed by the user's blanket approval on 2026-06-27 to continue the original task and allow subsequent governed actions. This change will repair `opt.md` section 1.1-1.5 as one coherent P0 lifecycle surface fix: shared route semantics, explicit missing `--change` fail-closed behavior, split freshness semantics, `status`/`validate` action alignment with `next`, and CLI-visible host capability/delegation fallback behavior. It excludes release security, architecture gate expansion, state-read performance, unrelated refactors, and compatibility layers for retired behavior.

--- a/artifacts/changes/archived/repair-lifecycle-surface-contracts/requirements.md
+++ b/artifacts/changes/archived/repair-lifecycle-surface-contracts/requirements.md
@@ -1,0 +1,50 @@
+# Requirements
+
+## Requirements
+
+### Requirement: Mutating lifecycle commands expose route contract
+REQ-001: The system MUST expose the same invocation route contract on successful JSON output for single-change `done` and evidence recording commands that `status`, `next`, and `validate` already expose.
+
+#### Scenario: done reports target route
+GIVEN an active governed change in a bound worktree
+WHEN `slipway done --json --change <slug>` finalizes that done-ready change from another workspace
+THEN the JSON output includes `invocation_route` with the target slug, invocation workspace, bound workspace, authority path, route kind, lifecycle execution allowance, and remediation/next command semantics consistent with `status`, `next`, and `validate`.
+
+#### Scenario: evidence reports target route
+GIVEN an active governed change for which a skill or task evidence command is valid
+WHEN `slipway evidence skill --json --change <slug>` or `slipway evidence task --json --change <slug>` records evidence
+THEN the JSON output includes `invocation_route` for the target change using the same route fields as other lifecycle commands.
+
+### Requirement: Existing fail-closed semantics remain intact
+REQ-002: The system MUST preserve explicit missing slug, bound-elsewhere, archived, no-active, and wrong-state fail-closed semantics while adding route projection.
+
+#### Scenario: explicit missing evidence target fails closed
+GIVEN no active change exists for slug `definitely-not-a-change`
+WHEN `slipway evidence skill --json --change definitely-not-a-change` is run
+THEN the command exits with code 3 and reports `error_code: change_not_found` rather than falling back to generic diagnostics.
+
+#### Scenario: done root bound-elsewhere remains actionable
+GIVEN a single active change is bound to another worktree
+WHEN unscoped `slipway done --json` is run from the root workspace
+THEN the command fails closed with `change_bound_to_other_worktree` and remediation naming the bound worktree or an explicit `--change <slug>` command.
+
+### Requirement: No compatibility layer for retired contracts
+REQ-003: The implementation MUST replace misleading or incomplete lifecycle surface behavior directly and MUST NOT add an adapter or legacy compatibility layer that preserves the old missing-route output contract.
+
+#### Scenario: consumers receive route data directly
+GIVEN a successful JSON response from a touched mutating lifecycle command
+WHEN a caller inspects the top-level response
+THEN route data is present as the normal `invocation_route` field, not hidden behind a legacy or compatibility envelope.
+
+### Requirement: Verification proves the coherent public surface
+REQ-004: The change MUST include targeted tests proving route consistency for touched commands and MUST rerun existing freshness, action, and host capability tests that protect the rest of `opt.md` section 1.
+
+#### Scenario: targeted tests cover touched command surfaces
+GIVEN the implementation is complete
+WHEN the targeted command tests run
+THEN they verify `done`, `evidence skill`, and `evidence task` route output or fail-closed behavior without relying on source-only assertions.
+
+#### Scenario: existing P0 contract tests continue to pass
+GIVEN the route completion patch is applied
+WHEN the existing route, freshness, action contract, and host capability tests run
+THEN they continue to pass, proving the implementation did not regress the already repaired `status`, `next`, `validate`, and `run` surfaces.

--- a/artifacts/changes/archived/repair-lifecycle-surface-contracts/research.md
+++ b/artifacts/changes/archived/repair-lifecycle-surface-contracts/research.md
@@ -1,0 +1,102 @@
+# Research
+
+## Alternatives Considered
+
+### Architecture
+- Affected modules:
+  - `cmd/common.go:445` and `cmd/common.go:535` own explicit slug resolution and `change_not_found` projection.
+  - `cmd/common.go:1070` owns the existing `buildInvocationRouteView` model used by route-aware command views.
+  - `cmd/freshness_diagnostics.go:29` applies invocation route views to `next`, `validate`, and `status`.
+  - `cmd/status_view_build.go:202` projects split execution, governance, and overall readiness freshness for `status` and `validate`.
+  - `cmd/status_view_build.go:248` projects the action contract shared by `status` and `validate`.
+  - `cmd/next.go:741` derives `next` confirmation/action contract; `cmd/next.go:863` applies host capability blockers.
+  - `cmd/done.go:23` defines `doneView` without route data; `cmd/done.go:266` resolves the active change through the older non-context helper.
+  - `cmd/evidence.go:40` defines `evidenceSkillView` without route data; `cmd/evidence.go:124` and `cmd/evidence.go:390` resolve evidence targets through the older non-context helper.
+- Dependency chains:
+  - CLI commands -> `stateReadContext` / `resolveActiveChangeRefWithReadContext` -> `internal/state` for change authority and worktree binding.
+  - CLI commands -> `progression.EvaluateGovernanceReadiness` -> `internal/model` reason codes and recovery projection.
+  - CLI commands -> `internal/engine/capability.ResolveHostCapabilityRequirement` for host capability availability and fallback contracts.
+- Blast radius:
+  - Keep production edits in `cmd` route/view assembly and, only if necessary, `internal/engine/capability`.
+  - Do not move lifecycle authority, archive behavior, evidence stamping, or readiness evaluation into a new layer.
+- Constraints:
+  - `internal/state` must remain a read/write authority layer and not gain engine lifecycle semantics.
+  - The user explicitly requested no compatibility layers; incorrect public contracts should be replaced directly.
+
+### Patterns
+- Existing conventions:
+  - New command JSON fields are small view structs in the command package (`nextView`, `validateView`, `statusView`).
+  - `buildInvocationRouteView` already centralizes route fields and remediation for active/archived/bound cases.
+  - `stateReadContext` already exists for per-command state reuse and should be used instead of adding another cache.
+  - Tests prefer black-box command execution with `commandForRoot`, `withWorkspace`, `withNestedWorkingDirectory`, and JSON decode assertions.
+- Reusable abstractions:
+  - Reuse `invocationRouteView` rather than introduce a parallel route struct for `done` and `evidence`.
+  - Reuse `resolveActiveChangeRefWithReadContext` in `done` and `evidence` so explicit missing slug behavior stays aligned.
+  - Reuse `hostCapabilityViewsForSkills`, `applyHostCapabilityContractToNext`, and `applyHostCapabilityContractToValidate` rather than duplicate capability resolution.
+- Convention deviations:
+  - `done` and `evidence` are mutating commands, so route information should appear in successful JSON views and error/remediation tests, but should not alter stamping or archiving semantics.
+
+### Risks
+- Technical risks:
+  - Medium: adding route fields to mutating command outputs could accidentally reload state after mutation, especially `done` after archiving. Mitigation: compute the route from the pre-archive active change and include it as execution context only.
+  - Medium: capability unavailable blockers could change `run` behavior if appended too early or for the wrong selected skills. Mitigation: keep capability checks only on selected S3 review/host surfaces and add focused tests.
+  - Low: split freshness fields already exist, but legacy `evidence_freshness` remains. Mitigation: assert `overall_readiness_freshness` is the completion signal and do not rely on the legacy field in new code.
+  - Low: explicit missing slug is already tested for `validate`; adding evidence/done route tests should not weaken this.
+- Guardrail domains:
+  - Lifecycle governance and public CLI contract. No credential, PII, financial, schema migration, or release-secret exposure.
+- Reversibility:
+  - Source changes are normal CLI/view/test edits and can be reverted by commit. Runtime evidence files are generated and ignored except for governed top-level artifacts.
+
+### Test Strategy
+- Existing coverage:
+  - `cmd/active_change_resolution_test.go:17` tests root `resolveActiveChangeRef` bound-elsewhere behavior.
+  - `cmd/active_change_resolution_test.go:127` verifies local bound route consistency for `status`, `next`, and `validate`.
+  - `cmd/active_change_resolution_test.go:224` verifies `validate --change missing` fails closed as `change_not_found`.
+  - `cmd/progression_next_test.go:1144` through `cmd/progression_next_test.go:1180` verifies review batch action and split freshness alignment for `next`, `validate`, and `status`.
+  - `cmd/progression_next_test.go:1234` through `cmd/progression_next_test.go:1310` verifies host capability unavailable and manual fallback behavior across `next`, `validate`, and `run`.
+  - `internal/engine/capability/resolver_test.go:92` verifies capability availability and fallback modes.
+- Infrastructure needs:
+  - Add command-level tests for `done` and `evidence` route/error consistency using existing command test helpers.
+  - If implementation changes capability projection, add focused tests in `cmd/progression_next_test.go` or `internal/engine/capability/resolver_test.go`.
+- Verification approach:
+  - First run targeted `go test ./cmd -run 'Test(.*InvocationRoute|.*ChangeFlag|.*HostCapability|.*ReviewBatch|.*Freshness)' -count=1` adjusted to actual test names.
+  - Run package tests for touched areas, then `go test ./... -count=1`.
+
+### Options
+- Option 1: Minimal route-completion patch.
+  - Add `InvocationRoute *invocationRouteView` to `doneView`, `evidenceSkillView`, `evidenceTaskView`, and `evidenceTaskBatchView`; switch done/evidence target resolution to `stateReadContext`; apply route views on successful JSON outputs; add black-box tests for bound-worktree/root/explicit cases.
+  - Tradeoffs: Smallest code change and directly closes the concrete gap in `opt.md` 1.1. Does not over-rewrite already working freshness/action/capability code.
+- Option 2: New public lifecycle contract package.
+  - Move route, action, freshness, and capability projections into a new shared package consumed by every command.
+  - Tradeoffs: More architectural purity, but much larger blast radius and likely duplicates existing `cmd` view conventions. Higher risk for no immediate contract gain.
+- Option 3: Full rewrite of command diagnostics.
+  - Replace command-specific JSON structures with one common envelope.
+  - Tradeoffs: Most uniform output but violates minimal-change discipline and would effectively preserve old behavior through transitional adapters or break a large surface unnecessarily.
+- Selected: Option 1.
+  - Rationale: Current main already contains shared route, split freshness, action contract, and host capability foundations for `status`, `next`, `validate`, and `run`. The remaining concrete gap is extending the route contract and tests to `done` and `evidence` while preserving the existing fail-closed behavior. This matches the user's no-compatibility-layer instruction and keeps the work scoped to the public lifecycle surface.
+
+## Unknowns
+- Resolved: Are `opt.md` 4.1-4.4 still pending? -> No. Current main contains merged state-read performance work through PRs #355 and #358, including read-context, explicit `--change` fast path, and timeline tail read evidence.
+- Resolved: Does `validate --change <missing>` still fall through to diagnostics? -> No. `cmd/active_change_resolution_test.go:224` tests fail-closed `change_not_found`, and `cmd/validate.go:174` only falls back to diagnostics when no explicit slug is provided.
+- Resolved: Are split freshness and review action contracts absent? -> No. `cmd/status_view_build.go:202`, `cmd/status_view_build.go:248`, and `cmd/progression_next_test.go:1144` through `cmd/progression_next_test.go:1180` show this is already present for the main read surfaces.
+- Remaining: None.
+
+## Assumptions
+- The current worktree CLI behavior is the authority, not old chat or remembered branch state. Evidence: `go run . status --json` in the bound worktree reported active `repair-lifecycle-surface-contracts`.
+- `done` route data must be computed before archive mutation. Evidence: `cmd/done.go:328` archives the active bundle, after which active-route loading is no longer valid.
+- Evidence route data should describe the target change of the evidence command, not the written verification file. Evidence: `cmd/evidence.go:124` and `cmd/evidence.go:390` both first resolve an active change before writing skill or task evidence.
+
+## Canonical References
+- `opt.md` section 1.1-1.5 for required lifecycle surface scope.
+- `cmd/common.go:445` explicit change resolution.
+- `cmd/common.go:1070` invocation route view construction.
+- `cmd/freshness_diagnostics.go:29` existing route application hooks.
+- `cmd/status_view_build.go:202` split freshness projection.
+- `cmd/status_view_build.go:248` action contract projection.
+- `cmd/next.go:741` confirmation/action contract projection.
+- `cmd/next.go:863` host capability contract projection.
+- `cmd/done.go:23` and `cmd/done.go:266` missing done route projection.
+- `cmd/evidence.go:40`, `cmd/evidence.go:124`, and `cmd/evidence.go:390` missing evidence route projection.
+- `cmd/active_change_resolution_test.go:127` existing route consistency tests.
+- `cmd/progression_next_test.go:1144` through `cmd/progression_next_test.go:1310` existing freshness/action/capability tests.
+- `internal/engine/capability/resolver.go:92` host capability resolver.

--- a/artifacts/changes/archived/repair-lifecycle-surface-contracts/tasks.md
+++ b/artifacts/changes/archived/repair-lifecycle-surface-contracts/tasks.md
@@ -1,0 +1,19 @@
+# Tasks
+
+## Task List
+
+- [x] `t-01` Add invocation route output to done and evidence command JSON surfaces.
+  - depends_on: []
+  - target_files: [`cmd/done.go`, `cmd/evidence.go`, `cmd/freshness_diagnostics.go`]
+  - task_kind: code
+  - covers: [REQ-001, REQ-002, REQ-003]
+  - acceptance: `done --json`, `evidence skill --json`, and `evidence task --json` include `invocation_route` for successful single-change operations without changing their mutation semantics.
+  - evidence: targeted command tests exercise successful route projection and explicit missing slug fail-closed behavior.
+
+- [x] `t-02` Add and run black-box lifecycle surface regression tests for the route completion patch.
+  - depends_on: [`t-01`]
+  - target_files: [`cmd/active_change_resolution_test.go`, `cmd/evidence_skill_test.go`, `cmd/evidence_task_test.go`, `cmd/lifecycle_commands_test.go`, `artifacts/changes/repair-lifecycle-surface-contracts/verification/lifecycle-surface-route-tests.md`]
+  - task_kind: test
+  - covers: [REQ-001, REQ-002, REQ-004]
+  - acceptance: tests assert route output for touched commands, including single-result `evidence task --json` and batch `evidence task --result-file ... --result-file ... --json` output with a batch-level `invocation_route`; tests explicitly cover each REQ-002 fail-closed semantic touched by route projection: explicit missing evidence target returns `change_not_found`, root bound-elsewhere `done` remains `change_bound_to_other_worktree`, archived explicit targets remain fail-closed, no-active unscoped evidence/done remains fail-closed, and wrong-state `done` and evidence commands remain fail-closed; existing route/freshness/action/capability regression tests continue to pass for `status`, `next`, `validate`, and `run`.
+  - evidence: targeted `go test` transcript names the new route-output tests, fail-closed tests, evidence task batch JSON test, and existing P0 contract tests; final package/full-suite transcript is recorded in verification notes.

--- a/cmd/done.go
+++ b/cmd/done.go
@@ -28,6 +28,7 @@ type doneView struct {
 	EffectiveWorkflowPreset string                   `json:"effective_workflow_preset,omitempty"`
 	PresetUpgradeReasons    []string                 `json:"preset_upgrade_reasons,omitempty"`
 	NeedsDiscovery          bool                     `json:"needs_discovery,omitempty"`
+	InvocationRoute         *invocationRouteView     `json:"invocation_route,omitempty"`
 	Status                  string                   `json:"status"`
 	Archived                bool                     `json:"archived"`
 	ArchivePath             string                   `json:"archive_path,omitempty"`
@@ -263,21 +264,27 @@ func makeDoneCmd() *cobra.Command {
 				return encodeJSONResponse(cmd, view)
 			}
 
-			active, err := resolveActiveChangeRef(root, changeSlug)
+			readCtx := newStateReadContext(root)
+			active, err := resolveActiveChangeRefWithReadContext(readCtx, changeSlug)
 			if err != nil {
 				return err
 			}
 
 			return withChangeStateLock(root, active.Slug, "done", func() error {
-				change, err := loadActiveChange(
-					root,
-					active.Slug,
-					"cannot finalize non-active change status %q",
-					"Only active changes can be finalized.",
-				)
+				change, err := readCtx.reloadChange(active.Slug)
 				if err != nil {
 					return err
 				}
+				if change.Status != model.ChangeStatusActive {
+					return newPreconditionError(
+						"not_active",
+						fmt.Sprintf("cannot finalize non-active change status %q", change.Status),
+						"Only active changes can be finalized.",
+						change.Slug,
+						map[string]any{"status": string(change.Status)},
+					)
+				}
+				route := commandInvocationRoute(cmd, root, change, strings.TrimSpace(changeSlug) != "")
 
 				if !action.CanFinalizeDone(change.CurrentState) {
 					return newGovernanceBlockedError(
@@ -346,6 +353,7 @@ func makeDoneCmd() *cobra.Command {
 					EffectiveWorkflowPreset: presetFields.EffectiveWorkflowPreset,
 					PresetUpgradeReasons:    presetFields.PresetUpgradeReasons,
 					NeedsDiscovery:          profile.NeedsDiscovery,
+					InvocationRoute:         route,
 					Status:                  string(model.ChangeStatusDone),
 					Archived:                true,
 					ArchivePath:             state.DisplayPath(root, archivePaths.GovernedBundleArchive),

--- a/cmd/evidence.go
+++ b/cmd/evidence.go
@@ -24,29 +24,32 @@ type evidenceTaskView struct {
 	Slug              string                             `json:"slug"`
 	TaskID            string                             `json:"task_id"`
 	RunSummaryVersion int                                `json:"run_summary_version"`
+	InvocationRoute   *invocationRouteView               `json:"invocation_route,omitempty"`
 	Path              string                             `json:"path"`
 	Recorded          bool                               `json:"recorded"`
 	FreshnessInputs   model.ExecutionTaskFreshnessInputs `json:"freshness_inputs"`
 }
 
 type evidenceTaskBatchView struct {
-	Slug              string             `json:"slug"`
-	RunSummaryVersion int                `json:"run_summary_version"`
-	Recorded          bool               `json:"recorded"`
-	RecordedCount     int                `json:"recorded_count"`
-	Tasks             []evidenceTaskView `json:"tasks"`
+	Slug              string               `json:"slug"`
+	RunSummaryVersion int                  `json:"run_summary_version"`
+	InvocationRoute   *invocationRouteView `json:"invocation_route,omitempty"`
+	Recorded          bool                 `json:"recorded"`
+	RecordedCount     int                  `json:"recorded_count"`
+	Tasks             []evidenceTaskView   `json:"tasks"`
 }
 
 type evidenceSkillView struct {
-	Slug       string   `json:"slug"`
-	Skill      string   `json:"skill"`
-	SkillName  string   `json:"skill_name"`
-	Verdict    string   `json:"verdict"`
-	RunVersion int      `json:"run_version"`
-	Path       string   `json:"path"`
-	Recorded   bool     `json:"recorded"`
-	Stamped    bool     `json:"stamped"`
-	References []string `json:"references,omitempty"`
+	Slug            string               `json:"slug"`
+	Skill           string               `json:"skill"`
+	SkillName       string               `json:"skill_name"`
+	Verdict         string               `json:"verdict"`
+	RunVersion      int                  `json:"run_version"`
+	InvocationRoute *invocationRouteView `json:"invocation_route,omitempty"`
+	Path            string               `json:"path"`
+	Recorded        bool                 `json:"recorded"`
+	Stamped         bool                 `json:"stamped"`
+	References      []string             `json:"references,omitempty"`
 }
 
 const (
@@ -121,7 +124,8 @@ func makeEvidenceSkillCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			ref, err := resolveActiveChangeRef(root, changeSlug)
+			readCtx := newStateReadContext(root)
+			ref, err := resolveActiveChangeRefWithReadContext(readCtx, changeSlug)
 			if err != nil {
 				return err
 			}
@@ -136,6 +140,7 @@ func makeEvidenceSkillCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
+				route := commandInvocationRoute(cmd, root, change, strings.TrimSpace(changeSlug) != "")
 
 				skillName = strings.TrimSpace(skillName)
 				def, err := validateEvidenceSkillName(root, skillName)
@@ -328,15 +333,16 @@ func makeEvidenceSkillCmd() *cobra.Command {
 				}
 
 				view := evidenceSkillView{
-					Slug:       change.Slug,
-					Skill:      skillName,
-					SkillName:  skillName,
-					Verdict:    verdict,
-					RunVersion: runVersion,
-					Path:       displayPath,
-					Recorded:   true,
-					Stamped:    stamped,
-					References: references,
+					Slug:            change.Slug,
+					Skill:           skillName,
+					SkillName:       skillName,
+					Verdict:         verdict,
+					RunVersion:      runVersion,
+					InvocationRoute: route,
+					Path:            displayPath,
+					Recorded:        true,
+					Stamped:         stamped,
+					References:      references,
 				}
 				if jsonOutput {
 					return encodeJSONResponse(cmd, view)
@@ -387,7 +393,8 @@ func makeEvidenceTaskCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			ref, err := resolveActiveChangeRef(root, changeSlug)
+			readCtx := newStateReadContext(root)
+			ref, err := resolveActiveChangeRefWithReadContext(readCtx, changeSlug)
 			if err != nil {
 				return err
 			}
@@ -402,6 +409,7 @@ func makeEvidenceTaskCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
+				route := commandInvocationRoute(cmd, root, change, strings.TrimSpace(changeSlug) != "")
 				if change.CurrentState != model.StateS2Implement && change.CurrentState != model.StateS3Review {
 					remediation := evidenceTaskWrongStateRemediation(root, change)
 					return newInvalidUsageError(
@@ -417,7 +425,7 @@ func makeEvidenceTaskCmd() *cobra.Command {
 					if err := rejectEvidenceTaskResultFileLedgerFlags(cmd); err != nil {
 						return err
 					}
-					return recordEvidenceTaskResultFiles(cmd, root, change, resultFiles, jsonOutput)
+					return recordEvidenceTaskResultFiles(cmd, root, change, resultFiles, route, jsonOutput)
 				}
 
 				taskID = strings.TrimSpace(taskID)
@@ -625,6 +633,7 @@ func makeEvidenceTaskCmd() *cobra.Command {
 					Slug:              change.Slug,
 					TaskID:            taskID,
 					RunSummaryVersion: runSummary,
+					InvocationRoute:   route,
 					Path:              state.DisplayPath(root, path),
 					Recorded:          true,
 					FreshnessInputs:   payload.FreshnessInputs,
@@ -679,6 +688,7 @@ func recordEvidenceTaskResultFiles(
 	root string,
 	change model.Change,
 	resultFiles []string,
+	route *invocationRouteView,
 	jsonOutput bool,
 ) error {
 	if len(resultFiles) == 0 {
@@ -748,6 +758,7 @@ func recordEvidenceTaskResultFiles(
 	taskVerdicts := make([]string, 0, len(prepared))
 	views := make([]evidenceTaskView, 0, len(prepared))
 	for _, item := range prepared {
+		item.view.InvocationRoute = route
 		taskIDs = append(taskIDs, item.payload.TaskID)
 		paths = append(paths, item.view.Path)
 		taskVerdicts = append(taskVerdicts, fmt.Sprintf("%s:%s", item.payload.TaskID, item.payload.Verdict))
@@ -782,6 +793,7 @@ func recordEvidenceTaskResultFiles(
 	view := evidenceTaskBatchView{
 		Slug:              change.Slug,
 		RunSummaryVersion: runSummary,
+		InvocationRoute:   route,
 		Recorded:          true,
 		RecordedCount:     len(views),
 		Tasks:             views,

--- a/cmd/evidence_skill_test.go
+++ b/cmd/evidence_skill_test.go
@@ -53,6 +53,12 @@ func TestEvidenceSkillRecordsPlanAuditVerification(t *testing.T) {
 		assert.Equal(t, progression.SkillPlanAudit, view.SkillName)
 		assert.Equal(t, model.VerificationVerdictPass, view.Verdict)
 		assert.Equal(t, 0, view.RunVersion)
+		require.NotNil(t, view.InvocationRoute)
+		assert.Equal(t, "unbound_active", view.InvocationRoute.Kind)
+		assert.Equal(t, slug, view.InvocationRoute.ChangeSlug)
+		assert.True(t, view.InvocationRoute.LocalLifecycleExecutionAllowed)
+		assert.True(t, view.InvocationRoute.EffectiveLifecycleExecutionAllowed)
+		assert.Equal(t, "slipway next --change "+slug, view.InvocationRoute.NextCommand)
 		assert.Equal(t, expectedPath, view.Path)
 		assert.True(t, view.Recorded)
 
@@ -81,6 +87,82 @@ func TestEvidenceSkillRecordsPlanAuditVerification(t *testing.T) {
 		assert.Equal(t, "skill.evidence_recorded", events[len(events)-1].EventType)
 		assert.Equal(t, "recorded", events[len(events)-1].Result)
 	})
+}
+
+func TestEvidenceSkillChangeFlagRejectsMissingSlugWithoutDiagnosticsFallback(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	ensureTestGitRepo(t, root)
+	initTestWorkspace(t, root)
+
+	cmd := commandForRoot(t, root, makeEvidenceCmd())
+	cmd.SetArgs([]string{
+		"skill",
+		"--json",
+		"--change", "definitely-not-a-change",
+		"--skill", progression.SkillPlanAudit,
+		"--verdict", model.VerificationVerdictPass,
+		"--notes", "will not be recorded",
+	})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cliErr := asCLIError(cmd.Execute())
+	require.NotNil(t, cliErr)
+	assert.Equal(t, "change_not_found", cliErr.ErrorCode)
+	assert.Equal(t, "definitely-not-a-change", cliErr.Slug)
+	assert.NotContains(t, out.String(), "no active change or ambiguous")
+}
+
+func TestEvidenceSkillFailsClosedWithoutActiveChange(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	ensureTestGitRepo(t, root)
+	initTestWorkspace(t, root)
+
+	cmd := commandForRoot(t, root, makeEvidenceCmd())
+	cmd.SetArgs([]string{
+		"skill",
+		"--json",
+		"--skill", progression.SkillPlanAudit,
+		"--verdict", model.VerificationVerdictPass,
+		"--notes", "will not be recorded",
+	})
+	cliErr := asCLIError(cmd.Execute())
+	require.NotNil(t, cliErr)
+	assert.Equal(t, "no_active_change", cliErr.ErrorCode)
+}
+
+func TestEvidenceSkillChangeFlagRejectsArchivedTarget(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	ensureTestGitRepo(t, root)
+	initTestWorkspace(t, root)
+
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "evidence archived target")
+	change, err := state.LoadChange(root, slug)
+	require.NoError(t, err)
+	change.Status = model.ChangeStatusDone
+	change.CurrentState = model.StateDone
+	require.NoError(t, state.SaveChange(root, change))
+	_, err = state.ArchiveChange(root, change, model.ChangeStatusDone)
+	require.NoError(t, err)
+
+	cmd := commandForRoot(t, root, makeEvidenceCmd())
+	cmd.SetArgs([]string{
+		"skill",
+		"--json",
+		"--change", slug,
+		"--skill", progression.SkillPlanAudit,
+		"--verdict", model.VerificationVerdictPass,
+		"--notes", "will not be recorded",
+	})
+	cliErr := asCLIError(cmd.Execute())
+	require.NotNil(t, cliErr)
+	assert.Equal(t, "archived_change_not_validatable", cliErr.ErrorCode)
+	assert.Equal(t, slug, cliErr.Slug)
 }
 
 func TestEvidenceSkillAllowsStaleResearchRestampFromAuditSubstep(t *testing.T) {

--- a/cmd/evidence_task_test.go
+++ b/cmd/evidence_task_test.go
@@ -55,6 +55,11 @@ func TestEvidenceTaskRecordsRuntimeEvidenceAndBuildsExecutionSummary(t *testing.
 		assert.Equal(t, slug, view.Slug)
 		assert.Equal(t, "t-01", view.TaskID)
 		assert.True(t, view.Recorded)
+		require.NotNil(t, view.InvocationRoute)
+		assert.Equal(t, "unbound_active", view.InvocationRoute.Kind)
+		assert.Equal(t, slug, view.InvocationRoute.ChangeSlug)
+		assert.True(t, view.InvocationRoute.LocalLifecycleExecutionAllowed)
+		assert.True(t, view.InvocationRoute.EffectiveLifecycleExecutionAllowed)
 		assert.True(t, view.FreshnessInputs.Equal(expectedFreshnessInputs))
 
 		taskEvidencePath := filepath.Join(state.EvidenceTasksDir(root, slug), "t-01.json")
@@ -131,6 +136,9 @@ func TestEvidenceTaskImportsResultFileWithDerivedLedgerFields(t *testing.T) {
 		assert.Equal(t, "t-01", view.TaskID)
 		assert.Equal(t, 1, view.RunSummaryVersion)
 		assert.True(t, view.Recorded)
+		require.NotNil(t, view.InvocationRoute)
+		assert.Equal(t, "unbound_active", view.InvocationRoute.Kind)
+		assert.Equal(t, slug, view.InvocationRoute.ChangeSlug)
 
 		wavePlan, err := state.LoadWavePlanForChange(root, change)
 		require.NoError(t, err)
@@ -175,10 +183,17 @@ func TestEvidenceTaskImportsMultipleResultFilesAtomically(t *testing.T) {
 		assert.Equal(t, slug, view.Slug)
 		assert.Equal(t, 1, view.RunSummaryVersion)
 		assert.True(t, view.Recorded)
+		require.NotNil(t, view.InvocationRoute)
+		assert.Equal(t, "unbound_active", view.InvocationRoute.Kind)
+		assert.Equal(t, slug, view.InvocationRoute.ChangeSlug)
 		assert.Equal(t, 2, view.RecordedCount)
 		require.Len(t, view.Tasks, 2)
 		assert.Equal(t, "t-01", view.Tasks[0].TaskID)
 		assert.Equal(t, "t-02", view.Tasks[1].TaskID)
+		for _, task := range view.Tasks {
+			require.NotNil(t, task.InvocationRoute)
+			assert.Equal(t, view.InvocationRoute, task.InvocationRoute)
+		}
 
 		wavePlan, err := state.LoadWavePlanForChange(root, change)
 		require.NoError(t, err)

--- a/cmd/freshness_diagnostics.go
+++ b/cmd/freshness_diagnostics.go
@@ -64,6 +64,11 @@ func applyStatusInvocationRoute(cmd *cobra.Command, root string, change model.Ch
 	view.InvocationRoute = buildInvocationRouteView(root, change, workspace, explicitChange)
 }
 
+func commandInvocationRoute(cmd *cobra.Command, root string, change model.Change, explicitChange bool) *invocationRouteView {
+	workspace := invocationWorkspaceRootFromCommand(cmd, root)
+	return buildInvocationRouteView(root, change, workspace, explicitChange)
+}
+
 func attachFreshnessDiagnostics(diagnostics state.ExecutionFreshnessDiagnostics) *state.ExecutionFreshnessDiagnostics {
 	if strings.TrimSpace(diagnostics.Status) == "" {
 		return nil

--- a/cmd/lifecycle_commands_test.go
+++ b/cmd/lifecycle_commands_test.go
@@ -119,9 +119,140 @@ func TestDoneJSONReportsWorktreeArchivePathWhenRunFromWorktree(t *testing.T) {
 		expectedArchive := filepath.Join(normalizedWT, "artifacts", "changes", "archived", slug)
 		assert.Equal(t, state.DisplayPath(root, expectedArchive), view.ArchivePath)
 		assert.True(t, view.ArchiveCommitRequired)
+		require.NotNil(t, view.InvocationRoute)
+		assert.Equal(t, "local_active", view.InvocationRoute.Kind)
+		assert.Equal(t, slug, view.InvocationRoute.ChangeSlug)
+		assert.True(t, view.InvocationRoute.LocalLifecycleExecutionAllowed)
+		assert.True(t, view.InvocationRoute.EffectiveLifecycleExecutionAllowed)
+		assert.Equal(t, state.DisplayPath(root, normalizedWT), view.InvocationRoute.BoundWorkspacePath)
 		require.FileExists(t, filepath.Join(expectedArchive, "change.yaml"))
 		require.NoFileExists(t, filepath.Join(root, "artifacts", "changes", "archived", slug, "change.yaml"))
 	})
+}
+
+func TestDoneJSONReportsExplicitBoundInvocationRoute(t *testing.T) {
+	root := t.TempDir()
+	initGitRepoForWorktreeTests(t, root)
+	withWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+
+		slug := "done-explicit-bound-route"
+		branch := "feat/" + slug
+		worktreeRoot := filepath.Join(t.TempDir(), slug)
+		runGit(t, root, "worktree", "add", worktreeRoot, "-b", branch)
+		normalizedWT, err := state.NormalizePath(worktreeRoot)
+		require.NoError(t, err)
+
+		change := model.NewChange(slug)
+		change.WorktreePath = normalizedWT
+		change.WorktreeBranch = branch
+		change.CurrentState = model.StateS3Review
+		change.PlanSubStep = model.PlanSubStepNone
+		require.NoError(t, state.SaveChange(root, change))
+
+		writeShipReadyGovernedBundle(t, normalizedWT, change)
+		writeAssuranceMD(t, normalizedWT, slug, validAssuranceContent())
+		writePassingExecutionSummary(t, root, slug, 1, "t-01")
+		writePassingWaveEvidence(t, root, slug, 1)
+		writePassingReviewEvidencePack(t, root, slug, 1)
+		writePassingShipVerificationEvidence(t, root, slug, 1)
+		gitCommitAll(t, normalizedWT, "ship-ready bundle")
+		refreshPassingSkillDigestsForTest(t, normalizedWT, slug)
+
+		var out bytes.Buffer
+		doneCmd := commandForRoot(t, root, makeDoneCmd())
+		doneCmd.SetArgs([]string{"--json", "--change", slug})
+		doneCmd.SetOut(&out)
+		require.NoError(t, doneCmd.Execute())
+
+		var view doneView
+		require.NoError(t, json.Unmarshal(out.Bytes(), &view))
+		require.NotNil(t, view.InvocationRoute)
+		assert.Equal(t, "explicit_bound_change", view.InvocationRoute.Kind)
+		assert.Equal(t, slug, view.InvocationRoute.ChangeSlug)
+		assert.False(t, view.InvocationRoute.LocalLifecycleExecutionAllowed)
+		assert.True(t, view.InvocationRoute.EffectiveLifecycleExecutionAllowed)
+		assert.Equal(t, "slipway next --change "+slug, view.InvocationRoute.NextCommand)
+		assert.Contains(t, view.InvocationRoute.Remediation, "--change "+slug)
+	})
+}
+
+func TestDoneFromRootReportsBoundElsewhereWithoutArchiving(t *testing.T) {
+	root := t.TempDir()
+	initGitRepoForWorktreeTests(t, root)
+	withWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+
+		slug := "done-bound-elsewhere"
+		branch := "feat/" + slug
+		worktreeRoot := filepath.Join(t.TempDir(), slug)
+		runGit(t, root, "worktree", "add", worktreeRoot, "-b", branch)
+		normalizedWT, err := state.NormalizePath(worktreeRoot)
+		require.NoError(t, err)
+
+		change := model.NewChange(slug)
+		change.WorktreePath = normalizedWT
+		change.WorktreeBranch = branch
+		change.CurrentState = model.StateS3Review
+		change.PlanSubStep = model.PlanSubStepNone
+		require.NoError(t, state.SaveChange(root, change))
+
+		var out bytes.Buffer
+		doneCmd := commandForRoot(t, root, makeDoneCmd())
+		doneCmd.SetArgs([]string{"--json"})
+		doneCmd.SetOut(&out)
+		cliErr := asCLIError(doneCmd.Execute())
+		require.NotNil(t, cliErr)
+
+		assert.Equal(t, "change_bound_to_other_worktree", cliErr.ErrorCode)
+		assert.Equal(t, categoryPrecondition, cliErr.Category)
+		assert.Contains(t, cliErr.Remediation, "--change "+slug)
+		assert.Contains(t, cliErr.Remediation, normalizedWT)
+		assert.Contains(t, fmt.Sprint(cliErr.Details["bound_changes"]), slug)
+		assert.Contains(t, fmt.Sprint(cliErr.Details["bound_changes"]), normalizedWT)
+		assert.NotContains(t, out.String(), `"archive_path"`, "done must fail before rendering a success payload")
+		assert.NotContains(t, out.String(), `"invocation_route"`, "done must fail before rendering a success payload")
+		require.NoFileExists(t, filepath.Join(normalizedWT, "artifacts", "changes", "archived", slug, "change.yaml"))
+		require.FileExists(t, filepath.Join(normalizedWT, "artifacts", "changes", slug, "change.yaml"))
+	})
+}
+
+func TestDoneFailsClosedWithoutActiveChange(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	ensureTestGitRepo(t, root)
+	initTestWorkspace(t, root)
+
+	doneCmd := commandForRoot(t, root, makeDoneCmd())
+	doneCmd.SetArgs([]string{"--json"})
+	cliErr := asCLIError(doneCmd.Execute())
+	require.NotNil(t, cliErr)
+	assert.Equal(t, "no_active_change", cliErr.ErrorCode)
+}
+
+func TestDoneChangeFlagRejectsArchivedTarget(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	ensureTestGitRepo(t, root)
+	initTestWorkspace(t, root)
+
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "done archived target")
+	change, err := state.LoadChange(root, slug)
+	require.NoError(t, err)
+	change.Status = model.ChangeStatusDone
+	change.CurrentState = model.StateDone
+	require.NoError(t, state.SaveChange(root, change))
+	_, err = state.ArchiveChange(root, change, model.ChangeStatusDone)
+	require.NoError(t, err)
+
+	doneCmd := commandForRoot(t, root, makeDoneCmd())
+	doneCmd.SetArgs([]string{"--json", "--change", slug})
+	cliErr := asCLIError(doneCmd.Execute())
+	require.NotNil(t, cliErr)
+	assert.Equal(t, "archived_change_not_validatable", cliErr.ErrorCode)
+	assert.Equal(t, slug, cliErr.Slug)
 }
 
 func TestDoneJSONWarnsButArchivesWhenWorktreeChangesAreUncommitted(t *testing.T) {


### PR DESCRIPTION
## Summary
- add invocation_route to successful JSON output for done and evidence recording surfaces
- share state-read-context target resolution for done/evidence route projection
- add fail-closed command coverage for root done --json against a change bound to another worktree
- archive governed change repair-lifecycle-surface-contracts without committing ignored runtime evidence/log files

## Verification
- go test ./cmd -run 'Test(DoneJSONReportsWorktreeArchivePathWhenRunFromWorktree|DoneJSONReportsExplicitBoundInvocationRoute|DoneFromRootReportsBoundElsewhereWithoutArchiving|DoneFailsClosedWithoutActiveChange|DoneChangeFlagRejectsArchivedTarget|EvidenceSkillRecordsPlanAuditVerification|EvidenceSkillChangeFlagRejectsMissingSlugWithoutDiagnosticsFallback|EvidenceSkillFailsClosedWithoutActiveChange|EvidenceSkillChangeFlagRejectsArchivedTarget|EvidenceTaskRecordsRuntimeEvidenceAndBuildsExecutionSummary|EvidenceTaskImportsResultFileWithDerivedLedgerFields|EvidenceTaskImportsMultipleResultFilesAtomically)' -count=1
- go test ./cmd -run 'Test(BoundWorktreeCommandsExposeConsistentLocalInvocationRoute|NextChangeFlagFromRootTargetsBoundWorktree|ValidateChangeFlagRejectsMissingSlugWithoutWritingState|StatusFromRootReportsBoundElsewhere|RunFromRootReportsBoundElsewhere|ReviewBatch|Freshness|HostCapability|EvidenceSkillWrongState|EvidenceTaskWrongState|Done.*not_done_ready|DoneRejects|Done.*NotDone|Done.*Ready)' -count=1
- go test ./cmd -count=1
- go test ./... -count=1
- golangci-lint run ./... --timeout=5m
- git diff --check