### PR TITLE
fix(recovery): exhaustive, test-enforced reason-code recovery coverage + skill discoverability

### DIFF
--- a/internal/model/recovery.go
+++ b/internal/model/recovery.go
@@ -779,6 +779,134 @@ var blockerRemediations = map[string]blockerRemediation{
 		CommandTemplate: "slipway done",
 		Class:           RecoveryClassAdvance,
 	},
+
+	// --- Wave/review blocker codes (completeness pass) ---
+	// These surface as gate blockers in the lists passed to BuildRecovery by
+	// next/status/validate/review, so each must carry a CLI-valid next action.
+	// Commands are sourced from the producing stage, not guessed.
+	"execution_verdict_fail": {
+		Remediation:     "The recorded execution verdict is fail; resolve the failing wave/task evidence and re-run wave-orchestration.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRefreshWave,
+	},
+	"missing_run_summary": {
+		Remediation:     "No execution run summary is recorded; run wave-orchestration to produce it.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRefreshWave,
+	},
+	"non_pass_wave": {
+		Remediation:     "A governed execution wave did not pass; resolve the failing wave's task evidence and re-run wave-orchestration.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRefreshWave,
+	},
+	"task_blockers": {
+		Remediation:     "A governed task reported blockers; resolve the task's blockers and re-run wave-orchestration.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRefreshWave,
+	},
+	"task_blockers_invalid_key": {
+		Remediation:     "A governed task blocker key is invalid; fix the malformed task ID in tasks.md, then re-run validation.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassFixScope,
+	},
+	"task": {
+		// Wrapper code: detail is taskID:<innerCode>:<innerDetail>. Surface the
+		// task ID and route to wave-orchestration, which owns task execution.
+		Remediation:     "Task {subject} reported an execution blocker ({detail}); resolve it and re-run wave-orchestration.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRefreshWave,
+		SplitDetail:     true,
+	},
+	"task_blocker": {
+		// Wrapper code: detail is taskID:<innerCode>:<innerDetail>.
+		Remediation:     "Task {subject} reported a wave blocker ({detail}); resolve it and re-run wave-orchestration.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRefreshWave,
+		SplitDetail:     true,
+	},
+	"task_evidence_invalid": {
+		Remediation:     "Task evidence is malformed; re-run wave-orchestration to re-record valid task evidence.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRefreshWave,
+	},
+	"task_changed_file_scope_escape": {
+		Remediation:     "Task {subject} recorded a changed file outside its planned target_files; fix the task's target_files in tasks.md to cover it (or revert the out-of-scope change), re-record evidence, then let review verify plan/code alignment.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassFixScope,
+		SplitDetail:     true,
+	},
+	"parallel_wave_changed_file_overlap": {
+		Remediation:     "Two tasks in the same parallel wave recorded the same changed file and can clobber each other in the shared worktree; split the overlapping target_files in tasks.md or record degraded_sequential dispatch for the wave, then re-run wave-orchestration.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRefreshWave,
+	},
+	"dispatch_mode_absent_on_started_parallel_wave": {
+		Remediation:     "A started parallel wave recorded no valid dispatch_mode; record dispatch_mode:wave=<n>:parallel_subagents (or degraded_sequential) evidence and re-run wave-orchestration.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRefreshWave,
+	},
+	"executor_agent_missing": {
+		Remediation:     "A parallel_subagents wave is missing the executor_agent handle for a planned task; record executor_agent:wave=<n>:task=<id>:<handle> for every task in the wave and re-run wave-orchestration.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassRefreshWave,
+	},
+	"intent_drift": {
+		Remediation:     "Implementation intent drift was detected; re-align the implementation with the approved intent and refresh affected evidence. If the intent itself changed, open a new governed change instead.",
+		CommandTemplate: "slipway run",
+		Class:           RecoveryClassReviewAlignment,
+	},
+	"invalid_blocker": {
+		Remediation:     "A blocker token is invalid; inspect the original token in the blocker detail, fix the producer to emit a canonical reason code, then re-run validation.",
+		CommandTemplate: "slipway validate",
+		Class:           RecoveryClassSatisfyControl,
+	},
+}
+
+// diagnosticOnlyReasonCodes are canonical reason codes that deliberately carry
+// NO BuildRecovery command. Their omission from blockerRemediations is
+// intentional, not a discoverability gap: each one's operator next-action is
+// carried by a different public surface (named per entry), or the code is a
+// terminal/informational/advisory state with no corrective command. This set is
+// the explicit, test-enforced companion to blockerRemediations — every canonical
+// reason code must appear in exactly one of the two (see TestRecoveryCoverageIsExhaustive),
+// so a newly added code cannot silently surface with no discoverable action.
+var diagnosticOnlyReasonCodes = map[string]struct{}{
+	// Surfaced only as `slipway health` findings; the operator next-action is
+	// carried by that finding's RepairHint, not by BuildRecovery (health never
+	// calls BuildRecovery). The RepairHint command is noted for traceability.
+	"multiple_active_changes":              {}, // RepairHint: slipway status
+	"execution_interrupted":                {}, // RepairHint: slipway run --resume
+	"orphan_task_evidence":                 {}, // RepairHint: slipway repair
+	"orphan_bundle_directory":              {}, // RepairHint: inspect/remove the orphan bundle manually
+	"task_evidence_unreadable":             {}, // RepairHint: regenerate execution evidence (slipway run)
+	"workspace_scope_config_missing":       {}, // RepairHint: slipway repair
+	"workspace_scope_marker_missing":       {}, // RepairHint: slipway repair
+	"skill_prompt_surface_missing":         {}, // RepairHint: slipway init --tools <id> --refresh
+	"skill_prompt_surface_unreadable":      {}, // RepairHint: slipway init --tools <id> --refresh
+	"codebase_map_freshness_missing":       {}, // RepairHint: slipway codebase-map
+	"codebase_map_freshness_partial":       {}, // RepairHint: slipway codebase-map
+	"codebase_map_freshness_scaffold_only": {}, // RepairHint: slipway codebase-map
+	"codebase_map_freshness_stale":         {}, // RepairHint: slipway codebase-map
+	"codebase_map_freshness_unknown":       {}, // RepairHint: slipway codebase-map
+	"lifecycle_event_log_unreadable":       {}, // RepairHint: inspect events/lifecycle.jsonl
+	"lifecycle_event_scan_failed":          {}, // RepairHint: inspect repo state, rerun health
+	"lifecycle_event_scan_skipped":         {}, // RepairHint: fix change.yaml (real issue surfaces as change_bundle_unreadable)
+	"archived_lifecycle_event_scan_failed": {}, // RepairHint: inspect archived change directory
+
+	// Surfaced as a state-integrity CLIError whose next-action is carried by the
+	// error's structured Remediation field (newStateIntegrityError), not by
+	// BuildRecovery (which receives no reasons on those error paths).
+	"config_parse_failure":         {}, // CLIError.Remediation: slipway repair
+	"change_bundle_unreadable":     {}, // CLIError.Remediation: fix change.yaml, then slipway repair
+	"execution_summary_unreadable": {}, // CLIError.Remediation: fix execution-summary.yaml, then slipway repair
+	"skill_registry_invalid":       {}, // CLIError.Remediation: slipway repair (restore generated skills)
+
+	// Terminal / informational / advisory states. These can reach BuildRecovery in
+	// a blocker list, but they need no corrective command: `next` renders their
+	// guidance directly, or they are non-actionable advisories.
+	"change_is_done":            {}, // terminal success; `next` renders done guidance
+	"no_skill_required":         {}, // informational advance posture; `next` renders advance guidance
+	"session_isolation_warning": {}, // advisory evidence warning; no single corrective command
 }
 
 // RecoveryStep is one actionable (code, subject) group rendered with its parsed

--- a/internal/model/recovery_test.go
+++ b/internal/model/recovery_test.go
@@ -101,6 +101,76 @@ func TestRecoveryRelevantTokensResolveToRemediation(t *testing.T) {
 	}
 }
 
+// preserveEmptyCommandReasonCodes are the canonical codes intentionally rendered
+// with prose-only recovery and NO primary command (preserve-first, multi-step
+// manual judgment with no single safe automated command). They are in
+// blockerRemediations but deliberately carry an empty CommandTemplate.
+var preserveEmptyCommandReasonCodes = map[string]struct{}{
+	"orphaned_bundle_ownership_unknown":  {},
+	"orphaned_bundle_unmanaged_worktree": {},
+}
+
+// TestRecoveryCoverageIsExhaustive is the completeness guard the hand-maintained
+// recoveryRelevantCanonicalCodes() allowlist could not provide. It iterates EVERY
+// canonical reason code and requires each to fall in exactly one recovery class,
+// so a newly added code cannot silently surface to an operator or host AI with no
+// discoverable next action — which is precisely the discoverability gap this guard
+// exists to prevent.
+func TestRecoveryCoverageIsExhaustive(t *testing.T) {
+	t.Parallel()
+
+	for code := range canonicalReasonDefinitions {
+		code := code
+		t.Run(code, func(t *testing.T) {
+			t.Parallel()
+
+			rec := BuildRecovery([]ReasonCode{NewReasonCode(code, "")})
+			hasCommand := rec != nil && strings.TrimSpace(rec.PrimaryCommand) != ""
+			_, isPreserve := preserveEmptyCommandReasonCodes[code]
+			_, isDiagnostic := diagnosticOnlyReasonCodes[code]
+
+			matched := 0
+			for _, in := range []bool{hasCommand, isPreserve, isDiagnostic} {
+				if in {
+					matched++
+				}
+			}
+			require.Equalf(t, 1, matched,
+				"canonical code %q must be in EXACTLY ONE recovery class "+
+					"(hasCommand=%v preserveEmptyCommand=%v diagnosticOnly=%v); add a "+
+					"blockerRemediations entry or classify it in diagnosticOnlyReasonCodes",
+				code, hasCommand, isPreserve, isDiagnostic)
+
+			if hasCommand {
+				assert.NotContainsf(t, rec.PrimaryCommand, "{",
+					"code %q primary command must not leak a placeholder", code)
+			}
+		})
+	}
+}
+
+// TestDiagnosticAndPreserveSetsAreCanonical guards the two hand-maintained
+// classification sets against typos: every code they name must be a real
+// canonical reason code, or the exhaustive guard above could be silently
+// satisfied by a misspelled entry.
+func TestDiagnosticAndPreserveSetsAreCanonical(t *testing.T) {
+	t.Parallel()
+
+	for code := range diagnosticOnlyReasonCodes {
+		_, ok := canonicalReasonDefinitions[code]
+		assert.Truef(t, ok, "diagnosticOnlyReasonCodes names non-canonical code %q", code)
+		_, alsoBlocker := blockerRemediations[code]
+		assert.Falsef(t, alsoBlocker, "code %q is in BOTH diagnosticOnlyReasonCodes and blockerRemediations", code)
+	}
+	for code := range preserveEmptyCommandReasonCodes {
+		_, ok := canonicalReasonDefinitions[code]
+		assert.Truef(t, ok, "preserveEmptyCommandReasonCodes names non-canonical code %q", code)
+		rem, ok := blockerRemediations[code]
+		require.Truef(t, ok, "preserve code %q must have a (prose-only) blockerRemediations entry", code)
+		assert.Emptyf(t, strings.TrimSpace(rem.CommandTemplate), "preserve code %q must have an empty CommandTemplate", code)
+	}
+}
+
 func TestInScopeProducedBlockersResolveToCanonicalRecovery(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tmpl/templates/skills/research-orchestration/SKILL.md
+++ b/internal/tmpl/templates/skills/research-orchestration/SKILL.md
@@ -120,6 +120,24 @@ slipway evidence skill \
   --notes-file artifacts/changes/{slug}/verification/research-orchestration-notes.md
 ```
 
+## Discovery Evidence States
+Slipway tracks discovery (research-orchestration) evidence in three states. Read
+the state from `slipway next --json` / `slipway validate --json` rather than
+inferring it: the engine decides freshness from whether the certified inputs
+changed after the verdict was recorded, not from your judgment.
+
+- **Present** — a current research-orchestration verdict exists and its certified
+  inputs have not changed since it was recorded. Discovery is satisfied; proceed
+  to planning.
+- **Stale** — a verdict exists, but the certified inputs changed *after* it was
+  recorded, so it is not usable as-is. Re-run discovery against the current inputs
+  and re-record fresh evidence (`slipway run` / `slipway evidence skill`). A stale
+  record is a re-run **and** re-record, not a first-time discovery run, and the
+  stale verdict must never be restamped or hand-edited into a fresh state.
+- **Missing** — no research-orchestration evidence is recorded at all. The
+  `missing_discovery_evidence` blocker fires, and discovery must be run to produce
+  the evidence before planning.
+
 ## Surface Findings
 Author `research.md` from `slipway instructions research` — its payload carries
 the template, the resolved output path to write, and the upstream inputs to read

--- a/internal/tmpl/templates/skills/research-orchestration/SKILL.md
+++ b/internal/tmpl/templates/skills/research-orchestration/SKILL.md
@@ -130,10 +130,11 @@ changed after the verdict was recorded, not from your judgment.
   inputs have not changed since it was recorded. Discovery is satisfied; proceed
   to planning.
 - **Stale** — a verdict exists, but the certified inputs changed *after* it was
-  recorded, so it is not usable as-is. Re-run discovery against the current inputs
-  and re-record fresh evidence (`slipway run` / `slipway evidence skill`). A stale
-  record is a re-run **and** re-record, not a first-time discovery run, and the
-  stale verdict must never be restamped or hand-edited into a fresh state.
+  recorded, so it is not usable as-is. Read the `required_skill_stale` recovery
+  from JSON, re-run this skill against the current inputs, then record fresh
+  evidence with `slipway evidence skill --skill research-orchestration --verdict pass`.
+  A stale record is a re-run **and** re-record, not a first-time discovery run,
+  and the stale verdict must never be restamped or hand-edited into a fresh state.
 - **Missing** — no research-orchestration evidence is recorded at all. The
   `missing_discovery_evidence` blocker fires, and discovery must be run to produce
   the evidence before planning.

--- a/internal/tmpl/templates/skills/workflow/SKILL.md.tmpl
+++ b/internal/tmpl/templates/skills/workflow/SKILL.md.tmpl
@@ -79,6 +79,23 @@ If these fields are omitted, the CLI applies conservative fallback defaults.
 - do not look for retired agent fields or a second exported prompt file
 - do not guess the next governed host without the CLI response
 
+## Reading Blockers And Recovery
+`slipway next --json`, `slipway status --json`, `slipway validate --json`, and any
+CLIError output emit a machine-readable next-action contract. Read it instead of
+guessing the recovery command.
+- `blockers[]` — each entry carries `code` and optional `detail` (plus
+  `severity`/`message`). Blockers name *what* is blocking, not the command to run.
+- `recovery` — the actionable projection of those blockers (absent when no blocker
+  has an actionable command):
+  - `primary_command` — the single governed CLI command to run next
+  - `primary_action` — the prose remediation for that command
+  - `recovery_class` — the category of the chosen recovery
+  - `steps[]` — one actionable step per blocker group; each carries `code`,
+    optional `subject`, `remediation`, `command`, and `recovery_class`
+- Operative rule: take the next governed action from `recovery.primary_command`
+  (and `recovery.steps[].command`), not from memory or a guessed command. When
+  `recovery` is absent, re-read `blockers[]` and the surface's own guidance.
+
 ## Runtime Session Handoff
 Use the generated `slipway-handoff` command surface for per-change advisory
 continuation notes. It owns when to run `slipway handoff write`, how to use

--- a/internal/tmpl/templates_test.go
+++ b/internal/tmpl/templates_test.go
@@ -885,6 +885,24 @@ func TestResearchOrchestrationUsesResearchArtifactSchemaHeadings(t *testing.T) {
 	assert.Contains(t, content, "research_section_placeholder")
 }
 
+func TestResearchOrchestrationStaleDiscoveryEvidenceRoutesToEvidenceSkill(t *testing.T) {
+	t.Parallel()
+
+	content, err := Content("skills/research-orchestration/SKILL.md")
+	require.NoError(t, err)
+
+	start := strings.Index(content, "- **Stale**")
+	require.NotEqual(t, -1, start)
+	end := strings.Index(content[start:], "- **Missing**")
+	require.NotEqual(t, -1, end)
+	staleBullet := content[start : start+end]
+
+	assert.Contains(t, staleBullet, "`required_skill_stale`")
+	assert.Contains(t, staleBullet, "`slipway evidence skill --skill research-orchestration --verdict pass`")
+	assert.NotContains(t, staleBullet, "`slipway run`")
+	assert.Contains(t, staleBullet, "must never be restamped")
+}
+
 func TestPlanningSkillsFollowArtifactDependencyOrder(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Why
Reviewing #383 surfaced that the recovery projection had no completeness guard: a probe found **39 of 163 canonical reason codes returned a nil `BuildRecovery`**, so a blocker could surface to an operator or host AI with no discoverable next action — and nothing failed when a new code was added unclassified. This closes that gap at the root and makes it impossible to reintroduce.

## L3 — kernel completeness guard (`internal/model`)
- Add `diagnosticOnlyReasonCodes` (25 codes) — codes that deliberately carry no `BuildRecovery` command because their next action is owned by a different public surface, documented per entry: `slipway health` `RepairHint` (18 health codes), the state-integrity `CLIError.Remediation` field (4 codes), or terminal/informational/advisory (3).
- Add 14 operator-facing `blockerRemediations` entries for the review.go / wave_sync.go blockers that actually flow through `BuildRecovery` (e.g. `intent_drift`, `non_pass_wave`, `task_changed_file_scope_escape`, `executor_agent_missing`, `parallel_wave_changed_file_overlap`, `dispatch_mode_absent_on_started_parallel_wave`). Commands are sourced from each producing stage and its matching `HealthFinding.RepairHint`, not guessed.
- `TestRecoveryCoverageIsExhaustive` iterates **all** canonical codes and requires each to be in exactly one of {has primary command} / {prose-only preserve} / {diagnostic-only} — a newly added code left unclassified **fails closed**. `TestDiagnosticAndPreserveSetsAreCanonical` guards the two sets against typos and double-classification.

Partition verified safe: health findings never call `BuildRecovery` (they render their own `RepairHint`); `newStateIntegrityError` CLIErrors carry their action in `.Remediation` (reasons=nil → Recovery=nil by design); only review.go + wave_sync.go blocker lists reach `BuildRecovery`, so only those needed entries.

## L2 — discoverability in generated skills (`internal/tmpl/templates/skills`)
- **research-orchestration**: new "Discovery Evidence States" section — Present / Stale / Missing (#377). A stale verdict is a re-run + re-record, never a restamp; read state from `slipway next/validate --json`.
- **workflow (entry skill)**: new "Reading Blockers And Recovery" section documenting the `blockers[]` / `recovery` JSON readback contract; take the next action from `recovery.primary_command`, not a guessed command. (Field names verified against `RecoverySummary`/`RecoveryStep`/`CLIError`; `subject` documented only on `recovery.steps[]` where it actually exists.)

## Verification
`go test ./...` green (incl. `internal/model`, `internal/toolgen` 139s, `cmd` 187s); `gofmt -s` clean. No golden regeneration needed — skill body prose does not hash into the surface-manifest or skill-tree goldens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)