### PR TITLE
docs: add localized demo videos

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -25,6 +25,7 @@
 </p>
 
 [ドキュメント](https://signalridge.github.io/slipway/) |
+[デモを見る](#デモを見る) |
 [ここから始める](docs/start-here.md) |
 [クイックスタート](#クイックスタート) |
 [インストール](docs/installation.md) |
@@ -41,6 +42,24 @@
 **AI 支援によるソフトウェアデリバリーのための、ローカルで動作する Git ネイティブな
 ガバナンス CLI。コードを書くのはエージェント、変更が本当に完了したかを判断するのは
 Slipway です。**
+
+## デモを見る
+
+<!-- markdownlint-disable MD034 -->
+<details open>
+<summary><strong>自動モード</strong>: 事前の承認がまだ有効なとき、ペーシング用の停止を自動で進めます。</summary>
+
+https://github.com/user-attachments/assets/23fe8af5-59de-4f07-898d-675badc86ba1
+
+</details>
+
+<details>
+<summary><strong>対話モード</strong>: 操作者の判断が必要な場所で停止します。</summary>
+
+https://github.com/user-attachments/assets/1e0048c0-7da5-41b4-a3da-e25cf2762ee1
+
+</details>
+<!-- markdownlint-enable MD034 -->
 
 AI コーディングエージェントは高速ですが、検証を飛ばしたり、計画から逸脱したり、
 現在のワークトリーで証明される前に「完了」と報告したりすることがあります。Slipway

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 </p>
 
 [Documentation](https://signalridge.github.io/slipway/) |
+[Watch Demos](#see-it-run) |
 [Start Here](docs/start-here.md) |
 [Quick Start](#quick-start) |
 [Installation](docs/installation.md) |
@@ -40,6 +41,24 @@
 
 **A local, Git-native governance CLI for AI-assisted software delivery. Your
 agent writes the code; Slipway decides when the change is actually done.**
+
+## See It Run
+
+<!-- markdownlint-disable MD034 -->
+<details open>
+<summary><strong>Auto mode</strong> - pacing pauses advance when prior authorization is still fresh.</summary>
+
+https://github.com/user-attachments/assets/fa0eb364-7967-4e74-ae56-e26e9e753b96
+
+</details>
+
+<details>
+<summary><strong>Interactive mode</strong> - checkpoints stop where operator judgment matters.</summary>
+
+https://github.com/user-attachments/assets/477ef7f0-cf68-49e1-be6f-76ba804be643
+
+</details>
+<!-- markdownlint-enable MD034 -->
 
 AI coding agents are fast, but they can skip verification, drift from the plan,
 or report "done" before the current worktree proves it. Slipway turns one unit

--- a/README.zh.md
+++ b/README.zh.md
@@ -25,6 +25,7 @@
 </p>
 
 [文档](https://signalridge.github.io/slipway/) |
+[观看动画](#看一遍流程) |
 [从这里开始](docs/start-here.md) |
 [快速上手](#快速上手) |
 [安装](docs/installation.md) |
@@ -39,6 +40,24 @@
 # Slipway
 
 **面向 AI 辅助软件交付的本地、Git 原生治理 CLI。你的 agent 负责写代码，Slipway 负责判定这个改动是否真的完成了。**
+
+## 看一遍流程
+
+<!-- markdownlint-disable MD034 -->
+<details open>
+<summary><strong>自动模式</strong>：在授权仍然有效时自动推进节奏性停顿。</summary>
+
+https://github.com/user-attachments/assets/a8a09c0d-b1eb-43d8-9137-a9fa4eaf601c
+
+</details>
+
+<details>
+<summary><strong>交互模式</strong>：在需要操作者判断的位置停下来。</summary>
+
+https://github.com/user-attachments/assets/fc10e83d-d08f-42ad-a51f-f3b3a58586de
+
+</details>
+<!-- markdownlint-enable MD034 -->
 
 AI 编码 agent 速度很快，但它们可能跳过验证、偏离计划，或者在当前 worktree 还没有给出证据之前就上报“完成”。Slipway 把一个工作单元变成一项受治理变更，带有生命周期状态、规划产物、任务证据、评审证据，以及一份留在仓库里的最终归档。
 

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -7,10 +7,14 @@ hero:
   image:
     file: ../../assets/slipway-wordmark.svg
   actions:
+    - text: Watch demos
+      link: "#watch-demos"
+      icon: right-arrow
+      variant: primary
     - text: Start Here
       link: /slipway/start-here/
       icon: right-arrow
-      variant: primary
+      variant: minimal
     - text: View on GitHub
       link: https://github.com/signalridge/slipway
       icon: external
@@ -29,6 +33,23 @@ what you want to build, and the generated adapter routes that request through th
 lifecycle — no command sequence to memorize. Slipway stays the authority on whether the
 change is actually done; the commands throughout these docs are what the agent runs for
 you, and what you can run directly whenever you want.
+
+<h2 id="watch-demos">Watch demos</h2>
+
+These short recordings show the two pacing modes most users care about first:
+hands-off progress when authorization is still fresh, and hard stops when operator
+judgment matters.
+
+<div class="demo-grid">
+	<figure class="demo-card">
+		<video controls muted playsInline preload="metadata" src="https://github.com/user-attachments/assets/fa0eb364-7967-4e74-ae56-e26e9e753b96"></video>
+		<figcaption><strong>Auto mode.</strong> Pacing pauses advance when prior authorization remains fresh.</figcaption>
+	</figure>
+	<figure class="demo-card">
+		<video controls muted playsInline preload="metadata" src="https://github.com/user-attachments/assets/477ef7f0-cf68-49e1-be6f-76ba804be643"></video>
+		<figcaption><strong>Interactive mode.</strong> Checkpoints stop where operator judgment matters.</figcaption>
+	</figure>
+</div>
 
 <CardGrid stagger>
 	<Card title="Tutorials" icon="open-book">

--- a/website/src/content/docs/ja/index.mdx
+++ b/website/src/content/docs/ja/index.mdx
@@ -7,10 +7,14 @@ hero:
   image:
     file: ../../../assets/slipway-wordmark.svg
   actions:
+    - text: デモを見る
+      link: "#watch-demos"
+      icon: right-arrow
+      variant: primary
     - text: はじめに
       link: /slipway/ja/start-here/
       icon: right-arrow
-      variant: primary
+      variant: minimal
     - text: GitHub で見る
       link: https://github.com/signalridge/slipway
       icon: external
@@ -22,6 +26,21 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 Slipway は、ローカルでの AI 支援開発を対象にした小さなガバナンス用コントロールプレーンです。AI コーディングツールやプロジェクト管理ツール、Git を置き換えるものではありません。すべての変更をライフサイクル、現在の権威ファイル、そしてセッションが終わったあとでも確認できる証拠に結びつけることで、エージェントの作業を読み取れるものにします。
 
 操作は自然言語で行います。一度だけ `slipway init` を実行すれば、あとは作りたいものを AI エージェントに伝えるだけで、生成されたアダプターがそのリクエストをガバナンス済みのライフサイクルへ流してくれます。覚えておくべきコマンドの並びはありません。変更が本当に完了したかどうかの判断は、最後まで Slipway が握ります。ドキュメントに出てくるコマンドは、エージェントがあなたの代わりに実行するものであり、好きなときに自分で実行することもできます。
+
+<h2 id="watch-demos">デモを見る</h2>
+
+この 2 つの短い録画では、最初に理解しておきたい 2 つの進み方を示します。承認がまだ有効なときの前進と、操作者の判断が必要な場所での停止です。
+
+<div class="demo-grid">
+	<figure class="demo-card">
+		<video controls muted playsInline preload="metadata" src="https://github.com/user-attachments/assets/23fe8af5-59de-4f07-898d-675badc86ba1"></video>
+		<figcaption><strong>自動モード。</strong>事前の承認がまだ有効なとき、ペーシング用の停止を進めます。</figcaption>
+	</figure>
+	<figure class="demo-card">
+		<video controls muted playsInline preload="metadata" src="https://github.com/user-attachments/assets/1e0048c0-7da5-41b4-a3da-e25cf2762ee1"></video>
+		<figcaption><strong>対話モード。</strong>操作者の判断が必要な場所で停止します。</figcaption>
+	</figure>
+</div>
 
 <CardGrid stagger>
 	<Card title="チュートリアル" icon="open-book">

--- a/website/src/content/docs/zh/index.mdx
+++ b/website/src/content/docs/zh/index.mdx
@@ -7,10 +7,14 @@ hero:
   image:
     file: ../../../assets/slipway-wordmark.svg
   actions:
+    - text: 观看动画
+      link: "#watch-demos"
+      icon: right-arrow
+      variant: primary
     - text: 从这里开始
       link: /slipway/zh/start-here/
       icon: right-arrow
-      variant: primary
+      variant: minimal
     - text: 在 GitHub 上查看
       link: https://github.com/signalridge/slipway
       icon: external
@@ -22,6 +26,21 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 Slipway 是一个轻量的治理控制面，服务于本地的 AI 辅助开发。它不取代你的 AI 编码工具、项目看板或 Git，而是把每一次变更绑定到一条生命周期、一份当前权威文件，以及一份会话结束后仍可查证的证据上，让 agent 的工作变得可读、可追溯。
 
 你用自然语言驱动它。一次性跑完 `slipway init` 之后，只要告诉 AI agent 你想做什么，生成的适配器就会把这个请求送进受管生命周期——没有命令序列需要背。一次变更到底有没有做完，由 Slipway 说了算；文档里出现的那些命令，是 agent 替你跑的，你也可以随时自己跑。
+
+<h2 id="watch-demos">观看动画</h2>
+
+这两段短录屏展示最先需要理解的两种节奏：授权仍然有效时继续向前推进，以及需要操作者判断时停下来。
+
+<div class="demo-grid">
+	<figure class="demo-card">
+		<video controls muted playsInline preload="metadata" src="https://github.com/user-attachments/assets/a8a09c0d-b1eb-43d8-9137-a9fa4eaf601c"></video>
+		<figcaption><strong>自动模式。</strong>授权仍然有效时，节奏性停顿会继续推进。</figcaption>
+	</figure>
+	<figure class="demo-card">
+		<video controls muted playsInline preload="metadata" src="https://github.com/user-attachments/assets/fc10e83d-d08f-42ad-a51f-f3b3a58586de"></video>
+		<figcaption><strong>交互模式。</strong>需要操作者判断的位置会停下来。</figcaption>
+	</figure>
+</div>
 
 <CardGrid stagger>
 	<Card title="教程" icon="open-book">

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -29,7 +29,7 @@ h3,
 .sl-markdown-content h2,
 .sl-markdown-content h3 {
 	font-family: var(--slip-display);
-	letter-spacing: -0.012em;
+	letter-spacing: 0;
 }
 
 /* Header wordmark sizing. */
@@ -76,4 +76,36 @@ a.site-title img {
 }
 .card .icon {
 	color: var(--slip-coral);
+}
+
+/* Landing page demo videos. */
+.demo-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(22rem, 1fr));
+	gap: 1rem;
+	margin: 1rem 0 2rem;
+}
+
+.demo-card {
+	margin: 0;
+}
+
+.demo-card video {
+	width: 100%;
+	aspect-ratio: 16 / 9;
+	border: 1px solid var(--sl-color-gray-5);
+	border-radius: 0.5rem;
+	background: #111;
+}
+
+.demo-card figcaption {
+	margin-top: 0.5rem;
+	font-size: var(--sl-text-sm);
+	color: var(--sl-color-gray-2);
+}
+
+@media (max-width: 36rem) {
+	.demo-grid {
+		grid-template-columns: 1fr;
+	}
 }


### PR DESCRIPTION
## Summary

- add language-matched demo video sections to the English, Chinese, and Japanese README files
- remove the English-only overview video from the README surface so each locale presents the same auto/interactive structure
- add localized demo videos to the Starlight docs landing pages and make the hero CTA point at the demo section
- add responsive styling for the docs video grid

## Validation

- `npx -y markdownlint-cli2@0.22.1 AGENTS.md CLAUDE.md CONTRIBUTING.md README.md README.zh.md README.ja.md "docs/**/*.md"`
- `git diff --check -- README.md README.zh.md README.ja.md website/src/content/docs/index.mdx website/src/content/docs/zh/index.mdx website/src/content/docs/ja/index.mdx website/src/styles/custom.css`
- `go run ./internal/toolgen/cmd/gen-surface-manifest --check`
- `(cd website && npm run build)`

## Notes

- Video URLs are GitHub issue attachments from #392.
- GitHub README video rendering requires the attachment URLs to remain bare, so the demo blocks locally disable `MD034/no-bare-urls` only around those URLs.
- The existing untracked `artifacts/reviews/` directory was left untouched.