### PR TITLE
feat(config): unify scattered SLIPWAY_* env vars with .slipway.yaml (#366)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,35 @@ identity and freshness fields only; it does not snapshot lifecycle state or the
 next action. Fresh sessions still run `slipway status --json` and
 `slipway next --json` for authority.
 
+## Configuration Surfaces
+
+Slipway keeps repository policy, host runtime facts, and secrets on separate
+surfaces:
+
+- `.slipway.yaml` is version-controlled repo policy. Use `slipway config list`,
+  `slipway config get <key>`, and `slipway config set <key> <value>` for these
+  dotted file keys.
+- Runtime/host environment variables describe the current AI host session:
+  context-window size, host capabilities, handoff owner identity, and similar
+  facts. Discover them with `slipway config list --env`.
+- Secret environment variables, including GitHub tokens, are environment-only
+  and are never representable in `.slipway.yaml`.
+
+Some repo policy can be set from either surface. For GitHub Enterprise, for
+example, `github.api_url` is the file key and `SLIPWAY_GITHUB_API_URL` is the
+environment override; `github.api_allowed_base_urls` and
+`SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS` define the allowlist. Environment wins
+over file config, and file config wins over defaults. Tokens stay env-only:
+`SLIPWAY_GITHUB_API_TOKEN` is used only for an allowlisted GitHub Enterprise API
+override, while ambient `GH_TOKEN` / `GITHUB_TOKEN` are sent only to
+`https://api.github.com`.
+
+```bash
+slipway config list
+slipway config list --env
+slipway config list --env --json
+```
+
 <details>
 <summary><strong>Command-first lifecycle</strong></summary>
 

--- a/README.md
+++ b/README.md
@@ -139,8 +139,10 @@ environment override; `github.api_allowed_base_urls` and
 `SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS` define the allowlist. Environment wins
 over file config, and file config wins over defaults. Tokens stay env-only:
 `SLIPWAY_GITHUB_API_TOKEN` is used only for an allowlisted GitHub Enterprise API
-override, while ambient `GH_TOKEN` / `GITHUB_TOKEN` are sent only to
-`https://api.github.com`.
+override, and a file-configured override URL cannot self-authorize token egress:
+set `SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS` to the exact URL, or set
+`SLIPWAY_GITHUB_API_URL` to the same URL, before the override token is sent.
+Ambient `GH_TOKEN` / `GITHUB_TOKEN` are sent only to `https://api.github.com`.
 
 ```bash
 slipway config list

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -21,6 +21,7 @@ type configGetView struct {
 // discoverable from `slipway --help`, not only `slipway help config`.
 func makeConfigCmd() *cobra.Command {
 	var listJSON bool
+	var listEnv bool
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: desc("config"),
@@ -30,24 +31,42 @@ func makeConfigCmd() *cobra.Command {
 		SilenceErrors: true,
 		Long: desc("config") + `
 
-Keys are the dotted leaves of .slipway.yaml (the same surface strict decoding
-accepts). With no subcommand, config lists every key; use list/get/set to read
-or update individual keys.
+Slipway has two configuration surfaces with distinct ownership:
+
+  Repo policy  -> .slipway.yaml, version-controlled. The file keys are the
+                 dotted leaves below; list/get/set operate on them.
+  Runtime/host -> environment variables the host injects per session (identity,
+                 context-window size, host capabilities). These are NOT file
+                 config; discover them with ` + "`config list --env`" + `.
+  Secrets      -> environment-only credentials (e.g. GitHub tokens). They are
+                 never written to .slipway.yaml.
+
+Some repo-policy settings are reachable from both surfaces (e.g.
+SLIPWAY_GITHUB_API_URL mirrors github.api_url); the environment value overrides
+the file value (env > file > default).
+
+File keys are the dotted leaves of .slipway.yaml (the same surface strict
+decoding accepts). With no subcommand, config lists every file key; use
+list/get/set to read or update individual keys.
 
 config set rewrites .slipway.yaml as deterministic YAML; comments and the
 original key ordering are not preserved.
 
-  config [list] [--json]   Enumerate every key (name, type, default,
+  config [list] [--json]   Enumerate every file key (name, type, default,
                            allowed-values, scope).
+  config list --env [--json]
+                           Enumerate the environment-variable surface (name,
+                           scope, default, file-config-key, description).
   config get <key> [--json]
-                           Print the resolved effective value for a key.
-  config set <key> <value> Validate and persist a key to .slipway.yaml.`,
+                           Print the resolved effective value for a file key.
+  config set <key> <value> Validate and persist a file key to .slipway.yaml.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runConfigList(cmd, listJSON)
+			return runConfigList(cmd, listJSON, listEnv)
 		},
 	}
 	cmd.Flags().BoolVar(&listJSON, "json", false, "JSON output")
+	cmd.Flags().BoolVar(&listEnv, "env", false, "List the environment-variable surface instead of file keys")
 	cmd.AddCommand(makeConfigListCmd())
 	cmd.AddCommand(makeConfigGetCmd())
 	cmd.AddCommand(makeConfigSetCmd())
@@ -56,15 +75,24 @@ original key ordering are not preserved.
 
 func makeConfigListCmd() *cobra.Command {
 	var jsonFlag bool
+	var envFlag bool
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List every configuration key with its type, default, allowed values, and scope",
-		Args:  cobra.NoArgs,
+		Long: `List every .slipway.yaml file key with its type, default, allowed values, and scope.
+
+With --env, list the environment-variable surface instead: the SLIPWAY_* (and
+ambient GitHub token) variables Slipway reads, each with its scope (repo-policy,
+runtime-host, or secret), default, the .slipway.yaml key it overrides (for
+repo-policy variables), and a description. The environment value overrides the
+matching file value (env > file > default).`,
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runConfigList(cmd, jsonFlag)
+			return runConfigList(cmd, jsonFlag, envFlag)
 		},
 	}
 	cmd.Flags().BoolVar(&jsonFlag, "json", false, "JSON output")
+	cmd.Flags().BoolVar(&envFlag, "env", false, "List the environment-variable surface instead of file keys")
 	return cmd
 }
 
@@ -110,12 +138,48 @@ func loadConfigForCommand(cmd *cobra.Command) (string, model.Config, error) {
 	return root, cfg, nil
 }
 
-func runConfigList(cmd *cobra.Command, jsonFlag bool) error {
+func runConfigList(cmd *cobra.Command, jsonFlag, envFlag bool) error {
+	if envFlag {
+		entries := model.EnvCatalog()
+		if jsonFlag {
+			return encodeJSONResponse(cmd, entries)
+		}
+		return writeEnvCatalogText(cmd, entries)
+	}
 	catalog := model.ConfigCatalog()
 	if jsonFlag {
 		return encodeJSONResponse(cmd, catalog)
 	}
 	return writeConfigCatalogText(cmd, catalog)
+}
+
+func writeEnvCatalogText(cmd *cobra.Command, entries []model.EnvCatalogEntry) error {
+	tw := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "NAME\tSCOPE\tSECRET\tDEFAULT\tFILE-CONFIG-KEY\tDESCRIPTION"); err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		def := entry.Default
+		if def == "" {
+			def = "-"
+		}
+		fileKey := entry.FileConfigKey
+		if fileKey == "" {
+			fileKey = "-"
+		}
+		description := entry.Description
+		if description == "" {
+			description = "-"
+		}
+		secret := "false"
+		if entry.Secret {
+			secret = "true"
+		}
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n", entry.Name, entry.Scope, secret, def, fileKey, description); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
 }
 
 func writeConfigCatalogText(cmd *cobra.Command, catalog []model.ConfigCatalogEntry) error {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -56,7 +56,8 @@ original key ordering are not preserved.
                            allowed-values, scope).
   config list --env [--json]
                            Enumerate the environment-variable surface (name,
-                           scope, default, file-config-key, description).
+                           scope, secret, default, file-config-key,
+                           description).
   config get <key> [--json]
                            Print the resolved effective value for a file key.
   config set <key> <value> Validate and persist a file key to .slipway.yaml.`,

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -97,6 +97,59 @@ func TestConfigListJSONSurvivesBrokenConfig(t *testing.T) {
 	})
 }
 
+func TestConfigListEnvTextShowsScopeAndSecretColumn(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+
+		out, errOut, err := runConfigCmd(t, root, "list", "--env")
+		require.NoError(t, err)
+		assert.Empty(t, errOut)
+		assert.Contains(t, out, "NAME")
+		assert.Contains(t, out, "SCOPE")
+		assert.Contains(t, out, "SECRET")
+		assert.Contains(t, out, "FILE-CONFIG-KEY")
+		assert.Contains(t, out, "SLIPWAY_GITHUB_API_URL")
+		assert.Contains(t, out, "github.api_url")
+		assert.Contains(t, out, "GH_TOKEN")
+		assert.Contains(t, out, "secret")
+		assert.Contains(t, out, "true")
+	})
+}
+
+func TestConfigListEnvJSONShape(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+
+		out, errOut, err := runConfigCmd(t, root, "list", "--env", "--json")
+		require.NoError(t, err)
+		assert.Empty(t, errOut)
+
+		var entries []model.EnvCatalogEntry
+		require.NoError(t, json.Unmarshal([]byte(out), &entries))
+		require.NotEmpty(t, entries)
+
+		byName := map[string]model.EnvCatalogEntry{}
+		for _, entry := range entries {
+			byName[entry.Name] = entry
+		}
+		apiURL, ok := byName["SLIPWAY_GITHUB_API_URL"]
+		require.True(t, ok)
+		assert.Equal(t, model.EnvScopeRepoPolicy, apiURL.Scope)
+		assert.Equal(t, "github.api_url", apiURL.FileConfigKey)
+		assert.False(t, apiURL.Secret)
+
+		token, ok := byName["GH_TOKEN"]
+		require.True(t, ok)
+		assert.Equal(t, model.EnvScopeSecret, token.Scope)
+		assert.True(t, token.Secret)
+		assert.Empty(t, token.FileConfigKey)
+	})
+}
+
 func TestConfigHelpDisclosesSetRewrite(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
@@ -384,6 +437,29 @@ func TestConfigSetInvalidRejectsWithFileUnchanged(t *testing.T) {
 		// Non-integer for an int field is rejected too.
 		_, _, typeErr := runConfigCmd(t, root, "set", "execution.lock_wait_timeout_seconds", "abc")
 		require.Error(t, typeErr)
+	})
+}
+
+func TestConfigSetRejectsUnsafeGitHubAPIURLBeforeWrite(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+
+		before, err := os.ReadFile(state.ConfigPath(root))
+		require.NoError(t, err)
+
+		_, _, setErr := runConfigCmd(t, root, "set", "github.api_url", "https://token@ghe.example.com/api/v3")
+		require.Error(t, setErr, "unsafe github.api_url must be rejected before persistence")
+		cliErr := asCLIError(setErr)
+		require.NotNil(t, cliErr)
+		assert.Equal(t, "config_value_invalid", cliErr.ErrorCode)
+		assert.Equal(t, "github.api_url", cliErr.Details["key"])
+
+		after, err := os.ReadFile(state.ConfigPath(root))
+		require.NoError(t, err)
+		assert.Equal(t, string(before), string(after), "rejected github.api_url must leave the config file unchanged")
+		assert.NotContains(t, string(after), "token@", "credentials must never be persisted to .slipway.yaml")
 	})
 }
 

--- a/cmd/tool_github.go
+++ b/cmd/tool_github.go
@@ -17,22 +17,27 @@ import (
 	"strings"
 	"time"
 
+	"github.com/signalridge/slipway/internal/model"
 	"github.com/spf13/cobra"
 )
 
-const githubBackendEnvHelp = `Environment variables:
+const githubBackendEnvHelp = `Environment variables (env > file > default; see ` + "`slipway config list --env`" + `):
   SLIPWAY_GITHUB_API_URL  Override the GitHub REST/GraphQL API base URL used by
                           the --backend api / token-backed HTTP path (default
                           https://api.github.com). Overrides must be HTTPS and
-                          listed in SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS.
+                          allowlisted. Falls back to the github.api_url key in
+                          .slipway.yaml when unset.
   SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS
                           Comma/space/semicolon separated HTTPS API base URLs
-                          allowed for SLIPWAY_GITHUB_API_URL.
+                          allowed for an API URL override. Falls back to the
+                          github.api_allowed_base_urls key in .slipway.yaml when
+                          unset.
   SLIPWAY_GITHUB_API_TOKEN
                           Token used only for an allowed override URL. Ambient
                           GH_TOKEN/GITHUB_TOKEN are sent only to
-                          https://api.github.com. The gh backend ignores these
-                          HTTP-only settings.`
+                          https://api.github.com. Tokens are env-only and are
+                          never read from .slipway.yaml. The gh backend ignores
+                          these HTTP-only settings.`
 
 func makeFetchPRChecksCmd() *cobra.Command {
 	var backend string
@@ -161,14 +166,36 @@ func addGitHubBackendFlag(cmd *cobra.Command, target *string) {
 	cmd.Flags().StringVar(target, "backend", githubBackendAuto, "GitHub backend: auto, gh, or api")
 }
 
-func newGitHubBackend(ctx context.Context, mode string) (githubBackend, error) {
+// githubFileConfigFromCommand best-effort loads the repo-policy GitHub settings
+// from .slipway.yaml for the command's project root. It is intentionally
+// non-fatal: `slipway tool ...` GitHub helpers may run outside a governed
+// workspace, so a missing root or unreadable config resolves to the zero
+// ConfigGitHub (env-only behavior, unchanged from before this surface existed)
+// rather than failing the GitHub call.
+func githubFileConfigFromCommand(cmd *cobra.Command) model.ConfigGitHub {
+	root, err := projectRootFromCommand(cmd)
+	if err != nil {
+		return model.ConfigGitHub{}
+	}
+	cfg, err := loadConfigAtRootWithStderr(root, cmd.ErrOrStderr())
+	if err != nil {
+		return model.ConfigGitHub{}
+	}
+	return cfg.GitHub
+}
+
+// newGitHubBackend builds the GitHub backend for mode. fileCfg carries the
+// repo-policy GitHub settings loaded from .slipway.yaml (zero value when none /
+// not in a workspace); the env vars still override these file values at
+// resolution time (env > file > default).
+func newGitHubBackend(ctx context.Context, mode string, fileCfg model.ConfigGitHub) (githubBackend, error) {
 	switch strings.ToLower(strings.TrimSpace(mode)) {
 	case "", githubBackendAuto:
 		if path, err := githubLookPath("gh"); err == nil && strings.TrimSpace(path) != "" {
-			return &autoGitHubBackend{cli: githubCLIClient{ctx: ctx, path: path}}, nil
+			return &autoGitHubBackend{cli: githubCLIClient{ctx: ctx, path: path}, fileCfg: fileCfg}, nil
 		}
 		if githubTokenAvailable() {
-			return newGitHubHTTPClient()
+			return newGitHubHTTPClient(fileCfg)
 		}
 		return nil, newPreconditionError(
 			"github_auth_unavailable",
@@ -190,7 +217,7 @@ func newGitHubBackend(ctx context.Context, mode string) (githubBackend, error) {
 		}
 		return githubCLIClient{ctx: ctx, path: path}, nil
 	case githubBackendAPI:
-		return newGitHubHTTPClient()
+		return newGitHubHTTPClient(fileCfg)
 	default:
 		return nil, newInvalidUsageError(
 			"github_backend_invalid",
@@ -223,6 +250,7 @@ func githubTokenAvailable() bool {
 // lazily-built HTTP client needs no synchronization.
 type autoGitHubBackend struct {
 	cli          githubBackend
+	fileCfg      model.ConfigGitHub
 	httpBE       githubBackend
 	httpErr      error
 	built        bool
@@ -245,7 +273,7 @@ func (a *autoGitHubBackend) fallbackFor(err error) (githubBackend, bool) {
 		return nil, false
 	}
 	if !a.built {
-		a.httpBE, a.httpErr = newGitHubHTTPClient()
+		a.httpBE, a.httpErr = newGitHubHTTPClient(a.fileCfg)
 		a.built = true
 	}
 	if a.httpErr != nil {
@@ -317,8 +345,8 @@ type githubHTTPClient struct {
 
 func (c githubHTTPClient) backendName() string { return githubBackendAPI }
 
-func newGitHubHTTPClient() (githubHTTPClient, error) {
-	cfg, err := resolveGitHubAPIConfigFromEnv()
+func newGitHubHTTPClient(fileCfg model.ConfigGitHub) (githubHTTPClient, error) {
+	cfg, err := resolveGitHubAPIConfig(fileCfg)
 	if err != nil {
 		return githubHTTPClient{}, err
 	}
@@ -334,20 +362,33 @@ type githubAPIConfig struct {
 	token   string
 }
 
-func resolveGitHubAPIConfigFromEnv() (githubAPIConfig, error) {
-	baseURL, err := normalizeGitHubAPIBaseURL(firstNonEmpty(os.Getenv(githubAPIURLEnv), githubDefaultAPIBaseURL))
+// resolveGitHubAPIConfig resolves the effective GitHub API base URL and token
+// with env > file > default precedence: the base URL is the env override
+// (SLIPWAY_GITHUB_API_URL) when set, else the file value (github.api_url), else
+// https://api.github.com. An override host must be allowlisted by the env list
+// (SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS) when set, else the file allowlist
+// (github.api_allowed_base_urls). The token stays env-only (secrets are never
+// read from .slipway.yaml).
+func resolveGitHubAPIConfig(fileCfg model.ConfigGitHub) (githubAPIConfig, error) {
+	baseURL, err := normalizeGitHubAPIBaseURL(firstNonEmpty(os.Getenv(githubAPIURLEnv), fileCfg.APIURL, githubDefaultAPIBaseURL))
 	if err != nil {
 		return githubAPIConfig{}, err
 	}
 	override := baseURL != githubDefaultAPIBaseURL
-	if override && !githubAPIBaseURLAllowed(baseURL) {
-		return githubAPIConfig{}, newPreconditionError(
-			"github_api_url_not_allowed",
-			fmt.Sprintf("GitHub API override %q is not allowlisted", baseURL),
-			"Set SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS to the exact HTTPS API base URL before using SLIPWAY_GITHUB_API_URL.",
-			"",
-			map[string]any{"base_url": baseURL},
-		)
+	if override {
+		allowed, err := githubAPIBaseURLAllowed(baseURL, fileCfg)
+		if err != nil {
+			return githubAPIConfig{}, err
+		}
+		if !allowed {
+			return githubAPIConfig{}, newPreconditionError(
+				"github_api_url_not_allowed",
+				fmt.Sprintf("GitHub API override %q is not allowlisted", baseURL),
+				"Allowlist the exact HTTPS API base URL via SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS or github.api_allowed_base_urls before using a github.api_url override.",
+				"",
+				map[string]any{"base_url": baseURL},
+			)
+		}
 	}
 	token := githubAPITokenForBaseURL(override)
 	if token == "" {
@@ -355,7 +396,7 @@ func resolveGitHubAPIConfigFromEnv() (githubAPIConfig, error) {
 			return githubAPIConfig{}, newPreconditionError(
 				"github_api_override_token_missing",
 				"GitHub API override token missing; ambient GH_TOKEN/GITHUB_TOKEN are not sent to override hosts",
-				"Set SLIPWAY_GITHUB_API_TOKEN for the allowed override host, or remove SLIPWAY_GITHUB_API_URL to use https://api.github.com.",
+				"Set SLIPWAY_GITHUB_API_TOKEN for the allowed override host, or clear the SLIPWAY_GITHUB_API_URL / github.api_url override to use https://api.github.com.",
 				"",
 				map[string]any{"base_url": baseURL},
 			)
@@ -376,63 +417,46 @@ func normalizeGitHubAPIBaseURL(raw string) (string, error) {
 	if value == "" {
 		value = githubDefaultAPIBaseURL
 	}
-	parsed, err := url.Parse(value)
-	if err != nil || parsed == nil {
-		return "", newInvalidGitHubAPIURLError(value, "parse URL")
+	normalized, err := model.NormalizeGitHubAPIBaseURL(value)
+	if err != nil {
+		return "", newInvalidGitHubAPIURLError(value, err.Error())
 	}
-	if !strings.EqualFold(parsed.Scheme, "https") {
-		return "", newInvalidGitHubAPIURLError(value, "scheme must be https")
-	}
-	if parsed.User != nil || strings.TrimSpace(parsed.Host) == "" {
-		return "", newInvalidGitHubAPIURLError(value, "URL must not include userinfo and must include a host")
-	}
-	if parsed.RawQuery != "" || parsed.Fragment != "" {
-		return "", newInvalidGitHubAPIURLError(value, "URL must not include query or fragment")
-	}
-	if parsed.RawPath != "" {
-		return "", newInvalidGitHubAPIURLError(value, "encoded path is not accepted")
-	}
-	cleanPath := path.Clean(parsed.Path)
-	switch cleanPath {
-	case ".", "/":
-		parsed.Path = ""
-	default:
-		if cleanPath != parsed.Path {
-			return "", newInvalidGitHubAPIURLError(value, "path must be canonical")
-		}
-		if strings.EqualFold(parsed.Hostname(), "api.github.com") {
-			return "", newInvalidGitHubAPIURLError(value, "public api.github.com override must not include a path")
-		}
-		parsed.Path = cleanPath
-	}
-	parsed.Scheme = "https"
-	parsed.Host = strings.ToLower(parsed.Host)
-	return strings.TrimRight(parsed.String(), "/"), nil
+	return normalized, nil
 }
 
 func newInvalidGitHubAPIURLError(value, reason string) error {
 	return newInvalidUsageError(
 		"github_api_url_invalid",
 		fmt.Sprintf("invalid GitHub API base URL %q: %s", value, reason),
-		"Use https://api.github.com, or an exact HTTPS GitHub Enterprise API base URL allowlisted by SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS.",
-		nil,
+		"Use https://api.github.com, or an exact HTTPS GitHub Enterprise API base URL allowlisted by SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS or github.api_allowed_base_urls.",
+		map[string]any{"value": value, "reason": reason},
 	)
 }
 
-func githubAPIBaseURLAllowed(baseURL string) bool {
-	entries, invalid := parseGitHubAPIAllowedBaseURLs(os.Getenv(githubAPIAllowedBaseURLsEnv))
-	if invalid != "" {
-		return false
+// githubAPIBaseURLAllowed reports whether baseURL is allowlisted, preferring the
+// env list (SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS) when set and otherwise falling
+// back to the file list (github.api_allowed_base_urls). Both lists are
+// normalized through the same URL rules as the override itself before matching.
+func githubAPIBaseURLAllowed(baseURL string, fileCfg model.ConfigGitHub) (bool, error) {
+	raw := strings.TrimSpace(os.Getenv(githubAPIAllowedBaseURLsEnv))
+	if raw == "" {
+		// File fallback: join the list with newlines (a recognized separator) so
+		// the same parser/normalizer covers both surfaces.
+		raw = strings.Join(fileCfg.APIAllowedBaseURLs, "\n")
+	}
+	entries, err := parseGitHubAPIAllowedBaseURLs(raw)
+	if err != nil {
+		return false, err
 	}
 	for _, entry := range entries {
 		if entry == baseURL {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
-func parseGitHubAPIAllowedBaseURLs(raw string) ([]string, string) {
+func parseGitHubAPIAllowedBaseURLs(raw string) ([]string, error) {
 	parts := strings.FieldsFunc(raw, func(r rune) bool {
 		return r == ',' || r == ';' || r == '\n' || r == '\t' || r == ' '
 	})
@@ -444,11 +468,11 @@ func parseGitHubAPIAllowedBaseURLs(raw string) ([]string, string) {
 		}
 		normalized, err := normalizeGitHubAPIBaseURL(value)
 		if err != nil {
-			return nil, value
+			return nil, err
 		}
 		out = append(out, normalized)
 	}
-	return out, ""
+	return out, nil
 }
 
 func githubAPITokenForBaseURL(override bool) string {
@@ -1103,7 +1127,7 @@ func runFetchPRChecks(cmd *cobra.Command, repo string, pr int, backend string) e
 	if err != nil {
 		return err
 	}
-	client, err := newGitHubBackend(cmd.Context(), backend)
+	client, err := newGitHubBackend(cmd.Context(), backend, githubFileConfigFromCommand(cmd))
 	if err != nil {
 		return err
 	}
@@ -1454,7 +1478,7 @@ func runFetchPRFeedback(cmd *cobra.Command, repo string, pr int, backend string)
 	if err != nil {
 		return err
 	}
-	client, err := newGitHubBackend(cmd.Context(), backend)
+	client, err := newGitHubBackend(cmd.Context(), backend, githubFileConfigFromCommand(cmd))
 	if err != nil {
 		return err
 	}
@@ -1698,7 +1722,7 @@ func runFetchReviewRequests(cmd *cobra.Command, org, teams, backend string) erro
 	if org == "" {
 		return newInvalidUsageError("fetch_review_requests_org_required", "--org is required", "Pass --org with the GitHub organization that owns the requested teams.", nil)
 	}
-	client, err := newGitHubBackend(cmd.Context(), backend)
+	client, err := newGitHubBackend(cmd.Context(), backend, githubFileConfigFromCommand(cmd))
 	if err != nil {
 		return err
 	}
@@ -1879,7 +1903,7 @@ func runReplyToThread(cmd *cobra.Command, args []string, confirm bool, backend s
 	fmt.Fprintln(cmd.OutOrStdout(), "BEGIN REQUEST")
 	_ = encodeJSONResponse(cmd, map[string]any{"query": replyThreadMutation, "requests": requests})
 
-	client, err := newGitHubBackend(cmd.Context(), backend)
+	client, err := newGitHubBackend(cmd.Context(), backend, githubFileConfigFromCommand(cmd))
 	if err != nil {
 		return err
 	}

--- a/cmd/tool_github.go
+++ b/cmd/tool_github.go
@@ -31,7 +31,9 @@ const githubBackendEnvHelp = `Environment variables (env > file > default; see `
                           Comma/space/semicolon separated HTTPS API base URLs
                           allowed for an API URL override. Falls back to the
                           github.api_allowed_base_urls key in .slipway.yaml when
-                          unset.
+                          unset. File-configured override URLs require this env
+                          allowlist, or a matching SLIPWAY_GITHUB_API_URL, before
+                          SLIPWAY_GITHUB_API_TOKEN is sent.
   SLIPWAY_GITHUB_API_TOKEN
                           Token used only for an allowed override URL. Ambient
                           GH_TOKEN/GITHUB_TOKEN are sent only to
@@ -362,31 +364,51 @@ type githubAPIConfig struct {
 	token   string
 }
 
+type githubAPIConfigSource string
+
+const (
+	githubAPIConfigSourceDefault githubAPIConfigSource = "default"
+	githubAPIConfigSourceEnv     githubAPIConfigSource = "env"
+	githubAPIConfigSourceFile    githubAPIConfigSource = "file"
+)
+
+type githubAPIBaseURLResolution struct {
+	value  string
+	source githubAPIConfigSource
+}
+
+type githubAPIAllowlistDecision struct {
+	allowed bool
+	source  githubAPIConfigSource
+}
+
 // resolveGitHubAPIConfig resolves the effective GitHub API base URL and token
 // with env > file > default precedence: the base URL is the env override
 // (SLIPWAY_GITHUB_API_URL) when set, else the file value (github.api_url), else
 // https://api.github.com. An override host must be allowlisted by the env list
 // (SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS) when set, else the file allowlist
-// (github.api_allowed_base_urls). The token stays env-only (secrets are never
-// read from .slipway.yaml).
+// (github.api_allowed_base_urls). The override token stays env-only and is sent
+// to a file-configured override only after an operator-controlled env value
+// confirms the destination.
 func resolveGitHubAPIConfig(fileCfg model.ConfigGitHub) (githubAPIConfig, error) {
-	baseURL, err := normalizeGitHubAPIBaseURL(firstNonEmpty(os.Getenv(githubAPIURLEnv), fileCfg.APIURL, githubDefaultAPIBaseURL))
+	baseURL, err := resolveGitHubAPIBaseURL(fileCfg)
 	if err != nil {
 		return githubAPIConfig{}, err
 	}
-	override := baseURL != githubDefaultAPIBaseURL
+	override := baseURL.value != githubDefaultAPIBaseURL
+	var allowlist githubAPIAllowlistDecision
 	if override {
-		allowed, err := githubAPIBaseURLAllowed(baseURL, fileCfg)
+		allowlist, err = githubAPIBaseURLAllowed(baseURL.value, fileCfg)
 		if err != nil {
 			return githubAPIConfig{}, err
 		}
-		if !allowed {
+		if !allowlist.allowed {
 			return githubAPIConfig{}, newPreconditionError(
 				"github_api_url_not_allowed",
-				fmt.Sprintf("GitHub API override %q is not allowlisted", baseURL),
+				fmt.Sprintf("GitHub API override %q is not allowlisted", baseURL.value),
 				"Allowlist the exact HTTPS API base URL via SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS or github.api_allowed_base_urls before using a github.api_url override.",
 				"",
-				map[string]any{"base_url": baseURL},
+				map[string]any{"base_url": baseURL.value},
 			)
 		}
 	}
@@ -398,7 +420,7 @@ func resolveGitHubAPIConfig(fileCfg model.ConfigGitHub) (githubAPIConfig, error)
 				"GitHub API override token missing; ambient GH_TOKEN/GITHUB_TOKEN are not sent to override hosts",
 				"Set SLIPWAY_GITHUB_API_TOKEN for the allowed override host, or clear the SLIPWAY_GITHUB_API_URL / github.api_url override to use https://api.github.com.",
 				"",
-				map[string]any{"base_url": baseURL},
+				map[string]any{"base_url": baseURL.value},
 			)
 		}
 		return githubAPIConfig{}, newPreconditionError(
@@ -409,7 +431,48 @@ func resolveGitHubAPIConfig(fileCfg model.ConfigGitHub) (githubAPIConfig, error)
 			nil,
 		)
 	}
-	return githubAPIConfig{baseURL: baseURL, token: token}, nil
+	if override && !githubAPIOverrideTokenDestinationAuthorized(baseURL, allowlist) {
+		return githubAPIConfig{}, newPreconditionError(
+			"github_api_override_token_destination_unconfirmed",
+			fmt.Sprintf("GitHub API override token destination %q is not operator-confirmed", baseURL.value),
+			"Set SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS to the exact HTTPS API base URL, or set SLIPWAY_GITHUB_API_URL to the same value, before sending SLIPWAY_GITHUB_API_TOKEN to a file-configured github.api_url.",
+			"",
+			map[string]any{
+				"base_url":         baseURL.value,
+				"base_url_source":  string(baseURL.source),
+				"allowlist_source": string(allowlist.source),
+			},
+		)
+	}
+	return githubAPIConfig{baseURL: baseURL.value, token: token}, nil
+}
+
+func resolveGitHubAPIBaseURL(fileCfg model.ConfigGitHub) (githubAPIBaseURLResolution, error) {
+	envURL := strings.TrimSpace(os.Getenv(githubAPIURLEnv))
+	if envURL != "" {
+		value, err := normalizeGitHubAPIBaseURL(envURL)
+		if err != nil {
+			return githubAPIBaseURLResolution{}, err
+		}
+		return githubAPIBaseURLResolution{value: value, source: githubAPIConfigSourceEnv}, nil
+	}
+	fileURL := strings.TrimSpace(fileCfg.APIURL)
+	if fileURL != "" {
+		value, err := normalizeGitHubAPIBaseURL(fileURL)
+		if err != nil {
+			return githubAPIBaseURLResolution{}, err
+		}
+		return githubAPIBaseURLResolution{value: value, source: githubAPIConfigSourceFile}, nil
+	}
+	value, err := normalizeGitHubAPIBaseURL(githubDefaultAPIBaseURL)
+	if err != nil {
+		return githubAPIBaseURLResolution{}, err
+	}
+	return githubAPIBaseURLResolution{value: value, source: githubAPIConfigSourceDefault}, nil
+}
+
+func githubAPIOverrideTokenDestinationAuthorized(baseURL githubAPIBaseURLResolution, allowlist githubAPIAllowlistDecision) bool {
+	return allowlist.source == githubAPIConfigSourceEnv || baseURL.source == githubAPIConfigSourceEnv
 }
 
 func normalizeGitHubAPIBaseURL(raw string) (string, error) {
@@ -433,27 +496,29 @@ func newInvalidGitHubAPIURLError(value, reason string) error {
 	)
 }
 
-// githubAPIBaseURLAllowed reports whether baseURL is allowlisted, preferring the
-// env list (SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS) when set and otherwise falling
-// back to the file list (github.api_allowed_base_urls). Both lists are
+// githubAPIBaseURLAllowed reports whether baseURL is allowlisted, preferring
+// the env list (SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS) when set and otherwise
+// falling back to the file list (github.api_allowed_base_urls). Both lists are
 // normalized through the same URL rules as the override itself before matching.
-func githubAPIBaseURLAllowed(baseURL string, fileCfg model.ConfigGitHub) (bool, error) {
+func githubAPIBaseURLAllowed(baseURL string, fileCfg model.ConfigGitHub) (githubAPIAllowlistDecision, error) {
 	raw := strings.TrimSpace(os.Getenv(githubAPIAllowedBaseURLsEnv))
+	source := githubAPIConfigSourceEnv
 	if raw == "" {
 		// File fallback: join the list with newlines (a recognized separator) so
 		// the same parser/normalizer covers both surfaces.
 		raw = strings.Join(fileCfg.APIAllowedBaseURLs, "\n")
+		source = githubAPIConfigSourceFile
 	}
 	entries, err := parseGitHubAPIAllowedBaseURLs(raw)
 	if err != nil {
-		return false, err
+		return githubAPIAllowlistDecision{}, err
 	}
 	for _, entry := range entries {
 		if entry == baseURL {
-			return true, nil
+			return githubAPIAllowlistDecision{allowed: true, source: source}, nil
 		}
 	}
-	return false, nil
+	return githubAPIAllowlistDecision{allowed: false, source: source}, nil
 }
 
 func parseGitHubAPIAllowedBaseURLs(raw string) ([]string, error) {
@@ -484,15 +549,6 @@ func githubAPITokenForBaseURL(override bool) string {
 		token = strings.TrimSpace(os.Getenv(githubAmbientTokenSecondaryEnv))
 	}
 	return token
-}
-
-func firstNonEmpty(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return value
-		}
-	}
-	return ""
 }
 
 type githubPageHandler func(raw []byte) (int, error)

--- a/cmd/tool_test.go
+++ b/cmd/tool_test.go
@@ -555,13 +555,15 @@ func TestGitHubAPIOverrideRequiresOverrideTokenAndDoesNotUseAmbient(t *testing.T
 	assert.Equal(t, "Bearer override-token", seenAuth)
 }
 
-// TestGitHubAPIConfigFileFallback proves the env > file > default precedence:
-// when SLIPWAY_GITHUB_API_URL is unset, github.api_url from .slipway.yaml is
-// used and its allowlist (github.api_allowed_base_urls) authorizes the override;
-// when the env var IS set it wins over the file value.
-func TestGitHubAPIConfigFileFallback(t *testing.T) {
+// TestGitHubAPIConfigFileFallback proves the env > file > default precedence
+// while keeping the override token's destination operator-confirmed. A repo file
+// may name and allowlist a GHE host, but that file cannot by itself authorize
+// sending SLIPWAY_GITHUB_API_TOKEN to the host.
+func TestGitHubAPIConfigFileFallbackRequiresOperatorTokenDestinationConfirmation(t *testing.T) {
+	var hits int
 	var seenAuth string
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
 		seenAuth = r.Header.Get("Authorization")
 		_, _ = io.WriteString(w, `{"number":11}`)
 	}))
@@ -581,8 +583,16 @@ func TestGitHubAPIConfigFileFallback(t *testing.T) {
 		APIURL:             server.URL,
 		APIAllowedBaseURLs: []string{server.URL},
 	}
+	_, err := newGitHubHTTPClient(fileCfg)
+	require.Error(t, err)
+	var cliErr *CLIError
+	require.True(t, errors.As(err, &cliErr))
+	assert.Equal(t, "github_api_override_token_destination_unconfirmed", cliErr.ErrorCode)
+	assert.Equal(t, 0, hits, "file config must not self-authorize override token egress")
+
+	t.Setenv(githubAPIAllowedBaseURLsEnv, server.URL)
 	client, err := newGitHubHTTPClient(fileCfg)
-	require.NoError(t, err, "file github.api_url + allowlist should authorize the override")
+	require.NoError(t, err, "env allowlist confirms the file-configured token destination")
 	var out struct {
 		Number int `json:"number"`
 	}
@@ -590,10 +600,18 @@ func TestGitHubAPIConfigFileFallback(t *testing.T) {
 	assert.Equal(t, 11, out.Number)
 	assert.Equal(t, "Bearer override-token", seenAuth)
 
+	t.Setenv(githubAPIAllowedBaseURLsEnv, "")
+	t.Setenv(githubAPIURLEnv, server.URL)
+	client, err = newGitHubHTTPClient(fileCfg)
+	require.NoError(t, err, "env URL confirms the destination when it matches the file policy")
+	require.NoError(t, client.getJSON("/repos/o/r/pulls/11", &out))
+	assert.Equal(t, 11, out.Number)
+	assert.Equal(t, "Bearer override-token", seenAuth)
+
 	// A file override host NOT in the file allowlist is rejected.
+	t.Setenv(githubAPIURLEnv, "")
 	_, err = newGitHubHTTPClient(model.ConfigGitHub{APIURL: server.URL})
 	require.Error(t, err)
-	var cliErr *CLIError
 	require.True(t, errors.As(err, &cliErr))
 	assert.Equal(t, "github_api_url_not_allowed", cliErr.ErrorCode)
 

--- a/cmd/tool_test.go
+++ b/cmd/tool_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/signalridge/slipway/internal/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -407,7 +408,7 @@ func TestGitHubBackendSelection(t *testing.T) {
 				return tt.ghPath, nil
 			}
 
-			backend, err := newGitHubBackend(context.Background(), tt.mode)
+			backend, err := newGitHubBackend(context.Background(), tt.mode, model.ConfigGitHub{})
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				var cliErr *CLIError
@@ -472,7 +473,7 @@ func TestGitHubAPIOverrideRejectsUnsafeURLs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv(githubAPIURLEnv, tt.baseURL)
-			_, err := newGitHubHTTPClient()
+			_, err := newGitHubHTTPClient(model.ConfigGitHub{})
 			require.Error(t, err)
 			var cliErr *CLIError
 			require.True(t, errors.As(err, &cliErr), "expected CLIError, got %T", err)
@@ -508,7 +509,7 @@ func TestGitHubAPIOverrideRejectsAllowlistedPublicPathConfusion(t *testing.T) {
 			t.Setenv(githubAmbientTokenPrimaryEnv, "ambient-token")
 			t.Setenv(githubAmbientTokenSecondaryEnv, "")
 
-			_, err := newGitHubHTTPClient()
+			_, err := newGitHubHTTPClient(model.ConfigGitHub{})
 			require.Error(t, err)
 			var cliErr *CLIError
 			require.True(t, errors.As(err, &cliErr), "expected CLIError, got %T", err)
@@ -536,7 +537,7 @@ func TestGitHubAPIOverrideRequiresOverrideTokenAndDoesNotUseAmbient(t *testing.T
 	t.Setenv(githubAmbientTokenSecondaryEnv, "secondary-ambient-token")
 	t.Setenv(githubAPIOverrideTokenEnv, "")
 
-	_, err := newGitHubHTTPClient()
+	_, err := newGitHubHTTPClient(model.ConfigGitHub{})
 	require.Error(t, err)
 	var cliErr *CLIError
 	require.True(t, errors.As(err, &cliErr), "expected CLIError, got %T", err)
@@ -544,7 +545,7 @@ func TestGitHubAPIOverrideRequiresOverrideTokenAndDoesNotUseAmbient(t *testing.T
 	assert.Equal(t, 0, hits, "ambient tokens must not be sent to override hosts")
 
 	t.Setenv(githubAPIOverrideTokenEnv, "override-token")
-	client, err := newGitHubHTTPClient()
+	client, err := newGitHubHTTPClient(model.ConfigGitHub{})
 	require.NoError(t, err)
 	var out struct {
 		Number int `json:"number"`
@@ -552,6 +553,79 @@ func TestGitHubAPIOverrideRequiresOverrideTokenAndDoesNotUseAmbient(t *testing.T
 	require.NoError(t, client.getJSON("/repos/o/r/pulls/7", &out))
 	assert.Equal(t, 7, out.Number)
 	assert.Equal(t, "Bearer override-token", seenAuth)
+}
+
+// TestGitHubAPIConfigFileFallback proves the env > file > default precedence:
+// when SLIPWAY_GITHUB_API_URL is unset, github.api_url from .slipway.yaml is
+// used and its allowlist (github.api_allowed_base_urls) authorizes the override;
+// when the env var IS set it wins over the file value.
+func TestGitHubAPIConfigFileFallback(t *testing.T) {
+	var seenAuth string
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenAuth = r.Header.Get("Authorization")
+		_, _ = io.WriteString(w, `{"number":11}`)
+	}))
+	defer server.Close()
+	previousTransport := githubHTTPTransport
+	githubHTTPTransport = server.Client().Transport
+	t.Cleanup(func() { githubHTTPTransport = previousTransport })
+
+	// No env override URL/allowlist; the file config supplies both.
+	t.Setenv(githubAPIURLEnv, "")
+	t.Setenv(githubAPIAllowedBaseURLsEnv, "")
+	t.Setenv(githubAPIOverrideTokenEnv, "override-token")
+	t.Setenv(githubAmbientTokenPrimaryEnv, "ambient-token")
+	t.Setenv(githubAmbientTokenSecondaryEnv, "")
+
+	fileCfg := model.ConfigGitHub{
+		APIURL:             server.URL,
+		APIAllowedBaseURLs: []string{server.URL},
+	}
+	client, err := newGitHubHTTPClient(fileCfg)
+	require.NoError(t, err, "file github.api_url + allowlist should authorize the override")
+	var out struct {
+		Number int `json:"number"`
+	}
+	require.NoError(t, client.getJSON("/repos/o/r/pulls/11", &out))
+	assert.Equal(t, 11, out.Number)
+	assert.Equal(t, "Bearer override-token", seenAuth)
+
+	// A file override host NOT in the file allowlist is rejected.
+	_, err = newGitHubHTTPClient(model.ConfigGitHub{APIURL: server.URL})
+	require.Error(t, err)
+	var cliErr *CLIError
+	require.True(t, errors.As(err, &cliErr))
+	assert.Equal(t, "github_api_url_not_allowed", cliErr.ErrorCode)
+
+	// Env URL overrides the file value: an env override that is NOT allowlisted
+	// (env list empty, file allowlist only covers the file URL) is rejected,
+	// proving the env value, not the file value, drove resolution.
+	t.Setenv(githubAPIURLEnv, "https://ghe.env-only.example/api/v3")
+	_, err = newGitHubHTTPClient(fileCfg)
+	require.Error(t, err)
+	require.True(t, errors.As(err, &cliErr))
+	assert.Equal(t, "github_api_url_not_allowed", cliErr.ErrorCode)
+}
+
+func TestGitHubAPIConfigFileAllowlistInvalidEntryIsURLInvalid(t *testing.T) {
+	t.Setenv(githubAPIURLEnv, "")
+	t.Setenv(githubAPIAllowedBaseURLsEnv, "")
+	t.Setenv(githubAPIOverrideTokenEnv, "override-token")
+	t.Setenv(githubAmbientTokenPrimaryEnv, "ambient-token")
+	t.Setenv(githubAmbientTokenSecondaryEnv, "")
+
+	_, err := newGitHubHTTPClient(model.ConfigGitHub{
+		APIURL: "https://ghe.example.com/api/v3",
+		APIAllowedBaseURLs: []string{
+			"https://ghe.example.com/api/v3",
+			"httpss://typo.example.com",
+		},
+	})
+	require.Error(t, err)
+	var cliErr *CLIError
+	require.True(t, errors.As(err, &cliErr), "expected CLIError, got %T", err)
+	assert.Equal(t, "github_api_url_invalid", cliErr.ErrorCode)
+	assert.Equal(t, "httpss://typo.example.com", cliErr.Details["value"])
 }
 
 func TestGitHubAPIOverrideRejectsUnsafePaginationLink(t *testing.T) {

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -171,7 +171,7 @@ codebase-map advisory.
 | Command | Class | Purpose |
 | --- | --- | --- |
 | `slipway init` | mutation | Initialize `.slipway.yaml`, the repo-local runtime layout, and optional AI-tool adapters. |
-| `slipway config [list\|get\|set]` | mutation | Inspect and update repo-level `.slipway.yaml` configuration keys. CLI-only; no generated adapter prompt surface. |
+| `slipway config [list\|get\|set]` | mutation | Inspect and update repo-level `.slipway.yaml` keys; `config list --env` lists runtime/secret environment variables and their ownership. CLI-only; no generated adapter prompt surface. |
 
 `docs/SURFACE-MANIFEST.json` is the committed generated-surface inventory for
 adapter, command, skill, JSON, and documentation rows. The manifest is rebuilt

--- a/docs/ja/commands.md
+++ b/docs/ja/commands.md
@@ -93,7 +93,7 @@ slipway new "schema migration" --full   # force fresh ship-verification evidence
 | コマンド | クラス | 目的 |
 | --- | --- | --- |
 | `slipway init` | mutation | `.slipway.yaml`、リポジトリローカルのランタイムレイアウト、および任意の AI ツールアダプターを初期化する。 |
-| `slipway config [list\|get\|set]` | mutation | リポジトリレベルの `.slipway.yaml` 設定キーを確認・更新する。CLI 専用で、生成されたアダプターのプロンプトサーフェスはありません。 |
+| `slipway config [list\|get\|set]` | mutation | リポジトリレベルの `.slipway.yaml` 設定キーを確認・更新する。`config list --env` はランタイム/シークレット環境変数とその所有範囲を一覧します。CLI 専用で、生成されたアダプターのプロンプトサーフェスはありません。 |
 
 `docs/SURFACE-MANIFEST.json` は、アダプター、コマンド、スキル、JSON、ドキュメントの各行についてコミットされた生成サーフェスのインベントリです。マニフェストは Slipway 所有の Go の権威ソースから再構築され、CI 向けの Go テストでチェックされます。
 

--- a/docs/ja/reference/commands.md
+++ b/docs/ja/reference/commands.md
@@ -86,7 +86,7 @@ slipway config list --json
 - `slipway health --doctor --json` は、ヘルスレポートに修復向けの診断を追加します。
 - `slipway tool <helper>` は生成されたスキルから直接呼び出され、生成されたアダプターのプロンプトサーフェスはありません。
 - `slipway hook session-start` と `slipway hook context-pressure` は生成されたホストフック設定から直接呼び出されます。フックヘルパーは、ホストの自動フックがユーザーをブロックしないよう静かに失敗します。
-- `slipway config`、`slipway config list --json`、`slipway config get <key> --json`、`slipway config set <key> <value>` は `.slipway.yaml` を確認・更新します。`config` は意図的に CLI 専用であり、生成されたアダプターのプロンプトサーフェスはありません。
+- `slipway config`、`slipway config list --json`、`slipway config list --env [--json]`、`slipway config get <key> --json`、`slipway config set <key> <value>` は `.slipway.yaml` キーとランタイム/シークレット環境変数サーフェスを確認します。更新できるのはファイル設定キーだけです。`config` は意図的に CLI 専用であり、生成されたアダプターのプロンプトサーフェスはありません。
 
 ## 読み取り専用サーフェス
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -82,7 +82,7 @@ artifact-readiness detail, transition traces, or context-budget diagnostics.
 - `slipway health --doctor --json` adds repair-oriented diagnostics to the health report.
 - `slipway tool <helper>` is invoked directly by generated skills and has no generated adapter prompt surface.
 - `slipway hook session-start` and `slipway hook context-pressure` are invoked directly by generated host hook configuration; hook helpers fail silent so automatic hooks cannot block the user.
-- `slipway config`, `slipway config list --json`, `slipway config get <key> --json`, and `slipway config set <key> <value>` inspect or update `.slipway.yaml`; `config` is intentionally CLI-only and has no generated adapter prompt surface.
+- `slipway config`, `slipway config list --json`, `slipway config list --env [--json]`, `slipway config get <key> --json`, and `slipway config set <key> <value>` inspect `.slipway.yaml` keys and the runtime/secret environment surface; only file keys can be updated. `config` is intentionally CLI-only and has no generated adapter prompt surface.
 
 ## Read-Only Authority
 

--- a/docs/zh/commands.md
+++ b/docs/zh/commands.md
@@ -142,7 +142,7 @@ codebase-map 提示。
 | 命令 | 类别 | 用途 |
 | --- | --- | --- |
 | `slipway init` | mutation | 初始化 `.slipway.yaml`、仓库本地的运行时布局，以及可选的 AI 工具适配器。 |
-| `slipway config [list\|get\|set]` | mutation | 查看并更新仓库级 `.slipway.yaml` 配置键。它是 CLI-only，不生成适配器 prompt surface。 |
+| `slipway config [list\|get\|set]` | mutation | 查看并更新仓库级 `.slipway.yaml` 配置键；`config list --env` 会列出运行时/密钥环境变量及其归属。它是 CLI-only，不生成适配器 prompt surface。 |
 
 `docs/SURFACE-MANIFEST.json` 是已提交的生成面清单，记录适配器、命令、skill、JSON 和文档各类行。
 该清单由 Slipway 拥有的 Go 权威源重建，并由面向 CI 的 Go 测试核对：

--- a/docs/zh/reference/commands.md
+++ b/docs/zh/reference/commands.md
@@ -81,7 +81,7 @@ slipway config list --json
 - `slipway health --doctor --json` 在 health 报告中加入面向修复的诊断。
 - `slipway tool <helper>` 由生成的 skill 直接调用，不生成适配器提示词接入面。
 - `slipway hook session-start` 和 `slipway hook context-pressure` 由生成的宿主 hook 配置直接调用；hook 辅助命令会静默失败，避免自动 hook 阻塞用户。
-- `slipway config`、`slipway config list --json`、`slipway config get <key> --json` 和 `slipway config set <key> <value>` 用于查看或更新 `.slipway.yaml`；`config` 刻意保持 CLI-only，不生成适配器提示词接入面。
+- `slipway config`、`slipway config list --json`、`slipway config list --env [--json]`、`slipway config get <key> --json` 和 `slipway config set <key> <value>` 用于查看 `.slipway.yaml` 配置键和运行时/密钥环境变量面；只有文件配置键可以更新。`config` 刻意保持 CLI-only，不生成适配器提示词接入面。
 
 ## 只读类命令
 

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -3,7 +3,9 @@ package model
 import (
 	"bytes"
 	"fmt"
+	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -16,6 +18,7 @@ type Config struct {
 	Defaults        ConfigDefaults        `yaml:"defaults" json:"defaults"`
 	Execution       ConfigExecution       `yaml:"execution" json:"execution"`
 	Governance      ConfigGovernance      `yaml:"governance,omitempty" json:"governance,omitempty"`
+	GitHub          ConfigGitHub          `yaml:"github,omitempty" json:"github,omitempty"`
 	Context         ProjectContext        `yaml:"context,omitempty" json:"context,omitempty"`
 	CustomArtifacts []ArtifactDefinition  `yaml:"custom_artifacts,omitempty" json:"custom_artifacts,omitempty"`
 	UnknownTopLevel map[string]*yaml.Node `yaml:"-" json:"-"`
@@ -98,6 +101,90 @@ func (t ConfigGovernanceThresholds) Validate() error {
 		return fmt.Errorf("governance.thresholds.worktree_blast_radius: invalid signal level %q", t.WorktreeBlastRadius)
 	}
 	return nil
+}
+
+// ConfigGitHub holds the repo-policy GitHub API settings that may live in
+// .slipway.yaml. These mirror the SLIPWAY_GITHUB_API_URL and
+// SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS environment variables so a project can
+// pin a GitHub Enterprise host in version control instead of relying on ambient
+// environment alone. The matching environment variables still override these
+// file values (env > file > default), and the override token
+// (SLIPWAY_GITHUB_API_TOKEN) is intentionally NOT representable here: secrets
+// stay environment-only.
+type ConfigGitHub struct {
+	// APIURL pins the GitHub REST/GraphQL API base URL used by the token-backed
+	// HTTP backend. Empty means the default https://api.github.com unless the
+	// SLIPWAY_GITHUB_API_URL environment variable overrides it.
+	APIURL string `yaml:"api_url,omitempty" json:"api_url,omitempty"`
+	// APIAllowedBaseURLs lists the HTTPS API base URLs allowed for an APIURL
+	// override. The SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS environment variable, when
+	// set, overrides this list wholesale.
+	APIAllowedBaseURLs []string `yaml:"api_allowed_base_urls,omitempty" json:"api_allowed_base_urls,omitempty"`
+}
+
+func (g ConfigGitHub) IsZero() bool {
+	return g.APIURL == "" && len(g.APIAllowedBaseURLs) == 0
+}
+
+// Validate checks that configured GitHub API base URLs obey the same safety
+// contract as the runtime HTTP backend. Empty api_url is valid: the env/default
+// precedence applies at the call site. The override token stays env-only and is
+// never on this struct.
+func (g ConfigGitHub) Validate() error {
+	trimmed := strings.TrimSpace(g.APIURL)
+	if trimmed != "" {
+		if _, err := NormalizeGitHubAPIBaseURL(trimmed); err != nil {
+			return fmt.Errorf("github.api_url: invalid URL %q: %w", g.APIURL, err)
+		}
+	}
+	for i, raw := range g.APIAllowedBaseURLs {
+		if _, err := NormalizeGitHubAPIBaseURL(raw); err != nil {
+			return fmt.Errorf("github.api_allowed_base_urls[%d]: invalid URL %q: %w", i, raw, err)
+		}
+	}
+	return nil
+}
+
+// NormalizeGitHubAPIBaseURL canonicalizes a GitHub REST/GraphQL API base URL and
+// rejects forms that could smuggle credentials, confuse path matching, or differ
+// from the runtime HTTP backend's allowlist comparison.
+func NormalizeGitHubAPIBaseURL(raw string) (string, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return "", fmt.Errorf("URL is empty")
+	}
+	parsed, err := url.Parse(value)
+	if err != nil || parsed == nil {
+		return "", fmt.Errorf("parse URL")
+	}
+	if !strings.EqualFold(parsed.Scheme, "https") {
+		return "", fmt.Errorf("scheme must be https")
+	}
+	if parsed.User != nil || strings.TrimSpace(parsed.Host) == "" {
+		return "", fmt.Errorf("URL must not include userinfo and must include a host")
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", fmt.Errorf("URL must not include query or fragment")
+	}
+	if parsed.RawPath != "" {
+		return "", fmt.Errorf("encoded path is not accepted")
+	}
+	cleanPath := path.Clean(parsed.Path)
+	switch cleanPath {
+	case ".", "/":
+		parsed.Path = ""
+	default:
+		if cleanPath != parsed.Path {
+			return "", fmt.Errorf("path must be canonical")
+		}
+		if strings.EqualFold(parsed.Hostname(), "api.github.com") {
+			return "", fmt.Errorf("public api.github.com override must not include a path")
+		}
+		parsed.Path = cleanPath
+	}
+	parsed.Scheme = "https"
+	parsed.Host = strings.ToLower(parsed.Host)
+	return strings.TrimRight(parsed.String(), "/"), nil
 }
 
 // ProjectContext provides project-specific context injected into skill templates.
@@ -265,6 +352,9 @@ func (c Config) Validate() error {
 	default:
 		return fmt.Errorf("execution.parallelization must be unset or one of: forced, off")
 	}
+	if err := c.GitHub.Validate(); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -298,6 +388,10 @@ func ParseConfigYAML(data []byte) (Config, error) {
 		case "governance":
 			if err := decodeNodeStrict(value, &cfg.Governance); err != nil {
 				return Config{}, fmt.Errorf("decode governance: %w", err)
+			}
+		case "github":
+			if err := decodeNodeStrict(value, &cfg.GitHub); err != nil {
+				return Config{}, fmt.Errorf("decode github: %w", err)
 			}
 		case "agents":
 			return Config{}, fmt.Errorf("top-level agents configuration has been removed; governed handoff is skill-based via next_skill.name and slipway-{name}/SKILL.md host skill surfaces")
@@ -346,6 +440,17 @@ func (c Config) ToYAML() ([]byte, error) {
 			return nil, err
 		}
 		appendMappingEntry(root, "governance", governanceNode)
+	}
+
+	// Emit the github section only when a repo-policy GitHub setting is present.
+	// Reuse IsZero() as the single empty-section predicate so the section never
+	// round-trips into UnknownTopLevel as an empty mapping.
+	if !cfg.GitHub.IsZero() {
+		githubNode, err := encodeYAMLNode(cfg.GitHub)
+		if err != nil {
+			return nil, err
+		}
+		appendMappingEntry(root, "github", githubNode)
 	}
 
 	// Emit the context section whenever any context leaf is set. Reuse IsZero()

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -108,9 +108,10 @@ func (t ConfigGovernanceThresholds) Validate() error {
 // SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS environment variables so a project can
 // pin a GitHub Enterprise host in version control instead of relying on ambient
 // environment alone. The matching environment variables still override these
-// file values (env > file > default), and the override token
+// file values (env > file > default). The override token
 // (SLIPWAY_GITHUB_API_TOKEN) is intentionally NOT representable here: secrets
-// stay environment-only.
+// stay environment-only, and the runtime must confirm file-configured token
+// destinations from env before sending the token.
 type ConfigGitHub struct {
 	// APIURL pins the GitHub REST/GraphQL API base URL used by the token-backed
 	// HTTP backend. Empty means the default https://api.github.com unless the
@@ -118,7 +119,8 @@ type ConfigGitHub struct {
 	APIURL string `yaml:"api_url,omitempty" json:"api_url,omitempty"`
 	// APIAllowedBaseURLs lists the HTTPS API base URLs allowed for an APIURL
 	// override. The SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS environment variable, when
-	// set, overrides this list wholesale.
+	// set, overrides this list wholesale and confirms token egress to a
+	// file-configured override.
 	APIAllowedBaseURLs []string `yaml:"api_allowed_base_urls,omitempty" json:"api_allowed_base_urls,omitempty"`
 }
 

--- a/internal/model/config_catalog.go
+++ b/internal/model/config_catalog.go
@@ -104,7 +104,7 @@ func configDescriptions() map[string]string {
 		"governance.thresholds.security_review_blast_radius":    "Minimum blast radius that triggers the security-review control.",
 		"governance.thresholds.worktree_blast_radius":           "Minimum blast radius that triggers the worktree-isolation control.",
 		"github.api_url":                                        "GitHub REST/GraphQL API base URL (env SLIPWAY_GITHUB_API_URL overrides; default https://api.github.com).",
-		"github.api_allowed_base_urls":                          "HTTPS API base URLs allowed for a github.api_url override (env SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS overrides).",
+		"github.api_allowed_base_urls":                          "HTTPS API base URLs allowed for a github.api_url override; env SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS overrides and confirms token egress.",
 		"context.tech_stack":                                    "Project tech stack injected into skill templates.",
 		"context.conventions":                                   "Project conventions injected into skill templates.",
 		"context.test_cmd":                                      "Project test command injected into skill templates.",

--- a/internal/model/config_catalog.go
+++ b/internal/model/config_catalog.go
@@ -35,9 +35,11 @@ func configEffectiveDefaults() map[string]string {
 
 // ConfigCatalogEntry describes one user-facing `.slipway.yaml` key as a flat,
 // dotted leaf. The catalog is the single discoverable source of truth for the
-// `slipway config` command surface; it is derived from the Config struct via
-// reflection over yaml tags so it cannot drift from what strict decoding
-// accepts.
+// FILE config surface (.slipway.yaml) exposed by the `slipway config` command;
+// it is derived from the Config struct via reflection over yaml tags so it
+// cannot drift from what strict decoding accepts. Runtime/host environment
+// variables are NOT file config and are catalogued separately via EnvCatalog()
+// and surfaced by `slipway config list --env`.
 type ConfigCatalogEntry struct {
 	// Name is the dotted key, e.g. "execution.auto" or
 	// "governance.thresholds.independent_review_blast_radius".
@@ -101,6 +103,8 @@ func configDescriptions() map[string]string {
 		"governance.thresholds.independent_review_blast_radius": "Minimum blast radius that triggers the independent-review control.",
 		"governance.thresholds.security_review_blast_radius":    "Minimum blast radius that triggers the security-review control.",
 		"governance.thresholds.worktree_blast_radius":           "Minimum blast radius that triggers the worktree-isolation control.",
+		"github.api_url":                                        "GitHub REST/GraphQL API base URL (env SLIPWAY_GITHUB_API_URL overrides; default https://api.github.com).",
+		"github.api_allowed_base_urls":                          "HTTPS API base URLs allowed for a github.api_url override (env SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS overrides).",
 		"context.tech_stack":                                    "Project tech stack injected into skill templates.",
 		"context.conventions":                                   "Project conventions injected into skill templates.",
 		"context.test_cmd":                                      "Project test command injected into skill templates.",

--- a/internal/model/config_coherence_test.go
+++ b/internal/model/config_coherence_test.go
@@ -1,0 +1,96 @@
+package model
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestConfigGitHubIsZeroAndRoundTrip(t *testing.T) {
+	if !(ConfigGitHub{}).IsZero() {
+		t.Error("empty ConfigGitHub should be zero")
+	}
+	in := []byte("github:\n  api_url: https://ghe.example.com/api/v3\n  api_allowed_base_urls:\n    - https://ghe.example.com/api/v3\n")
+	cfg, err := ParseConfigYAML(in)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.GitHub.APIURL != "https://ghe.example.com/api/v3" {
+		t.Errorf("api_url = %q", cfg.GitHub.APIURL)
+	}
+	if len(cfg.UnknownTopLevel) != 0 {
+		t.Errorf("github must not land in UnknownTopLevel: %v", cfg.UnknownTopLevel)
+	}
+	out, err := cfg.ToYAML()
+	if err != nil {
+		t.Fatalf("toYAML: %v", err)
+	}
+	back, err := ParseConfigYAML(out)
+	if err != nil {
+		t.Fatalf("reparse: %v", err)
+	}
+	if !reflect.DeepEqual(cfg.GitHub, back.GitHub) {
+		t.Errorf("github round-trip drift: %+v vs %+v", cfg.GitHub, back.GitHub)
+	}
+}
+
+func TestConfigGitHubValidateRejectsNonHTTPS(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.GitHub.APIURL = "http://insecure.example.com"
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected non-https github.api_url to be rejected")
+	} else if !strings.Contains(err.Error(), "github.api_url") {
+		t.Errorf("error should name github.api_url, got: %v", err)
+	}
+
+	// Empty api_url is valid (env/default precedence applies at the call site).
+	cfg.GitHub.APIURL = ""
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("empty github.api_url should be valid, got: %v", err)
+	}
+}
+
+func TestConfigGitHubValidateRejectsRuntimeUnsafeURLs(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{name: "userinfo", url: "https://token@ghe.example.com/api/v3"},
+		{name: "query", url: "https://ghe.example.com/api/v3?token=secret"},
+		{name: "fragment", url: "https://ghe.example.com/api/v3#token"},
+		{name: "noncanonical path", url: "https://ghe.example.com/api//v3"},
+		{name: "encoded path", url: "https://ghe.example.com/api%2Fv3"},
+		{name: "public host path", url: "https://api.github.com/api/v3"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.GitHub.APIURL = tt.url
+			err := cfg.Validate()
+			if err == nil {
+				t.Fatalf("expected github.api_url %q to be rejected", tt.url)
+			}
+			if !strings.Contains(err.Error(), "github.api_url") {
+				t.Errorf("error should name github.api_url, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestConfigGitHubValidateRejectsInvalidAllowedBaseURLs(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.GitHub.APIURL = "https://ghe.example.com/api/v3"
+	cfg.GitHub.APIAllowedBaseURLs = []string{
+		"https://ghe.example.com/api/v3",
+		"httpss://typo.example.com",
+	}
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected invalid github.api_allowed_base_urls entry to be rejected")
+	}
+	if !strings.Contains(err.Error(), "github.api_allowed_base_urls[1]") {
+		t.Errorf("error should name invalid allowlist index, got: %v", err)
+	}
+}

--- a/internal/model/env_catalog.go
+++ b/internal/model/env_catalog.go
@@ -61,13 +61,13 @@ func EnvCatalog() []EnvCatalogEntry {
 			Name:          "SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS",
 			Scope:         EnvScopeRepoPolicy,
 			FileConfigKey: "github.api_allowed_base_urls",
-			Description:   "Comma/space/semicolon separated HTTPS API base URLs allowed for a SLIPWAY_GITHUB_API_URL override; overrides github.api_allowed_base_urls.",
+			Description:   "Comma/space/semicolon separated HTTPS API base URLs allowed for a GitHub API override; overrides github.api_allowed_base_urls and confirms file-configured token destinations.",
 		},
 		{
 			Name:        "SLIPWAY_GITHUB_API_TOKEN",
 			Scope:       EnvScopeSecret,
 			Secret:      true,
-			Description: "Token used only for an allowlisted SLIPWAY_GITHUB_API_URL override host; never read from .slipway.yaml.",
+			Description: "Token used only for an allowlisted and env-confirmed GitHub API override host; never read from .slipway.yaml.",
 		},
 		{
 			Name:        "SLIPWAY_CONTEXT_WINDOW_TOKENS",

--- a/internal/model/env_catalog.go
+++ b/internal/model/env_catalog.go
@@ -1,0 +1,122 @@
+package model
+
+import "sort"
+
+// Environment-variable scopes classify how a SLIPWAY_* (or ambient) variable
+// relates to the file config surface. The scope tells an operator whether the
+// setting belongs in version-controlled `.slipway.yaml`, must be injected by the
+// runtime host per session, or is a secret that must never be written to a file.
+const (
+	// EnvScopeRepoPolicy marks a variable that expresses repository policy and is
+	// promotable to a `.slipway.yaml` key (carried in FileConfigKey). The
+	// environment value overrides the file value (env > file > default).
+	EnvScopeRepoPolicy = "repo-policy"
+	// EnvScopeRuntimeHost marks a variable the runtime host injects per session
+	// (identity, context-window size, metrics path, host capabilities). It has no
+	// file equivalent because it describes the host, not the project.
+	EnvScopeRuntimeHost = "runtime-host"
+	// EnvScopeSecret marks a credential that must stay environment-only and is
+	// never representable in `.slipway.yaml`.
+	EnvScopeSecret = "secret"
+)
+
+// EnvCatalogEntry describes one environment variable Slipway reads, giving the
+// runtime env surface the same discoverability the file config surface gets from
+// ConfigCatalog(). Unlike file keys, env vars are not derivable by reflection, so
+// this catalog is curated; a contract test (TestEnvCatalogCoversEveryGetenv)
+// asserts every SLIPWAY_* name read in source has an entry here.
+type EnvCatalogEntry struct {
+	// Name is the environment variable name, e.g. "SLIPWAY_GITHUB_API_URL".
+	Name string `json:"name"`
+	// Scope is one of repo-policy, runtime-host, or secret.
+	Scope string `json:"scope"`
+	// Default is the effective default applied when the variable is unset; empty
+	// when there is no static default.
+	Default string `json:"default,omitempty"`
+	// FileConfigKey is the dotted `.slipway.yaml` key this variable overrides, for
+	// repo-policy variables that are promotable to file config. Empty for
+	// runtime-host and secret variables.
+	FileConfigKey string `json:"file_config_key,omitempty"`
+	// Description is a short human-facing note.
+	Description string `json:"description,omitempty"`
+	// Secret reports whether the value is a credential that must not be logged or
+	// written to a file.
+	Secret bool `json:"secret,omitempty"`
+}
+
+// EnvCatalog returns the curated, name-sorted catalog of environment variables
+// Slipway reads. Repo-policy entries carry the FileConfigKey they override so an
+// operator can see the env > file > default relationship at a glance. Ambient
+// fallback variables are included even though they are not SLIPWAY_-prefixed.
+func EnvCatalog() []EnvCatalogEntry {
+	entries := []EnvCatalogEntry{
+		{
+			Name:          "SLIPWAY_GITHUB_API_URL",
+			Scope:         EnvScopeRepoPolicy,
+			Default:       "https://api.github.com",
+			FileConfigKey: "github.api_url",
+			Description:   "GitHub REST/GraphQL API base URL for the token-backed HTTP backend; overrides github.api_url.",
+		},
+		{
+			Name:          "SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS",
+			Scope:         EnvScopeRepoPolicy,
+			FileConfigKey: "github.api_allowed_base_urls",
+			Description:   "Comma/space/semicolon separated HTTPS API base URLs allowed for a SLIPWAY_GITHUB_API_URL override; overrides github.api_allowed_base_urls.",
+		},
+		{
+			Name:        "SLIPWAY_GITHUB_API_TOKEN",
+			Scope:       EnvScopeSecret,
+			Secret:      true,
+			Description: "Token used only for an allowlisted SLIPWAY_GITHUB_API_URL override host; never read from .slipway.yaml.",
+		},
+		{
+			Name:        "SLIPWAY_CONTEXT_WINDOW_TOKENS",
+			Scope:       EnvScopeRuntimeHost,
+			Description: "Host model context-window size (tokens) used to estimate context-budget pressure.",
+		},
+		{
+			Name:        "SLIPWAY_CONTEXT_METRICS_PATH",
+			Scope:       EnvScopeRuntimeHost,
+			Description: "Path the host writes live context-usage metrics to for the context-pressure hook.",
+		},
+		{
+			Name:        "SLIPWAY_SESSION_OWNER",
+			Scope:       EnvScopeRuntimeHost,
+			Description: "Session identity recorded on handoff notes; falls back to USER/USERNAME when unset.",
+		},
+		{
+			Name:        "SLIPWAY_HOST_CAPABILITIES",
+			Scope:       EnvScopeRuntimeHost,
+			Description: "Host-advertised capability tokens (e.g. subagent fan-out) the engine reads when shaping dispatch.",
+		},
+		{
+			Name:        "SLIPWAY_HOST_CAPABILITY_FALLBACKS",
+			Scope:       EnvScopeRuntimeHost,
+			Description: "Host-advertised capability fallbacks applied when a primary capability is unavailable.",
+		},
+		{
+			Name:        "GH_TOKEN",
+			Scope:       EnvScopeSecret,
+			Secret:      true,
+			Description: "Ambient GitHub token sent only to https://api.github.com (and honored by the gh backend); never read from .slipway.yaml.",
+		},
+		{
+			Name:        "GITHUB_TOKEN",
+			Scope:       EnvScopeSecret,
+			Secret:      true,
+			Description: "Ambient GitHub token fallback sent only to https://api.github.com; never read from .slipway.yaml.",
+		},
+		{
+			Name:        "USER",
+			Scope:       EnvScopeRuntimeHost,
+			Description: "Ambient OS username fallback for handoff session owner when SLIPWAY_SESSION_OWNER is unset.",
+		},
+		{
+			Name:        "USERNAME",
+			Scope:       EnvScopeRuntimeHost,
+			Description: "Ambient OS username fallback for handoff session owner when SLIPWAY_SESSION_OWNER and USER are unset.",
+		},
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name < entries[j].Name })
+	return entries
+}

--- a/internal/model/env_catalog_test.go
+++ b/internal/model/env_catalog_test.go
@@ -1,0 +1,166 @@
+package model
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// envLiteral matches environment-variable names Slipway treats as public
+// runtime/config surface: SLIPWAY_* names, ambient token fallbacks, and ambient
+// username fallbacks. Scanning string literals (rather than only
+// os.Getenv("...") call sites) catches vars read via const identifiers and
+// simple fallback slices.
+var envLiteral = regexp.MustCompile(`"(SLIPWAY_[A-Z0-9_]+|[A-Z][A-Z0-9_]*_TOKEN|GH_TOKEN|USER|USERNAME)"`)
+
+// repoRootForTest resolves the repository root from this test's package
+// directory (internal/model => ../..). Walking from here keeps the source scan
+// deterministic regardless of the caller's working directory.
+func repoRootForTest(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	return root
+}
+
+// scanEnvUsages walks the repo's Go source (excluding _test.go files and
+// env_catalog.go itself) and returns every distinct env name Slipway exposes as
+// runtime/config surface. env_catalog.go is excluded so the catalog cannot
+// trivially "cover itself": the test proves every use site elsewhere is
+// documented.
+func scanEnvUsages(t *testing.T, root string) map[string]string {
+	t.Helper()
+	skipDirs := map[string]bool{
+		".git": true, ".worktrees": true, "artifacts": true,
+		"node_modules": true, "vendor": true, "testdata": true,
+	}
+	found := map[string]string{}
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if skipDirs[d.Name()] {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		name := d.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			return nil
+		}
+		if name == "env_catalog.go" {
+			return nil
+		}
+		data, readErr := os.ReadFile(path) // #nosec G304 -- test-only scan of in-repo source.
+		if readErr != nil {
+			return readErr
+		}
+		for _, m := range envLiteral.FindAllStringSubmatch(string(data), -1) {
+			rel, relErr := filepath.Rel(root, path)
+			if relErr != nil {
+				rel = path
+			}
+			if _, ok := found[m[1]]; !ok {
+				found[m[1]] = rel
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk repo source: %v", err)
+	}
+	return found
+}
+
+// TestEnvCatalogCoversEveryGetenv is the drift guard for the runtime env
+// surface: every SLIPWAY_* env var plus ambient token/username fallback read
+// anywhere in source must have an EnvCatalog() entry. Reading a new env var
+// without cataloguing it FAILS here and names the missing variable and the file
+// that reads it — the env-side mirror of
+// TestConfigCatalogCoversEveryStructLeaf.
+func TestEnvCatalogCoversEveryGetenv(t *testing.T) {
+	have := map[string]bool{}
+	for _, entry := range EnvCatalog() {
+		have[entry.Name] = true
+	}
+	usages := scanEnvUsages(t, repoRootForTest(t))
+	if len(usages) == 0 {
+		t.Fatal("scanned zero env usages; the source scan is broken")
+	}
+	names := make([]string, 0, len(usages))
+	for name := range usages {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		if !have[name] {
+			t.Errorf("env var %q (read in %s) has no EnvCatalog() entry; add one to internal/model/env_catalog.go", name, usages[name])
+		}
+	}
+}
+
+// TestEnvCatalogEntriesAreWellFormed asserts each entry carries the required
+// metadata, uses a known scope, and that the env/file relationship is coherent:
+// repo-policy entries point at a real ConfigCatalog() file key, secret entries
+// set Secret and carry no file key, and runtime-host entries carry no file key.
+func TestEnvCatalogEntriesAreWellFormed(t *testing.T) {
+	fileKeys := map[string]bool{}
+	for _, entry := range ConfigCatalog() {
+		fileKeys[entry.Name] = true
+	}
+	seen := map[string]bool{}
+	for _, entry := range EnvCatalog() {
+		if strings.TrimSpace(entry.Name) == "" {
+			t.Errorf("env catalog entry has empty name: %+v", entry)
+		}
+		if seen[entry.Name] {
+			t.Errorf("duplicate env catalog entry for %q", entry.Name)
+		}
+		seen[entry.Name] = true
+		if strings.TrimSpace(entry.Description) == "" {
+			t.Errorf("env catalog entry %q has empty description", entry.Name)
+		}
+		switch entry.Scope {
+		case EnvScopeRepoPolicy:
+			if entry.FileConfigKey == "" {
+				t.Errorf("repo-policy env %q must carry a file_config_key", entry.Name)
+			} else if !fileKeys[entry.FileConfigKey] {
+				t.Errorf("repo-policy env %q references file_config_key %q with no ConfigCatalog() entry", entry.Name, entry.FileConfigKey)
+			}
+			if entry.Secret {
+				t.Errorf("repo-policy env %q must not be marked secret", entry.Name)
+			}
+		case EnvScopeRuntimeHost:
+			if entry.FileConfigKey != "" {
+				t.Errorf("runtime-host env %q must not carry a file_config_key", entry.Name)
+			}
+		case EnvScopeSecret:
+			if !entry.Secret {
+				t.Errorf("secret env %q must set Secret=true", entry.Name)
+			}
+			if entry.FileConfigKey != "" {
+				t.Errorf("secret env %q must not carry a file_config_key (secrets stay env-only)", entry.Name)
+			}
+		default:
+			t.Errorf("env catalog entry %q has unknown scope %q", entry.Name, entry.Scope)
+		}
+	}
+}
+
+// TestEnvCatalogSorted asserts EnvCatalog() returns entries in name order so the
+// discovery surface is stable.
+func TestEnvCatalogSorted(t *testing.T) {
+	entries := EnvCatalog()
+	for i := 1; i < len(entries); i++ {
+		if entries[i-1].Name > entries[i].Name {
+			t.Errorf("env catalog not sorted: %q before %q", entries[i-1].Name, entries[i].Name)
+		}
+	}
+}

--- a/internal/toolgen/toolgen.go
+++ b/internal/toolgen/toolgen.go
@@ -312,7 +312,7 @@ var commandRegistry = []CommandDef{
 		Arguments:     "[--tools all|none|claude,cursor,...] [--refresh]",
 		Prerequisites: []string{"Run from the target project root or any child directory inside it.", "The workspace must be inside a git working tree."}},
 	{ID: "config", Class: CommandClassMutation, Description: "Inspect and set repo-level Slipway configuration keys", Tier: "setup", HasPromptSurface: false,
-		Arguments:     "[list [--json] | get <key> [--json] | set <key> <value>]",
+		Arguments:     "[list [--json] [--env] | get <key> [--json] | set <key> <value>] [--env]",
 		Prerequisites: []string{"`.slipway.yaml` must exist (run `slipway init` first)"},
 		Notes: []string{
 			"`slipway config` is intentionally CLI-only: it is part of the public command inventory and JSON contracts, but Slipway does not export `$slipway-config` or host command prompt wrappers.",

--- a/internal/toolgen/toolgen.go
+++ b/internal/toolgen/toolgen.go
@@ -312,7 +312,7 @@ var commandRegistry = []CommandDef{
 		Arguments:     "[--tools all|none|claude,cursor,...] [--refresh]",
 		Prerequisites: []string{"Run from the target project root or any child directory inside it.", "The workspace must be inside a git working tree."}},
 	{ID: "config", Class: CommandClassMutation, Description: "Inspect and set repo-level Slipway configuration keys", Tier: "setup", HasPromptSurface: false,
-		Arguments:     "[list [--json] [--env] | get <key> [--json] | set <key> <value>] [--env]",
+		Arguments:     "[list [--json] [--env] | get <key> [--json] | set <key> <value>]",
 		Prerequisites: []string{"`.slipway.yaml` must exist (run `slipway init` first)"},
 		Notes: []string{
 			"`slipway config` is intentionally CLI-only: it is part of the public command inventory and JSON contracts, but Slipway does not export `$slipway-config` or host command prompt wrappers.",


### PR DESCRIPTION
Split out from #388: this PR lands **only** the #366 env-unification half so it can review and merge independently. The per-stage subagent directive work (#359/#360) is being redesigned separately (multiplicity + host-native `agent_type`).

## What this does (#366)
Runtime `SLIPWAY_*` env vars get a discovery + contract surface symmetric with the `.slipway.yaml` file catalog:

- `EnvCatalog()` (`internal/model/env_catalog.go`) registers each runtime env var with scope (`repo-policy` / `runtime-host` / `secret`), default, file-config key, description, and secret flag.
- A source-scanning coverage contract test (`env_catalog_test.go`) fails if a new `SLIPWAY_*` / ambient (`GH_TOKEN`, `GITHUB_TOKEN`, `USER`, `USERNAME`) getenv is added without a catalog entry — closing the asymmetry where file-config keys were drift-guarded but env vars were not.
- `slipway config list --env` exposes the env surface in text (with a `SECRET` column) and JSON.
- GitHub Enterprise overrides become first-class repo policy: `github.api_url` / `github.api_allowed_base_urls` mirror `SLIPWAY_GITHUB_API_URL` / `SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS` with **env > file > default** precedence. The override token stays env-only (`SLIPWAY_GITHUB_API_TOKEN`); ambient `GH_TOKEN`/`GITHUB_TOKEN` only ever reach `https://api.github.com`.
- README documents the three ownership classes (repo-policy / runtime-host / secret) and points at `slipway config list --env`.

## Verification (in-worktree)
- `go build ./...`, `go vet ./...`, `gofmt -s` clean
- `go test ./...` — exit 0
- `golangci-lint run ./...` — 0 issues

Closes #366.

🤖 Generated with [Claude Code](https://claude.com/claude-code)