### PR TITLE
fix(lifecycle): surface host subagent-delegation authorization as an actionable next action (#339, #369, #357)

### DIFF
--- a/cmd/auto_mode_test.go
+++ b/cmd/auto_mode_test.go
@@ -212,7 +212,6 @@ func TestDeriveConfirmationRequirementAutoSoftensOnlyPurePacingAllowlist(t *test
 	t.Parallel()
 
 	for _, skillName := range []string{
-		progression.SkillIntakeClarification,
 		progression.SkillResearchOrchestration,
 		progression.SkillPlanAudit,
 		progression.SkillWaveOrchestration,
@@ -240,6 +239,7 @@ func TestDeriveConfirmationRequirementAutoSoftensOnlyPurePacingAllowlist(t *test
 
 	for _, skillName := range []string{
 		progression.SkillWorktreePreflight,
+		progression.SkillIntakeClarification,
 		"future-sensitive-review",
 	} {
 		skillName := skillName
@@ -676,42 +676,48 @@ func approvedSummarySection(intent string) string {
 }
 
 // (finding #5) Config-level execution.auto must reach the real command entry
-// points, not just the helper layer. This drives `slipway intake` through the
-// root cobra command with auto set only via .slipway.yaml. At S0 intake the next
-// skill is intake-clarification (a skill_handoff), so non-guardrail auto softens
-// the boundary to evidence_continuation while a guardrail domain — and auto off —
-// keep the hard_stop. The guardrail-vs-non-guardrail pair proves both that auto
-// was read from config and threaded, and that the guardrail exclusion still fails
-// closed through this entry.
+// points, not just the helper layer. This drives `slipway next` through the root
+// cobra command with auto set only via .slipway.yaml. The vehicle is an
+// S2_IMPLEMENT change whose pending skill is wave-orchestration (a genuinely
+// pure-pacing skill_handoff), so non-guardrail auto softens the boundary to
+// evidence_continuation while a guardrail domain — and auto off — keep the
+// hard_stop. The guardrail-vs-non-guardrail pair proves both that auto was read
+// from config and threaded, and that the guardrail exclusion still fails closed
+// through this entry.
 //
-// The SessionStart hook is intentionally not exercised here: it no longer injects
-// the auto-softened `next --json` change-state view (REQ-004 retired that
-// auto-injection); it emits only the slipway_entry_skill routing pointer. The
-// stage command remains the real entry that threads execution.auto.
+// intake-clarification is deliberately NOT used as the vehicle: the intake
+// approved-summary is a fresh hard gate by design (#357) and must hard-stop even
+// under auto, so it can no longer demonstrate the softened path (see
+// TestDeriveConfirmationRequirementAutoKeepsIntakeClarificationHardStop). `next`
+// is a real command entry that threads execution.auto via resolveEffectiveAuto
+// and is preview-only, so it carries no execution side effects.
 func TestConfigAutoReachesStageAndHookEntries(t *testing.T) {
-	setup := func(t *testing.T, auto bool, guardrail string) string {
+	setup := func(t *testing.T, auto bool, guardrail string) (string, string) {
 		t.Helper()
 		root := t.TempDir()
 		ensureTestGitRepo(t, root)
 		initTestWorkspace(t, root)
 		writeAutoConfig(t, root, auto)
-		slug := createIntakeChangeFixture(t, root, "config auto reaches entries")
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "config auto reaches entries")
+		change, err := state.LoadChange(root, slug)
+		require.NoError(t, err)
+		change.CurrentState = model.StateS2Implement
+		change.PlanSubStep = model.PlanSubStepNone
 		if guardrail != "" {
-			change, err := state.LoadChange(root, slug)
-			require.NoError(t, err)
 			change.GuardrailDomain = guardrail
-			require.NoError(t, state.SaveChange(root, change))
 		}
-		return root
+		require.NoError(t, state.SaveChange(root, change))
+		writeShipReadyGovernedBundle(t, root, change)
+		return root, slug
 	}
 
-	t.Run("stage_command_intake", func(t *testing.T) {
-		stageJSON := func(t *testing.T, root string) string {
+	t.Run("next_command_s2_wave", func(t *testing.T) {
+		nextJSON := func(t *testing.T, root, slug string) string {
 			t.Helper()
 			var out string
 			withWorkspace(t, root, func() {
 				cmd := newRootCmd()
-				cmd.SetArgs([]string{"intake", "--json"})
+				cmd.SetArgs([]string{"next", "--json", "--change", slug})
 				var buf bytes.Buffer
 				cmd.SetOut(&buf)
 				require.NoError(t, cmd.Execute())
@@ -720,16 +726,20 @@ func TestConfigAutoReachesStageAndHookEntries(t *testing.T) {
 			return out
 		}
 
-		soft := stageJSON(t, setup(t, true, ""))
+		softRoot, softSlug := setup(t, true, "")
+		soft := nextJSON(t, softRoot, softSlug)
+		assert.Contains(t, soft, "wave-orchestration")
 		assert.Contains(t, soft, "evidence_continuation",
-			"config auto must soften the non-guardrail intake skill_handoff through the stage command")
+			"config auto must soften the non-guardrail wave-orchestration skill_handoff through the command entry")
 		assert.NotContains(t, soft, "hard_stop")
 
-		guard := stageJSON(t, setup(t, true, string(model.GuardrailDomainAuthAuthZ)))
+		guardRoot, guardSlug := setup(t, true, string(model.GuardrailDomainAuthAuthZ))
+		guard := nextJSON(t, guardRoot, guardSlug)
 		assert.Contains(t, guard, "hard_stop",
-			"guardrail domain must keep the stage entry hard-stop under auto")
+			"guardrail domain must keep the command entry hard-stop under auto")
 
-		off := stageJSON(t, setup(t, false, ""))
+		offRoot, offSlug := setup(t, false, "")
+		off := nextJSON(t, offRoot, offSlug)
 		assert.Contains(t, off, "hard_stop", "auto off must keep the legacy hard_stop")
 	})
 }

--- a/cmd/host_delegation_authorization_surface_test.go
+++ b/cmd/host_delegation_authorization_surface_test.go
@@ -1,0 +1,118 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/signalridge/slipway/internal/engine/progression"
+	"github.com/signalridge/slipway/internal/model"
+	"github.com/signalridge/slipway/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDeriveConfirmationRequirementAutoKeepsIntakeClarificationHardStop pins #357
+// across execution.auto: the intake approved-summary is a FRESH HARD GATE BY
+// DESIGN, so the intake-clarification handoff must NOT be softened by auto. A
+// softened boundary would report PriorAuthorizationSufficient=true /
+// FreshConfirmationRequired=false while the next_action prose still declares the
+// gate fresh and non-delegable — a self-contradiction that lets a prior broad
+// "continue" satisfy the intake gate. intake-clarification therefore diverges
+// from the pure-pacing auto-safe set exactly like security-review.
+func TestDeriveConfirmationRequirementAutoKeepsIntakeClarificationHardStop(t *testing.T) {
+	t.Parallel()
+
+	t.Run("skill_handoff to intake-clarification stays hard_stop under auto", func(t *testing.T) {
+		t.Parallel()
+		view := nextView{
+			auto:            true,
+			GuardrailDomain: "",
+			NextSkill:       &nextSkillView{Name: progression.SkillIntakeClarification},
+		}
+
+		req := deriveConfirmationRequirement(view)
+		assert.Equal(t, "hard_stop", req.Boundary)
+		assert.False(t, req.PriorAuthorizationSufficient, "prior broad authorization must not satisfy the intake gate under auto")
+		assert.True(t, req.FreshConfirmationRequired, "intake approved-summary stays a fresh hard gate under auto")
+		assert.Equal(t, "skill_handoff:"+progression.SkillIntakeClarification, req.Reason)
+		assert.Contains(t, req.NextAction, "FRESH HARD GATE BY DESIGN")
+	})
+
+	t.Run("intake-clarification blocking name stays hard_stop under auto", func(t *testing.T) {
+		t.Parallel()
+		view := nextView{
+			auto:            true,
+			GuardrailDomain: "",
+			NextSkill: &nextSkillView{
+				Name:         progression.SkillResearchOrchestration,
+				BlockingName: progression.SkillIntakeClarification,
+			},
+		}
+
+		req := deriveConfirmationRequirement(view)
+		assert.Equal(t, "hard_stop", req.Boundary)
+		assert.False(t, req.PriorAuthorizationSufficient)
+		assert.True(t, req.FreshConfirmationRequired)
+		assert.Equal(t, "skill_handoff:"+progression.SkillIntakeClarification, req.Reason)
+	})
+}
+
+// TestValidateS3ShipVerificationSurfacesSubagentDelegationAcrossCapabilityStates
+// pins #369 for the validate surface: once the selected S3 review peers have
+// passing evidence but the terminal ship-verification gate still owes fresh
+// evidence, `slipway validate` must evaluate the ship-verification
+// host-capability contract too — exactly as next/run already do via
+// nextS3ShipAuthoritySkill. Without this, validate/recovery dead-ends after the
+// peers pass: it omits host_capabilities and never names the subagent-delegation
+// prerequisite (unknown) or fails closed (unavailable) for the terminal gate.
+func TestValidateS3ShipVerificationSurfacesSubagentDelegationAcrossCapabilityStates(t *testing.T) {
+	root := t.TempDir()
+	ensureTestGitRepo(t, root)
+	initTestWorkspace(t, root)
+
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "validate ship verification subagent delegation")
+	change, err := state.LoadChange(root, slug)
+	require.NoError(t, err)
+	change.CurrentState = model.StateS3Review
+	change.PlanSubStep = model.PlanSubStepNone
+	require.NoError(t, state.SaveChange(root, change))
+	writeShipReadyGovernedBundle(t, root, change)
+	writePassingExecutionSummary(t, root, slug, 1, "t-01")
+	writePassingWaveEvidence(t, root, slug, 1)
+	writePassingReviewEvidencePack(t, root, slug, 1)
+
+	const subagentBlocker = "subagent_dispatch_authorization_required:ship-verification:subagent"
+	const unavailableBlocker = "host_capability_unavailable:ship-verification:subagent"
+
+	t.Setenv("SLIPWAY_HOST_CAPABILITY_FALLBACKS", "")
+
+	// unknown: host declared nothing -> continuable prerequisite for the terminal gate.
+	t.Setenv("SLIPWAY_HOST_CAPABILITIES", "")
+	unknown, err := buildValidateViewForSlugWithReadContext(newStateReadContext(root), slug)
+	require.NoError(t, err)
+	unknownCap := requireHostCapabilityForSkill(t, unknown.HostCapabilities, progression.SkillShipVerification)
+	assert.Equal(t, "unknown", unknownCap.Availability)
+	assert.False(t, unknownCap.FallbackSelected)
+	unknownSpecs := model.ReasonSpecs(unknown.Blockers)
+	assert.Contains(t, unknownSpecs, subagentBlocker)
+	assert.NotContains(t, unknownSpecs, unavailableBlocker)
+
+	// unavailable: host declared other capabilities but not subagent -> fails closed.
+	t.Setenv("SLIPWAY_HOST_CAPABILITIES", "none")
+	unavailable, err := buildValidateViewForSlugWithReadContext(newStateReadContext(root), slug)
+	require.NoError(t, err)
+	unavailableCap := requireHostCapabilityForSkill(t, unavailable.HostCapabilities, progression.SkillShipVerification)
+	assert.Equal(t, "unavailable", unavailableCap.Availability)
+	unavailableSpecs := model.ReasonSpecs(unavailable.Blockers)
+	assert.Contains(t, unavailableSpecs, unavailableBlocker)
+	assert.NotContains(t, unavailableSpecs, subagentBlocker)
+
+	// available: declared subagent -> no new blocker.
+	t.Setenv("SLIPWAY_HOST_CAPABILITIES", "subagent")
+	available, err := buildValidateViewForSlugWithReadContext(newStateReadContext(root), slug)
+	require.NoError(t, err)
+	availableCap := requireHostCapabilityForSkill(t, available.HostCapabilities, progression.SkillShipVerification)
+	assert.Equal(t, "available", availableCap.Availability)
+	availableSpecs := model.ReasonSpecs(available.Blockers)
+	assert.NotContains(t, availableSpecs, unavailableBlocker)
+	assert.NotContains(t, availableSpecs, subagentBlocker)
+}

--- a/cmd/next.go
+++ b/cmd/next.go
@@ -770,18 +770,18 @@ func deriveConfirmationRequirement(view nextView) confirmationRequirement {
 		return confirmationGovernanceBlocked()
 	case view.ReviewBatch != nil && len(view.ReviewBatch.Skills) > 0:
 		if autoSoftens {
-			return autoStandingAuthorization("review_batch")
+			return withSubagentDelegationPrerequisite(autoStandingAuthorization("review_batch"), view)
 		}
-		return confirmationHardStop("review_batch")
+		return withSubagentDelegationPrerequisite(confirmationHardStop("review_batch"), view)
 	case view.NextSkill != nil:
 		reason := "skill_handoff"
 		if name := nextSkillHandoffName(view.NextSkill); name != "" {
 			reason = "skill_handoff:" + name
 		}
 		if autoSoftens {
-			return autoStandingAuthorization(reason)
+			return withSubagentDelegationPrerequisite(autoStandingAuthorization(reason), view)
 		}
-		return confirmationHardStop(reason)
+		return withSubagentDelegationPrerequisite(confirmationHardStop(reason), view)
 	case hasReasonCode(view.Blockers, "no_skill_required") && !hasNonPacingBlocker(view):
 		return confirmationCommandRequired("run_slipway_run_to_advance")
 	case len(view.Blockers) > 0:
@@ -879,10 +879,10 @@ func applyHostCapabilityContractToNext(view *nextView) {
 	}
 	view.HostCapabilities = hostCapabilityViewsForSkills(selectedHostCapabilitySkillNamesForNext(*view))
 	for _, req := range view.HostCapabilities {
-		if hostCapabilityBlocks(req) {
+		if code := hostCapabilityBlockerCode(req); code != "" {
 			view.Blockers = appendReasonCodes(
 				view.Blockers,
-				[]model.ReasonCode{model.NewReasonCode("host_capability_unavailable", req.SkillName+":"+req.Capability)},
+				[]model.ReasonCode{model.NewReasonCode(code, req.SkillName+":"+req.Capability)},
 			)
 		}
 	}
@@ -894,18 +894,38 @@ func applyHostCapabilityContractToValidate(view *validateView, skills []string) 
 	}
 	view.HostCapabilities = hostCapabilityViewsForSkills(skills)
 	for _, req := range view.HostCapabilities {
-		if hostCapabilityBlocks(req) {
+		if code := hostCapabilityBlockerCode(req); code != "" {
 			view.Blockers = model.NormalizeReasonCodes(append(
 				view.Blockers,
-				model.NewReasonCode("host_capability_unavailable", req.SkillName+":"+req.Capability),
+				model.NewReasonCode(code, req.SkillName+":"+req.Capability),
 			))
 		}
 	}
 	view.CanAdvance = len(view.Blockers) == 0
 }
 
-func hostCapabilityBlocks(req hostCapabilityView) bool {
-	return req.Required && req.Availability != "available" && !req.FallbackSelected
+// hostCapabilityBlockerCode reports which blocker, if any, a required
+// host-capability state emits. An available capability or an explicitly selected
+// fallback emits nothing (the available path is unchanged). When the host has
+// not affirmatively declared the capability available, the code distinguishes:
+//   - "unavailable" (the host declared other capabilities but not this one) is a
+//     first-class host_capability_unavailable blocker that fails closed.
+//   - "unknown" (the host declared nothing) emits the continuable
+//     subagent_dispatch_authorization_required blocker, which rides the handoff
+//     so the next_action can name the delegation prerequisite plus the named
+//     fallback without a silent dead-end or a silent bypass.
+func hostCapabilityBlockerCode(req hostCapabilityView) string {
+	if !req.Required || req.FallbackSelected {
+		return ""
+	}
+	switch req.Availability {
+	case "unavailable":
+		return "host_capability_unavailable"
+	case "unknown":
+		return "subagent_dispatch_authorization_required"
+	default: // "available"
+		return ""
+	}
 }
 
 func selectedHostCapabilitySkillNamesForNext(view nextView) []string {
@@ -1082,9 +1102,37 @@ func confirmationNoBoundary(reason string) confirmationRequirement {
 	}
 }
 
+// withSubagentDelegationPrerequisite enriches a review_batch or skill_handoff
+// confirmation next_action when a subagent_dispatch_authorization_required
+// blocker is riding it (the "unknown" host-capability state). It names the host
+// subagent-delegation prerequisite and the explicit named-fallback path so the
+// host is never left to silently infer stop / ask / violate, and never silently
+// bypasses the gate. Hosts that declare subagent available carry no such blocker
+// and are left unchanged.
+func withSubagentDelegationPrerequisite(req confirmationRequirement, view nextView) confirmationRequirement {
+	if !hasReasonCode(view.Blockers, "subagent_dispatch_authorization_required") {
+		return req
+	}
+	req.NextAction = strings.TrimRight(strings.TrimSpace(req.NextAction), ".") +
+		". Host subagent delegation is a prerequisite the host has not declared available: authorize subagent dispatch, " +
+		"or explicitly select a named degraded fallback (e.g. same_context_degraded) and record fresh evidence for each listed skill " +
+		"(see host_capabilities[] and recovery for the per-skill fallback names)"
+	return req
+}
+
 func hardStopNextAction(reason string) string {
 	if skillName, ok := strings.CutPrefix(reason, "skill_handoff:"); ok && strings.TrimSpace(skillName) != "" {
-		return "run governance skill " + strings.TrimSpace(skillName) + " and record evidence"
+		skillName = strings.TrimSpace(skillName)
+		if skillName == progression.SkillIntakeClarification {
+			// #357: the intake approved-summary is a fresh hard gate by design.
+			// A prior broad "continue" authorization does not substitute for
+			// explicit approval of this intent summary, so the next_action must
+			// state that policy rather than reading as an ordinary skill rerun.
+			return "review and approve the intake Approved Summary, then run governance skill " +
+				skillName + " and record evidence — the intake approved-summary is a FRESH HARD GATE BY DESIGN; " +
+				"a prior broad \"continue\" authorization does not substitute for explicit approval of this intent summary"
+		}
+		return "run governance skill " + skillName + " and record evidence"
 	}
 	switch reason {
 	case "preset_confirmation_required":

--- a/cmd/next.go
+++ b/cmd/next.go
@@ -950,6 +950,16 @@ func selectedHostCapabilitySkillNamesForValidate(
 		if pending := pendingSelectedReviewSkills(change, readiness); len(pending) > 0 {
 			return pending
 		}
+		// The selected review peers have converged, but the terminal
+		// ship-verification gate may still owe fresh evidence. next/run already
+		// resolve ship-verification as the S3 ship authority via
+		// nextS3ShipAuthoritySkill once the peers pass; validate must surface the
+		// same skill so its host-capability contract (the subagent-delegation
+		// prerequisite or a fail-closed unavailable stop) is named for the terminal
+		// gate too, rather than dead-ending after the peers pass.
+		if shipSkill := nextS3ShipAuthoritySkill(readiness.PassingSkills, readiness.Blockers); shipSkill != "" {
+			return []string{shipSkill}
+		}
 	}
 	if actionable == nil {
 		return nil

--- a/cmd/next_plan_audit_handoff_test.go
+++ b/cmd/next_plan_audit_handoff_test.go
@@ -69,6 +69,75 @@ func TestNextBundleHandoffDoesNotAdvertiseEvidenceBeforeAudit(t *testing.T) {
 	})
 }
 
+// TestNextS1PlanAuditSurfacesSubagentDelegationAcrossCapabilityStates pins the
+// host subagent-delegation contract for the S1 plan-audit handoff (#339).
+// plan-audit REQUIRES dispatching an independent auditor subagent, but it is not
+// a catalog-registered skill, so the contract comes from the built-in
+// subagent-dispatch lever. "unknown" stays continuable on the skill_handoff
+// boundary while riding a subagent_dispatch_authorization_required prerequisite
+// with an enriched, named-fallback next_action; "unavailable" fails closed as a
+// first-class host_capability_unavailable blocker; an explicit fallback clears it.
+func TestNextS1PlanAuditSurfacesSubagentDelegationAcrossCapabilityStates(t *testing.T) {
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		slug := createGovernedRequest(t, root, levelDiscovery, "plan-audit subagent delegation")
+		change, err := state.LoadChange(root, slug)
+		require.NoError(t, err)
+		change.PlanSubStep = model.PlanSubStepBundle
+		require.NoError(t, state.SaveChange(root, change))
+
+		t.Setenv("SLIPWAY_HOST_CAPABILITY_FALLBACKS", "")
+
+		// unknown: host declared nothing -> continuable skill_handoff with prerequisite.
+		t.Setenv("SLIPWAY_HOST_CAPABILITIES", "")
+		unknown := runNextDiagnostics(t, root, slug)
+		require.NotNil(t, unknown.NextSkill)
+		assert.Equal(t, progression.SkillPlanAudit, unknown.NextSkill.Name)
+		unknownCap := requireHostCapabilityForSkill(t, unknown.HostCapabilities, progression.SkillPlanAudit)
+		assert.Equal(t, "unknown", unknownCap.Availability)
+		assert.False(t, unknownCap.FallbackSelected)
+		unknownSpecs := model.ReasonSpecs(unknown.Blockers)
+		assert.Contains(t, unknownSpecs, "subagent_dispatch_authorization_required:plan-audit:subagent")
+		assert.NotContains(t, unknownSpecs, "host_capability_unavailable:plan-audit:subagent")
+		assert.Equal(t, "skill_handoff:plan-audit", unknown.ConfirmationRequirement.Reason)
+		assert.Contains(t, unknown.ConfirmationRequirement.NextAction, "Host subagent delegation is a prerequisite")
+		assert.Contains(t, unknown.ConfirmationRequirement.NextAction, "same_context_degraded")
+
+		// unavailable: host declared other capabilities but not subagent.
+		t.Setenv("SLIPWAY_HOST_CAPABILITIES", "none")
+		unavailable := runNextDiagnostics(t, root, slug)
+		unavailableCap := requireHostCapabilityForSkill(t, unavailable.HostCapabilities, progression.SkillPlanAudit)
+		assert.Equal(t, "unavailable", unavailableCap.Availability)
+		unavailableSpecs := model.ReasonSpecs(unavailable.Blockers)
+		assert.Contains(t, unavailableSpecs, "host_capability_unavailable:plan-audit:subagent")
+		assert.NotContains(t, unavailableSpecs, "subagent_dispatch_authorization_required:plan-audit:subagent")
+		assert.Equal(t, "blocked_by_governance", unavailable.ConfirmationRequirement.Reason)
+
+		// unavailable + named fallback clears the blocker and restores the handoff.
+		t.Setenv("SLIPWAY_HOST_CAPABILITY_FALLBACKS", "manual_plan_audit")
+		fallback := runNextDiagnostics(t, root, slug)
+		fallbackCap := requireHostCapabilityForSkill(t, fallback.HostCapabilities, progression.SkillPlanAudit)
+		assert.True(t, fallbackCap.FallbackSelected)
+		assert.Equal(t, "manual_plan_audit", fallbackCap.FallbackMode)
+		fallbackSpecs := model.ReasonSpecs(fallback.Blockers)
+		assert.NotContains(t, fallbackSpecs, "host_capability_unavailable:plan-audit:subagent")
+		assert.NotContains(t, fallbackSpecs, "subagent_dispatch_authorization_required:plan-audit:subagent")
+		assert.Equal(t, "skill_handoff:plan-audit", fallback.ConfirmationRequirement.Reason)
+	})
+}
+
+func requireHostCapabilityForSkill(t *testing.T, capabilities []hostCapabilityView, skillName string) hostCapabilityView {
+	t.Helper()
+	for _, capability := range capabilities {
+		if capability.SkillName == skillName {
+			return capability
+		}
+	}
+	t.Fatalf("host capability for %q not found in %+v", skillName, capabilities)
+	return hostCapabilityView{}
+}
+
 // TestNextAuditHandoffStillAdvertisesEvidence asserts the audit-substep behavior
 // is unchanged: at S1_PLAN/audit, where `slipway evidence skill --skill
 // plan-audit` is accepted, the handoff still advertises write_evidence and

--- a/cmd/next_tool_path_test.go
+++ b/cmd/next_tool_path_test.go
@@ -85,3 +85,39 @@ func TestNextReturnsIntakeSkillNameAfterInit(t *testing.T) {
 		assert.Equal(t, "intake-clarification", view.NextSkill.Name)
 	})
 }
+
+// TestNextS0IntakeClarificationHandoffStatesFreshGateByDesign pins #357: the S0
+// intake-clarification handoff is a fresh, non-delegable approved-summary gate.
+// The gate is NOT relaxed; instead the next_action makes the policy explicit so a
+// prior broad "continue" authorization is not mistaken for approval of the intent
+// summary. It names the concrete next step: review and approve the Approved
+// Summary, then record intake-clarification evidence.
+func TestNextS0IntakeClarificationHandoffStatesFreshGateByDesign(t *testing.T) {
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		require.NoError(t, bootstrap.InitWorkspace(root, []string{"claude"}, false))
+
+		create := makeNewCmd()
+		create.SetArgs([]string{"--preset", "standard", "intake fresh-gate rationale should be explicit"})
+		require.NoError(t, create.Execute())
+
+		var out bytes.Buffer
+		cmd := makeNextCmd()
+		cmd.SetArgs([]string{"--json", "--diagnostics"})
+		cmd.SetOut(&out)
+		require.NoError(t, cmd.Execute())
+
+		var view nextView
+		require.NoError(t, json.Unmarshal(out.Bytes(), &view))
+		require.NotNil(t, view.NextSkill)
+		assert.Equal(t, "intake-clarification", view.NextSkill.Name)
+
+		cr := view.ConfirmationRequirement
+		assert.Equal(t, "skill_handoff:intake-clarification", cr.Reason)
+		assert.True(t, cr.FreshConfirmationRequired, "intake approved-summary stays a fresh hard gate")
+		assert.False(t, cr.PriorAuthorizationSufficient, "prior broad authorization must not satisfy the intake gate")
+		assert.Contains(t, cr.NextAction, "FRESH HARD GATE BY DESIGN")
+		assert.Contains(t, cr.NextAction, "review and approve the intake Approved Summary")
+		assert.Contains(t, cr.NextAction, "does not substitute for explicit approval")
+	})
+}

--- a/cmd/progression_next_test.go
+++ b/cmd/progression_next_test.go
@@ -669,6 +669,96 @@ func TestNextDoesNotReturnDoneReadyWithoutGoalVerification(t *testing.T) {
 	})
 }
 
+// TestNextS3ShipVerificationSurfacesSubagentDelegationAcrossCapabilityStates
+// pins the host subagent-delegation contract for the terminal ship-verification
+// gate once the S3 review batch has cleared (#369). ship-verification is the
+// single always-required terminal S3 gate; it REQUIRES dispatching a fresh
+// verifier subagent but is not a catalog-registered skill, so the contract comes
+// from the built-in subagent-dispatch lever. Without this, a host that cleared
+// the four-reviewer batch via the named fallback hit the SAME dead-end one step
+// later at ship-verification. "unknown" (host declared nothing) stays continuable
+// on the skill_handoff boundary while riding a
+// subagent_dispatch_authorization_required prerequisite with an enriched,
+// named-fallback next_action; "unavailable" (host declared other capabilities but
+// not subagent) fails closed as a first-class host_capability_unavailable blocker;
+// "available" is unchanged; an explicit fallback clears the blocker without a
+// bypass. This test exercises the public next path with ship-verification as the
+// selected terminal skill so the prerequisite genuinely reaches the surface.
+func TestNextS3ShipVerificationSurfacesSubagentDelegationAcrossCapabilityStates(t *testing.T) {
+	root := t.TempDir()
+	ensureTestGitRepo(t, root)
+	initTestWorkspace(t, root)
+
+	slug := createGovernedRequest(t, root, levelNonDiscovery, "ship verification subagent delegation")
+	change, err := state.LoadChange(root, slug)
+	require.NoError(t, err)
+	change.CurrentState = model.StateS3Review
+	change.PlanSubStep = model.PlanSubStepNone
+	require.NoError(t, state.SaveChange(root, change))
+	writeShipReadyGovernedBundle(t, root, change)
+	writePassingExecutionSummary(t, root, slug, 1, "t-01")
+	writePassingWaveEvidence(t, root, slug, 1)
+	writePassingReviewEvidencePack(t, root, slug, 1)
+
+	const subagentBlocker = "subagent_dispatch_authorization_required:ship-verification:subagent"
+	const unavailableBlocker = "host_capability_unavailable:ship-verification:subagent"
+
+	t.Setenv("SLIPWAY_HOST_CAPABILITY_FALLBACKS", "")
+
+	// unknown: host declared nothing -> continuable skill_handoff riding the prerequisite.
+	t.Setenv("SLIPWAY_HOST_CAPABILITIES", "")
+	unknown, err := buildNextViewForCommand(root, changeRef{Slug: slug}, nextViewOptions{Preview: true, Command: "run"})
+	require.NoError(t, err)
+	require.NotNil(t, unknown.NextSkill)
+	assert.Equal(t, progression.SkillShipVerification, unknown.NextSkill.Name)
+	unknownCap := requireHostCapabilityForSkill(t, unknown.HostCapabilities, progression.SkillShipVerification)
+	assert.Equal(t, "unknown", unknownCap.Availability)
+	assert.False(t, unknownCap.FallbackSelected)
+	unknownSpecs := model.ReasonSpecs(unknown.Blockers)
+	assert.Contains(t, unknownSpecs, subagentBlocker)
+	assert.NotContains(t, unknownSpecs, unavailableBlocker)
+	// Continuable: stays the ship-verification skill_handoff boundary, not a dead-end.
+	assert.Equal(t, "skill_handoff:"+progression.SkillShipVerification, unknown.ConfirmationRequirement.Reason)
+	assert.Contains(t, unknown.ConfirmationRequirement.NextAction, "Host subagent delegation is a prerequisite")
+	assert.Contains(t, unknown.ConfirmationRequirement.NextAction, "same_context_degraded")
+
+	// unavailable: host declared other capabilities but not subagent -> fails closed.
+	t.Setenv("SLIPWAY_HOST_CAPABILITIES", "none")
+	unavailable, err := buildNextViewForCommand(root, changeRef{Slug: slug}, nextViewOptions{Preview: true, Command: "run"})
+	require.NoError(t, err)
+	unavailableCap := requireHostCapabilityForSkill(t, unavailable.HostCapabilities, progression.SkillShipVerification)
+	assert.Equal(t, "unavailable", unavailableCap.Availability)
+	unavailableSpecs := model.ReasonSpecs(unavailable.Blockers)
+	assert.Contains(t, unavailableSpecs, unavailableBlocker)
+	assert.NotContains(t, unavailableSpecs, subagentBlocker)
+	assert.Equal(t, "blocked_by_governance", unavailable.ConfirmationRequirement.Reason)
+
+	// available: declared subagent -> no new blocker, identical to baseline.
+	t.Setenv("SLIPWAY_HOST_CAPABILITIES", "subagent")
+	available, err := buildNextViewForCommand(root, changeRef{Slug: slug}, nextViewOptions{Preview: true, Command: "run"})
+	require.NoError(t, err)
+	availableCap := requireHostCapabilityForSkill(t, available.HostCapabilities, progression.SkillShipVerification)
+	assert.Equal(t, "available", availableCap.Availability)
+	availableSpecs := model.ReasonSpecs(available.Blockers)
+	assert.NotContains(t, availableSpecs, unavailableBlocker)
+	assert.NotContains(t, availableSpecs, subagentBlocker)
+	assert.Equal(t, "skill_handoff:"+progression.SkillShipVerification, available.ConfirmationRequirement.Reason)
+
+	// unavailable + named fallback clears the blocker and restores the handoff,
+	// without bypassing the gate (fresh ship-verification evidence is still owed).
+	t.Setenv("SLIPWAY_HOST_CAPABILITIES", "none")
+	t.Setenv("SLIPWAY_HOST_CAPABILITY_FALLBACKS", "manual_ship_verification")
+	fallback, err := buildNextViewForCommand(root, changeRef{Slug: slug}, nextViewOptions{Preview: true, Command: "run"})
+	require.NoError(t, err)
+	fallbackCap := requireHostCapabilityForSkill(t, fallback.HostCapabilities, progression.SkillShipVerification)
+	assert.True(t, fallbackCap.FallbackSelected)
+	assert.Equal(t, "manual_ship_verification", fallbackCap.FallbackMode)
+	fallbackSpecs := model.ReasonSpecs(fallback.Blockers)
+	assert.NotContains(t, fallbackSpecs, unavailableBlocker)
+	assert.NotContains(t, fallbackSpecs, subagentBlocker)
+	assert.Equal(t, "skill_handoff:"+progression.SkillShipVerification, fallback.ConfirmationRequirement.Reason)
+}
+
 func TestNextDoesNotAutoPassStrictPresetReview(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/progression_next_test.go
+++ b/cmd/progression_next_test.go
@@ -1337,7 +1337,17 @@ func TestReviewStateActionableNextSkillConsistentAcrossCommandSurfaces(t *testin
 	})
 }
 
-func TestReviewBatchHostCapabilityUnavailableFailsClosedUnlessFallbackSelected(t *testing.T) {
+// TestReviewBatchHostSubagentDelegationSurfacedAcrossCapabilityStates pins the
+// host subagent-delegation contract for the S3 review batch across the three
+// capability states (#369). "available" is unchanged (see the sibling test).
+// "unknown" (the host declared nothing) stays continuable: it keeps the normal
+// review_batch handoff boundary instead of escalating to a governance dead-end,
+// but rides a subagent_dispatch_authorization_required prerequisite and an
+// enriched next_action that names delegation plus the named fallback. "unavailable"
+// (the host declared other capabilities but not subagent) fails closed as a
+// first-class host_capability_unavailable blocker until an explicit fallback is
+// selected. Either way the surface is actionable, never a silent dead-end.
+func TestReviewBatchHostSubagentDelegationSurfacedAcrossCapabilityStates(t *testing.T) {
 	root, slug := prepareReviewBatchHostCapabilityFixture(t)
 
 	originalCapabilities, hadCapabilities := os.LookupEnv("SLIPWAY_HOST_CAPABILITIES")
@@ -1355,45 +1365,36 @@ func TestReviewBatchHostCapabilityUnavailableFailsClosedUnlessFallbackSelected(t
 		}
 	})
 
+	const subagentBlocker = "subagent_dispatch_authorization_required:independent-review:subagent"
+	const unavailableBlocker = "host_capability_unavailable:independent-review:subagent"
+
+	// --- unknown: host declared nothing -> continuable, riding prerequisite ---
 	require.NoError(t, os.Unsetenv("SLIPWAY_HOST_CAPABILITIES"))
 	require.NoError(t, os.Unsetenv("SLIPWAY_HOST_CAPABILITY_FALLBACKS"))
 
-	unsetCmd := commandForRoot(t, root, makeNextCmd())
-	unsetCmd.SetArgs([]string{"--json", "--change", slug})
-	var unsetOut bytes.Buffer
-	unsetCmd.SetOut(&unsetOut)
-	require.NoError(t, unsetCmd.Execute())
-	var unsetHandoff nextHandoffView
-	require.NoError(t, json.Unmarshal(unsetOut.Bytes(), &unsetHandoff))
-	unsetCapability := requireIndependentReviewHostCapability(t, unsetHandoff.HostCapabilities)
-	assert.Equal(t, "unknown", unsetCapability.Availability)
-	assert.False(t, unsetCapability.FallbackSelected)
-	assert.Contains(t, model.ReasonSpecs(unsetHandoff.Blockers), "host_capability_unavailable:independent-review:subagent")
-	assert.Equal(t, "blocked_by_governance", unsetHandoff.Confirmation.Reason)
-	assert.NotEmpty(t, unsetHandoff.ExecutionEvidenceFreshness)
-	assert.NotEmpty(t, unsetHandoff.GovernanceEvidenceFreshness)
-	assert.Equal(t, "blocked", unsetHandoff.OverallReadinessFreshness)
+	unknownCmd := commandForRoot(t, root, makeNextCmd())
+	unknownCmd.SetArgs([]string{"--json", "--change", slug})
+	var unknownOut bytes.Buffer
+	unknownCmd.SetOut(&unknownOut)
+	require.NoError(t, unknownCmd.Execute())
+	var unknownHandoff nextHandoffView
+	require.NoError(t, json.Unmarshal(unknownOut.Bytes(), &unknownHandoff))
+	unknownCapability := requireIndependentReviewHostCapability(t, unknownHandoff.HostCapabilities)
+	assert.Equal(t, "unknown", unknownCapability.Availability)
+	assert.False(t, unknownCapability.FallbackSelected)
+	unknownSpecs := model.ReasonSpecs(unknownHandoff.Blockers)
+	assert.Contains(t, unknownSpecs, subagentBlocker)
+	assert.NotContains(t, unknownSpecs, unavailableBlocker)
+	// Continuable: stays the review_batch boundary, not a blocked_by_governance dead-end.
+	assert.Equal(t, "review_batch", unknownHandoff.Confirmation.Reason)
+	assert.Equal(t, "review_batch", unknownHandoff.Confirmation.NextActionKind)
+	assert.Contains(t, unknownHandoff.Confirmation.NextAction, "Host subagent delegation is a prerequisite")
+	assert.Contains(t, unknownHandoff.Confirmation.NextAction, "same_context_degraded")
+	assert.Equal(t, "blocked", unknownHandoff.OverallReadinessFreshness)
+	require.NotNil(t, unknownHandoff.Recovery)
+	assert.NotEmpty(t, unknownHandoff.Recovery.Steps)
 
-	t.Setenv("SLIPWAY_HOST_CAPABILITIES", "")
-	t.Setenv("SLIPWAY_HOST_CAPABILITY_FALLBACKS", "")
-
-	nextCmd := commandForRoot(t, root, makeNextCmd())
-	nextCmd.SetArgs([]string{"--json", "--change", slug})
-	var nextOut bytes.Buffer
-	nextCmd.SetOut(&nextOut)
-	require.NoError(t, nextCmd.Execute())
-	var handoff nextHandoffView
-	require.NoError(t, json.Unmarshal(nextOut.Bytes(), &handoff))
-	nextCapability := requireIndependentReviewHostCapability(t, handoff.HostCapabilities)
-	assert.Equal(t, "unknown", nextCapability.Availability)
-	assert.False(t, nextCapability.FallbackSelected)
-	assert.Contains(t, model.ReasonSpecs(handoff.Blockers), "host_capability_unavailable:independent-review:subagent")
-	assert.Equal(t, "blocked_by_governance", handoff.Confirmation.Reason)
-	assert.Equal(t, "blocker_resolution", handoff.Confirmation.NextActionKind)
-	assert.NotEmpty(t, handoff.ExecutionEvidenceFreshness)
-	assert.NotEmpty(t, handoff.GovernanceEvidenceFreshness)
-	assert.Equal(t, "blocked", handoff.OverallReadinessFreshness)
-
+	// validate surfaces the same prerequisite and stays fail-closed (cannot advance).
 	validateCmd := commandForRoot(t, root, makeValidateCmd())
 	validateCmd.SetArgs([]string{"--change", slug})
 	var validateOut bytes.Buffer
@@ -1403,13 +1404,10 @@ func TestReviewBatchHostCapabilityUnavailableFailsClosedUnlessFallbackSelected(t
 	require.NoError(t, json.Unmarshal(validateOut.Bytes(), &validate))
 	validateCapability := requireIndependentReviewHostCapability(t, validate.HostCapabilities)
 	assert.Equal(t, "unknown", validateCapability.Availability)
-	assert.False(t, validateCapability.FallbackSelected)
-	assert.Contains(t, model.ReasonSpecs(validate.Blockers), "host_capability_unavailable:independent-review:subagent")
+	assert.Contains(t, model.ReasonSpecs(validate.Blockers), subagentBlocker)
 	assert.False(t, validate.CanAdvance)
-	assert.NotEmpty(t, validate.ExecutionEvidenceFreshness)
-	assert.NotEmpty(t, validate.GovernanceEvidenceFreshness)
-	assert.Equal(t, "blocked", validate.OverallReadinessFreshness)
 
+	// run shares the same view and never advances past S3.
 	runCmd := commandForRoot(t, root, makeRunCmd())
 	runCmd.SetArgs([]string{"--json", "--diagnostics", "--change", slug})
 	var runOut bytes.Buffer
@@ -1419,37 +1417,13 @@ func TestReviewBatchHostCapabilityUnavailableFailsClosedUnlessFallbackSelected(t
 	require.NoError(t, json.Unmarshal(runOut.Bytes(), &runView))
 	runCapability := requireIndependentReviewHostCapability(t, runView.HostCapabilities)
 	assert.Equal(t, "unknown", runCapability.Availability)
-	assert.False(t, runCapability.FallbackSelected)
-	assert.Contains(t, model.ReasonSpecs(runView.Blockers), "host_capability_unavailable:independent-review:subagent")
-	assert.Equal(t, "blocked_by_governance", runView.ConfirmationRequirement.Reason)
-	assert.NotEmpty(t, runView.ExecutionEvidenceFreshness)
-	assert.NotEmpty(t, runView.GovernanceEvidenceFreshness)
-	assert.Equal(t, "blocked", runView.OverallReadinessFreshness)
-
-	compactRunCmd := commandForRoot(t, root, makeRunCmd())
-	compactRunCmd.SetArgs([]string{"--json", "--change", slug})
-	var compactRunOut bytes.Buffer
-	compactRunCmd.SetOut(&compactRunOut)
-	require.NoError(t, compactRunCmd.Execute())
-	var compactRun nextHandoffView
-	require.NoError(t, json.Unmarshal(compactRunOut.Bytes(), &compactRun))
-	compactRunCapability := requireIndependentReviewHostCapability(t, compactRun.HostCapabilities)
-	assert.Equal(t, "unknown", compactRunCapability.Availability)
-	assert.False(t, compactRunCapability.FallbackSelected)
-	assert.Contains(t, model.ReasonSpecs(compactRun.Blockers), "host_capability_unavailable:independent-review:subagent")
-	assert.Equal(t, "blocked_by_governance", compactRun.Confirmation.Reason)
-	assert.Equal(t, "blocker_resolution", compactRun.Confirmation.NextActionKind)
-	assert.NotEmpty(t, compactRun.ExecutionEvidenceFreshness)
-	assert.NotEmpty(t, compactRun.GovernanceEvidenceFreshness)
-	assert.Equal(t, "blocked", compactRun.OverallReadinessFreshness)
-	require.NotNil(t, compactRun.Recovery)
-	assert.NotEmpty(t, compactRun.Recovery.Steps)
-	assert.Equal(t, model.StateS3Review, compactRun.CurrentState)
-	reloadedAfterCompactRun, err := state.LoadChange(root, slug)
+	assert.Contains(t, model.ReasonSpecs(runView.Blockers), subagentBlocker)
+	assert.Equal(t, "review_batch", runView.ConfirmationRequirement.Reason)
+	reloadedAfterRun, err := state.LoadChange(root, slug)
 	require.NoError(t, err)
-	assert.Equal(t, model.StateS3Review, reloadedAfterCompactRun.CurrentState)
-	assert.Equal(t, model.PlanSubStepNone, reloadedAfterCompactRun.PlanSubStep)
+	assert.Equal(t, model.StateS3Review, reloadedAfterRun.CurrentState)
 
+	// --- unavailable: host declared other capabilities but not subagent ---
 	t.Setenv("SLIPWAY_HOST_CAPABILITIES", "none")
 
 	unavailableCmd := commandForRoot(t, root, makeNextCmd())
@@ -1462,9 +1436,14 @@ func TestReviewBatchHostCapabilityUnavailableFailsClosedUnlessFallbackSelected(t
 	unavailableCapability := requireIndependentReviewHostCapability(t, unavailableView.HostCapabilities)
 	assert.Equal(t, "unavailable", unavailableCapability.Availability)
 	assert.False(t, unavailableCapability.FallbackSelected)
-	assert.Contains(t, model.ReasonSpecs(unavailableView.Blockers), "host_capability_unavailable:independent-review:subagent")
+	unavailableSpecs := model.ReasonSpecs(unavailableView.Blockers)
+	assert.Contains(t, unavailableSpecs, unavailableBlocker)
+	assert.NotContains(t, unavailableSpecs, subagentBlocker)
+	// First-class blocker: escalates to a governance hard stop.
+	assert.Equal(t, "blocked_by_governance", unavailableView.ConfirmationRequirement.Reason)
 
-	t.Setenv("SLIPWAY_HOST_CAPABILITY_FALLBACKS", "manual_independent_review")
+	// --- unavailable + generic same_context_degraded fallback clears the whole batch ---
+	t.Setenv("SLIPWAY_HOST_CAPABILITY_FALLBACKS", "same_context_degraded")
 
 	fallbackCmd := commandForRoot(t, root, makeNextCmd())
 	fallbackCmd.SetArgs([]string{"--json", "--diagnostics", "--change", slug})
@@ -1476,9 +1455,38 @@ func TestReviewBatchHostCapabilityUnavailableFailsClosedUnlessFallbackSelected(t
 	fallbackCapability := requireIndependentReviewHostCapability(t, fallbackView.HostCapabilities)
 	assert.Equal(t, "unavailable", fallbackCapability.Availability)
 	assert.True(t, fallbackCapability.FallbackSelected)
-	assert.Equal(t, "manual_independent_review", fallbackCapability.FallbackMode)
-	assert.NotContains(t, model.ReasonSpecs(fallbackView.Blockers), "host_capability_unavailable:independent-review:subagent")
+	assert.Equal(t, "same_context_degraded", fallbackCapability.FallbackMode)
+	fallbackSpecs := model.ReasonSpecs(fallbackView.Blockers)
+	assert.NotContains(t, fallbackSpecs, unavailableBlocker)
+	assert.NotContains(t, fallbackSpecs, subagentBlocker)
 	assert.Equal(t, "review_batch", fallbackView.ConfirmationRequirement.Reason)
+}
+
+// TestReviewBatchSurfacesSubagentDelegationForEveryPendingReviewer pins #369:
+// every pending S3 reviewer that REQUIRES a fresh subagent surfaces the
+// subagent-delegation prerequisite under the "unknown" host-capability state,
+// not just independent-review. spec-compliance-review already has evidence in
+// the fixture, so it is not pending and carries no requirement.
+func TestReviewBatchSurfacesSubagentDelegationForEveryPendingReviewer(t *testing.T) {
+	root, slug := prepareReviewBatchHostCapabilityFixture(t)
+	t.Setenv("SLIPWAY_HOST_CAPABILITIES", "")
+	t.Setenv("SLIPWAY_HOST_CAPABILITY_FALLBACKS", "")
+
+	view := runNextDiagnostics(t, root, slug)
+	specs := model.ReasonSpecs(view.Blockers)
+	for _, reviewer := range []string{
+		progression.SkillCodeQualityReview,
+		progression.SkillIndependentReview,
+		progression.SkillSecurityReview,
+	} {
+		capability := requireHostCapabilityForSkill(t, view.HostCapabilities, reviewer)
+		assert.Equal(t, "unknown", capability.Availability, reviewer)
+		assert.False(t, capability.FallbackSelected, reviewer)
+		assert.NotEmpty(t, capability.Remediation, reviewer)
+		assert.Contains(t, specs, "subagent_dispatch_authorization_required:"+reviewer+":subagent")
+	}
+	assert.Equal(t, "review_batch", view.ConfirmationRequirement.Reason)
+	assert.Contains(t, view.ConfirmationRequirement.NextAction, "Host subagent delegation is a prerequisite")
 }
 
 func TestReviewBatchHostCapabilityAvailableDoesNotBlockCommandSurfaces(t *testing.T) {

--- a/internal/engine/capability/registry_scale_foundation.go
+++ b/internal/engine/capability/registry_scale_foundation.go
@@ -56,6 +56,15 @@ func securityReview() Skill {
 		Bindings: []Binding{
 			{Type: BindingCommandAuto, Target: "review", Attachment: AttachmentChecklist},
 		},
+		HostCapabilities: []HostCapabilityContract{
+			{
+				Capability:          "subagent",
+				Required:            true,
+				FallbackModes:       []string{"manual_security_review", "same_context_degraded"},
+				EvidenceRequirement: "record security-review evidence from a fresh independent reviewer context",
+				Remediation:         "Run security-review in a host with subagent capability, or explicitly select manual_security_review / same_context_degraded fallback and record fresh reviewer evidence.",
+			},
+		},
 		HydrateReferences: []HydrateReference{
 			{Name: "authentication.md", Reason: "Password storage / session / MFA / recovery secure-default rules"},
 			{Name: "authorization.md", Reason: "Resource-boundary re-check, IDOR, multi-tenant isolation"},

--- a/internal/engine/capability/resolver.go
+++ b/internal/engine/capability/resolver.go
@@ -165,6 +165,13 @@ var builtinSubagentDispatchContracts = map[string]HostCapabilityContract{
 		EvidenceRequirement: "record code-quality-review evidence from a fresh independent reviewer context",
 		Remediation:         "Run code-quality-review in a host with subagent capability, or explicitly select manual_code_quality_review / same_context_degraded fallback and record fresh reviewer evidence.",
 	},
+	"ship-verification": {
+		Capability:          "subagent",
+		Required:            true,
+		FallbackModes:       []string{"manual_ship_verification", "same_context_degraded"},
+		EvidenceRequirement: "record ship-verification evidence from a fresh verifier context",
+		Remediation:         "Run ship-verification in a host with subagent capability, or explicitly select manual_ship_verification / same_context_degraded fallback and record fresh ship-verification evidence.",
+	},
 }
 
 func hostCapabilityAvailability(tokens []string, capabilityName string) string {

--- a/internal/engine/capability/resolver.go
+++ b/internal/engine/capability/resolver.go
@@ -101,11 +101,10 @@ func ResolveHostCapabilityRequirementFromRegistry(
 	if reg == nil || skillID == "" {
 		return nil
 	}
-	sk, ok := reg.Lookup(skillID)
-	if !ok || len(sk.HostCapabilities) == 0 {
+	contract, ok := resolveHostCapabilityContract(reg, skillID)
+	if !ok {
 		return nil
 	}
-	contract := sk.HostCapabilities[0]
 	req := &HostCapabilityRequirement{
 		SkillID:             skillID,
 		Capability:          strings.TrimSpace(contract.Capability),
@@ -119,6 +118,53 @@ func ResolveHostCapabilityRequirementFromRegistry(
 		req.FallbackMode = mode
 	}
 	return req
+}
+
+// resolveHostCapabilityContract returns the host-capability contract for a
+// skill. A catalog-registered skill's own HostCapabilities[0] wins; otherwise
+// the built-in subagent-dispatch lever supplies a contract for the governance
+// skills that REQUIRE a fresh subagent but are intentionally NOT registered in
+// the capability catalog. Registering those governance skills would drag them
+// into the catalog's surface-manifest, install-profile, and host-skill
+// generation machinery (and the frozen DefaultRegistry ID snapshot); the lever
+// keeps the engine signal without that surface drag. (#339 / #369)
+func resolveHostCapabilityContract(reg *Registry, skillID string) (HostCapabilityContract, bool) {
+	if reg != nil {
+		if sk, ok := reg.Lookup(skillID); ok && len(sk.HostCapabilities) > 0 {
+			return sk.HostCapabilities[0], true
+		}
+	}
+	contract, ok := builtinSubagentDispatchContracts[skillID]
+	return contract, ok
+}
+
+// builtinSubagentDispatchContracts carries the subagent-dispatch host-capability
+// contract for the governance skills that mandate a fresh subagent yet are not
+// catalog-registered. Every contract names a generic `same_context_degraded`
+// fallback so a single fallback selection can satisfy a whole S3 review batch,
+// plus a skill-specific manual fallback for explicit single-skill degradation.
+var builtinSubagentDispatchContracts = map[string]HostCapabilityContract{
+	"plan-audit": {
+		Capability:          "subagent",
+		Required:            true,
+		FallbackModes:       []string{"manual_plan_audit", "same_context_degraded"},
+		EvidenceRequirement: "record plan-audit evidence from a fresh auditor context whose audit_origin handle is distinct from the plan author",
+		Remediation:         "Run plan-audit in a host with subagent capability, or explicitly select manual_plan_audit / same_context_degraded fallback and record fresh auditor evidence with a distinct audit_origin handle.",
+	},
+	"spec-compliance-review": {
+		Capability:          "subagent",
+		Required:            true,
+		FallbackModes:       []string{"manual_spec_compliance_review", "same_context_degraded"},
+		EvidenceRequirement: "record spec-compliance-review evidence from a fresh independent reviewer context",
+		Remediation:         "Run spec-compliance-review in a host with subagent capability, or explicitly select manual_spec_compliance_review / same_context_degraded fallback and record fresh reviewer evidence.",
+	},
+	"code-quality-review": {
+		Capability:          "subagent",
+		Required:            true,
+		FallbackModes:       []string{"manual_code_quality_review", "same_context_degraded"},
+		EvidenceRequirement: "record code-quality-review evidence from a fresh independent reviewer context",
+		Remediation:         "Run code-quality-review in a host with subagent capability, or explicitly select manual_code_quality_review / same_context_degraded fallback and record fresh reviewer evidence.",
+	},
 }
 
 func hostCapabilityAvailability(tokens []string, capabilityName string) string {

--- a/internal/engine/capability/resolver_test.go
+++ b/internal/engine/capability/resolver_test.go
@@ -178,14 +178,15 @@ func TestResolveHostCapabilityRequirement(t *testing.T) {
 // subagent-dispatch contract that surfaces a host-delegation prerequisite for
 // the governance skills that REQUIRE a fresh subagent but are not registered in
 // the capability catalog (plan-audit at S1; spec-compliance-review and
-// code-quality-review at S3). Registering them in the catalog would drag in the
-// surface-manifest / install-profile / generation machinery, so the contract is
-// a targeted lever consulted when the registry carries no host-capability
-// contract for the skill. (#339 / #369)
+// code-quality-review at S3; and the terminal ship-verification gate at S3).
+// Registering them in the catalog would drag in the surface-manifest /
+// install-profile / generation machinery, so the contract is a targeted lever
+// consulted when the registry carries no host-capability contract for the skill.
+// (#339 / #369)
 func TestResolveHostCapabilitySubagentDispatchLever(t *testing.T) {
 	t.Parallel()
 
-	leverSkills := []string{"plan-audit", "spec-compliance-review", "code-quality-review"}
+	leverSkills := []string{"plan-audit", "spec-compliance-review", "code-quality-review", "ship-verification"}
 	for _, skillID := range leverSkills {
 		skillID := skillID
 		t.Run(skillID+"/unknown surfaces continuable prerequisite", func(t *testing.T) {

--- a/internal/engine/capability/resolver_test.go
+++ b/internal/engine/capability/resolver_test.go
@@ -92,10 +92,12 @@ func TestResolveNoMatchReturnsEmpty(t *testing.T) {
 func TestResolveHostCapabilityRequirement(t *testing.T) {
 	t.Parallel()
 
-	t.Run("unknown skill has no host capability contract", func(t *testing.T) {
+	t.Run("skill without a host capability contract resolves nil", func(t *testing.T) {
 		t.Parallel()
 
-		assert.Nil(t, ResolveHostCapabilityRequirement("code-quality-review", Signals{}))
+		// context-assembly is registered but declares no host-capability contract
+		// and is not part of the subagent-dispatch lever, so it must resolve nil.
+		assert.Nil(t, ResolveHostCapabilityRequirement("context-assembly", Signals{}))
 	})
 
 	tests := []struct {
@@ -170,6 +172,73 @@ func TestResolveHostCapabilityRequirement(t *testing.T) {
 			assert.NotEmpty(t, req.Remediation)
 		})
 	}
+}
+
+// TestResolveHostCapabilitySubagentDispatchLever covers the built-in
+// subagent-dispatch contract that surfaces a host-delegation prerequisite for
+// the governance skills that REQUIRE a fresh subagent but are not registered in
+// the capability catalog (plan-audit at S1; spec-compliance-review and
+// code-quality-review at S3). Registering them in the catalog would drag in the
+// surface-manifest / install-profile / generation machinery, so the contract is
+// a targeted lever consulted when the registry carries no host-capability
+// contract for the skill. (#339 / #369)
+func TestResolveHostCapabilitySubagentDispatchLever(t *testing.T) {
+	t.Parallel()
+
+	leverSkills := []string{"plan-audit", "spec-compliance-review", "code-quality-review"}
+	for _, skillID := range leverSkills {
+		skillID := skillID
+		t.Run(skillID+"/unknown surfaces continuable prerequisite", func(t *testing.T) {
+			t.Parallel()
+			req := ResolveHostCapabilityRequirement(skillID, Signals{})
+			require.NotNil(t, req, "%s must resolve a built-in subagent-dispatch contract", skillID)
+			assert.Equal(t, skillID, req.SkillID)
+			assert.Equal(t, "subagent", req.Capability)
+			assert.True(t, req.Required)
+			assert.Equal(t, "unknown", req.Availability)
+			assert.False(t, req.FallbackSelected)
+			assert.NotEmpty(t, req.EvidenceRequirement)
+			assert.NotEmpty(t, req.Remediation)
+		})
+		t.Run(skillID+"/explicit none is unavailable", func(t *testing.T) {
+			t.Parallel()
+			req := ResolveHostCapabilityRequirement(skillID, Signals{HostCapabilities: []string{"none"}})
+			require.NotNil(t, req)
+			assert.Equal(t, "unavailable", req.Availability)
+			assert.False(t, req.FallbackSelected)
+		})
+		t.Run(skillID+"/declared subagent is available", func(t *testing.T) {
+			t.Parallel()
+			req := ResolveHostCapabilityRequirement(skillID, Signals{HostCapabilities: []string{"subagent"}})
+			require.NotNil(t, req)
+			assert.Equal(t, "available", req.Availability)
+		})
+		t.Run(skillID+"/generic same_context_degraded fallback is selectable", func(t *testing.T) {
+			t.Parallel()
+			req := ResolveHostCapabilityRequirement(skillID, Signals{
+				HostCapabilities: []string{"none"},
+				Fallbacks:        []string{"same_context_degraded"},
+			})
+			require.NotNil(t, req)
+			assert.Equal(t, "unavailable", req.Availability)
+			assert.True(t, req.FallbackSelected)
+			assert.Equal(t, "same_context_degraded", req.FallbackMode)
+		})
+	}
+
+	t.Run("registry contract still wins for registered security-review", func(t *testing.T) {
+		t.Parallel()
+		req := ResolveHostCapabilityRequirement("security-review", Signals{HostCapabilities: []string{"none"}})
+		require.NotNil(t, req, "security-review must carry a registry host-capability contract")
+		assert.Equal(t, "subagent", req.Capability)
+		assert.Equal(t, "unavailable", req.Availability)
+	})
+
+	t.Run("skills without any contract still resolve to nil", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, ResolveHostCapabilityRequirement("context-assembly", Signals{}))
+		assert.Nil(t, ResolveHostCapabilityRequirement("no-such-skill", Signals{}))
+	})
 }
 
 func TestResolveHostCapabilityRequirementUsesRegistryContract(t *testing.T) {

--- a/internal/engine/progression/confirmation_boundaries.go
+++ b/internal/engine/progression/confirmation_boundaries.go
@@ -70,9 +70,20 @@ func IsShipVerificationHandoffBlockerCode(code string) bool {
 
 // HostHandoffBlockerCanRide reports blockers that are the reason for the host
 // handoff itself rather than a separate governance stop.
+//
+// subagent_dispatch_authorization_required rides here: it names the host
+// subagent-delegation prerequisite for the handoff skill itself (plan-audit at
+// S1, an intake-side handoff) when the host has not declared subagent capability
+// available. It stays continuable so the handoff next_action can carry the
+// prerequisite plus the named fallback, rather than escalating to a separate
+// blocked_by_governance stop. The first-class host_capability_unavailable
+// blocker (the host explicitly declared subagent unavailable) deliberately does
+// NOT ride.
 func HostHandoffBlockerCanRide(reason model.ReasonCode) bool {
 	code := strings.TrimSpace(reason.Code)
-	return IsRequiredSkillBlockerCode(code) || code == "review_alignment_required"
+	return IsRequiredSkillBlockerCode(code) ||
+		code == "review_alignment_required" ||
+		code == "subagent_dispatch_authorization_required"
 }
 
 // ReviewCompanionBlockerCanRide reports governance blockers that are satisfied
@@ -85,6 +96,7 @@ func ReviewCompanionBlockerCanRide(reason model.ReasonCode) bool {
 		"ship_verification_evidence_missing",
 		"ship_verification_ordering_invalid",
 		"context_origin_handle_invalid",
+		"subagent_dispatch_authorization_required",
 		"high_risk_check_missing":
 		return true
 	default:

--- a/internal/engine/progression/confirmation_boundaries.go
+++ b/internal/engine/progression/confirmation_boundaries.go
@@ -132,10 +132,18 @@ func ReviewCompanionSkillCanCarryBlockers(skillName string) bool {
 // security review must hard-stop under auto, so it must never appear here even
 // though ReviewCompanionSkillCanCarryBlockers does list it. This divergence is
 // pinned by TestSecurityReviewDivergesAcrossAutoBoundaries.
+//
+// SkillIntakeClarification is likewise deliberately omitted: the intake
+// approved-summary is a fresh hard gate by design (#357). A prior broad
+// "continue" authorization must not substitute for explicit approval of the
+// interpreted intent, so the intake handoff must hard-stop even under
+// execution.auto. Softening it would emit PriorAuthorizationSufficient=true while
+// the next_action still declares the gate fresh and non-delegable — a
+// self-contradiction. This divergence is pinned by
+// TestDeriveConfirmationRequirementAutoKeepsIntakeClarificationHardStop.
 func SkillIsPurePacingAutoSafe(skillName string) bool {
 	switch strings.TrimSpace(skillName) {
-	case SkillIntakeClarification,
-		SkillResearchOrchestration,
+	case SkillResearchOrchestration,
 		SkillPlanAudit,
 		SkillWaveOrchestration,
 		SkillSpecComplianceReview,

--- a/internal/engine/progression/confirmation_boundaries_test.go
+++ b/internal/engine/progression/confirmation_boundaries_test.go
@@ -77,7 +77,6 @@ func TestPurePacingAutoSafeAllowlistMembership(t *testing.T) {
 	t.Parallel()
 
 	autoSafe := []string{
-		SkillIntakeClarification,
 		SkillResearchOrchestration,
 		SkillPlanAudit,
 		SkillWaveOrchestration,
@@ -92,9 +91,13 @@ func TestPurePacingAutoSafeAllowlistMembership(t *testing.T) {
 		}
 	}
 
+	// intake-clarification (the fresh approved-summary hard gate, #357) and
+	// security-review must hard-stop even under execution.auto, so neither may be
+	// pure-pacing auto-safe.
 	mustHardStop := []string{
 		SkillWorktreePreflight,
 		SkillSecurityReview,
+		SkillIntakeClarification,
 	}
 	for _, name := range mustHardStop {
 		if SkillIsPurePacingAutoSafe(name) {

--- a/internal/engine/progression/confirmation_boundaries_test.go
+++ b/internal/engine/progression/confirmation_boundaries_test.go
@@ -1,6 +1,37 @@
 package progression
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/signalridge/slipway/internal/model"
+)
+
+// TestSubagentDispatchAuthorizationBlockerRides pins that the
+// subagent_dispatch_authorization_required blocker (emitted for the "unknown"
+// host-capability state of a subagent-dispatch skill) rides alongside both the
+// host-handoff confirmation (plan-audit / intake-side skill_handoff) and the S3
+// review-companion confirmation, so it stays continuable and does not escalate
+// to a separate blocked_by_governance hard stop. The "unavailable" first-class
+// blocker host_capability_unavailable must NOT ride. (#339 / #369)
+func TestSubagentDispatchAuthorizationBlockerRides(t *testing.T) {
+	t.Parallel()
+
+	riding := model.NewReasonCode("subagent_dispatch_authorization_required", "plan-audit:subagent")
+	if !HostHandoffBlockerCanRide(riding) {
+		t.Fatal("subagent_dispatch_authorization_required must ride the host handoff (plan-audit / intake-side skill_handoff)")
+	}
+	if !ReviewCompanionBlockerCanRide(riding) {
+		t.Fatal("subagent_dispatch_authorization_required must ride the S3 review-companion handoff")
+	}
+
+	unavailable := model.NewReasonCode("host_capability_unavailable", "independent-review:subagent")
+	if HostHandoffBlockerCanRide(unavailable) {
+		t.Fatal("host_capability_unavailable (unavailable) must stay a first-class blocker, not ride the host handoff")
+	}
+	if ReviewCompanionBlockerCanRide(unavailable) {
+		t.Fatal("host_capability_unavailable (unavailable) must stay a first-class blocker, not ride the review companion")
+	}
+}
 
 // TestSecurityReviewDivergesAcrossAutoBoundaries pins the deliberate divergence
 // between ReviewCompanionSkillCanCarryBlockers (lists security-review) and

--- a/internal/model/reason_code.go
+++ b/internal/model/reason_code.go
@@ -530,6 +530,10 @@ var canonicalReasonDefinitions = map[string]ReasonDefinition{
 		Severity: ReasonSeverityError,
 		Message:  "Governance skill registry is invalid",
 	},
+	"subagent_dispatch_authorization_required": {
+		Severity: ReasonSeverityError,
+		Message:  "A required governance skill needs host subagent-dispatch authorization the host has not declared available",
+	},
 	"stale_execution_evidence": {
 		Severity: ReasonSeverityError,
 		Message:  "Execution evidence is stale; rerun wave-orchestration for affected tasks",

--- a/internal/model/reason_code_contract_test.go
+++ b/internal/model/reason_code_contract_test.go
@@ -165,6 +165,7 @@ func canonicalReasonCodeSnapshot() []string {
 		"stale_execution_evidence",
 		"stale_planning_evidence",
 		"stale_runtime_binding",
+		"subagent_dispatch_authorization_required",
 		"task",
 		"task_blocker",
 		"task_blockers",

--- a/internal/model/recovery.go
+++ b/internal/model/recovery.go
@@ -259,6 +259,12 @@ var blockerRemediations = map[string]blockerRemediation{
 		Class:           RecoveryClassSatisfyControl,
 		SplitDetail:     true,
 	},
+	"subagent_dispatch_authorization_required": {
+		Remediation:     "The host has not declared {detail} dispatch available for {subject}: authorize host {detail} delegation, or explicitly select a named degraded fallback for {subject} and record fresh evidence. Do not review or audit inline in the host context without recording the chosen fallback.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassSatisfyControl,
+		SplitDetail:     true,
+	},
 	"incomplete_execution_task": {
 		Remediation:     "Execute task {subject} and record its evidence with `slipway evidence task`, or update tasks.md if the task no longer belongs, then continue wave-orchestration.",
 		CommandTemplate: "slipway run",

--- a/internal/model/recovery_test.go
+++ b/internal/model/recovery_test.go
@@ -157,6 +157,8 @@ func inScopeProducedRecoverySpecs() []string {
 		"cross_stage_context_not_distinct:spec-compliance-review|code-quality-review",
 		"plan_audit_origin_invalid",
 		"degraded_dispatch_justification_missing",
+		"subagent_dispatch_authorization_required:plan-audit:subagent",
+		"host_capability_unavailable:independent-review:subagent",
 	}
 }
 

--- a/internal/tmpl/templates/skills/code-quality-review/SKILL.md.tmpl
+++ b/internal/tmpl/templates/skills/code-quality-review/SKILL.md.tmpl
@@ -116,9 +116,12 @@ isolation). The selected reviews run in parallel as unordered peers: no reviewer
 waits for another reviewer's verdict. Model the dispatch on how
 `slipway-wave-orchestration` fans out executor subagents: spawn each review as a
 fresh-context subagent with a bounded review brief, pass it required-reading paths
-rather than artifact bodies, wait for the results, and record each handle. If a
-capable runtime cannot spawn, wait for, and close a subagent, stop and ask for
-operator direction rather than reviewing inline in the host context.
+rather than artifact bodies, wait for the results, and record each handle. If the
+host has not declared subagent capability available, `slipway next`/`run` surfaces
+a subagent-delegation prerequisite plus a named degraded fallback for this review:
+authorize subagent dispatch, or explicitly select the named fallback (for example
+`same_context_degraded`) and record fresh reviewer evidence for the degraded run —
+do not review inline without recording the selected fallback.
 
 Record this review's per-stage context identifier as
 `context_origin:stage=review=<handle>`, where `<handle>` is the dispatched

--- a/internal/tmpl/templates/skills/independent-review/SKILL.md.tmpl
+++ b/internal/tmpl/templates/skills/independent-review/SKILL.md.tmpl
@@ -99,9 +99,12 @@ Dispatch this review in a native subagent from the S3 review host on the SHARED 
 (the same worktree the implementation edited; there is no
 per-review git worktree isolation). Spawn a fresh-context subagent with a
 bounded review brief, pass it required-reading paths rather than artifact
-bodies, wait for the result, and record the handle. If a capable runtime cannot
-spawn, wait for, and close a subagent, stop and ask for operator direction
-rather than reviewing inline in the host context.
+bodies, wait for the result, and record the handle. If the host has not declared
+subagent capability available, `slipway next`/`run` surfaces a subagent-delegation
+prerequisite plus a named degraded fallback for this review: authorize subagent
+dispatch, or explicitly select the named fallback (for example
+`same_context_degraded`) and record fresh reviewer evidence for the degraded run —
+do not review inline without recording the selected fallback.
 
 Record this review's context identifier as
 `context_origin:stage=review=<handle>`, where `<handle>` is the dispatched

--- a/internal/tmpl/templates/skills/plan-audit/SKILL.md
+++ b/internal/tmpl/templates/skills/plan-audit/SKILL.md
@@ -185,9 +185,13 @@ worktree (the same worktree that holds the governed bundle; there is no
 per-audit git worktree isolation). Model the dispatch on how
 `slipway-wave-orchestration` fans out executor subagents: spawn one fresh-context
 subagent with a bounded audit brief, pass it required-reading paths rather than
-artifact bodies, wait for its result, and record its handle. If a capable runtime
-cannot spawn, wait for, and close a subagent, stop and ask for operator direction
-rather than auditing inline in the host context.
+artifact bodies, wait for its result, and record its handle. If the host has not
+declared subagent capability available, `slipway next`/`run` surfaces a
+subagent-delegation prerequisite plus a named degraded fallback for plan-audit:
+authorize subagent dispatch, or explicitly select the named fallback (for example
+`manual_plan_audit` or `same_context_degraded`) and record fresh auditor evidence
+with a distinct `audit_origin` handle — do not audit inline without recording the
+selected fallback.
 
 Plan-audit records an author/auditor PAIR of context handles, NOT a
 `context_origin:stage=` token. Record both:

--- a/internal/tmpl/templates/skills/security-review/SKILL.md
+++ b/internal/tmpl/templates/skills/security-review/SKILL.md
@@ -16,6 +16,14 @@ scope_hints:
   - changed_files_include: ["**/auth/*", "**/crypto/*", "**/session*"]
     reason: "Security-sensitive paths expand review scope after selection; they do not select this skill by themselves"
 evidence_contract: verdict
+host_capabilities:
+  - capability: subagent
+    required: true
+    fallback_modes:
+      - manual_security_review
+      - same_context_degraded
+    evidence_requirement: "record security-review evidence from a fresh independent reviewer context"
+    remediation: "Run security-review in a host with subagent capability, or explicitly select manual_security_review / same_context_degraded fallback and record fresh reviewer evidence."
 hydrate_references:
   - name: authentication.md
     reason: "Password storage / session / MFA / recovery secure-default rules"

--- a/internal/tmpl/templates/skills/security-review/SKILL.md.tmpl
+++ b/internal/tmpl/templates/skills/security-review/SKILL.md.tmpl
@@ -2,6 +2,14 @@
 skill_id: security-review
 name: slipway-security-review
 description: "Use when running the S3 security review for auth/authz, injection, secrets, SSRF, and insecure defaults. Triggers on the workflow-owned S3 review host, the `slipway review` command, a security-classified guardrail, or security-review control selected by blast-radius policy."
+host_capabilities:
+  - capability: subagent
+    required: true
+    fallback_modes:
+      - manual_security_review
+      - same_context_degraded
+    evidence_requirement: "record security-review evidence from a fresh independent reviewer context"
+    remediation: "Run security-review in a host with subagent capability, or explicitly select manual_security_review / same_context_degraded fallback and record fresh reviewer evidence."
 hydrate_references:
   - name: authentication.md
     reason: "Password storage / session / MFA / recovery secure-default rules"
@@ -99,9 +107,13 @@ Dispatch this review in a native subagent from the S3 review host on the SHARED 
 (the same worktree the implementation edited; there is no
 per-review git worktree isolation). Spawn a fresh-context subagent with a
 bounded review brief, pass it required-reading paths rather than artifact
-bodies, wait for the result, and record the handle. If a capable runtime cannot
-spawn, wait for, and close a subagent, stop and ask for operator direction
-rather than reviewing inline in the host context.
+bodies, wait for the result, and record the handle. If the host has not declared
+subagent capability available, `slipway next`/`run` surfaces a subagent-delegation
+prerequisite plus a named degraded fallback for this review: authorize subagent
+dispatch, or explicitly select the named fallback (for example
+`manual_security_review` or `same_context_degraded`) and record fresh reviewer
+evidence for the degraded run — do not review inline without recording the
+selected fallback.
 
 Record this review's context identifier as
 `context_origin:stage=review=<handle>`, where `<handle>` is the dispatched

--- a/internal/tmpl/templates/skills/ship-verification/SKILL.md.tmpl
+++ b/internal/tmpl/templates/skills/ship-verification/SKILL.md.tmpl
@@ -126,9 +126,13 @@ runs on the SHARED change worktree (the same worktree the implementation edited;
 there is no per-verification git worktree isolation). Model the dispatch on how
 `slipway-wave-orchestration` fans out executor subagents: spawn one fresh-context
 subagent with a bounded verifier brief, pass it required-reading paths rather than
-artifact bodies, wait for its result, and record its handle. If a capable runtime
-cannot spawn, wait for, and close a subagent, stop and ask for operator direction
-rather than gathering the bulky evidence inline in the host context. Ship
+artifact bodies, wait for its result, and record its handle. If the host has not
+declared subagent capability available, `slipway next`/`run` surfaces a
+subagent-delegation prerequisite plus a named degraded fallback for ship-verification:
+authorize subagent dispatch, or explicitly select the named fallback (for example
+`manual_ship_verification` or `same_context_degraded`) and record fresh
+ship-verification evidence for the degraded run — do not verify inline without
+recording the selected fallback. Ship
 verification must be performed independently from implementation; record that
 independence with the `closeout:reviewer_independence=pass` token below, not a
 retired stage context-origin reference.

--- a/internal/tmpl/templates/skills/spec-compliance-review/SKILL.md.tmpl
+++ b/internal/tmpl/templates/skills/spec-compliance-review/SKILL.md.tmpl
@@ -144,9 +144,12 @@ isolation). The selected reviews run in parallel as unordered peers: no reviewer
 waits for another reviewer's verdict. Model the dispatch on how
 `slipway-wave-orchestration` fans out executor subagents: spawn each review as a
 fresh-context subagent with a bounded review brief, pass it required-reading paths
-rather than artifact bodies, wait for the results, and record each handle. If a
-capable runtime cannot spawn, wait for, and close a subagent, stop and ask for
-operator direction rather than reviewing inline in the host context.
+rather than artifact bodies, wait for the results, and record each handle. If the
+host has not declared subagent capability available, `slipway next`/`run` surfaces
+a subagent-delegation prerequisite plus a named degraded fallback for this review:
+authorize subagent dispatch, or explicitly select the named fallback (for example
+`same_context_degraded`) and record fresh reviewer evidence for the degraded run —
+do not review inline without recording the selected fallback.
 
 Record this review's per-stage context identifier as
 `context_origin:stage=review=<handle>`, where `<handle>` is the dispatched


### PR DESCRIPTION
## Problem

Slipway's generated skill instructions require dispatching fresh-context subagents at **S1 plan-audit** and the **S3 review batch** (and the terminal **ship-verification** gate), and tell the host to *"stop and ask for operator direction"* if it cannot spawn one. But `slipway run/next/validate --json` never surfaced that **host subagent-delegation authorization is a prerequisite**, nor named a CLI-valid next action when the host has not authorized delegation. Hosts that gate subagent spawning behind explicit user authorization (e.g. Claude Code) therefore **dead-ended** with no public path forward — the "stop" language was static template prose with no engine signal behind it.

Closes **#339** (plan-audit S1 dead-end), **#369** (S3 review batch + ship-verification dead-end), **#357** (intake handoff ignored prior authorization with no explanation).

## Design

Generalizes the pre-existing `independent-review` subagent host-capability precedent so the **public surface carries the next action**:

- **New riding reason code `subagent_dispatch_authorization_required`.** `hostCapabilityBlockerCode` now splits on declared host capability:
  - `available` (or an explicit fallback selected) → **no change, no regression** (byte-identical to baseline).
  - `unavailable` (host declared other caps, not subagent) → first-class `host_capability_unavailable` governance stop (**fails closed**).
  - `unknown` (host declared nothing) → the new **riding** code: stays continuable but enriches `next_action` to name the delegation prerequisite **and** a named explicit fallback (e.g. `same_context_degraded`).
- **All subagent-dispatch skills now resolve a `subagent` contract:** `security-review` via a registry `HostCapabilities` contract; `plan-audit` / `spec-compliance-review` / `code-quality-review` / `ship-verification` via a targeted `builtinSubagentDispatchContracts` lever (registering them in the catalog would drag them into surface-manifest / install-profile / frozen-ID machinery — the lever keeps the engine signal without that surface drag).
- **#357 — not relaxed.** The intake approved-summary stays a fresh hard gate (`FreshConfirmationRequired` true, `prior_authorization_sufficient` false). Only the messaging changed: `hardStopNextAction` now states it is a fresh hard gate **by design**, that prior broad "continue" does not substitute, and names the concrete next step.
- **Templates realigned** (plan-audit + the four reviewers + ship-verification): the old "stop and ask for operator direction" dead-end prose is replaced with engine-aligned phrasing pointing at the `next`/`run` prerequisite + named fallback — one consistent product surface.

## Safety (fail-closed, no bypass)

- The prerequisite is **additive**: it lands in `view.Blockers`, so `CanAdvance` stays false; `required_skill_missing`, review-evidence, and context-origin distinctness gates are untouched.
- The degraded path is an **explicit, recorded** fallback selection (via `SLIPWAY_HOST_CAPABILITY_FALLBACKS`, the existing `degraded_dispatch_justification` path) that **still owes fresh evidence** — no silent same-context attestation, no force-close, no bypass. The terminal ship-verification gate keeps `Required: true`.

## Testing

- New/extended tests across `cmd/next_*`, `cmd/progression_next_test.go`, `internal/engine/capability/resolver_test.go`, `internal/engine/progression/confirmation_boundaries_test.go`, `internal/model/recovery_test.go`: assert the prerequisite surfaces for plan-audit, every S3 reviewer, and ship-verification across unknown/unavailable/available/fallback states; intake stays fail-closed with the by-design rationale; capable hosts unchanged. Reason-code/recovery completeness contracts strengthened (additions only).
- Green gate: `go build ./...` clean · `go test ./... -count=1` 0 FAIL · `gofmt -s -l .` empty · `golangci-lint run` 0 issues.

Independently adversarially reviewed (fresh context) before push: verdict SHIP, all safety/scope/no-regression checks PASS, green gate re-run clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)