### PR TITLE
fix(lifecycle): honest S1_PLAN read-only surfaces — next/validate/recovery consistency (#382, #377, #376)

### DIFF
--- a/cmd/next.go
+++ b/cmd/next.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/signalridge/slipway/internal/engine/artifact"
 	"github.com/signalridge/slipway/internal/engine/capability"
+	"github.com/signalridge/slipway/internal/engine/gate"
 	"github.com/signalridge/slipway/internal/engine/progression"
 	"github.com/signalridge/slipway/internal/model"
 	"github.com/signalridge/slipway/internal/state"
@@ -66,6 +67,13 @@ type nextView struct {
 	// It is unexported (never serialized) and drives whether a parsed decision.md
 	// selection is reported as a locked or pending skill_constraint (issue #140).
 	planLocked bool
+	// ownedAdvanceGateDeadEndBlockers holds the genuine dead-end reason codes of the
+	// gate that OWNS advancement out of the current (state, plan substep), captured
+	// only when that gate is blocked. It is unexported (never serialized) and is
+	// applied to Blockers in the no-skill ready/run-to-advance posture so a
+	// dead-end (e.g. plan_audit_origin_invalid) overrides "ready to advance" while
+	// pacing blocks keep riding the normal handoff/run guidance (#382).
+	ownedAdvanceGateDeadEndBlockers []model.ReasonCode
 	// auto records whether auto-advance execution is in effect for this view. It is
 	// unexported (never serialized) and only softens pure-pacing confirmation
 	// boundaries in deriveConfirmationRequirement for non-guardrail changes; it
@@ -539,6 +547,25 @@ func buildNextViewForCommandWithReadContext(readCtx *stateReadContext, ref chang
 		}
 		view.Warnings = append(view.Warnings, readiness.Diagnostics...)
 		view.Blockers = appendReasonCodes(view.Blockers, readiness.Blockers)
+		// Capture the genuine dead-end reason codes of the gate that OWNS
+		// advancement out of the current (state, plan substep) when that gate is
+		// blocked. They are applied later in applyReadyAdvanceDiagnostics, bounded
+		// to the no-skill ready/run-to-advance posture, so a dead-end (e.g.
+		// plan_audit_origin_invalid) stops `next` advertising the step ready to
+		// advance while the gate that owns advancement is blocked (#382). PACING
+		// blocks (required-skill handoffs and other host-handoff ride-along codes)
+		// are filtered out here so they keep riding the normal handoff/run guidance;
+		// surfacing every blocked visible gate over-surfaced that pacing work and
+		// erased the no_skill_required / run_slipway_run_to_advance guidance.
+		if owning := progression.OwningAdvanceGateID(view.CurrentState, governedChange.PlanSubStep); owning != "" {
+			if eval, ok := readiness.GateEvaluations[gate.GateID(owning)]; ok && eval.Status == model.GateStatusBlocked {
+				for _, rc := range eval.ReasonCodes {
+					if !progression.HostHandoffBlockerCanRide(rc) {
+						view.ownedAdvanceGateDeadEndBlockers = append(view.ownedAdvanceGateDeadEndBlockers, rc)
+					}
+				}
+			}
+		}
 		view.FreshnessDiagnostics = attachFreshnessDiagnostics(readiness.FreshnessDiagnostics)
 		var summary *model.ExecutionSummary
 		if execCtx != nil {

--- a/cmd/next_plan_audit_handoff_test.go
+++ b/cmd/next_plan_audit_handoff_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/signalridge/slipway/internal/engine/progression"
 	"github.com/signalridge/slipway/internal/model"
@@ -124,6 +125,56 @@ func TestNextS1PlanAuditSurfacesSubagentDelegationAcrossCapabilityStates(t *test
 		assert.NotContains(t, fallbackSpecs, "host_capability_unavailable:plan-audit:subagent")
 		assert.NotContains(t, fallbackSpecs, "subagent_dispatch_authorization_required:plan-audit:subagent")
 		assert.Equal(t, "skill_handoff:plan-audit", fallback.ConfirmationRequirement.Reason)
+	})
+}
+
+// TestNextS1PlanAuditOriginBlockedIsNotReadyToAdvance is the #382 regression for the
+// S1 plan-audit surface. When the plan-audit record self-audits (identical
+// plan_origin and audit_origin handles), the G_plan gate blocks with
+// plan_audit_origin_invalid. `slipway next` must surface that blocked-gate reason
+// code on its blockers and project a non-advance recovery — not advertise the step
+// as ready to advance (no_skill_required / run_slipway_run_to_advance) while G_plan
+// is blocked.
+func TestNextS1PlanAuditOriginBlockedIsNotReadyToAdvance(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		slug := createGovernedRequest(t, root, levelDiscovery, "plan-audit self-audit blocked")
+		change, err := state.LoadChange(root, slug)
+		require.NoError(t, err)
+		change.PlanSubStep = model.PlanSubStepAudit
+		require.NoError(t, state.SaveChange(root, change))
+
+		// A passing plan-audit record whose plan_origin and audit_origin handles are
+		// identical is a self-audit: the plan author also audited their own bundle.
+		writeSkillVerification(t, root, slug, progression.SkillPlanAudit, model.VerificationRecord{
+			Verdict:   model.VerificationVerdictPass,
+			Blockers:  []model.ReasonCode{},
+			Timestamp: time.Date(2026, 6, 4, 1, 0, 0, 0, time.UTC),
+			References: []string{
+				model.PlanOriginReferencePrefix + "same-ctx",
+				model.AuditOriginReferencePrefix + "same-ctx",
+			},
+		})
+
+		view := runNextDiagnostics(t, root, slug)
+
+		assert.True(t, hasReasonCode(view.Blockers, "plan_audit_origin_invalid"),
+			"the blocked G_plan self-audit reason code must surface on next's blockers (#382)")
+		assert.False(t, hasReasonCode(view.Blockers, "no_skill_required"),
+			"a blocked plan-audit gate must not advertise no_skill_required")
+		assert.False(t, hasReasonCode(view.Blockers, "run_slipway_run_to_advance"),
+			"a blocked plan-audit gate must not advertise the step as ready to advance")
+
+		require.NotNil(t, view.Recovery)
+		assert.NotEqual(t, model.RecoveryClassAdvance, view.Recovery.RecoveryClass,
+			"a blocked gate must not project an advance-class recovery")
+		assert.False(t, view.ConfirmationRequirement.PriorAuthorizationSufficient,
+			"a blocked plan-audit gate must require fresh confirmation, not standing prior authorization")
+		assert.Equal(t, "blocked", view.InputContext.GateStatus["G_plan"],
+			"the G_plan gate status must read blocked on next's input_context")
 	})
 }
 

--- a/cmd/next_skill_view.go
+++ b/cmd/next_skill_view.go
@@ -244,6 +244,15 @@ func assembleSkillViewWithOptions(
 		if advanced.Action == "blocked" {
 			blockers = append(blockers, advanced.Blockers...)
 		}
+		// A genuine dead-end on the gate that owns advancement out of this
+		// (state, plan substep) must keep the no-skill step from advertising
+		// ready to advance. Folding the captured dead-end codes into the blocker
+		// set here makes the readiness guard below skip the no_skill_required /
+		// run_slipway_run_to_advance advertisement and surfaces the dead-end so
+		// confirmation and recovery read governance-blocked (#382). Pacing blocks
+		// were already filtered out at capture time, so they keep riding the
+		// normal handoff/run guidance instead of surfacing here.
+		blockers = append(blockers, view.ownedAdvanceGateDeadEndBlockers...)
 		if len(blockers) == 0 {
 			if governedChange != nil {
 				canAdvance, advanceBlockers := noSkillStateAdvanceReadiness(root, *governedChange)

--- a/cmd/progression_next_test.go
+++ b/cmd/progression_next_test.go
@@ -2093,9 +2093,10 @@ func TestNextReadOnlyReportsRunGuidanceAfterPassingPlanAudit(t *testing.T) {
 	require.NoError(t, state.SaveChange(root, change))
 	writeShipReadyGovernedBundle(t, root, change)
 	writeSkillVerification(t, root, slug, "plan-audit", model.VerificationRecord{
-		Verdict:   model.VerificationVerdictPass,
-		Blockers:  []model.ReasonCode{},
-		Timestamp: time.Now().UTC(),
+		Verdict:    model.VerificationVerdictPass,
+		Blockers:   []model.ReasonCode{},
+		Timestamp:  time.Now().UTC(),
+		References: planAuditOriginReferences(),
 	})
 
 	view, err := buildNextViewForCommand(root, changeRef{Slug: slug}, nextViewOptions{Preview: true, AutoSkipEvidence: true, Command: "run"})

--- a/internal/engine/gate/gate.go
+++ b/internal/engine/gate/gate.go
@@ -21,16 +21,25 @@ type GateEvaluation struct {
 	ReasonCodes []model.ReasonCode `json:"reason_codes,omitempty"`
 }
 
+// DiscoveryEvidenceState captures the non-passing discovery evidence taxonomy
+// without relying on adjacent bool parameters at EvaluateGScope call sites.
+type DiscoveryEvidenceState struct {
+	Present bool
+	Stale   bool
+}
+
 func EvaluateGScope(
 	change model.Change,
 	researchContent string,
 	discoveryEvidenceOK bool,
 	worktreeValidationReasons []model.ReasonCode,
-	discoveryRecordPresent bool,
-	discoveryRecordStale bool,
+	discoveryEvidence DiscoveryEvidenceState,
 	researchArtifactReasons ...model.ReasonCode,
 ) GateEvaluation {
 	reasonCodes := []model.ReasonCode{}
+	if discoveryEvidence.Stale {
+		discoveryEvidence.Present = true
+	}
 	if change.NeedsDiscovery {
 		if !discoveryEvidenceOK {
 			// Distinguish three present-state cases so the generic discovery reason
@@ -46,9 +55,9 @@ func EvaluateGScope(
 			//     here would misdirect recovery toward a first-time discovery run.
 			//   - genuinely absent: reserve the _missing code.
 			switch {
-			case discoveryRecordStale:
+			case discoveryEvidence.Stale:
 				// required_skill_stale carries it; emit no generic reason.
-			case discoveryRecordPresent:
+			case discoveryEvidence.Present:
 				// Present but not passing for its own reason; specific blocker carries it.
 			default:
 				reasonCodes = append(reasonCodes, model.NewReasonCode("missing_discovery_evidence", ""))

--- a/internal/engine/gate/gate.go
+++ b/internal/engine/gate/gate.go
@@ -26,12 +26,33 @@ func EvaluateGScope(
 	researchContent string,
 	discoveryEvidenceOK bool,
 	worktreeValidationReasons []model.ReasonCode,
+	discoveryRecordPresent bool,
+	discoveryRecordStale bool,
 	researchArtifactReasons ...model.ReasonCode,
 ) GateEvaluation {
 	reasonCodes := []model.ReasonCode{}
 	if change.NeedsDiscovery {
 		if !discoveryEvidenceOK {
-			reasonCodes = append(reasonCodes, model.NewReasonCode("missing_discovery_evidence", ""))
+			// Distinguish three present-state cases so the generic discovery reason
+			// never contradicts the specific one in the same response (mirrors the
+			// EvaluateGShip ship-evidence taxonomy):
+			//   - stale: a research-orchestration record EXISTS, was passing, and its
+			//     certified discovery inputs changed after the verdict. Report _stale
+			//     via the merged required_skill_stale blocker, never _missing — _missing
+			//     would hide the present-but-stale state and contradict required_actions.
+			//   - present but failed on its OWN merits (fail verdict / recorded
+			//     blockers): the specific required_skill_* blocker already explains it,
+			//     so emit no generic reason and let the specific blocker stand; a _missing
+			//     here would misdirect recovery toward a first-time discovery run.
+			//   - genuinely absent: reserve the _missing code.
+			switch {
+			case discoveryRecordStale:
+				// required_skill_stale carries it; emit no generic reason.
+			case discoveryRecordPresent:
+				// Present but not passing for its own reason; specific blocker carries it.
+			default:
+				reasonCodes = append(reasonCodes, model.NewReasonCode("missing_discovery_evidence", ""))
+			}
 		}
 
 		if len(researchArtifactReasons) > 0 {

--- a/internal/engine/gate/gate_test.go
+++ b/internal/engine/gate/gate_test.go
@@ -43,11 +43,11 @@ Standard deployment environment.
 ## Canonical References
 Internal API docs, RFC-2024-auth.`
 
-	eval := EvaluateGScope(change, research, true, nil, false, false)
+	eval := EvaluateGScope(change, research, true, nil, DiscoveryEvidenceState{})
 	assert.Equal(t, model.GateStatusApproved, eval.Status)
 	assert.Empty(t, eval.ReasonCodes)
 
-	eval = EvaluateGScope(change, "", true, []model.ReasonCode{model.NewReasonCode("dedicated_worktree_branch_mismatch", "")}, false, false)
+	eval = EvaluateGScope(change, "", true, []model.ReasonCode{model.NewReasonCode("dedicated_worktree_branch_mismatch", "")}, DiscoveryEvidenceState{})
 	assert.Equal(t, model.GateStatusBlocked, eval.Status)
 	assert.True(t, hasGateReasonCode(eval.ReasonCodes, "dedicated_worktree_branch_mismatch"))
 	require.NotEmpty(t, eval.ReasonCodes)
@@ -68,7 +68,7 @@ func TestEvaluateGScopePresentButStaleDiscoveryEvidence(t *testing.T) {
 	change := model.NewChange("slug")
 	change.NeedsDiscovery = true
 
-	eval := EvaluateGScope(change, "", false, nil, true, true)
+	eval := EvaluateGScope(change, "", false, nil, DiscoveryEvidenceState{Present: true, Stale: true})
 	assert.False(t, hasGateReasonCode(eval.ReasonCodes, "missing_discovery_evidence"),
 		"a present-but-stale discovery record must not be reported as missing")
 }
@@ -85,12 +85,12 @@ func TestEvaluateGScopePresentButFailedDiscoveryEvidence(t *testing.T) {
 	change := model.NewChange("slug")
 	change.NeedsDiscovery = true
 
-	present := EvaluateGScope(change, "", false, nil, true, false)
+	present := EvaluateGScope(change, "", false, nil, DiscoveryEvidenceState{Present: true})
 	assert.False(t, hasGateReasonCode(present.ReasonCodes, "missing_discovery_evidence"),
 		"a present-but-failed discovery record must not be reported as missing")
 
 	// Genuinely absent: no record present, not stale -> the _missing code is reserved.
-	absent := EvaluateGScope(change, "", false, nil, false, false)
+	absent := EvaluateGScope(change, "", false, nil, DiscoveryEvidenceState{})
 	assert.True(t, hasGateReasonCode(absent.ReasonCodes, "missing_discovery_evidence"),
 		"a genuinely absent discovery record must still report missing_discovery_evidence")
 }

--- a/internal/engine/gate/gate_test.go
+++ b/internal/engine/gate/gate_test.go
@@ -43,16 +43,56 @@ Standard deployment environment.
 ## Canonical References
 Internal API docs, RFC-2024-auth.`
 
-	eval := EvaluateGScope(change, research, true, nil)
+	eval := EvaluateGScope(change, research, true, nil, false, false)
 	assert.Equal(t, model.GateStatusApproved, eval.Status)
 	assert.Empty(t, eval.ReasonCodes)
 
-	eval = EvaluateGScope(change, "", true, []model.ReasonCode{model.NewReasonCode("dedicated_worktree_branch_mismatch", "")})
+	eval = EvaluateGScope(change, "", true, []model.ReasonCode{model.NewReasonCode("dedicated_worktree_branch_mismatch", "")}, false, false)
 	assert.Equal(t, model.GateStatusBlocked, eval.Status)
 	assert.True(t, hasGateReasonCode(eval.ReasonCodes, "dedicated_worktree_branch_mismatch"))
 	require.NotEmpty(t, eval.ReasonCodes)
 	assert.Equal(t, "dedicated_worktree_branch_mismatch", eval.ReasonCodes[0].Code)
 	assert.Equal(t, model.ReasonSeverityError, eval.ReasonCodes[0].Severity)
+}
+
+// TestEvaluateGScopePresentButStaleDiscoveryEvidence pins the honest-wording
+// distinction (#377), mirroring the EvaluateGShip stale taxonomy: when a
+// research-orchestration record EXISTS but its certified discovery inputs went
+// stale after the verdict (discoveryRecordPresent=true, discoveryRecordStale=true,
+// discoveryEvidenceOK=false), G_scope must NOT report the misleading
+// missing_discovery_evidence — the merged required_skill_stale carries the
+// present-but-stale state instead.
+func TestEvaluateGScopePresentButStaleDiscoveryEvidence(t *testing.T) {
+	t.Parallel()
+
+	change := model.NewChange("slug")
+	change.NeedsDiscovery = true
+
+	eval := EvaluateGScope(change, "", false, nil, true, true)
+	assert.False(t, hasGateReasonCode(eval.ReasonCodes, "missing_discovery_evidence"),
+		"a present-but-stale discovery record must not be reported as missing")
+}
+
+// TestEvaluateGScopePresentButFailedDiscoveryEvidence proves a research-orchestration
+// record that is PRESENT but failed on its own merits (not stale,
+// discoveryRecordPresent=true, discoveryRecordStale=false) is not relabeled missing:
+// the specific required-skill blocker carries the block. It also pins the
+// genuinely-absent case (present=false, stale=false) which STILL reserves the
+// missing_discovery_evidence code, so the three arms stay distinct (#377).
+func TestEvaluateGScopePresentButFailedDiscoveryEvidence(t *testing.T) {
+	t.Parallel()
+
+	change := model.NewChange("slug")
+	change.NeedsDiscovery = true
+
+	present := EvaluateGScope(change, "", false, nil, true, false)
+	assert.False(t, hasGateReasonCode(present.ReasonCodes, "missing_discovery_evidence"),
+		"a present-but-failed discovery record must not be reported as missing")
+
+	// Genuinely absent: no record present, not stale -> the _missing code is reserved.
+	absent := EvaluateGScope(change, "", false, nil, false, false)
+	assert.True(t, hasGateReasonCode(absent.ReasonCodes, "missing_discovery_evidence"),
+		"a genuinely absent discovery record must still report missing_discovery_evidence")
 }
 
 func TestEvaluateGPlan(t *testing.T) {

--- a/internal/engine/governance/actions.go
+++ b/internal/engine/governance/actions.go
@@ -12,6 +12,8 @@ type RequiredAction struct {
 	Description string             `json:"description"`
 	Satisfied   bool               `json:"satisfied"`
 	SatisfiedBy []SatisfiedBy      `json:"satisfied_by,omitempty"`
+
+	unsatisfiedOnlyByStaleEvidence bool
 }
 
 // SatisfiedBy names the evidence source that satisfied a governance action.
@@ -49,7 +51,9 @@ func ResolveRequiredActions(input RequiredActionsInput) []RequiredAction {
 
 		case model.ControlResearch:
 			action.Description = researchActionDescription(input.CurrentState)
-			action.Satisfied = input.IntentExists && input.ScopeConfirmed && input.ResearchStructureOK && !input.ResearchEvidenceStale
+			researchReadyExceptFreshness := input.IntentExists && input.ScopeConfirmed && input.ResearchStructureOK
+			action.Satisfied = researchReadyExceptFreshness && !input.ResearchEvidenceStale
+			action.unsatisfiedOnlyByStaleEvidence = researchReadyExceptFreshness && input.ResearchEvidenceStale
 
 		case model.ControlDomainReview:
 			action.Description = "run domain-aware review via the spec-compliance-review skill and record it with `slipway evidence skill --skill spec-compliance-review`"

--- a/internal/engine/governance/actions.go
+++ b/internal/engine/governance/actions.go
@@ -49,7 +49,7 @@ func ResolveRequiredActions(input RequiredActionsInput) []RequiredAction {
 
 		case model.ControlResearch:
 			action.Description = researchActionDescription(input.CurrentState)
-			action.Satisfied = input.IntentExists && input.ScopeConfirmed && input.ResearchStructureOK
+			action.Satisfied = input.IntentExists && input.ScopeConfirmed && input.ResearchStructureOK && !input.ResearchEvidenceStale
 
 		case model.ControlDomainReview:
 			action.Description = "run domain-aware review via the spec-compliance-review skill and record it with `slipway evidence skill --skill spec-compliance-review`"
@@ -100,6 +100,7 @@ type RequiredActionsInput struct {
 	IntentExists                 bool
 	ScopeConfirmed               bool
 	ResearchStructureOK          bool // research.md has all required sections (always true for non-discovery)
+	ResearchEvidenceStale        bool // research-orchestration evidence is present but certified stale (its inputs changed after the verdict)
 	DomainReviewDone             bool
 	DomainReviewSatisfiedBy      []SatisfiedBy
 	IndependentReviewDone        bool

--- a/internal/engine/governance/actions_test.go
+++ b/internal/engine/governance/actions_test.go
@@ -211,6 +211,19 @@ func TestExplorationControlSatisfaction(t *testing.T) {
 		ResearchStructureOK: true,
 	})
 	assert.Empty(t, UnsatisfiedBlockingActions(actions))
+
+	// #377: present-but-stale research evidence un-satisfies the control even when
+	// intent, scope, and structure are all in place — effective freshness, not mere
+	// structural presence, drives satisfaction.
+	actions = ResolveRequiredActions(RequiredActionsInput{
+		ActiveControls:        controls,
+		IntentExists:          true,
+		ScopeConfirmed:        true,
+		ResearchStructureOK:   true,
+		ResearchEvidenceStale: true,
+	})
+	assert.NotEmpty(t, UnsatisfiedBlockingActions(actions),
+		"stale research-orchestration evidence must un-satisfy the research control")
 }
 
 func TestClarificationControlSatisfaction(t *testing.T) {

--- a/internal/engine/governance/runtime_actions.go
+++ b/internal/engine/governance/runtime_actions.go
@@ -182,6 +182,15 @@ func actionBlocksCurrentState(change model.Change, action RequiredAction) bool {
 		// discovery and non-discovery paths before research is possible.
 		return false
 	}
+	if action.ControlID == model.ControlResearch &&
+		action.unsatisfiedOnlyByStaleEvidence &&
+		(change.CurrentState == model.StateS2Implement || change.CurrentState == model.StateS3Review) {
+		// Once the change has moved past S1, stale research evidence is no longer
+		// recertified by the generic research required-action. The progression
+		// stale-evidence path defers upstream S1 drift to S3 review alignment, so
+		// re-blocking here would route recovery to a backward S1 action.
+		return false
+	}
 
 	switch action.Scope {
 	case model.ControlScopeDiscovery:

--- a/internal/engine/governance/runtime_actions.go
+++ b/internal/engine/governance/runtime_actions.go
@@ -22,7 +22,13 @@ const (
 	assuranceRollbackTemplateText = "Summarize rollback constraints, prerequisites, and verification status when rollback planning is required."
 )
 
-func ResolveRuntimeRequiredActions(root string, change model.Change, snap model.GovernanceSnapshot) []RequiredAction {
+// ResolveRuntimeRequiredActions resolves the runtime governance action queue.
+// researchEvidenceStale is supplied by the progression caller (digest-freshness
+// state lives in progression, which imports governance and never the reverse) and
+// reports whether a present research-orchestration record is certified stale, so
+// the research action reflects effective freshness rather than mere structural
+// presence (#377).
+func ResolveRuntimeRequiredActions(root string, change model.Change, snap model.GovernanceSnapshot, researchEvidenceStale bool) []RequiredAction {
 	verifications := loadRuntimeVerificationState(root, change)
 	executionSummaryCtx, err := state.LoadRelevantExecutionSummaryContext(root, change)
 	if err != nil {
@@ -96,6 +102,7 @@ func ResolveRuntimeRequiredActions(root string, change model.Change, snap model.
 		IntentExists:                 artifactExistsInBundle(root, change, "intent.md"),
 		ScopeConfirmed:               changeScopeConfirmed(change, intakeConfirmed),
 		ResearchStructureOK:          researchOK,
+		ResearchEvidenceStale:        researchEvidenceStale,
 		DomainReviewDone:             domainReviewDone,
 		DomainReviewSatisfiedBy:      domainSatisfiedBy,
 		IndependentReviewDone:        independentReviewDone,

--- a/internal/engine/governance/runtime_actions_test.go
+++ b/internal/engine/governance/runtime_actions_test.go
@@ -946,6 +946,60 @@ func TestExplorationDoesNotBlockAtS1Plan(t *testing.T) {
 	assert.Empty(t, blockers, "exploration should surface at S1 but not hard-block before scope confirmation is even possible")
 }
 
+func TestStaleResearchOnlyDoesNotBlockPastS1Plan(t *testing.T) {
+	t.Parallel()
+
+	controls := []model.ControlActivation{
+		makeControl(model.ControlResearch, model.ControlModeBlocking, model.ControlScopeDiscovery),
+	}
+	for _, state := range []model.WorkflowState{model.StateS2Implement, model.StateS3Review} {
+		t.Run(string(state), func(t *testing.T) {
+			t.Parallel()
+
+			change := model.Change{
+				CurrentState:   state,
+				NeedsDiscovery: true,
+			}
+			actions := ResolveRequiredActions(RequiredActionsInput{
+				ActiveControls:        controls,
+				CurrentState:          state,
+				IntentExists:          true,
+				ScopeConfirmed:        true,
+				ResearchStructureOK:   true,
+				ResearchEvidenceStale: true,
+			})
+			require.Len(t, actions, 1)
+			assert.False(t, actions[0].Satisfied, "stale research evidence must still be visible in required_actions")
+			assert.Empty(t, RequiredActionBlockers(change, actions),
+				"stale S1 research evidence past S1 must use stale-evidence/review recovery, not generic research required-action")
+		})
+	}
+}
+
+func TestResearchActionStillBlocksPastS1WhenNotOnlyStale(t *testing.T) {
+	t.Parallel()
+
+	controls := []model.ControlActivation{
+		makeControl(model.ControlResearch, model.ControlModeBlocking, model.ControlScopeDiscovery),
+	}
+	change := model.Change{
+		CurrentState:   model.StateS2Implement,
+		NeedsDiscovery: true,
+	}
+	actions := ResolveRequiredActions(RequiredActionsInput{
+		ActiveControls:        controls,
+		CurrentState:          model.StateS2Implement,
+		IntentExists:          true,
+		ScopeConfirmed:        true,
+		ResearchStructureOK:   false,
+		ResearchEvidenceStale: true,
+	})
+
+	require.Len(t, actions, 1)
+	assert.NotEmpty(t, RequiredActionBlockers(change, actions),
+		"only the stale-only research case is delegated away from required-action blockers")
+}
+
 func TestResolveRuntimeRequiredActionsUsesScopeConfirmationEvidenceAtS1Plan(t *testing.T) {
 	t.Parallel()
 

--- a/internal/engine/governance/runtime_actions_test.go
+++ b/internal/engine/governance/runtime_actions_test.go
@@ -125,7 +125,7 @@ Pending.
 		ComputedAt: time.Now().UTC(),
 	}
 
-	actions := ResolveRuntimeRequiredActions(root, change, snap)
+	actions := ResolveRuntimeRequiredActions(root, change, snap, false)
 	byID := map[model.ControlID]RequiredAction{}
 	for _, action := range actions {
 		byID[action.ControlID] = action
@@ -183,7 +183,7 @@ func TestResolveRuntimeRequiredActionsExplainsDomainReviewSatisfiedBySpecComplia
 		ComputedAt: time.Now().UTC(),
 	}
 
-	actions := ResolveRuntimeRequiredActions(root, change, snap)
+	actions := ResolveRuntimeRequiredActions(root, change, snap, false)
 	require.Len(t, actions, 1)
 	action := actions[0]
 	require.True(t, action.Satisfied)
@@ -237,7 +237,7 @@ func TestResolveRuntimeRequiredActionsDoesNotUseCodeQualityForIndependentReview(
 		ComputedAt: time.Now().UTC(),
 	}
 
-	actions := ResolveRuntimeRequiredActions(root, change, snap)
+	actions := ResolveRuntimeRequiredActions(root, change, snap, false)
 	require.Len(t, actions, 1)
 	assert.False(t, actions[0].Satisfied, "code-quality-review evidence must not satisfy independent-review")
 	assert.Empty(t, actions[0].SatisfiedBy)
@@ -287,7 +287,7 @@ func TestResolveRuntimeRequiredActionsExplainsSecurityReviewSatisfiedBySecurityR
 		ComputedAt: time.Now().UTC(),
 	}
 
-	actions := ResolveRuntimeRequiredActions(root, change, snap)
+	actions := ResolveRuntimeRequiredActions(root, change, snap, false)
 	require.Len(t, actions, 1)
 	action := actions[0]
 	require.True(t, action.Satisfied)
@@ -366,7 +366,7 @@ Pending.
 		ComputedAt: time.Now().UTC(),
 	}
 
-	actions := ResolveRuntimeRequiredActions(root, change, snap)
+	actions := ResolveRuntimeRequiredActions(root, change, snap, false)
 	require.Len(t, actions, 1)
 	assert.False(t, actions[0].Satisfied, "template placeholder headings must not satisfy rollback-required")
 }
@@ -440,7 +440,7 @@ Pending.
 		ComputedAt: time.Now().UTC(),
 	}
 
-	actions := ResolveRuntimeRequiredActions(root, change, snap)
+	actions := ResolveRuntimeRequiredActions(root, change, snap, false)
 	require.Len(t, actions, 1)
 	assert.False(t, actions[0].Satisfied, "seeded rollback draft text must not satisfy rollback-required until the decision section is explicitly confirmed")
 }
@@ -469,7 +469,7 @@ func TestResolveRuntimeRequiredActionsRequiresBoundWorktreeMetadata(t *testing.T
 		ComputedAt: time.Now().UTC(),
 	}
 
-	actions := ResolveRuntimeRequiredActions(root, change, snap)
+	actions := ResolveRuntimeRequiredActions(root, change, snap, false)
 	require.Len(t, actions, 1)
 	assert.False(t, actions[0].Satisfied, "worktree-isolation should remain unsatisfied until the change is bound to a dedicated worktree")
 }
@@ -497,7 +497,7 @@ func TestResolveRuntimeRequiredActionsHandlesMissingVerification(t *testing.T) {
 		ComputedAt: time.Now().UTC(),
 	}
 
-	actions := ResolveRuntimeRequiredActions(root, change, snap)
+	actions := ResolveRuntimeRequiredActions(root, change, snap, false)
 	require.Len(t, actions, 1)
 	assert.False(t, actions[0].Satisfied, "no verification records should leave domain-review unsatisfied")
 }
@@ -539,7 +539,7 @@ func TestResolveRuntimeRequiredActionsFailsClosedWhenRunSummaryIsMissing(t *test
 		ComputedAt: time.Now().UTC(),
 	}
 
-	actions := ResolveRuntimeRequiredActions(root, change, snap)
+	actions := ResolveRuntimeRequiredActions(root, change, snap, false)
 	byID := map[model.ControlID]RequiredAction{}
 	for _, action := range actions {
 		byID[action.ControlID] = action
@@ -594,7 +594,7 @@ func TestResolveRuntimeRequiredActionsRejectsExecutionSummaryLevelBlockers(t *te
 		ComputedAt: time.Now().UTC(),
 	}
 
-	actions := ResolveRuntimeRequiredActions(root, change, snap)
+	actions := ResolveRuntimeRequiredActions(root, change, snap, false)
 	byID := map[model.ControlID]RequiredAction{}
 	for _, action := range actions {
 		byID[action.ControlID] = action
@@ -666,7 +666,7 @@ func TestResolveRuntimeRequiredActionsAbsorbsS3TaskPlanDriftAfterReviewEvidence(
 		ComputedAt: time.Now().UTC(),
 	}
 
-	actions := ResolveRuntimeRequiredActions(root, change, snap)
+	actions := ResolveRuntimeRequiredActions(root, change, snap, false)
 	byID := map[model.ControlID]RequiredAction{}
 	for _, action := range actions {
 		byID[action.ControlID] = action
@@ -732,7 +732,7 @@ func TestResolveRuntimeRequiredActionsDoesNotAbsorbStaleExecutionEvidence(t *tes
 		ComputedAt: time.Now().UTC(),
 	}
 
-	actions := ResolveRuntimeRequiredActions(root, change, snap)
+	actions := ResolveRuntimeRequiredActions(root, change, snap, false)
 	byID := map[model.ControlID]RequiredAction{}
 	for _, action := range actions {
 		byID[action.ControlID] = action
@@ -828,7 +828,7 @@ func TestResolveRuntimeRequiredActionsUsesAuthoritativeChangeVerificationsForHid
 		ComputedAt: time.Now().UTC(),
 	}
 
-	actions := ResolveRuntimeRequiredActions(root, change, snap)
+	actions := ResolveRuntimeRequiredActions(root, change, snap, false)
 	byID := map[model.ControlID]RequiredAction{}
 	for _, action := range actions {
 		byID[action.ControlID] = action
@@ -884,7 +884,7 @@ func TestResolveRuntimeRequiredActionsFailsClosedWhenExecutionSummaryIsInvalid(t
 		ComputedAt: time.Now().UTC(),
 	}
 
-	actions := ResolveRuntimeRequiredActions(root, change, snap)
+	actions := ResolveRuntimeRequiredActions(root, change, snap, false)
 	byID := map[model.ControlID]RequiredAction{}
 	for _, action := range actions {
 		byID[action.ControlID] = action
@@ -992,7 +992,7 @@ Internal docs.
 		ComputedAt: time.Now().UTC(),
 	}
 
-	actions := ResolveRuntimeRequiredActions(root, change, snap)
+	actions := ResolveRuntimeRequiredActions(root, change, snap, false)
 	require.Len(t, actions, 1)
 	assert.True(t, actions[0].Satisfied, "intake + scope + research.md structure should satisfy the research control")
 	assert.Empty(t, RequiredActionBlockers(change, actions), "satisfied research action must not block S1_PLAN")

--- a/internal/engine/progression/advance_governed.go
+++ b/internal/engine/progression/advance_governed.go
@@ -84,14 +84,16 @@ func AdvanceGoverned(root, slug string, opts ...AdvanceOptions) (summary Advance
 			// S2 owns implementation evidence. Upstream intake/planning drift is
 			// reviewed at S3 as plan/code/evidence alignment; requiring an S0/S1
 			// evidence replay here creates an impossible forward-only dead end.
-		} else if fromState == model.StateS2Implement {
-			// In S2 the owning stage still holds this evidence (e.g. a stale
+		} else if fromState != model.StateS3Review {
+			// Pre-S3 (S0_INTAKE / S1_PLAN / S2_IMPLEMENT) the owning stage still
+			// holds this evidence (e.g. a stale intake-clarification or
 			// wave-orchestration authority). Surface its blockers directly — whose
-			// remediation is the state-valid `slipway run` — instead of the
-			// review-alignment path, which maps to the S3-only `slipway fix` and
-			// would yield fix_state_invalid here. This only changes the recommended
-			// command; the stale-evidence gate stays fail-closed and S3 keeps the
-			// forward-only review-alignment path below (issue #324).
+			// remediation is the state-valid `slipway run` / `slipway evidence
+			// skill` — instead of the review-alignment path, which maps to the
+			// S3-only `slipway fix` and would yield fix_state_invalid here. This
+			// only changes the recommended command; the stale-evidence gate stays
+			// fail-closed. Only S3, where review owns plan/code/evidence alignment,
+			// keeps the forward-only review-alignment path below (issues #324, #376).
 			return blockedAdvanceSummary(fromState, target.Blockers), nil
 		} else {
 			return forwardOnlyStaleEvidenceSummary(fromState, target), nil
@@ -267,7 +269,11 @@ func AdvanceGoverned(root, slug string, opts ...AdvanceOptions) (summary Advance
 	if snapErr != nil {
 		return AdvanceSummary{}, fmt.Errorf("recompute governance snapshot: %w", snapErr)
 	}
-	if blockers := governance.RequiredActionBlockers(change, governance.ResolveRuntimeRequiredActions(root, change, snap)); len(blockers) > 0 {
+	researchEvidenceStale, staleErr := researchOrchestrationEvidenceStale(root, change)
+	if staleErr != nil {
+		return AdvanceSummary{}, staleErr
+	}
+	if blockers := governance.RequiredActionBlockers(change, governance.ResolveRuntimeRequiredActions(root, change, snap, researchEvidenceStale)); len(blockers) > 0 {
 		return blockedAdvanceSummary(fromState, model.ReasonCodesFromSpecs(blockers)), nil
 	}
 	reviewSelection := ReviewSkillSelectionFromControls(snap.ActiveControls)
@@ -1013,12 +1019,23 @@ func advanceGateID(before model.Change, summary AdvanceSummary) string {
 	if summary.Action != "blocked" && summary.Action != "done_ready" {
 		return ""
 	}
-	switch before.CurrentState {
+	substep := before.PlanSubStep
+	if summary.FromSubStep != "" {
+		substep = model.PlanSubStep(summary.FromSubStep)
+	}
+	return OwningAdvanceGateID(before.CurrentState, substep)
+}
+
+// OwningAdvanceGateID reports the gate that owns advancement out of the given
+// (state, plan substep), or "" when no gate owns advancement there. S0_INTAKE
+// and S2_IMPLEMENT advance on run/evidence pacing rather than on a gate that
+// can dead-end, so they own no advance gate. It is the pure (state, substep)
+// projection of advanceGateID's ownership switch, exported so surfaces like
+// `next` can ask which gate — if blocked by a genuine dead-end — must override a
+// "ready to advance" posture without duplicating the ownership map.
+func OwningAdvanceGateID(state model.WorkflowState, substep model.PlanSubStep) string {
+	switch state {
 	case model.StateS1Plan:
-		substep := before.PlanSubStep
-		if summary.FromSubStep != "" {
-			substep = model.PlanSubStep(summary.FromSubStep)
-		}
 		switch substep {
 		case model.PlanSubStepResearch:
 			return string(gate.GateScope)
@@ -1367,6 +1384,27 @@ func EvaluateScopeGate(root string, change model.Change, passingSkills map[strin
 
 	_, discoveryOK := passingSkills[SkillResearchOrchestration]
 
+	// Discovery present/stale signals mirror the ship path (authority.go
+	// shipVerificationRecordPresent/Stale): a research-orchestration record that
+	// EXISTS but was excluded from the passing set because its certified inputs went
+	// stale must surface as required_skill_stale, not missing_discovery_evidence
+	// (#377). present = the record exists at all; stale = it exists, was passing, and
+	// its digest-freshness blockers fired. Computing present first guarantees present
+	// is true whenever stale is true.
+	verifications, err := state.ListVerificationsForChange(root, change)
+	if err != nil {
+		return gate.GateEvaluation{}, err
+	}
+	discoveryRecord, discoveryRecordPresent := verifications[SkillResearchOrchestration]
+	discoveryRecordStale := false
+	if discoveryRecordPresent && discoveryRecord.IsPassing() {
+		staleBlockers, staleErr := skillDigestFreshnessBlockers(root, change, SkillResearchOrchestration)
+		if staleErr != nil {
+			return gate.GateEvaluation{}, staleErr
+		}
+		discoveryRecordStale = len(staleBlockers) > 0
+	}
+
 	// Worktree validation is only meaningful when a worktree is already bound.
 	// G_scope runs at S1_PLAN/research (before worktree creation at S2_IMPLEMENT),
 	// so skip worktree validation when WorktreePath is empty.
@@ -1378,5 +1416,5 @@ func EvaluateScopeGate(root string, change model.Change, passingSkills map[strin
 			return gate.GateEvaluation{}, wtErr
 		}
 	}
-	return gate.EvaluateGScope(change, researchContent, discoveryOK, worktreeReasons, researchArtifactReasons...), nil
+	return gate.EvaluateGScope(change, researchContent, discoveryOK, worktreeReasons, discoveryRecordPresent, discoveryRecordStale, researchArtifactReasons...), nil
 }

--- a/internal/engine/progression/advance_governed.go
+++ b/internal/engine/progression/advance_governed.go
@@ -269,11 +269,10 @@ func AdvanceGoverned(root, slug string, opts ...AdvanceOptions) (summary Advance
 	if snapErr != nil {
 		return AdvanceSummary{}, fmt.Errorf("recompute governance snapshot: %w", snapErr)
 	}
-	researchEvidenceStale, staleErr := researchOrchestrationEvidenceStale(root, change)
-	if staleErr != nil {
-		return AdvanceSummary{}, staleErr
-	}
-	if blockers := governance.RequiredActionBlockers(change, governance.ResolveRuntimeRequiredActions(root, change, snap, researchEvidenceStale)); len(blockers) > 0 {
+	// Advancement handles stale skill evidence above through the owning evidence
+	// repair path, which preserves state-valid recovery. Do not re-route stale
+	// S1 research evidence through generic required-action blockers here.
+	if blockers := governance.RequiredActionBlockers(change, governance.ResolveRuntimeRequiredActions(root, change, snap, false)); len(blockers) > 0 {
 		return blockedAdvanceSummary(fromState, model.ReasonCodesFromSpecs(blockers)), nil
 	}
 	reviewSelection := ReviewSkillSelectionFromControls(snap.ActiveControls)
@@ -288,23 +287,33 @@ func AdvanceGoverned(root, slug string, opts ...AdvanceOptions) (summary Advance
 	nextSkillName, evidenceState := PrimaryNextSkillWithReviewSelection(change, reviewSelection)
 
 	var passingSkills map[string]model.VerificationRecord
+	researchDiscoveryEvidence := gate.DiscoveryEvidenceState{}
 	// worktree-preflight is not a governance skill; its gate is checked in
 	// step 5 (worktree validation). Skip governance skill evaluation when
 	// the resolved next skill is worktree-preflight so the worktree gate
 	// can surface the correct blocker.
 	if nextSkillName != "" && nextSkillName != SkillWorktreePreflight {
 		var skillBlockers []string
-		passingSkills, skillBlockers, err = EvaluateRequiredSkillsForChangeWithReviewSelection(
+		verificationRecords, err := state.ListVerificationsForChange(root, change)
+		if err != nil {
+			return AdvanceSummary{}, err
+		}
+		passingSkills, skillBlockers, err = evaluateRequiredSkillsForChangeWithReviewSelectionWithRecords(
 			root,
 			change,
 			model.WorkflowState(evidenceState),
 			executionSummaryCtx.LatestRunVersion,
 			reviewSelection,
+			verificationRecords,
 			change.PlanSubStep,
 		)
 		if err != nil {
 			return AdvanceSummary{}, err
 		}
+		researchDiscoveryEvidence = researchOrchestrationEvidenceStateFromSkillBlockers(
+			verificationRecords,
+			skillBlockers,
+		)
 		if len(skillBlockers) > 0 {
 			return blockedAdvanceSummary(fromState, model.ReasonCodesFromSpecs(skillBlockers)), nil
 		}
@@ -379,7 +388,7 @@ func AdvanceGoverned(root, slug string, opts ...AdvanceOptions) (summary Advance
 	// discovery changes could skip research validation entirely.
 	isResearchGate := fromState == model.StateS1Plan && change.PlanSubStep == model.PlanSubStepResearch && change.NeedsDiscovery
 	if isResearchGate {
-		scopeResult, err := EvaluateScopeGate(root, change, passingSkills)
+		scopeResult, err := EvaluateScopeGate(root, change, passingSkills, researchDiscoveryEvidence)
 		if err != nil {
 			return AdvanceSummary{}, err
 		}
@@ -1364,7 +1373,12 @@ func EvaluateShipGate(root string, change model.Change) (gate.GateEvaluation, er
 	return shipAuthority.Result, nil
 }
 
-func EvaluateScopeGate(root string, change model.Change, passingSkills map[string]model.VerificationRecord) (gate.GateEvaluation, error) {
+func EvaluateScopeGate(
+	root string,
+	change model.Change,
+	passingSkills map[string]model.VerificationRecord,
+	discoveryEvidence gate.DiscoveryEvidenceState,
+) (gate.GateEvaluation, error) {
 	paths, err := state.ResolveChangePaths(root, change)
 	if err != nil {
 		return gate.GateEvaluation{}, err
@@ -1384,27 +1398,6 @@ func EvaluateScopeGate(root string, change model.Change, passingSkills map[strin
 
 	_, discoveryOK := passingSkills[SkillResearchOrchestration]
 
-	// Discovery present/stale signals mirror the ship path (authority.go
-	// shipVerificationRecordPresent/Stale): a research-orchestration record that
-	// EXISTS but was excluded from the passing set because its certified inputs went
-	// stale must surface as required_skill_stale, not missing_discovery_evidence
-	// (#377). present = the record exists at all; stale = it exists, was passing, and
-	// its digest-freshness blockers fired. Computing present first guarantees present
-	// is true whenever stale is true.
-	verifications, err := state.ListVerificationsForChange(root, change)
-	if err != nil {
-		return gate.GateEvaluation{}, err
-	}
-	discoveryRecord, discoveryRecordPresent := verifications[SkillResearchOrchestration]
-	discoveryRecordStale := false
-	if discoveryRecordPresent && discoveryRecord.IsPassing() {
-		staleBlockers, staleErr := skillDigestFreshnessBlockers(root, change, SkillResearchOrchestration)
-		if staleErr != nil {
-			return gate.GateEvaluation{}, staleErr
-		}
-		discoveryRecordStale = len(staleBlockers) > 0
-	}
-
 	// Worktree validation is only meaningful when a worktree is already bound.
 	// G_scope runs at S1_PLAN/research (before worktree creation at S2_IMPLEMENT),
 	// so skip worktree validation when WorktreePath is empty.
@@ -1416,5 +1409,5 @@ func EvaluateScopeGate(root string, change model.Change, passingSkills map[strin
 			return gate.GateEvaluation{}, wtErr
 		}
 	}
-	return gate.EvaluateGScope(change, researchContent, discoveryOK, worktreeReasons, discoveryRecordPresent, discoveryRecordStale, researchArtifactReasons...), nil
+	return gate.EvaluateGScope(change, researchContent, discoveryOK, worktreeReasons, discoveryEvidence, researchArtifactReasons...), nil
 }

--- a/internal/engine/progression/advance_governed_test.go
+++ b/internal/engine/progression/advance_governed_test.go
@@ -638,3 +638,88 @@ func TestAdvanceGoverned_S2StaleWaveEvidenceRecommendsRunnableCommand(t *testing
 		t.Fatalf("expected change held at S2_IMPLEMENT by the stale-evidence gate, got %s", reloaded.CurrentState)
 	}
 }
+
+// TestAdvanceGoverned_S1StaleIntakeAuthorityRecommendsRunnableCommand is the #376
+// regression at S1_PLAN. When a change is IN S1_PLAN with stale-but-passing
+// intake-clarification authority, the early stale-evidence repair path must surface
+// the owning-stage blockers via blockedAdvanceSummary, NOT the review-alignment path
+// that maps to the S3-only `slipway fix` command (fix_state_invalid at S1). The
+// recommended recovery must be RUNNABLE at S1, asserted through the public recovery
+// projection (model.BuildRecovery) rather than the stale reason-code spelling.
+func TestAdvanceGoverned_S1StaleIntakeAuthorityRecommendsRunnableCommand(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	if err := model.SaveConfig(state.ConfigPath(root), model.DefaultConfig()); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	change := model.NewChange("s1-stale-intake-recovery")
+	change.CurrentState = model.StateS1Plan
+	change.PlanSubStep = model.PlanSubStepAudit
+	change.WorkflowPreset = model.WorkflowPresetStandard
+	if err := state.SaveChange(root, change); err != nil {
+		t.Fatalf("save change: %v", err)
+	}
+
+	bundleDir := filepath.Join(root, "artifacts", "changes", change.Slug)
+	if err := os.MkdirAll(bundleDir, 0o755); err != nil {
+		t.Fatalf("mkdir bundle: %v", err)
+	}
+	intentPath := filepath.Join(bundleDir, "intent.md")
+	if err := os.WriteFile(intentPath, []byte("# Intent\n\n## Summary\nOriginal clarified intent.\n"), 0o644); err != nil {
+		t.Fatalf("write intent.md: %v", err)
+	}
+
+	// intake-clarification passed and its digest was stamped from the original
+	// intent.md content — a genuine passing intake authority.
+	verdictAt := time.Date(2026, 6, 6, 1, 0, 0, 0, time.UTC)
+	record := model.VerificationRecord{
+		Verdict:    model.VerificationVerdictPass,
+		Timestamp:  verdictAt,
+		RunVersion: 1,
+	}
+	writeVerificationForTest(t, root, change.Slug, SkillIntakeClarification, record)
+	if err := StampEvidenceDigestForSkill(root, change, SkillIntakeClarification, record, nil); err != nil {
+		t.Fatalf("stamp intake-clarification digest: %v", err)
+	}
+
+	// intent.md changes after the accepted verdict → intake-clarification is now stale.
+	if err := os.WriteFile(intentPath, []byte("# Intent\n\n## Summary\nIntent changed after clarification.\n"), 0o644); err != nil {
+		t.Fatalf("stale intent.md: %v", err)
+	}
+
+	summaryOut, err := AdvanceGoverned(root, change.Slug)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if summaryOut.Action != "blocked" {
+		t.Fatalf("expected the stale intake-clarification authority to block at S1, got %+v", summaryOut)
+	}
+
+	recovery := model.BuildRecovery(summaryOut.Blockers)
+	if recovery == nil {
+		t.Fatalf("expected a recovery projection for the stale S1 intake blockers, got nil (blockers %v)", summaryOut.Blockers)
+	}
+	if recovery.PrimaryCommand == "slipway fix" {
+		t.Fatalf("S1 stale intake-clarification recovery must not recommend the S3-only `slipway fix` "+
+			"(fix_state_invalid at S1); got primary_command=%q for blockers %v",
+			recovery.PrimaryCommand, model.ReasonSpecs(summaryOut.Blockers))
+	}
+	// The recommended command must be runnable at S1: either advance the lifecycle
+	// (`slipway run`) or re-record the owning skill's evidence with `slipway evidence skill`.
+	if recovery.PrimaryCommand != "slipway run" &&
+		recovery.PrimaryCommand != "slipway evidence skill --skill intake-clarification --verdict pass" {
+		t.Fatalf("expected a state-valid S1 recovery command, got primary_command=%q for blockers %v",
+			recovery.PrimaryCommand, model.ReasonSpecs(summaryOut.Blockers))
+	}
+
+	// The change must stay at S1_PLAN: the fix corrects only the recommended command,
+	// never the fail-closed stale-evidence gate.
+	reloaded, err := state.LoadChange(root, change.Slug)
+	if err != nil {
+		t.Fatalf("reload change: %v", err)
+	}
+	if reloaded.CurrentState != model.StateS1Plan {
+		t.Fatalf("expected change held at S1_PLAN by the stale-evidence gate, got %s", reloaded.CurrentState)
+	}
+}

--- a/internal/engine/progression/advance_governed_test.go
+++ b/internal/engine/progression/advance_governed_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -637,6 +638,66 @@ func TestAdvanceGoverned_S2StaleWaveEvidenceRecommendsRunnableCommand(t *testing
 	if reloaded.CurrentState != model.StateS2Implement {
 		t.Fatalf("expected change held at S2_IMPLEMENT by the stale-evidence gate, got %s", reloaded.CurrentState)
 	}
+}
+
+func TestAdvanceGoverned_S2StaleResearchEvidenceDoesNotReblockRequiredAction(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	if err := model.SaveConfig(state.ConfigPath(root), model.DefaultConfig()); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	change := model.NewChange("s2-stale-research-required-action")
+	change.CurrentState = model.StateS2Implement
+	change.NeedsDiscovery = true
+	change.WorkflowPreset = model.WorkflowPresetStandard
+	if err := state.SaveChange(root, change); err != nil {
+		t.Fatalf("save change: %v", err)
+	}
+	bundleDir := writeDigestPlanningBundle(t, root, change, uncheckedDigestTasks())
+	if err := os.WriteFile(filepath.Join(bundleDir, "research.md"), []byte(validResearchForRequiredActionTest()), 0o644); err != nil {
+		t.Fatalf("write research.md: %v", err)
+	}
+
+	record := model.VerificationRecord{
+		Verdict:   model.VerificationVerdictPass,
+		Blockers:  []model.ReasonCode{},
+		Timestamp: time.Date(2026, 6, 20, 1, 0, 0, 0, time.UTC),
+	}
+	writeVerificationForTest(t, root, change.Slug, SkillResearchOrchestration, record)
+	if err := StampEvidenceDigestForSkill(root, change, SkillResearchOrchestration, record, nil); err != nil {
+		t.Fatalf("stamp research-orchestration digest: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(bundleDir, "research.md"), []byte(validResearchForRequiredActionTest()+"\nAdditional current finding.\n"), 0o644); err != nil {
+		t.Fatalf("stale research.md: %v", err)
+	}
+
+	summary, err := AdvanceGoverned(root, change.Slug)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	blockerText := strings.Join(model.ReasonSpecs(summary.Blockers), "\n")
+	if strings.Contains(blockerText, "governance_action_required:research") {
+		t.Fatalf("stale S1 research at S2 must not route to generic research required-action; got blockers %v", summary.Blockers)
+	}
+}
+
+func validResearchForRequiredActionTest() string {
+	return `# Research
+
+## Alternatives Considered
+Option A keeps the existing recovery route. Option B replays S1 from S2. Option A is selected.
+
+## Unknowns
+None remaining.
+
+## Assumptions
+The existing stale-evidence repair path owns upstream freshness recovery after S1.
+
+## Canonical References
+Local test fixture.
+`
 }
 
 // TestAdvanceGoverned_S1StaleIntakeAuthorityRecommendsRunnableCommand is the #376

--- a/internal/engine/progression/advance_test.go
+++ b/internal/engine/progression/advance_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/signalridge/slipway/internal/engine/artifact"
+	"github.com/signalridge/slipway/internal/engine/gate"
 	"github.com/signalridge/slipway/internal/model"
 	"github.com/signalridge/slipway/internal/state"
 	"github.com/stretchr/testify/assert"
@@ -1635,13 +1636,18 @@ func TestEvaluateScopeGateReportsMissingResearchArtifact(t *testing.T) {
 		}
 	}
 
-	evaluation, err := EvaluateScopeGate(root, change, map[string]model.VerificationRecord{
-		SkillResearchOrchestration: {
-			Verdict:    model.VerificationVerdictPass,
-			Timestamp:  change.CreatedAt,
-			RunVersion: 0,
+	evaluation, err := EvaluateScopeGate(
+		root,
+		change,
+		map[string]model.VerificationRecord{
+			SkillResearchOrchestration: {
+				Verdict:    model.VerificationVerdictPass,
+				Timestamp:  change.CreatedAt,
+				RunVersion: 0,
+			},
 		},
-	})
+		gate.DiscoveryEvidenceState{Present: true},
+	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/engine/progression/evidence_digests.go
+++ b/internal/engine/progression/evidence_digests.go
@@ -152,6 +152,24 @@ func pruneEvidenceDigestForSkill(root string, change model.Change, skillName str
 	return state.SaveEvidenceDigests(root, change.Slug, *digests)
 }
 
+// researchOrchestrationEvidenceStale reports whether a discovery change carries a
+// present-but-stale research-orchestration record (its certified discovery inputs
+// changed after the verdict). Non-discovery changes have no research-orchestration
+// obligation and always report false. The boolean feeds
+// governance.ResolveRuntimeRequiredActions so the research required-action reflects
+// effective freshness, not just structural presence (#377): progression owns digest
+// freshness and passes the result into governance, never the reverse.
+func researchOrchestrationEvidenceStale(root string, change model.Change) (bool, error) {
+	if !change.NeedsDiscovery {
+		return false, nil
+	}
+	blockers, err := skillDigestFreshnessBlockers(root, change, SkillResearchOrchestration)
+	if err != nil {
+		return false, err
+	}
+	return len(blockers) > 0, nil
+}
+
 func skillDigestFreshnessBlockers(
 	root string,
 	change model.Change,

--- a/internal/engine/progression/evidence_digests.go
+++ b/internal/engine/progression/evidence_digests.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/signalridge/slipway/internal/engine/gate"
 	"github.com/signalridge/slipway/internal/engine/skill"
 	"github.com/signalridge/slipway/internal/model"
 	"github.com/signalridge/slipway/internal/state"
@@ -160,14 +161,63 @@ func pruneEvidenceDigestForSkill(root string, change model.Change, skillName str
 // effective freshness, not just structural presence (#377): progression owns digest
 // freshness and passes the result into governance, never the reverse.
 func researchOrchestrationEvidenceStale(root string, change model.Change) (bool, error) {
-	if !change.NeedsDiscovery {
-		return false, nil
-	}
-	blockers, err := skillDigestFreshnessBlockers(root, change, SkillResearchOrchestration)
+	discoveryEvidence, err := researchOrchestrationEvidenceState(root, change, nil)
 	if err != nil {
 		return false, err
 	}
-	return len(blockers) > 0, nil
+	return discoveryEvidence.Stale, nil
+}
+
+func researchOrchestrationEvidenceState(
+	root string,
+	change model.Change,
+	verificationRecords map[string]model.VerificationRecord,
+) (gate.DiscoveryEvidenceState, error) {
+	if !change.NeedsDiscovery {
+		return gate.DiscoveryEvidenceState{}, nil
+	}
+	if verificationRecords == nil {
+		var err error
+		verificationRecords, err = state.ListVerificationsForChange(root, change)
+		if err != nil {
+			return gate.DiscoveryEvidenceState{}, err
+		}
+	}
+	record, present := verificationRecords[SkillResearchOrchestration]
+	discoveryEvidence := gate.DiscoveryEvidenceState{Present: present}
+	if !present || !record.IsPassing() {
+		return discoveryEvidence, nil
+	}
+	blockers, err := skillDigestFreshnessBlockers(root, change, SkillResearchOrchestration)
+	if err != nil {
+		return gate.DiscoveryEvidenceState{}, err
+	}
+	discoveryEvidence.Stale = len(blockers) > 0
+	return discoveryEvidence, nil
+}
+
+func researchOrchestrationEvidenceStateFromSkillBlockers(
+	verificationRecords map[string]model.VerificationRecord,
+	skillBlockers []string,
+) gate.DiscoveryEvidenceState {
+	_, present := verificationRecords[SkillResearchOrchestration]
+	discoveryEvidence := gate.DiscoveryEvidenceState{
+		Present: present,
+		Stale:   hasSkillBlockerPrefix(skillBlockers, "required_skill_stale:"+SkillResearchOrchestration+":"),
+	}
+	if discoveryEvidence.Stale {
+		discoveryEvidence.Present = true
+	}
+	return discoveryEvidence
+}
+
+func hasSkillBlockerPrefix(blockers []string, prefix string) bool {
+	for _, blocker := range blockers {
+		if strings.HasPrefix(strings.TrimSpace(blocker), prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func skillDigestFreshnessBlockers(

--- a/internal/engine/progression/evidence_digests.go
+++ b/internal/engine/progression/evidence_digests.go
@@ -153,21 +153,6 @@ func pruneEvidenceDigestForSkill(root string, change model.Change, skillName str
 	return state.SaveEvidenceDigests(root, change.Slug, *digests)
 }
 
-// researchOrchestrationEvidenceStale reports whether a discovery change carries a
-// present-but-stale research-orchestration record (its certified discovery inputs
-// changed after the verdict). Non-discovery changes have no research-orchestration
-// obligation and always report false. The boolean feeds
-// governance.ResolveRuntimeRequiredActions so the research required-action reflects
-// effective freshness, not just structural presence (#377): progression owns digest
-// freshness and passes the result into governance, never the reverse.
-func researchOrchestrationEvidenceStale(root string, change model.Change) (bool, error) {
-	discoveryEvidence, err := researchOrchestrationEvidenceState(root, change, nil)
-	if err != nil {
-		return false, err
-	}
-	return discoveryEvidence.Stale, nil
-}
-
 func researchOrchestrationEvidenceState(
 	root string,
 	change model.Change,

--- a/internal/engine/progression/evidence_digests_test.go
+++ b/internal/engine/progression/evidence_digests_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/signalridge/slipway/internal/engine/gate"
 	"github.com/signalridge/slipway/internal/engine/governance"
 	freshnesspkg "github.com/signalridge/slipway/internal/freshness"
 	"github.com/signalridge/slipway/internal/model"
@@ -982,7 +983,12 @@ func TestEvaluateScopeGateStaleDiscoveryEvidenceReportsStaleNotMissing(t *testin
 
 	// G_scope (evaluated with the stale record excluded from the passing set) must
 	// not contradict it with missing_discovery_evidence.
-	eval, err := EvaluateScopeGate(root, change, map[string]model.VerificationRecord{})
+	eval, err := EvaluateScopeGate(
+		root,
+		change,
+		map[string]model.VerificationRecord{},
+		gate.DiscoveryEvidenceState{Present: true, Stale: true},
+	)
 	require.NoError(t, err)
 	assert.NotContains(t, model.ReasonSpecs(eval.ReasonCodes), "missing_discovery_evidence",
 		"a present-but-stale discovery record must not surface as missing_discovery_evidence")

--- a/internal/engine/progression/evidence_digests_test.go
+++ b/internal/engine/progression/evidence_digests_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/signalridge/slipway/internal/engine/governance"
 	freshnesspkg "github.com/signalridge/slipway/internal/freshness"
 	"github.com/signalridge/slipway/internal/model"
 	"github.com/signalridge/slipway/internal/state"
@@ -941,6 +942,77 @@ func TestResearchOrchestrationInputDigestIncludesResearchArtifact(t *testing.T) 
 	blockers, err := skillDigestFreshnessBlockers(root, change, SkillResearchOrchestration)
 	require.NoError(t, err)
 	assert.Contains(t, blockers, "required_skill_stale:research-orchestration:research.md")
+}
+
+// TestEvaluateScopeGateStaleDiscoveryEvidenceReportsStaleNotMissing is the #377
+// integration regression. A research-orchestration record that is present, passing,
+// and digest-stamped, then whose research.md input changes, is present-but-stale —
+// not missing. The G_scope evaluation must NOT emit the misleading
+// missing_discovery_evidence (the honest signal is the merged required_skill_stale
+// produced by the separate digest-freshness path), and the resolved research
+// required-action must read satisfied=false so the surface stops advertising
+// "provide discovery evidence" while the record is merely stale.
+func TestEvaluateScopeGateStaleDiscoveryEvidenceReportsStaleNotMissing(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	change := model.NewChange("scope-gate-stale-discovery")
+	change.NeedsDiscovery = true
+	change.CurrentState = model.StateS1Plan
+	change.PlanSubStep = model.PlanSubStepResearch
+	require.NoError(t, state.SaveChange(root, change))
+	bundleDir := writeDigestPlanningBundle(t, root, change, uncheckedDigestTasks())
+
+	record := model.VerificationRecord{
+		Verdict:   model.VerificationVerdictPass,
+		Blockers:  []model.ReasonCode{},
+		Timestamp: time.Date(2026, 6, 4, 1, 0, 0, 0, time.UTC),
+	}
+	writeVerificationForTest(t, root, change.Slug, SkillResearchOrchestration, record)
+	require.NoError(t, StampEvidenceDigestForSkill(root, change, SkillResearchOrchestration, record, nil))
+
+	// research.md changes after the stamped verdict -> present-but-stale, not missing.
+	require.NoError(t, os.WriteFile(filepath.Join(bundleDir, "research.md"), []byte("# Research\nchanged after research verdict\n"), 0o644))
+
+	// The digest-freshness path (the separate path the readiness surface merges into
+	// G_scope) carries the honest required_skill_stale blocker.
+	staleBlockers, err := skillDigestFreshnessBlockers(root, change, SkillResearchOrchestration)
+	require.NoError(t, err)
+	assert.Contains(t, staleBlockers, "required_skill_stale:research-orchestration:research.md")
+
+	// G_scope (evaluated with the stale record excluded from the passing set) must
+	// not contradict it with missing_discovery_evidence.
+	eval, err := EvaluateScopeGate(root, change, map[string]model.VerificationRecord{})
+	require.NoError(t, err)
+	assert.NotContains(t, model.ReasonSpecs(eval.ReasonCodes), "missing_discovery_evidence",
+		"a present-but-stale discovery record must not surface as missing_discovery_evidence")
+
+	// The resolved research required-action reflects effective freshness: a stale
+	// record is not "satisfied".
+	snap := model.GovernanceSnapshot{
+		Version:      model.GovernanceSnapshotVersion,
+		Traceability: model.TraceabilitySummary{Status: model.TraceabilityStatusOK},
+		ActiveControls: []model.ControlActivation{{
+			ControlID:    model.ControlResearch,
+			Mode:         model.ControlModeBlocking,
+			Scope:        model.ControlScopeDiscovery,
+			Active:       true,
+			PolicySource: model.BuiltinPolicySource,
+		}},
+		ComputedAt: time.Now().UTC(),
+	}
+	actions := governance.ResolveRuntimeRequiredActions(root, change, snap, len(staleBlockers) > 0)
+	var researchAction governance.RequiredAction
+	found := false
+	for _, action := range actions {
+		if action.ControlID == model.ControlResearch {
+			researchAction = action
+			found = true
+		}
+	}
+	require.True(t, found, "research required-action must resolve for a discovery change with the research control active")
+	assert.False(t, researchAction.Satisfied,
+		"present-but-stale research-orchestration evidence must not satisfy the research required-action")
 }
 
 func TestStoredShipVerificationDigestStalesWhenInputContentChanges(t *testing.T) {

--- a/internal/engine/progression/evidence_repair_test.go
+++ b/internal/engine/progression/evidence_repair_test.go
@@ -157,7 +157,13 @@ func TestStaleIntakeRepairBlocksWithoutRewritingMachineOnlySubsteps(t *testing.T
 			summary, err := AdvanceGoverned(root, change.Slug)
 			require.NoError(t, err)
 			assert.Equal(t, "blocked", summary.Action)
-			assert.Equal(t, "stale_evidence_requires_review_alignment", summary.Reason)
+			// #376: pre-S3 stale evidence now surfaces the owning-stage blockers via
+			// blockedAdvanceSummary (no review-alignment Reason), so the recommended
+			// recovery is state-valid here and never the S3-only `slipway fix`.
+			recovery := model.BuildRecovery(summary.Blockers)
+			require.NotNil(t, recovery)
+			assert.NotEqual(t, "slipway fix", recovery.PrimaryCommand,
+				"pre-S3 stale intake evidence must recommend a state-valid command, not the S3-only `slipway fix`")
 			assert.Empty(t, summary.ToState)
 			assert.Empty(t, summary.ToSubStep)
 			assert.False(t, summary.RecoveryOnly)

--- a/internal/engine/progression/readiness.go
+++ b/internal/engine/progression/readiness.go
@@ -206,11 +206,16 @@ func evaluateGovernanceReadinessBaseWithReaders(
 	}
 	readiness.SignalSummary = cloneSignalSummary(snap.Summary)
 	readiness.ActiveControls = cloneControlActivations(snap.ActiveControls)
-	researchEvidenceStale, err := researchOrchestrationEvidenceStale(root, evaluationChange)
+	verificationRecords, err := governanceReadinessVerificationRecords(root, evaluationChange, opts)
 	if err != nil {
 		return GovernanceReadiness{}, err
 	}
-	readiness.RequiredActions = governance.ResolveRuntimeRequiredActions(root, evaluationChange, snap, researchEvidenceStale)
+	readiness.verificationRecords = cloneVerificationRecords(verificationRecords)
+	researchEvidenceState, err := researchOrchestrationEvidenceState(root, evaluationChange, verificationRecords)
+	if err != nil {
+		return GovernanceReadiness{}, err
+	}
+	readiness.RequiredActions = governance.ResolveRuntimeRequiredActions(root, evaluationChange, snap, researchEvidenceState.Stale)
 	readiness.Blockers = append(readiness.Blockers, model.ReasonCodesFromSpecs(governance.RequiredActionBlockers(evaluationChange, readiness.RequiredActions))...)
 	reviewSelection := ReviewSkillSelectionFromControls(snap.ActiveControls)
 
@@ -227,11 +232,6 @@ func evaluateGovernanceReadinessBaseWithReaders(
 	if artifactProjectionReader == nil {
 		artifactProjectionReader = contextualArtifactProjectionReader{ctx: artifactCtx}
 	}
-	verificationRecords, err := governanceReadinessVerificationRecords(root, evaluationChange, opts)
-	if err != nil {
-		return GovernanceReadiness{}, err
-	}
-	readiness.verificationRecords = cloneVerificationRecords(verificationRecords)
 	planningSubSteps := activePlanningSubStepsForState(evaluationChange, effectiveState)
 	passingSkills, skillBlockers, err := evaluateRequiredSkillsForChangeWithReviewSelectionWithRecords(
 		root,
@@ -559,7 +559,11 @@ func evaluateGateReadiness(
 				if err != nil {
 					return nil, nil, err
 				}
-				scopeEval, err := EvaluateScopeGate(root, change, scopeSkills)
+				discoveryEvidence := researchOrchestrationEvidenceStateFromSkillBlockers(
+					verificationRecords,
+					scopeSkillBlockers,
+				)
+				scopeEval, err := EvaluateScopeGate(root, change, scopeSkills, discoveryEvidence)
 				if err != nil {
 					return nil, nil, err
 				}

--- a/internal/engine/progression/readiness.go
+++ b/internal/engine/progression/readiness.go
@@ -206,7 +206,11 @@ func evaluateGovernanceReadinessBaseWithReaders(
 	}
 	readiness.SignalSummary = cloneSignalSummary(snap.Summary)
 	readiness.ActiveControls = cloneControlActivations(snap.ActiveControls)
-	readiness.RequiredActions = governance.ResolveRuntimeRequiredActions(root, evaluationChange, snap)
+	researchEvidenceStale, err := researchOrchestrationEvidenceStale(root, evaluationChange)
+	if err != nil {
+		return GovernanceReadiness{}, err
+	}
+	readiness.RequiredActions = governance.ResolveRuntimeRequiredActions(root, evaluationChange, snap, researchEvidenceStale)
 	readiness.Blockers = append(readiness.Blockers, model.ReasonCodesFromSpecs(governance.RequiredActionBlockers(evaluationChange, readiness.RequiredActions))...)
 	reviewSelection := ReviewSkillSelectionFromControls(snap.ActiveControls)
 

--- a/internal/engine/progression/readiness_optimization_test.go
+++ b/internal/engine/progression/readiness_optimization_test.go
@@ -144,7 +144,7 @@ func TestEvaluateGovernanceReadinessRetainsRequiredActionBlockersWhenSnapshotCac
 	require.NoError(t, err)
 	snap, err := governance.PreviewGovernanceSnapshot(root, change, bundleDir)
 	require.NoError(t, err)
-	expectedBlockers := governance.RequiredActionBlockers(change, governance.ResolveRuntimeRequiredActions(root, change, snap))
+	expectedBlockers := governance.RequiredActionBlockers(change, governance.ResolveRuntimeRequiredActions(root, change, snap, false))
 	require.NotEmpty(t, expectedBlockers, "test setup must exercise required-action blockers")
 
 	snapshotDir := filepath.Dir(state.GovernanceSnapshotCachePath(root, change.Slug))

--- a/internal/model/recovery_test.go
+++ b/internal/model/recovery_test.go
@@ -429,6 +429,23 @@ func TestBuildRecoveryWorktreeBranchMismatchRoutesToRun(t *testing.T) {
 	assert.Contains(t, got.PrimaryAction, "slipway run")
 }
 
+func TestBuildRecoveryStaleDiscoveryEvidenceRecertifiesNotProvideDiscovery(t *testing.T) {
+	t.Parallel()
+
+	// #377: when a present research-orchestration record is stale (its certified
+	// discovery inputs changed after the verdict), the only honest blocker is
+	// required_skill_stale — never missing_discovery_evidence. The recovery primary
+	// must re-certify the stale skill via `slipway evidence skill`, not advertise
+	// "Provide discovery ... before planning" as if the evidence were absent.
+	got := BuildRecovery([]ReasonCode{
+		NewReasonCode("required_skill_stale", "research-orchestration:research.md"),
+	})
+	require.NotNil(t, got)
+	assert.Equal(t, "slipway evidence skill --skill research-orchestration --verdict pass", got.PrimaryCommand)
+	assert.Equal(t, RecoveryClassRerunSkill, got.RecoveryClass)
+	assert.NotContains(t, got.PrimaryAction, "Provide discovery")
+}
+
 func TestBuildRecoveryOrphanedChangeBundleRoutesToDelete(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This batch makes the S1_PLAN read-only surfaces (`next`, `validate`, `status`, `plan`) agree about readiness and route recovery to state-valid commands.

**#382 — honest blocked-gate surfacing.** `next` mapped a blocked gate to a status string in `input_context.gate_status` but dropped its reason codes, then advertised the step ready-to-advance while `G_plan` was blocked. `next` now surfaces the owning advance gate's dead-end reason codes — scoped via the new engine helper `progression.OwningAdvanceGateID` and filtered through `HostHandoffBlockerCanRide` so pacing blockers (work the next run/handoff performs) still ride the handoff — keeping it consistent with `validate`/`status`.

**#377 — present-vs-stale discovery evidence.** `G_scope` emitted `missing_discovery_evidence` even when research-orchestration evidence was present-but-stale, contradicting `required_skill_stale` and `required_actions.research.satisfied`. `EvaluateGScope` now uses the same three-way present/stale/missing taxonomy as `EvaluateGShip`, and `required_actions.research.satisfied` reflects effective freshness rather than mere structural presence.

**#376 — pre-S3 stale-authority recovery routing.** A stale S0/S1 authority at `S1_PLAN` routed top-level recovery to the S3-only `slipway fix`. The pre-S3 stale-evidence path now surfaces owning-stage blockers directly (state-valid `slipway run` / `slipway evidence skill`); only S3 keeps the review-alignment path.

## Evidence

- `go test ./...` — 30 packages ok (4 more have no test files), 0 FAIL (from the worktree).
- `golangci-lint run` (gofmt simplify) — 0 findings.

Closes #382
Closes #377
Closes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)
