### PR TITLE
fix(governance): align lifecycle handoff surfaces

### DIFF
--- a/artifacts/changes/archived/repair-route-freshness-capability-gaps-2/assurance.md
+++ b/artifacts/changes/archived/repair-route-freshness-capability-gaps-2/assurance.md
@@ -1,0 +1,121 @@
+# Assurance
+
+## Scope Summary
+
+This change deep-confirmed the remaining route/freshness/capability reports
+against current `main` and narrowed the repair to the two confirmed public
+lifecycle-surface gaps:
+
+- default compact `run --json` needed explicit regression coverage for
+  selected host capability requirements, capability blockers, blocked freshness,
+  recovery, confirmation, and no-advance behavior when independent review
+  subagent capability is unavailable;
+- `status --json` needed to expose the same actionable selected review skill
+  that `next`, `next --diagnostics`, `validate`, and `run` already expose for
+  blocker-driven review-alignment handoffs.
+
+The production repair is intentionally small. `statusView` now includes
+`actionable_next_skill`, and `buildStatusViewWithReadContext` populates it from
+the existing shared `buildActionableNextSkillView` helper. The rest of the work
+is focused regression coverage in `cmd/progression_next_test.go`.
+
+Out-of-scope reported items were not changed: StateReadContext performance, CI
+scheduling, release/ruleset policy, supply-chain workflow hardening, and the
+stale claim that `run` bypasses the shared next-view capability gate.
+
+## Verification Verdict
+
+Pre-ship verification is passing for the implemented scope. The peer review set
+is complete and fresh for `run_summary_version=1`:
+
+- `spec-compliance-review`: pass, `layer:R0=pass`,
+  `scope_contract:pass`, `negative_path:pass`,
+  `context_origin:stage=review=spec-review-20260628-r2`;
+- `code-quality-review`: pass, `layer:IR1=pass`,
+  `context_origin:stage=review=quality-review-20260628-r2`;
+- `independent-review`: pass, `layer:IR1=pass`,
+  `context_origin:stage=review=independent-review-20260628-r2`.
+
+Fresh local verification also passed:
+
+- `go test -count=1 ./cmd -run 'TestStalePlanningReviewAlignmentActionContractStaysConsistentAcrossSurfaces|TestReviewStateActionableNextSkillConsistentAcrossCommandSurfaces|TestReviewBatchHostCapabilityUnavailableFailsClosedUnlessFallbackSelected'`
+- `go test -count=1 ./cmd`
+- `golangci-lint run ./...`
+- `git diff --check`
+- `SLIPWAY_HOST_CAPABILITIES=subagent go run . validate --json`
+
+The active validation captured after peer evidence and with the explicit
+subagent host capability signal reported `skills_ready` pass for all selected
+peer reviews, `execution_evidence_freshness=fresh`, and
+`scope_contract.status=pass`. The only remaining blockers at that point were
+the expected terminal closeout blockers for this assurance artifact and
+ship-verification evidence/attestations.
+
+## Evidence Index
+
+- `verification/execution-summary.yaml`: S2 task evidence for `t-01`, `t-02`,
+  and `t-03`, all passing for `run_summary_version=1`.
+- `verification/wave-orchestration.yaml`: wave orchestration pass for the three
+  planned implementation tasks.
+- `verification/spec-compliance-review.yaml`: S3 spec-compliance pass after the
+  r2 repair.
+- `verification/code-quality-review.yaml`: S3 code-quality pass after the r2
+  production projection change.
+- `verification/independent-review.yaml`: S3 independent-review pass after the
+  r2 repair.
+- Focused regression tests:
+  `TestReviewBatchHostCapabilityUnavailableFailsClosedUnlessFallbackSelected`,
+  `TestStalePlanningReviewAlignmentActionContractStaysConsistentAcrossSurfaces`,
+  and `TestReviewStateActionableNextSkillConsistentAcrossCommandSurfaces`.
+- Command-package suite: `go test -count=1 ./cmd`.
+- Lint and diff hygiene: `golangci-lint run ./...` and `git diff --check`.
+
+## Requirement Coverage
+
+- REQ-001 is covered by
+  `TestReviewBatchHostCapabilityUnavailableFailsClosedUnlessFallbackSelected`.
+  The test asserts compact `run --json` includes host capability details,
+  `host_capability_unavailable`, `blocked_by_governance`, blocker-resolution
+  confirmation, blocked freshness, recovery guidance, compact handoff
+  `S3_REVIEW`, and a persisted reload proving `CurrentState == S3_REVIEW` and
+  `PlanSubStepNone`.
+- REQ-002 is covered by
+  `TestStalePlanningReviewAlignmentActionContractStaysConsistentAcrossSurfaces`
+  and `TestReviewStateActionableNextSkillConsistentAcrossCommandSurfaces`.
+  The tests prove `status --json`, `validate --json`, `next --json`,
+  `next --json --diagnostics`, and `run --json` report the same current action
+  class and the same actionable selected review skill.
+
+## Residual Risks and Exceptions
+
+- The active S3 surface still carries the expected
+  `s3_task_plan_amendment_review_required` diagnostic because `tasks.md` was
+  amended during S3 review to include the newly touched status projection files.
+  `validate --json` treats this as a review-required diagnostic, not an
+  execution freshness failure; the r2 peer reviews covered the amended scope.
+- `SLIPWAY_HOST_CAPABILITIES=subagent` is required for validation in this host
+  when independent-review subagent capability has actually been provided. With
+  the signal omitted, Slipway correctly fails closed with
+  `host_capability_unavailable`.
+- Terminal ship-verification is intentionally still pending at this assurance
+  authoring point. It must run last and record the required
+  `closeout:assurance_complete=pass` and
+  `closeout:reviewer_independence=pass` attestations before the change can
+  advance to done-ready.
+
+## Rollback Readiness
+
+Rollback is simple because the production change is additive status JSON
+projection plus tests. Reverting `cmd/status.go`, `cmd/status_view_build.go`,
+and the added regression blocks in `cmd/progression_next_test.go` restores the
+previous public status shape and test suite. No data migration, external API
+write, irreversible operation, dependency update, or configuration mutation was
+introduced.
+
+## Archive Decision
+
+Not archive-ready yet. The implementation and peer review scope are complete,
+but the active change must still pass terminal ship-verification and then active
+`validate --json` before `done`. Archived bundles must be treated as frozen
+records only; active readiness must come from the current governed worktree
+before finalization.

--- a/artifacts/changes/archived/repair-route-freshness-capability-gaps-2/change.yaml
+++ b/artifacts/changes/archived/repair-route-freshness-capability-gaps-2/change.yaml
@@ -1,0 +1,46 @@
+version: 1
+slug: repair-route-freshness-capability-gaps-2
+description: repair route freshness capability gaps
+status: done
+current_state: DONE
+complexity_level: simple
+base_ref: HEAD
+created_at: 2026-06-28T03:46:27.11Z
+quality_mode: standard
+workflow_profile: code
+workflow_preset: standard
+worktree_branch: feat/repair-route-freshness-capability-gaps-2
+artifact_schema: core
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: 30e8031291bdde6668d9da6f85f7d96fc8f513816e6ea2324cc6d5fa3c8bb5ea
+        updated_at: 2026-06-28T04:31:20.331569701Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: d48a64b3f1467770e589e57270ac49339e159f20e035c241165c7ef0985b026a
+        updated_at: 2026-06-28T03:48:32.56668552Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: 3cfdcc30ec2043929479a1a7079fe8d0428b986e3befb34e3d94bc876bf3f46e
+        updated_at: 2026-06-28T03:49:20.531798926Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: 596b98bad8fded7991e188c9f90211071b8e94dd1cf98b5319d68639fc2276ff
+        updated_at: 2026-06-28T04:15:59.797587756Z
+evidence_refs:
+    code-quality-review: .worktrees/repair-route-freshness-capability-gaps-2/artifacts/changes/repair-route-freshness-capability-gaps-2/verification/code-quality-review.yaml
+    independent-review: .worktrees/repair-route-freshness-capability-gaps-2/artifacts/changes/repair-route-freshness-capability-gaps-2/verification/independent-review.yaml
+    intake-clarification: .worktrees/repair-route-freshness-capability-gaps-2/artifacts/changes/repair-route-freshness-capability-gaps-2/verification/intake-clarification.yaml
+    plan-audit: .worktrees/repair-route-freshness-capability-gaps-2/artifacts/changes/repair-route-freshness-capability-gaps-2/verification/plan-audit.yaml
+    ship-verification: .worktrees/repair-route-freshness-capability-gaps-2/artifacts/changes/repair-route-freshness-capability-gaps-2/verification/ship-verification.yaml
+    spec-compliance-review: .worktrees/repair-route-freshness-capability-gaps-2/artifacts/changes/repair-route-freshness-capability-gaps-2/verification/spec-compliance-review.yaml
+    wave-orchestration: .worktrees/repair-route-freshness-capability-gaps-2/artifacts/changes/repair-route-freshness-capability-gaps-2/verification/wave-orchestration.yaml

--- a/artifacts/changes/archived/repair-route-freshness-capability-gaps-2/intent.md
+++ b/artifacts/changes/archived/repair-route-freshness-capability-gaps-2/intent.md
@@ -1,0 +1,69 @@
+# Intent
+
+## Summary
+repair route freshness capability gaps
+
+## Complexity Assessment
+simple
+
+The change is simple because the current code already routes `run` through the
+shared next-view gate and stops on blockers. The remaining work is a focused
+regression hardening pass over public lifecycle JSON surfaces, not a new
+capability framework, performance rewrite, or release/security redesign.
+
+## In Scope
+- Confirm the two attached analyses against current `main` before treating any
+  item as actionable.
+- Add regression coverage for default compact `run --json` output so host
+  capability requirements, freshness fields, blockers, recovery, and
+  confirmation remain visible outside `--diagnostics`.
+- Add or tighten regression coverage proving blocker-driven review-alignment
+  handoff decisions stay consistent across `status --json`, `validate --json`,
+  `next --json`, `next --json --diagnostics`, and `run --json`.
+- Apply the smallest code change needed if those regressions expose a real
+  current behavior gap.
+
+## Out of Scope
+- Do not rework StateReadContext or WorkspaceIndex performance in this change.
+- Do not add CI scheduling or perf-baseline automation.
+- Do not move state-layer semantic ownership into engine/wave/freshness
+  packages.
+- Do not treat already-closed current-main items as bugs, including the old
+  claim that `run` does not use the shared next-view capability gate.
+- Do not change GitHub release protection, rulesets, or supply-chain workflow
+  policy.
+
+## Constraints
+- Preserve unrelated root worktree dirt (`.gemini/`, `coverage.out`, `opt.md`,
+  and `opt-gap-analysis.md`).
+- Keep the fix inside the provisioned governed worktree for
+  `repair-route-freshness-capability-gaps-2`.
+- Prefer existing command/view helpers over duplicating command-specific
+  lifecycle logic.
+- Use current worktree behavior and tests as authority; do not rely on stale
+  opt-gap notes when they contradict current code.
+
+## Acceptance Signals
+- Focused `go test` coverage demonstrates default `run --json` carries the same
+  host capability, blocker, freshness, recovery, and confirmation contract as the
+  diagnostic path when review host capability is unavailable.
+- Focused `go test` coverage demonstrates blocker-driven review alignment
+  produces consistent current action and handoff targets across public JSON
+  surfaces.
+- `go test -count=1 ./cmd` passes.
+- `go run . validate --json` and `go run . next --json --diagnostics` in the
+  governed worktree report the change ready for the next lifecycle step after
+  required evidence is recorded.
+
+## Open Questions
+None.
+
+## Approved Summary
+The user requested deep confirmation and complete repair of the remaining
+reported route/freshness/capability issues from two attached analyses. Current
+fact checking narrows the repair to regression hardening for the remaining
+public lifecycle surface risks: default compact `run --json` capability
+handoff output and cross-surface blocker-driven review-alignment consistency.
+Already-fixed or unproven items, performance work, CI automation, release
+hardening, and broader state/engine architecture changes are out of scope for
+this change.

--- a/artifacts/changes/archived/repair-route-freshness-capability-gaps-2/requirements.md
+++ b/artifacts/changes/archived/repair-route-freshness-capability-gaps-2/requirements.md
@@ -1,0 +1,37 @@
+# Requirements
+
+## Requirements
+
+### Requirement: Compact run JSON preserves governance blockers
+REQ-001: The system MUST expose selected host capability requirements,
+capability blocker state, freshness fields, recovery guidance, and confirmation
+requirements in default compact `run --json` output whenever the diagnostic
+`run --json --diagnostics` view would stop on unavailable required host
+capability.
+
+#### Scenario: Review host capability unavailable in compact run handoff
+GIVEN a governed change in `S3_REVIEW` with selected review skills that require
+subagent capability and the host reports no available subagent capability
+WHEN an operator runs `slipway run --json --change <slug>` without
+`--diagnostics`
+THEN the JSON response includes the selected host capability requirement,
+`host_capability_unavailable` blocker, blocked freshness state, recovery
+guidance, and a `blocked_by_governance` confirmation requirement without
+advancing past the blocked review handoff.
+
+### Requirement: Review-alignment action contracts stay cross-surface consistent
+REQ-002: The system MUST keep blocker-driven review-alignment handoff decisions
+consistent across `status --json`, `validate --json`, `next --json`,
+`next --json --diagnostics`, and `run --json` so operators see the same current
+action class and the same actionable review skill on every public lifecycle
+surface.
+
+#### Scenario: Stale upstream evidence maps to a selected review skill
+GIVEN a governed change in `S3_REVIEW` where selected review evidence appears
+passing but stale upstream evidence requires rerunning an aligned selected
+review skill
+WHEN an operator queries status, validate, next, diagnostic next, and compact
+run JSON surfaces
+THEN each surface reports the aligned review skill as the actionable handoff and
+uses a governance-blocked action contract rather than splitting into unrelated
+current action kinds or commands.

--- a/artifacts/changes/archived/repair-route-freshness-capability-gaps-2/tasks.md
+++ b/artifacts/changes/archived/repair-route-freshness-capability-gaps-2/tasks.md
@@ -1,0 +1,21 @@
+# Tasks
+
+## Task List
+
+- [x] `t-01` Add default compact `run --json` host capability regression
+  - depends_on: []
+  - target_files: [cmd/progression_next_test.go]
+  - task_kind: test
+  - covers: [REQ-001]
+
+- [x] `t-02` Add blocker-driven review-alignment cross-surface regression
+  - depends_on: []
+  - target_files: [cmd/progression_next_test.go]
+  - task_kind: test
+  - covers: [REQ-002]
+
+- [x] `t-03` Repair any command/view projection gap exposed by the focused regressions
+  - depends_on: [`t-01`, `t-02`]
+  - target_files: [cmd/next.go, cmd/next_handoff.go, cmd/status.go, cmd/status_view_build.go, cmd/validate.go, cmd/progression_next_test.go]
+  - task_kind: code
+  - covers: [REQ-001, REQ-002]

--- a/cmd/progression_next_test.go
+++ b/cmd/progression_next_test.go
@@ -185,6 +185,135 @@ func TestNextStalePlanningEvidenceReportsReviewAlignmentHandoff(t *testing.T) {
 	assert.Equal(t, model.PlanSubStepNone, loaded.PlanSubStep)
 }
 
+func TestStalePlanningReviewAlignmentActionContractStaysConsistentAcrossSurfaces(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	slug, _ := prepareStalePlanningRecoveryFixture(t, root, model.StateS3Review)
+	bundlePath := filepath.Join(root, "artifacts", "changes", slug)
+	tasksPath := filepath.Join(bundlePath, "tasks.md")
+	require.NoError(t, writeBundleArtifactFile(bundlePath, slug, "tasks.md", []byte(`# Tasks
+
+- [ ] `+"`t-01`"+` verify recovered planning chain
+  - depends_on: []
+  - target_files: ["cmd/done.go"]
+  - task_kind: verification
+  - covers: [REQ-001]
+`)))
+	staleAt := time.Now().UTC().Add(2 * time.Second)
+	require.NoError(t, os.Chtimes(tasksPath, staleAt, staleAt))
+	change, err := state.LoadChange(root, slug)
+	require.NoError(t, err)
+	_, err = state.MaterializeWavePlan(root, change)
+	require.NoError(t, err)
+	summary, err := state.LoadExecutionSummary(root, slug)
+	require.NoError(t, err)
+	require.NotEmpty(t, summary.Tasks)
+	summary.Tasks[0].ChangedFiles = []string{"cmd/done.go"}
+	summary.Tasks[0].TargetFiles = []string{"cmd/done.go"}
+	writeExecutionSummary(t, root, slug, summary)
+
+	assertReviewAlignmentHandoff := func(t *testing.T, surface, skillName, actionKind, actionReason string, selected []string) {
+		t.Helper()
+		assert.NotEmpty(t, skillName, surface)
+		assert.NotEqual(t, progression.SkillPlanAudit, skillName, surface)
+		assert.Contains(t, selected, skillName, surface)
+		assert.Equal(t, "review_batch", actionKind, surface)
+		assert.Equal(t, "review_batch", actionReason, surface)
+	}
+
+	nextCmd := commandForRoot(t, root, makeNextCmd())
+	nextCmd.SetArgs([]string{"--json", "--change", slug})
+	var nextOut bytes.Buffer
+	nextCmd.SetOut(&nextOut)
+	require.NoError(t, nextCmd.Execute())
+	var nextHandoff nextHandoffView
+	require.NoError(t, json.Unmarshal(nextOut.Bytes(), &nextHandoff))
+	require.NotNil(t, nextHandoff.NextSkill)
+	assertReviewAlignmentHandoff(
+		t,
+		"next handoff",
+		nextHandoff.NextSkill.Name,
+		nextHandoff.Confirmation.NextActionKind,
+		nextHandoff.Confirmation.Reason,
+		nextHandoff.NextSkill.SelectedReviewSkills,
+	)
+
+	nextDiagCmd := commandForRoot(t, root, makeNextCmd())
+	nextDiagCmd.SetArgs([]string{"--json", "--diagnostics", "--change", slug})
+	var nextDiagOut bytes.Buffer
+	nextDiagCmd.SetOut(&nextDiagOut)
+	require.NoError(t, nextDiagCmd.Execute())
+	var nextDiag nextView
+	require.NoError(t, json.Unmarshal(nextDiagOut.Bytes(), &nextDiag))
+	require.NotNil(t, nextDiag.NextSkill)
+	assertReviewAlignmentHandoff(
+		t,
+		"next diagnostics",
+		nextDiag.NextSkill.Name,
+		nextDiag.CurrentActionKind,
+		nextDiag.ConfirmationRequirement.Reason,
+		nextDiag.NextSkill.SelectedReviewSkills,
+	)
+
+	validateCmd := commandForRoot(t, root, makeValidateCmd())
+	validateCmd.SetArgs([]string{"--json", "--change", slug})
+	var validateOut bytes.Buffer
+	validateCmd.SetOut(&validateOut)
+	require.NoError(t, validateCmd.Execute())
+	var validate validateView
+	require.NoError(t, json.Unmarshal(validateOut.Bytes(), &validate))
+	require.NotNil(t, validate.ActionableNextSkill)
+	assertReviewAlignmentHandoff(
+		t,
+		"validate",
+		validate.ActionableNextSkill.Name,
+		validate.CurrentActionKind,
+		validate.CurrentActionKind,
+		validate.ActionableNextSkill.SelectedReviewSkills,
+	)
+
+	statusCmd := commandForRoot(t, root, makeStatusCmd())
+	statusCmd.SetArgs([]string{"--json", "--change", slug})
+	var statusOut bytes.Buffer
+	statusCmd.SetOut(&statusOut)
+	require.NoError(t, statusCmd.Execute())
+	var status statusView
+	require.NoError(t, json.Unmarshal(statusOut.Bytes(), &status))
+	require.NotNil(t, status.ActionableNextSkill)
+	assert.Equal(t, "review_batch", status.CurrentActionKind)
+	assert.Equal(t, "slipway run", status.CurrentActionCommand)
+	assertReviewAlignmentHandoff(
+		t,
+		"status",
+		status.ActionableNextSkill.Name,
+		status.CurrentActionKind,
+		status.CurrentActionKind,
+		status.ActionableNextSkill.SelectedReviewSkills,
+	)
+
+	runCmd := commandForRoot(t, root, makeRunCmd())
+	runCmd.SetArgs([]string{"--json", "--change", slug})
+	var runOut bytes.Buffer
+	runCmd.SetOut(&runOut)
+	require.NoError(t, runCmd.Execute())
+	var runHandoff nextHandoffView
+	require.NoError(t, json.Unmarshal(runOut.Bytes(), &runHandoff))
+	require.NotNil(t, runHandoff.NextSkill)
+	assertReviewAlignmentHandoff(
+		t,
+		"run handoff",
+		runHandoff.NextSkill.Name,
+		runHandoff.Confirmation.NextActionKind,
+		runHandoff.Confirmation.Reason,
+		runHandoff.NextSkill.SelectedReviewSkills,
+	)
+	assert.Equal(t, nextDiag.NextSkill.Name, nextHandoff.NextSkill.Name)
+	assert.Equal(t, nextDiag.NextSkill.Name, status.ActionableNextSkill.Name)
+	assert.Equal(t, nextDiag.NextSkill.Name, validate.ActionableNextSkill.Name)
+	assert.Equal(t, nextDiag.NextSkill.Name, runHandoff.NextSkill.Name)
+}
+
 func TestNextS0ConfirmWithoutApprovedSummaryDoesNotReportRunGuidance(t *testing.T) {
 	t.Parallel()
 
@@ -1173,6 +1302,10 @@ func TestReviewStateActionableNextSkillConsistentAcrossCommandSurfaces(t *testin
 		require.NoError(t, statusCmd.Execute())
 		var status statusView
 		require.NoError(t, json.Unmarshal(statusOut.Bytes(), &status))
+		require.NotNil(t, status.ActionableNextSkill)
+		assert.Equal(t, progression.SkillCodeQualityReview, status.ActionableNextSkill.Name)
+		assert.ElementsMatch(t, selectedReviewSkills, status.ActionableNextSkill.SelectedReviewSkills)
+		assert.Contains(t, status.ActionableNextSkill.RequiredTokens, "layer:IR1=pass")
 		assert.Equal(t, "review_batch", status.CurrentActionKind)
 		assert.Equal(t, "slipway run", status.CurrentActionCommand)
 		assert.Equal(t, "fresh", status.ExecutionEvidenceFreshness)
@@ -1291,6 +1424,30 @@ func TestReviewBatchHostCapabilityUnavailableFailsClosedUnlessFallbackSelected(t
 	assert.NotEmpty(t, runView.ExecutionEvidenceFreshness)
 	assert.NotEmpty(t, runView.GovernanceEvidenceFreshness)
 	assert.Equal(t, "blocked", runView.OverallReadinessFreshness)
+
+	compactRunCmd := commandForRoot(t, root, makeRunCmd())
+	compactRunCmd.SetArgs([]string{"--json", "--change", slug})
+	var compactRunOut bytes.Buffer
+	compactRunCmd.SetOut(&compactRunOut)
+	require.NoError(t, compactRunCmd.Execute())
+	var compactRun nextHandoffView
+	require.NoError(t, json.Unmarshal(compactRunOut.Bytes(), &compactRun))
+	compactRunCapability := requireIndependentReviewHostCapability(t, compactRun.HostCapabilities)
+	assert.Equal(t, "unknown", compactRunCapability.Availability)
+	assert.False(t, compactRunCapability.FallbackSelected)
+	assert.Contains(t, model.ReasonSpecs(compactRun.Blockers), "host_capability_unavailable:independent-review:subagent")
+	assert.Equal(t, "blocked_by_governance", compactRun.Confirmation.Reason)
+	assert.Equal(t, "blocker_resolution", compactRun.Confirmation.NextActionKind)
+	assert.NotEmpty(t, compactRun.ExecutionEvidenceFreshness)
+	assert.NotEmpty(t, compactRun.GovernanceEvidenceFreshness)
+	assert.Equal(t, "blocked", compactRun.OverallReadinessFreshness)
+	require.NotNil(t, compactRun.Recovery)
+	assert.NotEmpty(t, compactRun.Recovery.Steps)
+	assert.Equal(t, model.StateS3Review, compactRun.CurrentState)
+	reloadedAfterCompactRun, err := state.LoadChange(root, slug)
+	require.NoError(t, err)
+	assert.Equal(t, model.StateS3Review, reloadedAfterCompactRun.CurrentState)
+	assert.Equal(t, model.PlanSubStepNone, reloadedAfterCompactRun.PlanSubStep)
 
 	t.Setenv("SLIPWAY_HOST_CAPABILITIES", "none")
 

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -60,6 +60,7 @@ type statusView struct {
 	FreshnessDiagnostics        *state.ExecutionFreshnessDiagnostics `json:"freshness_diagnostics,omitempty"`
 	CurrentActionKind           string                               `json:"current_action_kind,omitempty"`
 	CurrentActionCommand        string                               `json:"current_action_command,omitempty"`
+	ActionableNextSkill         *actionableNextSkillView             `json:"actionable_next_skill,omitempty"`
 	SelectedReviewSkills        []string                             `json:"selected_review_skills,omitempty"`
 	ScopeContract               *scopeContractView                   `json:"scope_contract,omitempty"`
 	SourceStateFile             string                               `json:"source_state_file,omitempty"`

--- a/cmd/status_view_build.go
+++ b/cmd/status_view_build.go
@@ -148,6 +148,7 @@ func buildGovernedStatusViewWithReadContext(readCtx *stateReadContext, change mo
 	view.Recovery = model.BuildRecovery(view.Blockers)
 	applyReadinessFreshnessToStatus(&view, readiness)
 	view.CurrentActionKind, view.CurrentActionCommand = projectCurrentActionContract(change, readiness)
+	view.ActionableNextSkill = buildActionableNextSkillView(change, readiness)
 	view.FreshnessDiagnostics = attachFreshnessDiagnostics(readiness.FreshnessDiagnostics)
 	view.Diagnostics = append([]string(nil), projection.Diagnostics...)
 	view.Diagnostics = append(view.Diagnostics, waveDiagnostics...)


### PR DESCRIPTION
## Summary

- add `status --json` projection for the shared actionable review skill via `actionable_next_skill`
- tighten regressions for compact `run --json` host-capability blockers, freshness, recovery, confirmation, and no-advance behavior
- archive the completed governed change `repair-route-freshness-capability-gaps-2`

## Root Cause

The current `run` path already used the shared next-view capability gate, so the remaining real gap was public lifecycle surface consistency: `status --json` exposed the selected review batch but not the same actionable review skill shown by `next`, `next --diagnostics`, `validate`, and `run`.

## Validation

- `SLIPWAY_HOST_CAPABILITIES=subagent go run . status --json --change repair-route-freshness-capability-gaps-2` -> `DONE` / archived
- `go test -count=1 ./...`
- `golangci-lint run ./...`
- `git diff --check`
- `git diff --cached --check` before commit
