### PR TITLE
fix(recovery): make blocker recoveries name a state-valid next action

### DIFF
--- a/cmd/instructions.go
+++ b/cmd/instructions.go
@@ -85,7 +85,8 @@ func instructionsGuidance(name string) string {
 			"the substance gate and cannot reach done."
 	case "tasks":
 		return "Author each task as a checklist line (- [ ] t-NN <objective>) with depends_on, " +
-			"target_files, task_kind, and covers metadata. Every task names concrete target_files " +
+			"target_files, task_kind (one of: code, test, doc, ops, verification, investigation, other — " +
+			"a documentation-only task uses `doc`, not `docs`), and covers metadata. Every task names concrete target_files " +
 			"that bound the files or evidence targets it changes or verifies. Do not author a `wave:` " +
 			"line — the engine rejects it and assigns waves from depends_on and target_files, " +
 			"dispatching multi-task waves in parallel. Declare only real execution-order dependencies " +

--- a/cmd/instructions_test.go
+++ b/cmd/instructions_test.go
@@ -123,7 +123,8 @@ func TestInstructionsTasksGuidanceTeachesComputedWaves(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(out), &view))
 
 	// Authored metadata no longer includes wave.
-	assert.Contains(t, view.Guidance, "with depends_on, target_files, task_kind, and covers metadata")
+	assert.Contains(t, view.Guidance, "with depends_on, target_files, task_kind (one of: code, test, doc, ops, verification, investigation, other")
+	assert.Contains(t, view.Guidance, "a documentation-only task uses `doc`, not `docs`")
 	assert.NotContains(t, view.Guidance, "with wave",
 		"wave must not be taught as authored task metadata")
 

--- a/cmd/recovery_view_test.go
+++ b/cmd/recovery_view_test.go
@@ -93,8 +93,10 @@ func TestValidateRecoveryIncludesGateDetailBlockers(t *testing.T) {
 	}
 	require.NotNil(t, step, "plan-audit gate_details blocker must render a recovery step")
 	assert.Equal(t, []string{"requirements.md", "tasks.md"}, step.Details)
-	assert.Equal(t, "slipway run", step.Command)
-	assert.NotContains(t, step.Command, "--skill")
+	// A stale required skill is recovered by re-running the owning skill and
+	// re-recording its evidence; `slipway run` only loops on the blocker (#347).
+	assert.Equal(t, "slipway evidence skill --skill plan-audit --verdict pass", step.Command)
+	assert.Contains(t, step.Command, "--skill plan-audit")
 	assert.NotEmpty(t, step.Remediation)
 }
 

--- a/internal/engine/governance/actions.go
+++ b/internal/engine/governance/actions.go
@@ -52,7 +52,7 @@ func ResolveRequiredActions(input RequiredActionsInput) []RequiredAction {
 			action.Satisfied = input.IntentExists && input.ScopeConfirmed && input.ResearchStructureOK
 
 		case model.ControlDomainReview:
-			action.Description = "run domain-aware compliance review and attach review evidence"
+			action.Description = "run domain-aware review via the spec-compliance-review skill and record it with `slipway evidence skill --skill spec-compliance-review`"
 			action.Satisfied = input.DomainReviewDone
 			if action.Satisfied {
 				action.SatisfiedBy = append(action.SatisfiedBy, input.DomainReviewSatisfiedBy...)

--- a/internal/engine/progression/advance_governed_test.go
+++ b/internal/engine/progression/advance_governed_test.go
@@ -618,11 +618,14 @@ func TestAdvanceGoverned_S2StaleWaveEvidenceRecommendsRunnableCommand(t *testing
 			"(fix_state_invalid in S2); got primary_command=%q for blockers %v",
 			recovery.PrimaryCommand, model.ReasonSpecs(summaryOut.Blockers))
 	}
-	// The recommended command must be runnable in S2: the state-valid driver for a
-	// stale owning-stage authority is `slipway run`.
-	if recovery.PrimaryCommand != "slipway run" {
-		t.Fatalf("expected an S2-runnable recovery command (`slipway run`), got primary_command=%q for blockers %v",
-			recovery.PrimaryCommand, model.ReasonSpecs(summaryOut.Blockers))
+	// The recommended command must be runnable in S2 AND actually clear the stale
+	// authority. `slipway run` only loops on a stale required-skill blocker — it
+	// never re-certifies it (#347); the working recovery is to re-run the owning
+	// skill and re-record its evidence, which `slipway evidence skill` does.
+	wantCmd := "slipway evidence skill --skill wave-orchestration --verdict pass"
+	if recovery.PrimaryCommand != wantCmd {
+		t.Fatalf("expected the stale-authority recovery to re-record evidence (%q), got primary_command=%q for blockers %v",
+			wantCmd, recovery.PrimaryCommand, model.ReasonSpecs(summaryOut.Blockers))
 	}
 
 	// The change must stay at S2_IMPLEMENT: the fix corrects only the recommended

--- a/internal/model/recovery.go
+++ b/internal/model/recovery.go
@@ -452,8 +452,8 @@ var blockerRemediations = map[string]blockerRemediation{
 		Class:           RecoveryClassRerunSkill,
 	},
 	"required_skill_stale": {
-		Remediation:     "Inputs certified by {subject} changed; repair the owning lifecycle evidence and rerun the current alignment gate.",
-		CommandTemplate: "slipway run",
+		Remediation:     "Inputs {subject} certified changed after its verdict; re-run the {subject} skill against the current inputs and record the fresh result with `slipway evidence skill` — do not restamp the stale verdict.",
+		CommandTemplate: "slipway evidence skill --skill {subject} --verdict pass",
 		Class:           RecoveryClassRerunSkill,
 	},
 	"research_structure_invalid": {
@@ -576,8 +576,8 @@ var blockerRemediations = map[string]blockerRemediation{
 		Priority:        90,
 	},
 	"scope_contract_drift": {
-		Remediation:     "Changed files fall outside the planned Scope Contract; recorded wave evidence is preserved. If it is legitimate same-intent work, run `slipway fix`, dispatch a fresh-context repair subagent, update the owning task `target_files` in `tasks.md`, refresh affected evidence, and rerun `slipway review`. If the objective changed, open a new governed change.",
-		CommandTemplate: "slipway fix",
+		Remediation:     "Changed files fall outside the planned Scope Contract; recorded wave evidence is preserved. If it is legitimate same-intent work, update the owning task `target_files` in `tasks.md` to cover them, refresh affected evidence, and re-run the current stage with `slipway run`. If the objective changed, open a new governed change.",
+		CommandTemplate: "slipway run",
 		Class:           RecoveryClassReviewAlignment,
 	},
 	"scope_contract_missing": {

--- a/internal/model/recovery_test.go
+++ b/internal/model/recovery_test.go
@@ -384,7 +384,7 @@ func TestRecoveryStepFillsSubjectIntoCommand(t *testing.T) {
 	rc := ReasonCodeFromSpec("required_skill_stale:plan-audit:assurance.md")
 	step, ok := recoveryStepFor(rc)
 	require.True(t, ok)
-	assert.Equal(t, "slipway run", step.Command)
+	assert.Equal(t, "slipway evidence skill --skill plan-audit --verdict pass", step.Command)
 	assert.NotContains(t, step.Remediation, "{subject}")
 	assert.NotContains(t, step.Remediation, "{detail}")
 }
@@ -800,7 +800,7 @@ func TestBuildRecoveryGroupsBlockersByCodeAndSubject(t *testing.T) {
 	require.NotNil(t, cqr, "the code-quality-review group must be one step")
 	assert.Equal(t, []string{"CLAUDE.md", "README.md", "cmd/next.go"}, cqr.Details,
 		"details are de-duplicated and sorted")
-	assert.Equal(t, "slipway run", cqr.Command)
+	assert.Equal(t, "slipway evidence skill --skill code-quality-review --verdict pass", cqr.Command)
 	assert.NotContains(t, cqr.Remediation, "{", "remediation must not embed a per-detail placeholder")
 }
 

--- a/internal/state/verification.go
+++ b/internal/state/verification.go
@@ -333,8 +333,45 @@ func decodeVerificationStrict(raw []byte, rec *model.VerificationRecord) error {
 	return decodeYAMLKnownFields(raw, rec)
 }
 
+// governanceEvidenceSkills mirrors the registered governance skills that
+// `slipway evidence skill` accepts (engine/skill.defaultGovernanceRegistry). It
+// is duplicated here as a literal set because internal/state cannot import
+// internal/engine/skill: that package imports internal/toolgen, which imports
+// internal/state, so the dependency would cycle. Keep this list in sync with the
+// registry — a skill added there but omitted here would regress #343 (its
+// recovery would dead-end at an unknown-skill evidence command).
+var governanceEvidenceSkills = map[string]struct{}{
+	"intake-clarification":   {},
+	"research-orchestration": {},
+	"plan-audit":             {},
+	"wave-orchestration":     {},
+	"spec-compliance-review": {},
+	"code-quality-review":    {},
+	"independent-review":     {},
+	"security-review":        {},
+	"ship-verification":      {},
+}
+
+func isGovernanceEvidenceSkill(name string) bool {
+	_, ok := governanceEvidenceSkills[strings.TrimSpace(name)]
+	return ok
+}
+
 func verificationRecordRecoveryGuidance(skillName string) string {
 	recordPath := filepath.ToSlash(filepath.Join("verification", skillName+".yaml"))
+	if !isGovernanceEvidenceSkill(skillName) {
+		// A name that is not a registered governance evidence skill (e.g.
+		// coverage-analysis, a ship-verification host-embedded sub-technique) is
+		// not recordable through `slipway evidence skill`; pointing there is a
+		// dead-end because the command rejects the unknown skill (#343). Such a
+		// file is not engine-owned evidence, so the recovery is to remove the
+		// stray file and let the owning host gate record its VerificationRecord.
+		return fmt.Sprintf(
+			"%s is not a registered governance evidence skill, so `slipway evidence skill --skill %s` cannot record it; remove this stray file and let its owning host gate produce the verification (for example, ship-verification owns coverage analysis)",
+			recordPath,
+			skillName,
+		)
+	}
 	notesPath := filepath.ToSlash(filepath.Join("verification", skillName+"-notes.md"))
 	return fmt.Sprintf(
 		"%s is an engine-owned VerificationRecord file; move free-form notes to %s and pass them through `slipway evidence skill --skill %s --notes-file %s`",

--- a/internal/wave/parse.go
+++ b/internal/wave/parse.go
@@ -287,7 +287,7 @@ func (b *taskNodeBuilder) build() (TaskNode, error) {
 		// default resume behavior.
 		kind = model.TaskKindOther
 	default:
-		return TaskNode{}, fmt.Errorf("task %q has unknown task_kind %q", b.taskID, b.taskKind)
+		return TaskNode{}, fmt.Errorf("task %q has unknown task_kind %q (allowed: code, test, doc, ops, verification, investigation, other)", b.taskID, b.taskKind)
 	}
 
 	return TaskNode{


### PR DESCRIPTION
Five governed blockers each pointed at a next command the CLI rejects in the state where the blocker fires. Every fix makes the public recovery surface carry a command that actually works.

| Issue | Blocker | Before | After |
|---|---|---|---|
| #356 | unknown `task_kind` | error/instructions don't list values | enumerate `code/test/doc/ops/verification/investigation/other`; docs-only = `doc` |
| #341 | `scope_contract_drift` | `slipway fix` (S3-only → `fix_state_invalid` in S2) | state-neutral `slipway run` |
| #347 | `required_skill_stale` | `slipway run` loops on the blocker | `slipway evidence skill --skill <skill> --verdict pass` (re-run skill, no restamp) |
| #346 | `domain-review` control | names control id (rejected by `evidence skill`) | names registered `spec-compliance-review` skill + its evidence command |
| #343 | stray `verification/<name>.yaml` | dead-end `evidence skill --skill coverage-analysis` | remove file; owning host gate records it |

## Notes
- #347 recovery is safe across states: at S3 an upstream-stale authority is filtered to `review_alignment_required` (so this entry only fires at S2-direct and S3 review-skill-self-stale, both valid commands); `resolveCommandTemplate` already falls back to `slipway run` when the blocker has no subject.
- #343 mirrors the 9-skill governance registry as a local set in `internal/state` because importing `engine/skill` would cycle (skill → toolgen → state); a comment flags the sync requirement.
- Tests updated to the corrected recoveries (one had encoded the #347 bug, asserting `slipway run`).

Verification: `go build ./...`, `gofmt -s`, `golangci-lint` (0 issues), and the affected package suites (model/cmd/wave/state/governance/progression) all pass.

Closes #341
Closes #343
Closes #346
Closes #347
Closes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)