### PR TITLE
fix(lifecycle): cache route read context

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -447,67 +447,7 @@ func resolveActiveChangeRef(root string, explicitSlug string) (changeRef, error)
 }
 
 func resolveActiveChangeRefWithReadContext(readCtx *stateReadContext, explicitSlug string) (changeRef, error) {
-	root := readCtx.root
-	// When --change is provided, load that specific change.
-	if strings.TrimSpace(explicitSlug) != "" {
-		return resolveExplicitChangeWithReadContext(readCtx, strings.TrimSpace(explicitSlug))
-	}
-
-	// Worktree-based resolution.
-	worktreePath, err := currentWorktreeRoot()
-	if err != nil {
-		return changeRef{}, wrapResolutionErrorForRoot(root, err)
-	}
-	if worktreePath != "" {
-		if change, ok, err := resolveActiveChangeRefFromWorktreeBinding(root, worktreePath); err != nil {
-			return changeRef{}, err
-		} else if ok {
-			readCtx.rememberChange(change)
-			return changeRef{Slug: change.Slug}, nil
-		}
-
-		change, err := state.FindActiveChangeForWorktree(root, worktreePath)
-		if err != nil {
-			// Before surfacing "no active change here" or "bound to another
-			// worktree", prefer this worktree's own archived change when it hosts
-			// one, so an archived-change worktree reports its own terminal state
-			// (archived_change_not_validatable) instead of an unrelated active
-			// change bound to a different worktree (#283).
-			if shouldTryArchivedWorktreeFallback(err) {
-				if archived, ok, archErr := state.FindArchivedChangeForWorktree(root, worktreePath); archErr != nil {
-					return changeRef{}, wrapArchivedWorktreeResolutionError(archErr)
-				} else if ok {
-					return resolveExplicitChangeWithReadContext(readCtx, archived.Slug)
-				}
-			}
-			if recoveryErr := deleteRecoveryError(root, ""); recoveryErr != nil {
-				return changeRef{}, recoveryErr
-			}
-			return changeRef{}, wrapResolutionErrorForRoot(root, err)
-		}
-		if strings.TrimSpace(change.WorktreePath) == "" {
-			// A single unbound active change is only a fallback. In an archived
-			// review worktree, local archived authority is more specific and must
-			// fail closed before commands operate on the unrelated unbound change.
-			if archived, ok, archErr := state.FindArchivedChangeForWorktree(root, worktreePath); archErr != nil {
-				return changeRef{}, wrapArchivedWorktreeResolutionError(archErr)
-			} else if ok {
-				return resolveExplicitChangeWithReadContext(readCtx, archived.Slug)
-			}
-		}
-		readCtx.rememberChange(change)
-		return changeRef{Slug: change.Slug}, nil
-	}
-
-	change, err := state.FindActiveChange(root)
-	if err != nil {
-		if recoveryErr := deleteRecoveryError(root, ""); recoveryErr != nil {
-			return changeRef{}, recoveryErr
-		}
-		return changeRef{}, wrapResolutionErrorForRoot(root, err)
-	}
-	readCtx.rememberChange(change)
-	return changeRef{Slug: change.Slug}, nil
+	return readCtx.activeRef(explicitSlug)
 }
 
 func resolveActiveChangeRefFromWorktreeBinding(root, worktreePath string) (model.Change, bool, error) {
@@ -1187,6 +1127,16 @@ func buildInvocationRouteView(
 	invocationWorkspace string,
 	explicitChange bool,
 ) *invocationRouteView {
+	return buildInvocationRouteViewWithReadContext(newStateReadContext(root), change, invocationWorkspace, explicitChange)
+}
+
+func buildInvocationRouteViewWithReadContext(
+	readCtx *stateReadContext,
+	change model.Change,
+	invocationWorkspace string,
+	explicitChange bool,
+) *invocationRouteView {
+	root := readCtx.root
 	slug := strings.TrimSpace(change.Slug)
 	if slug == "" {
 		return nil
@@ -1197,7 +1147,7 @@ func buildInvocationRouteView(
 	if strings.TrimSpace(invocationWorkspace) != "" {
 		route.InvocationWorkspacePath = state.DisplayPath(root, invocationWorkspace)
 	}
-	if paths, err := state.ResolveChangePaths(root, change); err == nil {
+	if paths, err := readCtx.resolvedPaths(change); err == nil {
 		route.BoundWorkspacePath = state.DisplayPath(root, paths.WorkspaceRoot)
 		route.ChangeAuthorityPath = state.DisplayPath(root, filepath.Join(paths.GovernedBundleDir, "change.yaml"))
 	}

--- a/cmd/freshness_diagnostics.go
+++ b/cmd/freshness_diagnostics.go
@@ -9,64 +9,103 @@ import (
 )
 
 func applyCommandInvocationWorkspacePath(cmd *cobra.Command, root string, diagnostics *state.ExecutionFreshnessDiagnostics) {
+	applyCommandInvocationWorkspacePathWithReadContext(cmd, newStateReadContext(root), diagnostics)
+}
+
+func applyCommandInvocationWorkspacePathWithReadContext(cmd *cobra.Command, readCtx *stateReadContext, diagnostics *state.ExecutionFreshnessDiagnostics) {
 	if diagnostics == nil || diagnostics.PathAuthority == nil {
 		return
 	}
-	workspace := invocationWorkspaceRootFromCommand(cmd, root)
+	workspace := invocationWorkspaceRootFromCommandWithReadContext(cmd, readCtx)
 	if strings.TrimSpace(workspace) == "" {
 		return
 	}
-	diagnostics.PathAuthority.InvocationWorkspacePath = state.DisplayPath(root, workspace)
+	diagnostics.PathAuthority.InvocationWorkspacePath = state.DisplayPath(readCtx.root, workspace)
 }
 
 func applyNextInvocationWorkspacePath(cmd *cobra.Command, root string, view *nextView) {
+	applyNextInvocationWorkspacePathWithReadContext(cmd, newStateReadContext(root), view)
+}
+
+func applyNextInvocationWorkspacePathWithReadContext(cmd *cobra.Command, readCtx *stateReadContext, view *nextView) {
 	if view == nil {
 		return
 	}
-	applyCommandInvocationWorkspacePath(cmd, root, view.FreshnessDiagnostics)
+	applyCommandInvocationWorkspacePathWithReadContext(cmd, readCtx, view.FreshnessDiagnostics)
 }
 
 func applyNextInvocationRoute(cmd *cobra.Command, root string, change model.Change, explicitChange bool, view *nextView) {
+	applyNextInvocationRouteWithReadContext(cmd, newStateReadContext(root), change, explicitChange, view)
+}
+
+func applyNextInvocationRouteWithReadContext(cmd *cobra.Command, readCtx *stateReadContext, change model.Change, explicitChange bool, view *nextView) {
 	if view == nil {
 		return
 	}
-	workspace := invocationWorkspaceRootFromCommand(cmd, root)
-	view.InvocationRoute = buildInvocationRouteView(root, change, workspace, explicitChange)
+	workspace := invocationWorkspaceRootFromCommandWithReadContext(cmd, readCtx)
+	view.InvocationRoute = buildInvocationRouteViewWithReadContext(readCtx, change, workspace, explicitChange)
 }
 
 func applyValidateInvocationWorkspacePath(cmd *cobra.Command, root string, view *validateView) {
+	applyValidateInvocationWorkspacePathWithReadContext(cmd, newStateReadContext(root), view)
+}
+
+func applyValidateInvocationWorkspacePathWithReadContext(cmd *cobra.Command, readCtx *stateReadContext, view *validateView) {
 	if view == nil {
 		return
 	}
-	applyCommandInvocationWorkspacePath(cmd, root, view.FreshnessDiagnostics)
+	applyCommandInvocationWorkspacePathWithReadContext(cmd, readCtx, view.FreshnessDiagnostics)
 }
 
 func applyValidateInvocationRoute(cmd *cobra.Command, root string, change model.Change, explicitChange bool, view *validateView) {
+	applyValidateInvocationRouteWithReadContext(cmd, newStateReadContext(root), change, explicitChange, view)
+}
+
+func applyValidateInvocationRouteWithReadContext(cmd *cobra.Command, readCtx *stateReadContext, change model.Change, explicitChange bool, view *validateView) {
 	if view == nil {
 		return
 	}
-	workspace := invocationWorkspaceRootFromCommand(cmd, root)
-	view.InvocationRoute = buildInvocationRouteView(root, change, workspace, explicitChange)
+	workspace := invocationWorkspaceRootFromCommandWithReadContext(cmd, readCtx)
+	view.InvocationRoute = buildInvocationRouteViewWithReadContext(readCtx, change, workspace, explicitChange)
 }
 
 func applyStatusInvocationWorkspacePath(cmd *cobra.Command, root string, view *statusView) {
+	applyStatusInvocationWorkspacePathWithReadContext(cmd, newStateReadContext(root), view)
+}
+
+func applyStatusInvocationWorkspacePathWithReadContext(cmd *cobra.Command, readCtx *stateReadContext, view *statusView) {
 	if view == nil {
 		return
 	}
-	applyCommandInvocationWorkspacePath(cmd, root, view.FreshnessDiagnostics)
+	applyCommandInvocationWorkspacePathWithReadContext(cmd, readCtx, view.FreshnessDiagnostics)
 }
 
 func applyStatusInvocationRoute(cmd *cobra.Command, root string, change model.Change, explicitChange bool, view *statusView) {
+	applyStatusInvocationRouteWithReadContext(cmd, newStateReadContext(root), change, explicitChange, view)
+}
+
+func applyStatusInvocationRouteWithReadContext(cmd *cobra.Command, readCtx *stateReadContext, change model.Change, explicitChange bool, view *statusView) {
 	if view == nil {
 		return
 	}
-	workspace := invocationWorkspaceRootFromCommand(cmd, root)
-	view.InvocationRoute = buildInvocationRouteView(root, change, workspace, explicitChange)
+	workspace := invocationWorkspaceRootFromCommandWithReadContext(cmd, readCtx)
+	view.InvocationRoute = buildInvocationRouteViewWithReadContext(readCtx, change, workspace, explicitChange)
 }
 
 func commandInvocationRoute(cmd *cobra.Command, root string, change model.Change, explicitChange bool) *invocationRouteView {
-	workspace := invocationWorkspaceRootFromCommand(cmd, root)
-	return buildInvocationRouteView(root, change, workspace, explicitChange)
+	return commandInvocationRouteWithReadContext(cmd, newStateReadContext(root), change, explicitChange)
+}
+
+func commandInvocationRouteWithReadContext(cmd *cobra.Command, readCtx *stateReadContext, change model.Change, explicitChange bool) *invocationRouteView {
+	workspace := invocationWorkspaceRootFromCommandWithReadContext(cmd, readCtx)
+	return buildInvocationRouteViewWithReadContext(readCtx, change, workspace, explicitChange)
+}
+
+func invocationWorkspaceRootFromCommandWithReadContext(cmd *cobra.Command, readCtx *stateReadContext) string {
+	if root, ok := projectRootOverrideFromCommand(cmd); ok {
+		return root
+	}
+	return readCtx.invocationWorkspace()
 }
 
 func attachFreshnessDiagnostics(diagnostics state.ExecutionFreshnessDiagnostics) *state.ExecutionFreshnessDiagnostics {

--- a/cmd/freshness_diagnostics.go
+++ b/cmd/freshness_diagnostics.go
@@ -34,20 +34,12 @@ func applyNextInvocationWorkspacePathWithReadContext(cmd *cobra.Command, readCtx
 	applyCommandInvocationWorkspacePathWithReadContext(cmd, readCtx, view.FreshnessDiagnostics)
 }
 
-func applyNextInvocationRoute(cmd *cobra.Command, root string, change model.Change, explicitChange bool, view *nextView) {
-	applyNextInvocationRouteWithReadContext(cmd, newStateReadContext(root), change, explicitChange, view)
-}
-
 func applyNextInvocationRouteWithReadContext(cmd *cobra.Command, readCtx *stateReadContext, change model.Change, explicitChange bool, view *nextView) {
 	if view == nil {
 		return
 	}
 	workspace := invocationWorkspaceRootFromCommandWithReadContext(cmd, readCtx)
 	view.InvocationRoute = buildInvocationRouteViewWithReadContext(readCtx, change, workspace, explicitChange)
-}
-
-func applyValidateInvocationWorkspacePath(cmd *cobra.Command, root string, view *validateView) {
-	applyValidateInvocationWorkspacePathWithReadContext(cmd, newStateReadContext(root), view)
 }
 
 func applyValidateInvocationWorkspacePathWithReadContext(cmd *cobra.Command, readCtx *stateReadContext, view *validateView) {
@@ -57,20 +49,12 @@ func applyValidateInvocationWorkspacePathWithReadContext(cmd *cobra.Command, rea
 	applyCommandInvocationWorkspacePathWithReadContext(cmd, readCtx, view.FreshnessDiagnostics)
 }
 
-func applyValidateInvocationRoute(cmd *cobra.Command, root string, change model.Change, explicitChange bool, view *validateView) {
-	applyValidateInvocationRouteWithReadContext(cmd, newStateReadContext(root), change, explicitChange, view)
-}
-
 func applyValidateInvocationRouteWithReadContext(cmd *cobra.Command, readCtx *stateReadContext, change model.Change, explicitChange bool, view *validateView) {
 	if view == nil {
 		return
 	}
 	workspace := invocationWorkspaceRootFromCommandWithReadContext(cmd, readCtx)
 	view.InvocationRoute = buildInvocationRouteViewWithReadContext(readCtx, change, workspace, explicitChange)
-}
-
-func applyStatusInvocationWorkspacePath(cmd *cobra.Command, root string, view *statusView) {
-	applyStatusInvocationWorkspacePathWithReadContext(cmd, newStateReadContext(root), view)
 }
 
 func applyStatusInvocationWorkspacePathWithReadContext(cmd *cobra.Command, readCtx *stateReadContext, view *statusView) {

--- a/cmd/next.go
+++ b/cmd/next.go
@@ -373,8 +373,8 @@ Environment variables:
 					if err != nil {
 						return err
 					}
-					applyNextInvocationWorkspacePath(cmd, root, &view)
-					applyNextInvocationRoute(cmd, root, lockedChange, strings.TrimSpace(changeSlug) != "", &view)
+					applyNextInvocationWorkspacePathWithReadContext(cmd, readCtx, &view)
+					applyNextInvocationRouteWithReadContext(cmd, readCtx, lockedChange, strings.TrimSpace(changeSlug) != "", &view)
 					return encodeJSONResponse(cmd, buildNextHandoffView(view))
 				}
 
@@ -389,8 +389,8 @@ Environment variables:
 				if err != nil {
 					return err
 				}
-				applyNextInvocationWorkspacePath(cmd, root, &view)
-				applyNextInvocationRoute(cmd, root, lockedChange, strings.TrimSpace(changeSlug) != "", &view)
+				applyNextInvocationWorkspacePathWithReadContext(cmd, readCtx, &view)
+				applyNextInvocationRouteWithReadContext(cmd, readCtx, lockedChange, strings.TrimSpace(changeSlug) != "", &view)
 
 				if contextGuard {
 					return writeContextGuardHookMessages(cmd.OutOrStdout(), view)

--- a/cmd/progression_next_test.go
+++ b/cmd/progression_next_test.go
@@ -1480,6 +1480,50 @@ func TestReviewBatchHostCapabilityUnavailableFailsClosedUnlessFallbackSelected(t
 	assert.Equal(t, "review_batch", fallbackView.ConfirmationRequirement.Reason)
 }
 
+func TestReviewBatchHostCapabilityAvailableDoesNotBlockCommandSurfaces(t *testing.T) {
+	root, slug := prepareReviewBatchHostCapabilityFixture(t)
+	t.Setenv("SLIPWAY_HOST_CAPABILITIES", "delegation")
+	t.Setenv("SLIPWAY_HOST_CAPABILITY_FALLBACKS", "")
+
+	nextCmd := commandForRoot(t, root, makeNextCmd())
+	nextCmd.SetArgs([]string{"--json", "--diagnostics", "--change", slug})
+	var nextOut bytes.Buffer
+	nextCmd.SetOut(&nextOut)
+	require.NoError(t, nextCmd.Execute())
+	var nextOutputView nextView
+	require.NoError(t, json.Unmarshal(nextOut.Bytes(), &nextOutputView))
+	nextCapability := requireIndependentReviewHostCapability(t, nextOutputView.HostCapabilities)
+	assert.Equal(t, "available", nextCapability.Availability)
+	assert.False(t, nextCapability.FallbackSelected)
+	assert.NotContains(t, model.ReasonSpecs(nextOutputView.Blockers), "host_capability_unavailable:independent-review:subagent")
+	assert.Equal(t, "review_batch", nextOutputView.ConfirmationRequirement.Reason)
+
+	validateCmd := commandForRoot(t, root, makeValidateCmd())
+	validateCmd.SetArgs([]string{"--json", "--change", slug})
+	var validateOut bytes.Buffer
+	validateCmd.SetOut(&validateOut)
+	require.NoError(t, validateCmd.Execute())
+	var validate validateView
+	require.NoError(t, json.Unmarshal(validateOut.Bytes(), &validate))
+	validateCapability := requireIndependentReviewHostCapability(t, validate.HostCapabilities)
+	assert.Equal(t, "available", validateCapability.Availability)
+	assert.False(t, validateCapability.FallbackSelected)
+	assert.NotContains(t, model.ReasonSpecs(validate.Blockers), "host_capability_unavailable:independent-review:subagent")
+
+	runCmd := commandForRoot(t, root, makeRunCmd())
+	runCmd.SetArgs([]string{"--json", "--diagnostics", "--change", slug})
+	var runOut bytes.Buffer
+	runCmd.SetOut(&runOut)
+	require.NoError(t, runCmd.Execute())
+	var runView nextView
+	require.NoError(t, json.Unmarshal(runOut.Bytes(), &runView))
+	runCapability := requireIndependentReviewHostCapability(t, runView.HostCapabilities)
+	assert.Equal(t, "available", runCapability.Availability)
+	assert.False(t, runCapability.FallbackSelected)
+	assert.NotContains(t, model.ReasonSpecs(runView.Blockers), "host_capability_unavailable:independent-review:subagent")
+	assert.Equal(t, "review_batch", runView.ConfirmationRequirement.Reason)
+}
+
 func prepareReviewBatchHostCapabilityFixture(t *testing.T) (string, string) {
 	t.Helper()
 

--- a/cmd/state_read_context.go
+++ b/cmd/state_read_context.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/signalridge/slipway/internal/model"
@@ -11,11 +12,26 @@ import (
 )
 
 type stateReadContext struct {
-	root          string
-	changes       map[string]model.Change
-	paths         map[string]state.ResolvedChangePaths
-	verifications map[string]map[string]model.VerificationRecord
-	execution     map[string]executionContext
+	root                      string
+	gitCommonDir              string
+	gitCommonDirLoaded        bool
+	invocationWorkspaceRoot   string
+	invocationWorkspaceLoaded bool
+	currentWorktreeRoot       string
+	currentWorktreeRootErr    error
+	currentWorktreeRootLoaded bool
+	changes                   map[string]model.Change
+	changesList               []model.Change
+	changesListLoaded         bool
+	paths                     map[string]state.ResolvedChangePaths
+	verifications             map[string]map[string]model.VerificationRecord
+	execution                 map[string]executionContext
+	activeRefs                map[string]activeChangeRefCacheEntry
+}
+
+type activeChangeRefCacheEntry struct {
+	ref changeRef
+	err error
 }
 
 func newStateReadContext(root string) *stateReadContext {
@@ -25,6 +41,7 @@ func newStateReadContext(root string) *stateReadContext {
 		paths:         make(map[string]state.ResolvedChangePaths),
 		verifications: make(map[string]map[string]model.VerificationRecord),
 		execution:     make(map[string]executionContext),
+		activeRefs:    make(map[string]activeChangeRefCacheEntry),
 	}
 }
 
@@ -33,6 +50,7 @@ func (ctx *stateReadContext) loadChange(slug string) (model.Change, error) {
 	if change, ok := ctx.changes[slug]; ok {
 		return change, nil
 	}
+	_ = ctx.gitCommonDirPath()
 	change, err := state.LoadChangeFast(ctx.root, slug)
 	if err != nil {
 		return model.Change{}, err
@@ -50,7 +68,9 @@ func (ctx *stateReadContext) reloadChange(slug string) (model.Change, error) {
 	delete(ctx.paths, slug)
 	delete(ctx.verifications, slug)
 	delete(ctx.execution, slug)
+	ctx.invalidateRouteCaches()
 
+	_ = ctx.gitCommonDirPath()
 	change, err := state.LoadChangeFast(ctx.root, slug)
 	if err != nil {
 		return model.Change{}, err
@@ -65,6 +85,156 @@ func (ctx *stateReadContext) rememberChange(change model.Change) {
 		return
 	}
 	ctx.changes[slug] = change
+}
+
+func (ctx *stateReadContext) invalidateRouteCaches() {
+	ctx.changesList = nil
+	ctx.changesListLoaded = false
+	ctx.activeRefs = make(map[string]activeChangeRefCacheEntry)
+}
+
+func (ctx *stateReadContext) gitCommonDirPath() string {
+	if ctx.gitCommonDirLoaded {
+		return ctx.gitCommonDir
+	}
+	ctx.gitCommonDir = state.GitCommonDir(ctx.root)
+	ctx.gitCommonDirLoaded = true
+	return ctx.gitCommonDir
+}
+
+func (ctx *stateReadContext) invocationWorkspace() string {
+	if ctx.invocationWorkspaceLoaded {
+		return ctx.invocationWorkspaceRoot
+	}
+	workspaceRoot := ctx.root
+	wd, err := os.Getwd()
+	if err == nil {
+		if resolved, resolveErr := state.ResolveGitWorkspaceRoot(wd); resolveErr == nil && resolved != "" {
+			workspaceRoot = resolved
+		}
+	}
+	if normalized, err := state.NormalizePath(workspaceRoot); err == nil {
+		workspaceRoot = normalized
+	} else {
+		workspaceRoot = filepath.Clean(workspaceRoot)
+	}
+	ctx.invocationWorkspaceRoot = workspaceRoot
+	ctx.invocationWorkspaceLoaded = true
+	return ctx.invocationWorkspaceRoot
+}
+
+func (ctx *stateReadContext) currentWorktree() (string, error) {
+	if ctx.currentWorktreeRootLoaded {
+		return ctx.currentWorktreeRoot, ctx.currentWorktreeRootErr
+	}
+	ctx.currentWorktreeRoot, ctx.currentWorktreeRootErr = currentWorktreeRoot()
+	ctx.currentWorktreeRootLoaded = true
+	return ctx.currentWorktreeRoot, ctx.currentWorktreeRootErr
+}
+
+func (ctx *stateReadContext) activeRef(explicitSlug string) (changeRef, error) {
+	key := strings.TrimSpace(explicitSlug)
+	if entry, ok := ctx.activeRefs[key]; ok {
+		return entry.ref, entry.err
+	}
+	ref, err := ctx.resolveActiveRefUncached(key)
+	ctx.activeRefs[key] = activeChangeRefCacheEntry{ref: ref, err: err}
+	return ref, err
+}
+
+func (ctx *stateReadContext) resolveActiveRefUncached(explicitSlug string) (changeRef, error) {
+	root := ctx.root
+	if strings.TrimSpace(explicitSlug) != "" {
+		return resolveExplicitChangeWithReadContext(ctx, strings.TrimSpace(explicitSlug))
+	}
+
+	worktreePath, err := ctx.currentWorktree()
+	if err != nil {
+		return changeRef{}, wrapResolutionErrorForRoot(root, err)
+	}
+	if worktreePath != "" {
+		if change, ok, err := resolveActiveChangeRefFromWorktreeBinding(root, worktreePath); err != nil {
+			return changeRef{}, err
+		} else if ok {
+			ctx.rememberChange(change)
+			return changeRef{Slug: change.Slug}, nil
+		}
+
+		change, err := ctx.findActiveChangeForWorktree(worktreePath)
+		if err != nil {
+			// Before surfacing "no active change here" or "bound to another
+			// worktree", prefer this worktree's own archived change when it hosts
+			// one, so an archived-change worktree reports its own terminal state
+			// (archived_change_not_validatable) instead of an unrelated active
+			// change bound to a different worktree (#283).
+			if shouldTryArchivedWorktreeFallback(err) {
+				if archived, ok, archErr := state.FindArchivedChangeForWorktree(root, worktreePath); archErr != nil {
+					return changeRef{}, wrapArchivedWorktreeResolutionError(archErr)
+				} else if ok {
+					return resolveExplicitChangeWithReadContext(ctx, archived.Slug)
+				}
+			}
+			if recoveryErr := deleteRecoveryError(root, ""); recoveryErr != nil {
+				return changeRef{}, recoveryErr
+			}
+			return changeRef{}, wrapResolutionErrorForRoot(root, err)
+		}
+		if strings.TrimSpace(change.WorktreePath) == "" {
+			// A single unbound active change is only a fallback. In an archived
+			// review worktree, local archived authority is more specific and must
+			// fail closed before commands operate on the unrelated unbound change.
+			if archived, ok, archErr := state.FindArchivedChangeForWorktree(root, worktreePath); archErr != nil {
+				return changeRef{}, wrapArchivedWorktreeResolutionError(archErr)
+			} else if ok {
+				return resolveExplicitChangeWithReadContext(ctx, archived.Slug)
+			}
+		}
+		ctx.rememberChange(change)
+		return changeRef{Slug: change.Slug}, nil
+	}
+
+	change, err := ctx.findActiveChange()
+	if err != nil {
+		if recoveryErr := deleteRecoveryError(root, ""); recoveryErr != nil {
+			return changeRef{}, recoveryErr
+		}
+		return changeRef{}, wrapResolutionErrorForRoot(root, err)
+	}
+	ctx.rememberChange(change)
+	return changeRef{Slug: change.Slug}, nil
+}
+
+func (ctx *stateReadContext) listChanges() ([]model.Change, error) {
+	if ctx.changesListLoaded {
+		return slices.Clone(ctx.changesList), nil
+	}
+	_ = ctx.gitCommonDirPath()
+	changes, err := state.ListChanges(ctx.root)
+	if err != nil {
+		return nil, err
+	}
+	ctx.changesList = slices.Clone(changes)
+	ctx.changesListLoaded = true
+	for _, change := range changes {
+		ctx.rememberChange(change)
+	}
+	return slices.Clone(changes), nil
+}
+
+func (ctx *stateReadContext) findActiveChange() (model.Change, error) {
+	changes, err := ctx.listChanges()
+	if err != nil {
+		return model.Change{}, err
+	}
+	return state.SelectActiveChange(changes)
+}
+
+func (ctx *stateReadContext) findActiveChangeForWorktree(currentWorktreePath string) (model.Change, error) {
+	changes, err := ctx.listChanges()
+	if err != nil {
+		return model.Change{}, err
+	}
+	return state.SelectActiveChangeForWorktree(changes, currentWorktreePath)
 }
 
 func (ctx *stateReadContext) resolvedPaths(change model.Change) (state.ResolvedChangePaths, error) {

--- a/cmd/state_read_context.go
+++ b/cmd/state_read_context.go
@@ -13,8 +13,6 @@ import (
 
 type stateReadContext struct {
 	root                      string
-	gitCommonDir              string
-	gitCommonDirLoaded        bool
 	invocationWorkspaceRoot   string
 	invocationWorkspaceLoaded bool
 	currentWorktreeRoot       string
@@ -50,7 +48,6 @@ func (ctx *stateReadContext) loadChange(slug string) (model.Change, error) {
 	if change, ok := ctx.changes[slug]; ok {
 		return change, nil
 	}
-	_ = ctx.gitCommonDirPath()
 	change, err := state.LoadChangeFast(ctx.root, slug)
 	if err != nil {
 		return model.Change{}, err
@@ -70,7 +67,6 @@ func (ctx *stateReadContext) reloadChange(slug string) (model.Change, error) {
 	delete(ctx.execution, slug)
 	ctx.invalidateRouteCaches()
 
-	_ = ctx.gitCommonDirPath()
 	change, err := state.LoadChangeFast(ctx.root, slug)
 	if err != nil {
 		return model.Change{}, err
@@ -91,15 +87,6 @@ func (ctx *stateReadContext) invalidateRouteCaches() {
 	ctx.changesList = nil
 	ctx.changesListLoaded = false
 	ctx.activeRefs = make(map[string]activeChangeRefCacheEntry)
-}
-
-func (ctx *stateReadContext) gitCommonDirPath() string {
-	if ctx.gitCommonDirLoaded {
-		return ctx.gitCommonDir
-	}
-	ctx.gitCommonDir = state.GitCommonDir(ctx.root)
-	ctx.gitCommonDirLoaded = true
-	return ctx.gitCommonDir
 }
 
 func (ctx *stateReadContext) invocationWorkspace() string {
@@ -208,7 +195,6 @@ func (ctx *stateReadContext) listChanges() ([]model.Change, error) {
 	if ctx.changesListLoaded {
 		return slices.Clone(ctx.changesList), nil
 	}
-	_ = ctx.gitCommonDirPath()
 	changes, err := state.ListChanges(ctx.root)
 	if err != nil {
 		return nil, err

--- a/cmd/state_read_context_test.go
+++ b/cmd/state_read_context_test.go
@@ -99,3 +99,57 @@ func TestStateReadContextResolvesPathsOncePerInvocation(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, expectedBundleDir, first.GovernedBundleDir)
 }
+
+func TestStateReadContextCachesActiveRouteWithinInvocation(t *testing.T) {
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		ensureTestGitRepo(t, root)
+		initTestWorkspace(t, root)
+
+		first := model.NewChange("read-context-route-a")
+		require.NoError(t, state.SaveChange(root, first))
+
+		readCtx := newStateReadContext(root)
+		ref, err := resolveActiveChangeRefWithReadContext(readCtx, "")
+		require.NoError(t, err)
+		assert.Equal(t, first.Slug, ref.Slug)
+
+		second := model.NewChange("read-context-route-b")
+		require.NoError(t, state.SaveChange(root, second))
+
+		cachedRef, err := resolveActiveChangeRefWithReadContext(readCtx, "")
+		require.NoError(t, err)
+		assert.Equal(t, first.Slug, cachedRef.Slug)
+
+		_, err = resolveActiveChangeRefWithReadContext(newStateReadContext(root), "")
+		cliErr := asCLIError(err)
+		require.NotNil(t, cliErr)
+		assert.Equal(t, "active_context_ambiguous", cliErr.ErrorCode)
+	})
+}
+
+func TestStateReadContextReloadInvalidatesActiveRouteCache(t *testing.T) {
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		ensureTestGitRepo(t, root)
+		initTestWorkspace(t, root)
+
+		first := model.NewChange("read-context-route-reload-a")
+		require.NoError(t, state.SaveChange(root, first))
+
+		readCtx := newStateReadContext(root)
+		ref, err := resolveActiveChangeRefWithReadContext(readCtx, "")
+		require.NoError(t, err)
+		assert.Equal(t, first.Slug, ref.Slug)
+
+		second := model.NewChange("read-context-route-reload-b")
+		require.NoError(t, state.SaveChange(root, second))
+		_, err = readCtx.reloadChange(first.Slug)
+		require.NoError(t, err)
+
+		_, err = resolveActiveChangeRefWithReadContext(readCtx, "")
+		cliErr := asCLIError(err)
+		require.NotNil(t, cliErr)
+		assert.Equal(t, "active_context_ambiguous", cliErr.ErrorCode)
+	})
+}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -409,10 +409,6 @@ func resolveStatusRouteForRootWithReadContext(readCtx *stateReadContext, active 
 	return statusRoute{change: &change}, nil
 }
 
-func statusChangeFromCurrentWorktreeBinding(root string) (model.Change, bool, error) {
-	return statusChangeFromCurrentWorktreeBindingWithReadContext(newStateReadContext(root))
-}
-
 func statusChangeFromCurrentWorktreeBindingWithReadContext(readCtx *stateReadContext) (model.Change, bool, error) {
 	root := readCtx.root
 	worktreePath, err := readCtx.currentWorktree()
@@ -438,10 +434,6 @@ func statusChangeFromCurrentWorktreeBindingWithReadContext(readCtx *stateReadCon
 // dedicated worktree is the current invocation worktree, so unscoped status in
 // an archived-change worktree reports that local archived change instead of an
 // unrelated global active change bound elsewhere (#283).
-func statusArchivedChangeForCurrentWorktree(root string) (model.Change, bool, error) {
-	return statusArchivedChangeForCurrentWorktreeWithReadContext(newStateReadContext(root))
-}
-
 func statusArchivedChangeForCurrentWorktreeWithReadContext(readCtx *stateReadContext) (model.Change, bool, error) {
 	root := readCtx.root
 	worktreePath, err := readCtx.currentWorktree()

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -255,7 +255,7 @@ func makeStatusCmd() *cobra.Command {
 				return showStatusForChangeWithReadContext(cmd, readCtx, change, outputFormat, effectiveView, hydrateKeys, hydrate, true)
 			}
 
-			if change, ok, err := statusChangeFromCurrentWorktreeBinding(root); err != nil {
+			if change, ok, err := statusChangeFromCurrentWorktreeBindingWithReadContext(readCtx); err != nil {
 				return err
 			} else if ok {
 				readCtx.rememberChange(change)
@@ -275,7 +275,7 @@ func makeStatusCmd() *cobra.Command {
 			// unscoped status silently reports that unrelated active change as if it
 			// were local, switching the review context out from under an
 			// archived-change review (#283).
-			if change, ok, err := statusArchivedChangeForCurrentWorktree(root); err != nil {
+			if change, ok, err := statusArchivedChangeForCurrentWorktreeWithReadContext(readCtx); err != nil {
 				return err
 			} else if ok {
 				effectiveView := resolveEffectiveFocus("status", explicitFocus)
@@ -289,7 +289,7 @@ func makeStatusCmd() *cobra.Command {
 				return showArchivedStatusForChange(cmd, root, change, outputFormat, effectiveView, hydrateKeys, hydrate)
 			}
 
-			changes, err := state.ListChanges(root)
+			changes, err := readCtx.listChanges()
 			if err != nil {
 				// A partially-deleted change (a governed bundle directory that
 				// survived without its change.yaml authority) otherwise dead-ends
@@ -322,7 +322,7 @@ func makeStatusCmd() *cobra.Command {
 				route.diagnostics.Mode = explicitFocus
 				route.diagnostics.InvocationRoute = buildNoActiveInvocationRouteView(
 					root,
-					invocationWorkspaceRootFromCommand(cmd, root),
+					invocationWorkspaceRootFromCommandWithReadContext(cmd, readCtx),
 				)
 				if explicitFocus != "" {
 					route.diagnostics.HydrateReferences = normalizeHydrateKeys(resolveEffectiveFocusHydrate("status", explicitFocus))
@@ -410,7 +410,12 @@ func resolveStatusRouteForRootWithReadContext(readCtx *stateReadContext, active 
 }
 
 func statusChangeFromCurrentWorktreeBinding(root string) (model.Change, bool, error) {
-	worktreePath, err := currentWorktreeRoot()
+	return statusChangeFromCurrentWorktreeBindingWithReadContext(newStateReadContext(root))
+}
+
+func statusChangeFromCurrentWorktreeBindingWithReadContext(readCtx *stateReadContext) (model.Change, bool, error) {
+	root := readCtx.root
+	worktreePath, err := readCtx.currentWorktree()
 	if err != nil {
 		return model.Change{}, false, wrapResolutionErrorForRoot(root, err)
 	}
@@ -434,7 +439,12 @@ func statusChangeFromCurrentWorktreeBinding(root string) (model.Change, bool, er
 // an archived-change worktree reports that local archived change instead of an
 // unrelated global active change bound elsewhere (#283).
 func statusArchivedChangeForCurrentWorktree(root string) (model.Change, bool, error) {
-	worktreePath, err := currentWorktreeRoot()
+	return statusArchivedChangeForCurrentWorktreeWithReadContext(newStateReadContext(root))
+}
+
+func statusArchivedChangeForCurrentWorktreeWithReadContext(readCtx *stateReadContext) (model.Change, bool, error) {
+	root := readCtx.root
+	worktreePath, err := readCtx.currentWorktree()
 	if err != nil {
 		return model.Change{}, false, wrapResolutionErrorForRoot(root, err)
 	}
@@ -535,8 +545,8 @@ func showStatusForChangeWithReadContext(cmd *cobra.Command, readCtx *stateReadCo
 		if err != nil {
 			return err
 		}
-		applyStatusInvocationWorkspacePath(cmd, root, &view)
-		applyStatusInvocationRoute(cmd, root, lockedChange, explicitChange, &view)
+		applyStatusInvocationWorkspacePathWithReadContext(cmd, readCtx, &view)
+		applyStatusInvocationRouteWithReadContext(cmd, readCtx, lockedChange, explicitChange, &view)
 		view.Mode = requestedView
 		view.HydrateReferences = hydrateKeys
 		return printStatusView(cmd, root, view, outputFormat, hydrate)

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -182,7 +182,7 @@ func makeValidateCmd() *cobra.Command {
 					} else {
 						view.InvocationRoute = buildDiagnosticInvocationRouteView(
 							root,
-							invocationWorkspaceRootFromCommand(cmd, root),
+							invocationWorkspaceRootFromCommandWithReadContext(cmd, readCtx),
 							"no_active",
 							"",
 							"Use `slipway new` to create a governed change, or specify an active change with `--change <slug>`.",
@@ -198,9 +198,9 @@ func makeValidateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			applyValidateInvocationWorkspacePath(cmd, root, &view)
+			applyValidateInvocationWorkspacePathWithReadContext(cmd, readCtx, &view)
 			if change, loadErr := readCtx.loadChange(ref.Slug); loadErr == nil {
-				applyValidateInvocationRoute(cmd, root, change, strings.TrimSpace(changeSlug) != "", &view)
+				applyValidateInvocationRouteWithReadContext(cmd, readCtx, change, strings.TrimSpace(changeSlug) != "", &view)
 			}
 			view.Mode = effectiveMode
 			view.HydrateReferences = normalizeHydrateKeys(resolveEffectiveFocusHydrate("validate", focus))

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -293,6 +293,11 @@ an archived terminal change, the command fails with
 `change.yaml` path instead of the generic no-active diagnostic. This is an
 active-readiness contract: `validate` proves the currently active governed state
 before `done`; it is not a post-archive audit surface for frozen bundles.
+If the explicit slug does not name an active or archived change, `validate
+--change <slug> --json` fails closed with exit code 3 and
+`error_code=change_not_found`. By contrast, unscoped `validate --json` with no
+active change is a diagnostics view: it exits 0 and reports
+`invocation_route.kind=no_active` with `next_command=slipway new`.
 
 The durable codebase map under `artifacts/codebase/**` is exempt from
 scope-contract changed-file accounting. When only those context files are dirty,

--- a/docs/ja/commands.md
+++ b/docs/ja/commands.md
@@ -178,6 +178,7 @@ JSON コントラクトのカバレッジ向けの安定したマニフェスト
 `status --json` は、実行エビデンスが陳腐化していると分かっている場合に `freshness_diagnostics` を含め、各 `artifact_dag` ノードに `blocking` と `blocking_reason` を付与します。これにより、ドラフトの計画アーティファクトが現在のレビューブロッカーと取り違えられないようにします。
 
 `validate --change <slug>` は明示的なアクティブ変更を選択します。slug がアーカイブ済みの終端変更を指す場合、コマンドは `archived_change_not_validatable` で失敗し、汎用の no-active 診断の代わりに終端状態とアーカイブ済みの `change.yaml` パスを返します。これはアクティブな準備状況のコントラクトです。`validate` は `done` の前に現在アクティブな統制状態を証明するものであり、凍結されたバンドルに対するアーカイブ後の監査サーフェスではありません。
+明示した slug がアクティブ変更またはアーカイブ済み変更を指さない場合、`validate --change <slug> --json` は fail closed し、終了コード 3 と `error_code=change_not_found` を返します。一方、`--change` を指定しない `validate --json` は、アクティブ変更がない場合でも診断ビューとして終了コード 0 で返り、`invocation_route.kind=no_active` と `next_command=slipway new` を報告します。
 
 `artifacts/codebase/**` 配下の耐久性あるコードベースマップは、スコープコントラクトの変更ファイル計上から免除されます。それらのコンテキストファイルのみがダーティな場合、`scope_contract.changed_files` と `scope_contract.out_of_scope_files` に含まれず、`scope_contract.status` は `pass` のままです。リフレッシュされたコードベースマップ単独ではスコープコントラクトのドリフトを引き起こしません。このフィルタリングを `git diff` の不一致から推測させるのではなく可視にするため、免除されたファイルは `scope_contract.exempt_context_files` フィールドで明示的に開示され、`slipway validate --json`、`slipway status --json`、`slipway review --json` で表示されます。
 

--- a/docs/zh/commands.md
+++ b/docs/zh/commands.md
@@ -258,6 +258,10 @@ error 级阻塞项。`health --governance --json` 是诊断性的健康反馈；
 `archived_change_not_validatable` 失败，并返回终态状态以及已归档的 `change.yaml` 路径，而不是返回
 通用的“无活动变更”诊断。这是一项活动就绪契约：`validate` 在 `done` 之前证明当前活动的受治理状态；
 它不是面向已冻结包的归档后审计面。
+如果明确给出的 slug 不对应活动或归档变更，`validate --change <slug> --json` 会 fail closed，
+以退出码 3 和 `error_code=change_not_found` 返回。相对地，未指定 `--change` 的
+`validate --json` 在没有活动变更时是诊断视图：退出码为 0，并报告
+`invocation_route.kind=no_active` 与 `next_command=slipway new`。
 
 `artifacts/codebase/**` 下的持久 codebase map 不计入 scope-contract 的改动文件核算。当只有这些
 上下文文件是脏的时候，它们不会进入 `scope_contract.changed_files` 和

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -687,7 +687,12 @@ func FindActiveChange(root string) (model.Change, error) {
 	if err != nil {
 		return model.Change{}, err
 	}
+	return SelectActiveChange(changes)
+}
 
+// SelectActiveChange resolves the single active change from an already-loaded
+// change list. It mirrors FindActiveChange without re-running discovery.
+func SelectActiveChange(changes []model.Change) (model.Change, error) {
 	var active []model.Change
 	for _, c := range changes {
 		if c.Status == model.ChangeStatusActive {
@@ -706,14 +711,20 @@ func FindActiveChange(root string) (model.Change, error) {
 
 // FindActiveChangeForWorktree finds the active change bound to the given worktree path.
 func FindActiveChangeForWorktree(root, currentWorktreePath string) (model.Change, error) {
-	normalizedCurrent, err := NormalizePath(currentWorktreePath)
-	if err != nil {
-		return model.Change{}, fmt.Errorf("normalize worktree path: %w", err)
-	}
-
 	changes, err := ListChanges(root)
 	if err != nil {
 		return model.Change{}, err
+	}
+	return SelectActiveChangeForWorktree(changes, currentWorktreePath)
+}
+
+// SelectActiveChangeForWorktree resolves the active change for worktree from an
+// already-loaded change list. It mirrors FindActiveChangeForWorktree without
+// re-running discovery.
+func SelectActiveChangeForWorktree(changes []model.Change, currentWorktreePath string) (model.Change, error) {
+	normalizedCurrent, err := NormalizePath(currentWorktreePath)
+	if err != nil {
+		return model.Change{}, fmt.Errorf("normalize worktree path: %w", err)
 	}
 
 	// Phase 1: Match by worktree path.

--- a/internal/tmpl/templates/_partials/command-validate-body.tmpl
+++ b/internal/tmpl/templates/_partials/command-validate-body.tmpl
@@ -15,6 +15,10 @@ slipway validate
 - Reports pass/fail status and specific blockers.
 - Does not modify state — read-only diagnostic.
 - Show validation summary to user with actionable remediation steps.
+- `--change <slug>` is fail-closed: a missing explicit slug returns exit code
+  3 with `error_code=change_not_found`. Unscoped `validate --json` with no
+  active change is a diagnostics view that exits 0 and reports
+  `invocation_route.kind=no_active`.
 
 ## Flags
 - `--focus <alias>`: run a focus check (see `--list-focuses`)


### PR DESCRIPTION
## Summary
- cache active route, invocation workspace, current worktree, and change-list reads inside the single command read context
- route status, next, and validate invocation metadata through the shared read context
- add the missing delegation-available CLI coverage for host capability handling
- document the validate explicit-missing versus unscoped no-active contract in command docs and templates

## Why
`opt.md` still had small confirmed gaps after the lifecycle surface work: the available delegation path only had indirect coverage, the command read context did not own route/workspace reads, and the validate no-active contract was implicit.

## Impact
Agents get a more consistent black-box route/action surface across status, next, and validate. The route cache remains scoped to one CLI invocation and is invalidated on change reload, so it does not become durable lifecycle authority.

## Validation
- `golangci-lint run --timeout=5m`
- `go test ./cmd ./internal/state -run "Test(StateReadContext|ReviewBatchHostCapability|FindActiveChange|ListChanges|SelectActiveChange|NoActiveStatusAndValidateExposeInvocationRoute|ValidateChangeFlagRejectsMissingSlugWithoutWritingState|StatusChangeFlagMissingSlugExposesExplicitMissingRoute|BoundWorktreeCommandsExposeConsistentLocalInvocationRoute|NextChangeFlagFromRootTargetsBoundWorktree)" -count=1`
- `go test ./... -count=1`
- `go run ./internal/perfbaseline/cmd/state-read-baseline -mode check -baseline state-read-performance-baseline.json -out /tmp/slipway-state-read-current-after-remove-dead-git-common-dir-cache.json -samples 3 -warmups 1 -check-attempts 3`
- `git diff --check`