### PR TITLE
feat(evidence): add --refresh-current for intentional review-evidence refresh (#384)

### DIFF
--- a/artifacts/changes/archived/fix-issue-384-expose-an-intentional-refresh-path-for-already/assurance.md
+++ b/artifacts/changes/archived/fix-issue-384-expose-an-intentional-refresh-path-for-already/assurance.md
@@ -1,0 +1,135 @@
+# Assurance
+
+## Scope Summary
+
+This change fixes issue #384 by adding an explicit `--refresh-current` option
+to `slipway evidence skill` for the narrow case where a selected S3 review
+skill already has current passing evidence and an operator intentionally reruns
+that review.
+
+Delivered scope:
+
+- `cmd/evidence.go`: parses `--refresh-current`, threads it into evidence skill
+  actionability, and permits replacement only inside the selected S3
+  review/current-passing branch.
+- `cmd/evidence_skill_test.go`: covers ordinary duplicate rejection and
+  explicit refresh success for `spec-compliance-review`, `code-quality-review`,
+  and `independent-review`.
+- `internal/tmpl/templates/_partials/command-evidence-body.tmpl`: documents the
+  flag in generated command-skill invocation, contract, and flags text.
+- `internal/toolgen/toolgen.go`: exposes `[--refresh-current]` in the
+  command-registry arguments used by generated command skills.
+- `internal/toolgen/surface_manifest.go` and
+  `internal/toolgen/surface_manifest_test.go`: add and pin the
+  `evidence-skill-refresh-current-json` public inventory row.
+- `docs/SURFACE-MANIFEST.json`: commits the regenerated inventory row.
+- `docs/commands.md`, `docs/reference/commands.md`, `docs/ja/commands.md`,
+  `docs/ja/reference/commands.md`, `docs/zh/commands.md`, and
+  `docs/zh/reference/commands.md`: expose the full refresh command token and
+  selected-review-only scope.
+
+Out-of-scope items remain out of scope: subagent configuration redesign,
+execution.auto behavior, plan-audit semantic rigor, release publishing, and
+broad evidence schema redesign.
+
+## Verification Verdict
+
+Verdict: pass for the repaired findings, subject to the normal governed
+`slipway run` gate before done-ready is re-established.
+
+The implementation satisfies the approved requirements while preserving default
+fail-closed duplicate evidence behavior. Selected S3 review evidence is
+re-recorded with explicit `same_context_degraded` fallback handles because this
+host did not have user-authorized native subagent dispatch for the review batch.
+
+## Evidence Index
+
+- `verification/spec-compliance-review.yaml`: pass; records `layer:R0=pass`,
+  `scope_contract:pass`, `negative_path:pass`, and a distinct review context
+  handle.
+- `verification/code-quality-review.yaml`: pass; records `layer:IR1=pass`,
+  `toolchain_compat:pass`, and a distinct review context handle.
+- `verification/independent-review.yaml`: pass; records independent review
+  pass with a distinct review context handle.
+- `verification/logs/ship-suite.txt`: fresh authoritative
+  `go test ./... -count=1` transcript.
+- `verification/logs/golangci-lint.txt`: `golangci-lint run ./...` transcript.
+- `verification/logs/diff-check.txt`: `git diff --check` transcript.
+- `verification/logs/surface-manifest-check.txt`:
+  `go run ./internal/toolgen/cmd/gen-surface-manifest --check` transcript.
+- `verification/logs/surface-manifest-tests.txt`: focused manifest/docs/args
+  contract test transcript.
+
+## Requirement Coverage
+
+- REQ-001 explicit current review evidence refresh: covered by
+  `cmd/evidence.go` and the refresh-current regression tests.
+- REQ-002 duplicate review evidence remains fail-closed by default: covered by
+  duplicate-rejection regression tests and unchanged fail-closed validation.
+- REQ-003 refresh path is discoverable: covered by CLI help, generated command
+  body template, command-registry arguments, committed surface manifest, focused
+  manifest tests, English docs, and localized Japanese/Chinese docs.
+
+## Added Args Visibility
+
+The newly added arg is visible in the source-owned and committed public
+surfaces:
+
+- CLI help lists `--refresh-current`.
+- `internal/toolgen/toolgen.go` command arguments include `[--refresh-current]`.
+- The command-skill body template includes the refresh invocation and flag.
+- `TestCodexCommandSkillsUseCommandRegistryArguments` proves fresh generated
+  Codex command skills render the updated arguments.
+- `docs/SURFACE-MANIFEST.json` includes
+  `evidence-skill-refresh-current-json`.
+- English, Japanese, and Chinese command docs include the full command token.
+
+Caveat: the root checkout's existing
+`.codex/skills/slipway-evidence/SKILL.md` is a generated local cache from an
+older export and still lacks `--refresh-current` until regenerated. The target
+worktree has no `.codex/skills/slipway-evidence` export. This change fixes the
+generation sources and tests the generated command-skill argument contract; it
+does not hand-edit that stale root-local cache.
+
+## Residual Risks and Exceptions
+
+- Audit-history tradeoff: the selected approach replaces the current
+  verification record instead of storing supplemental review history. This was
+  accepted in `decision.md` as the smallest fix for #384.
+- Same-context degraded review: native subagent dispatch was not user-authorized
+  in this host, so review and ship verification use the engine-exposed degraded
+  fallback path with explicit references.
+- Local generated cache drift: root `.codex/skills` must be refreshed after
+  this branch is applied if an agent reads that cache directly.
+- No guardrail domain is active for this change; no SAST high-risk token is
+  required.
+
+No unresolved blockers remain in the implemented scope.
+
+## Rollback Readiness
+
+Rollback is local and low-risk:
+
+- Remove `--refresh-current` flag registration and the boolean path through
+  `validateEvidenceSkillActionable`.
+- Restore the previous actionable validation signature and remediation text.
+- Remove the refresh-success regression rows and documentation updates.
+- Remove `evidence-skill-refresh-current-json` from the manifest generator and
+  regenerate `docs/SURFACE-MANIFEST.json`.
+- Re-run `go test ./cmd -run 'TestEvidenceSkill' -count=1`,
+  `go test ./internal/tmpl ./internal/toolgen -count=1`,
+  `go run ./internal/toolgen/cmd/gen-surface-manifest --check`,
+  `golangci-lint run ./...`, and `go test ./... -count=1`.
+
+No schema migration, data migration, irreversible operation, or external API
+rollback is needed.
+
+## Archive Decision
+
+Archive decision for this turn: do not archive yet. The user requested repair
+and confirmation, not `slipway done`.
+
+This assurance supports returning the active change to done-ready. Active
+validation/readiness proof must be captured before any future `slipway done`;
+archival must use the active `slipway done` gate rather than treating this
+active bundle as already archived.

--- a/artifacts/changes/archived/fix-issue-384-expose-an-intentional-refresh-path-for-already/change.yaml
+++ b/artifacts/changes/archived/fix-issue-384-expose-an-intentional-refresh-path-for-already/change.yaml
@@ -1,0 +1,60 @@
+version: 1
+slug: fix-issue-384-expose-an-intentional-refresh-path-for-already
+description: 'Fix issue #384: expose an intentional refresh path for already-current passing review evidence'
+status: done
+current_state: DONE
+needs_discovery: true
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-06-30T13:55:03.9079Z
+quality_mode: standard
+workflow_profile: code
+workflow_preset: standard
+worktree_branch: feat/fix-issue-384-expose-an-intentional-refresh-path-for-already
+artifact_schema: expanded
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: 7f3ac82a6996067a2386605b85f03fbaa86dd6bf4bc943141b18d1a2d54871d4
+        updated_at: 2026-06-30T15:34:01.369668249Z
+    decision:
+        id: decision
+        path: decision.md
+        state: frozen
+        content_hash: e1deb9601fed5e055e379a0f8a5a31d01446de89c4bf5921cc067785679be7ab
+        updated_at: 2026-06-30T14:18:19.738312648Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: 4492ea832b053a6b9aa638146c29ecc4147d5b556fae3fb3ef208cd89f1aece3
+        updated_at: 2026-06-30T14:10:05.25456465Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: 8082a5489b64fea8876fbbc92f3887635ccd974412c81eec0e39701157ae0556
+        updated_at: 2026-06-30T14:18:19.736806872Z
+    research:
+        id: research
+        path: research.md
+        state: frozen
+        content_hash: b544db237ac57ad2deb0514bfc63133a7f84a7b4349a733b2df03530baab6f8e
+        updated_at: 2026-06-30T14:13:08.216746781Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: 88c453d2df905401cf6e19d97ca9dd8d118e8de81f85093b52fdf3b623d6f14c
+        updated_at: 2026-06-30T15:17:33.063386946Z
+evidence_refs:
+    code-quality-review: .worktrees/fix-issue-384-expose-an-intentional-refresh-path-for-already/artifacts/changes/fix-issue-384-expose-an-intentional-refresh-path-for-already/verification/code-quality-review.yaml
+    independent-review: .worktrees/fix-issue-384-expose-an-intentional-refresh-path-for-already/artifacts/changes/fix-issue-384-expose-an-intentional-refresh-path-for-already/verification/independent-review.yaml
+    intake-clarification: .worktrees/fix-issue-384-expose-an-intentional-refresh-path-for-already/artifacts/changes/fix-issue-384-expose-an-intentional-refresh-path-for-already/verification/intake-clarification.yaml
+    plan-audit: .worktrees/fix-issue-384-expose-an-intentional-refresh-path-for-already/artifacts/changes/fix-issue-384-expose-an-intentional-refresh-path-for-already/verification/plan-audit.yaml
+    research-orchestration: .worktrees/fix-issue-384-expose-an-intentional-refresh-path-for-already/artifacts/changes/fix-issue-384-expose-an-intentional-refresh-path-for-already/verification/research-orchestration.yaml
+    ship-verification: .worktrees/fix-issue-384-expose-an-intentional-refresh-path-for-already/artifacts/changes/fix-issue-384-expose-an-intentional-refresh-path-for-already/verification/ship-verification.yaml
+    spec-compliance-review: .worktrees/fix-issue-384-expose-an-intentional-refresh-path-for-already/artifacts/changes/fix-issue-384-expose-an-intentional-refresh-path-for-already/verification/spec-compliance-review.yaml
+    wave-orchestration: .worktrees/fix-issue-384-expose-an-intentional-refresh-path-for-already/artifacts/changes/fix-issue-384-expose-an-intentional-refresh-path-for-already/verification/wave-orchestration.yaml

--- a/artifacts/changes/archived/fix-issue-384-expose-an-intentional-refresh-path-for-already/decision.md
+++ b/artifacts/changes/archived/fix-issue-384-expose-an-intentional-refresh-path-for-already/decision.md
@@ -1,0 +1,37 @@
+# Decision
+
+## Alternatives Considered
+
+### Always allow selected reviewer overwrite
+This would remove the current duplicate-evidence barrier for selected S3 review skills. It is simple, but it weakens the default fail-closed behavior and makes accidental restamps indistinguishable from intentional operator reruns.
+
+### Add explicit refresh flag
+This keeps the current default rejection and adds an opt-in path for the exact #384 workflow. It reuses the existing verification write and digest stamp path after the actionable guard accepts the explicit refresh.
+
+### Add supplemental review-note storage
+This would preserve both the original and rerun notes without replacing the current verification record. It has better audit-history ergonomics, but it requires new storage and read surfaces that are larger than the issue requires.
+
+Selected direction: add an explicit refresh flag.
+
+## Selected Approach
+
+Add a `--refresh-current` flag to `slipway evidence skill`. The flag only affects S3 selected review skills that already have passing evidence for the current review set. Without the flag, existing duplicate-evidence behavior remains unchanged. With the flag, the command may pass the current-evidence guard and then reuse the existing record creation, `state.SaveVerification`, digest stamping, change evidence-ref update, and lifecycle event path.
+
+The option is intentionally narrow: it is not a generic bypass for wrong lifecycle state, unselected review skills, missing execution summaries, failing blockers, or stale digest input failures.
+
+## Interfaces and Data Flow
+
+- CLI interface: `slipway evidence skill --refresh-current --skill <review-skill> --verdict pass ...`.
+- Command flow: Cobra parses `--refresh-current`, `makeEvidenceSkillCmd` passes it into the actionable validation, and validation only permits it when the requested skill is in the selected S3 review set and already has passing evidence for the current run.
+- Persistence flow: unchanged after validation. The replacement writes `verification/<skill>.yaml`, stamps the evidence digest for passing records, updates `change.yaml` evidence refs, and appends the lifecycle event.
+- Generated/agent surface: command metadata and the evidence command partial document the flag.
+
+## Rollout and Rollback
+
+Rollout is additive and local to the evidence command. Rollback is to remove the flag, restore the previous actionable validation signature, remove the tests, and rerun `go test ./cmd -run 'TestEvidenceSkill' -count=1` plus the full suite used for ship verification.
+
+## Risk
+
+- Accidental restamp risk is controlled by requiring `--refresh-current`.
+- Scope-creep risk is controlled by limiting the flag to selected S3 review skills and leaving task evidence, ship verification, and non-review skill ordering untouched.
+- Documentation drift risk is controlled by updating generated command metadata and template coverage so agents can discover the flag.

--- a/artifacts/changes/archived/fix-issue-384-expose-an-intentional-refresh-path-for-already/intent.md
+++ b/artifacts/changes/archived/fix-issue-384-expose-an-intentional-refresh-path-for-already/intent.md
@@ -1,0 +1,46 @@
+# Intent
+
+## Summary
+Fix issue #384: expose an intentional refresh path for already-current passing review evidence
+## Complexity Assessment
+complex
+Rationale: this changes a public evidence CLI workflow and must preserve existing fail-closed evidence semantics while adding an explicit operator-requested refresh path.
+
+## Guardrail Domains
+None detected.
+
+## In Scope
+- Update the `slipway evidence skill` public behavior for already-current passing review evidence.
+- Add or adjust CLI help, remediation, and validation text so an explicit review rerun has an actionable path.
+- Add focused regression tests covering refresh of already-current passing review evidence for selected review skills.
+- Keep the fix scoped to issue #384 and the evidence recording surface.
+
+## Out of Scope
+- Subagent configuration redesign from #359/#360.
+- `execution.auto` behavior changes from #361.
+- Plan-audit semantic rigor and decision-soundness changes from #371.
+- Release publishing or unrelated active governed changes.
+- Broad evidence schema redesign unless a minimal local extension is required for #384.
+
+## Constraints
+- Preserve fail-closed evidence discipline: no silent restamp, bypass, or forged freshness state.
+- Existing non-refresh evidence behavior must remain compatible unless explicitly invalid.
+- The public CLI must make the supported operator action discoverable.
+- Keep implementation and tests narrow enough for a high-ROI fix.
+
+## Acceptance Signals
+- A previously passing and current review skill can be intentionally refreshed or otherwise recorded through a documented public command path.
+- The old dead-end `skill already has passing evidence for the current review set` behavior no longer blocks an explicit refresh workflow.
+- Regression tests cover the already-current passing evidence case and prove ordinary duplicate recording still fails unless the explicit refresh path is requested.
+- `go test ./...` passes or any failure is documented with root cause.
+
+## Open Questions
+None.
+
+## Deferred Ideas
+- A broader supplemental-review attachment model can be considered later if refresh semantics need richer audit history.
+
+## Approved Summary
+Confirmed by user on 2026-06-30T14:09:07Z.
+
+Fix issue #384 by adding a supported public path for intentionally refreshing already-current passing review evidence. Scope includes the evidence CLI behavior, user-facing help/remediation, and focused regression tests for the already-current passing evidence case across review skills. Out of scope: the broader subagent configuration redesign in #359/#360, execution.auto behavior in #361, plan-audit semantic rigor in #371, and unrelated release publishing work. Primary acceptance signal: a previously passing/current review skill can be intentionally refreshed or otherwise recorded through a documented public command path, with tests proving the old dead-end error no longer blocks the explicit refresh workflow.

--- a/artifacts/changes/archived/fix-issue-384-expose-an-intentional-refresh-path-for-already/requirements.md
+++ b/artifacts/changes/archived/fix-issue-384-expose-an-intentional-refresh-path-for-already/requirements.md
@@ -1,0 +1,27 @@
+# Requirements
+
+## Requirements
+
+### Requirement: Explicit current review evidence refresh
+REQ-001: The system MUST provide a documented `slipway evidence skill` option that lets an operator intentionally refresh already-current passing evidence for a selected S3 review skill.
+
+#### Scenario: Refresh a selected current reviewer
+GIVEN an active governed change in S3 review with a selected review skill that already has passing evidence for the current review set
+WHEN an operator records a new passing result for that same skill using the explicit refresh option
+THEN Slipway SHALL replace the skill verification record and stamp the current evidence digest instead of returning the existing duplicate-evidence dead end.
+
+### Requirement: Duplicate review evidence remains fail-closed by default
+REQ-002: The system MUST reject ordinary duplicate recording of already-current passing selected review evidence unless the operator supplied the explicit refresh option or an existing narrow repair condition applies.
+
+#### Scenario: Duplicate reviewer without refresh opt-in
+GIVEN an active governed change in S3 review with current passing selected review evidence
+WHEN an operator records a new passing result for the same skill without the explicit refresh option
+THEN Slipway SHALL reject the command with a clear invalid-usage error and preserve the existing verification record.
+
+### Requirement: Refresh path is discoverable
+REQ-003: The system MUST document the explicit refresh option in the CLI help-facing command surface and generated command metadata.
+
+#### Scenario: Agent discovers refresh workflow
+GIVEN an agent or operator reads the evidence command surface
+WHEN they need to record an intentional rerun for already-current passing review evidence
+THEN the command documentation SHALL name the explicit refresh option and its selected-review scope.

--- a/artifacts/changes/archived/fix-issue-384-expose-an-intentional-refresh-path-for-already/research.md
+++ b/artifacts/changes/archived/fix-issue-384-expose-an-intentional-refresh-path-for-already/research.md
@@ -1,0 +1,52 @@
+# Research
+
+## Alternatives Considered
+
+### Architecture
+- Affected modules: `cmd/evidence.go`, `cmd/evidence_skill_test.go`, `internal/tmpl/templates/_partials/command-evidence-body.tmpl`, `internal/toolgen/toolgen.go`, and `docs/reference/commands.md`.
+- Dependency chains: `makeEvidenceSkillCmd` parses CLI flags and validates skill/stage state before writing `model.VerificationRecord` through `state.SaveVerification` and stamping digests through `progression.StampEvidenceDigestForSkill` (`cmd/evidence.go:108`, `cmd/evidence.go:196`, `cmd/evidence.go:217`, `cmd/evidence.go:235`, `cmd/evidence.go:247`). The actionable gate for selected S3 review skills is `validateEvidenceSkillActionable` (`cmd/evidence.go:2241`).
+- Blast radius: the change should stay inside the evidence skill command, tests, and generated command surface text. It should not alter `VerificationRecord` storage or lifecycle stage advancement.
+- Constraints: current passing review evidence is deliberately rejected by default (`cmd/evidence.go:2257`) while narrow in-place replacement already exists for invalid review context origin and repair alignment cases (`cmd/evidence.go:2243`, `cmd/evidence.go:2250`).
+
+### Patterns
+- Existing conventions: `evidence skill` is a Cobra command with local flags and no positional args (`cmd/evidence.go:117`); flags are registered near command construction (`cmd/evidence.go:364`). Command handlers return typed CLI errors instead of printing or exiting.
+- Reusable abstractions: existing duplicate/current evidence rejection can be extended by threading a boolean through `validateEvidenceSkillActionable` rather than adding a new persistence shape.
+- Convention deviations: allowing refresh by default would violate the current fail-closed default, so any refresh path needs an explicit opt-in flag and clear help text.
+
+### Risks
+- Technical risks: medium. Incorrectly relaxing the duplicate check could let agents restamp evidence silently and mask stale review state.
+- Guardrail domains: none detected; this is governance workflow logic, not auth, credentials, privacy, finance, schema migration, irreversible operations, or external API contracts.
+- Reversibility: high. The recommended change is additive CLI surface plus tests; rollback removes the flag and restores the previous actionable check.
+
+### Test Strategy
+- Existing coverage: `TestEvidenceSkillAllowsSelectedReviewerRestampForInvalidContextOrigin` proves the narrow replacement door for invalid context origin (`cmd/evidence_skill_test.go:527`). `TestEvidenceSkillRejectsSelectedReviewerRestampWithValidContextOrigin` proves valid/current duplicate review evidence is rejected today (`cmd/evidence_skill_test.go:583`).
+- Infrastructure needs: no new helpers are required; existing fixtures already create S3 review state, execution summary, selected review evidence, and evidence digests.
+- Verification approach: add tests showing ordinary duplicate recording remains rejected, while the same duplicate with an explicit refresh flag overwrites the selected review skill record, restamps the digest, and returns JSON with recorded/stamped true.
+
+### Options
+- Option 1: Make current passing selected review evidence always overwriteable. Tradeoff: simplest implementation, but it weakens the default fail-closed guard and makes accidental restamps indistinguishable from intentional operator reruns.
+- Option 2: Add an explicit `--refresh-current` flag for selected S3 review skills that already have current passing evidence. Tradeoff: one public flag plus documentation/tests, but preserves existing default rejection and gives operators the missing intentional path from #384.
+- Option 3: Add a supplemental notes model without overwriting verification records. Tradeoff: preserves history better, but requires new storage/read surfaces and does not satisfy the existing CLI's expectation that the rerun pass can update the current review handle.
+- Selected: Option 2. It is the smallest public-surface fix that addresses #384 without weakening ordinary duplicate evidence rejection.
+
+## Unknowns
+- Resolved: Whether this needs a schema change -> no; the current `VerificationRecord` write/stamp flow already supports replacing a record once `validateEvidenceSkillActionable` permits it.
+- Resolved: Whether docs/agent surfaces need updates -> yes; the evidence command partial and command manifest currently list no refresh path (`internal/tmpl/templates/_partials/command-evidence-body.tmpl:14`, `internal/tmpl/templates/_partials/command-evidence-body.tmpl:53`, `internal/toolgen/toolgen.go:345`).
+- Remaining: None.
+
+## Assumptions
+- `--refresh-current` should be limited to S3 selected review skills that already have passing evidence for the current review set. Evidence: the observed issue concerns rerun review peers in S3, and `validateEvidenceSkillActionable` has S3 selected-review-specific logic (`cmd/evidence.go:2241`).
+- Ordinary duplicate recording without explicit refresh should continue to fail. Evidence: existing regression test asserts this fail-closed behavior for valid context origin (`cmd/evidence_skill_test.go:583`).
+- The codebase map is stale for this change. Evidence: `artifacts/codebase/ARCHITECTURE.md` and related docs describe route/freshness/capability public surfaces, not `evidence skill` refresh behavior.
+
+## Canonical References
+- `cmd/evidence.go:108`
+- `cmd/evidence.go:196`
+- `cmd/evidence.go:217`
+- `cmd/evidence.go:2241`
+- `cmd/evidence.go:2257`
+- `cmd/evidence_skill_test.go:527`
+- `cmd/evidence_skill_test.go:583`
+- `internal/tmpl/templates/_partials/command-evidence-body.tmpl:14`
+- `internal/tmpl/templates/_partials/command-evidence-body.tmpl:53`
+- `internal/toolgen/toolgen.go:345`

--- a/artifacts/changes/archived/fix-issue-384-expose-an-intentional-refresh-path-for-already/tasks.md
+++ b/artifacts/changes/archived/fix-issue-384-expose-an-intentional-refresh-path-for-already/tasks.md
@@ -1,0 +1,21 @@
+# Tasks
+
+## Task List
+
+- [x] `t-01` Add explicit current-review refresh behavior to the evidence skill command
+  - depends_on: []
+  - target_files: [cmd/evidence.go]
+  - task_kind: code
+  - covers: [REQ-001, REQ-002]
+
+- [x] `t-02` Add focused regression coverage for duplicate rejection and explicit refresh success
+  - depends_on: [t-01]
+  - target_files: [cmd/evidence_skill_test.go]
+  - task_kind: test
+  - covers: [REQ-001, REQ-002]
+
+- [x] `t-03` Document the refresh option in public command surfaces
+  - depends_on: [t-01]
+  - target_files: [internal/tmpl/templates/_partials/command-evidence-body.tmpl, internal/toolgen/toolgen.go, internal/toolgen/surface_manifest.go, internal/toolgen/surface_manifest_test.go, docs/SURFACE-MANIFEST.json, docs/reference/commands.md, docs/commands.md, docs/ja/reference/commands.md, docs/ja/commands.md, docs/zh/reference/commands.md, docs/zh/commands.md]
+  - task_kind: doc
+  - covers: [REQ-003]

--- a/cmd/evidence.go
+++ b/cmd/evidence.go
@@ -104,14 +104,15 @@ func rejectRetiredEvidenceSubcommands(cmd *cobra.Command, args []string) error {
 
 func makeEvidenceSkillCmd() *cobra.Command {
 	var (
-		jsonOutput bool
-		changeSlug string
-		skillName  string
-		verdictRaw string
-		references []string
-		blockers   []string
-		notes      string
-		notesFile  string
+		jsonOutput     bool
+		changeSlug     string
+		skillName      string
+		verdictRaw     string
+		references     []string
+		blockers       []string
+		notes          string
+		notesFile      string
+		refreshCurrent bool
 	)
 
 	cmd := &cobra.Command{
@@ -197,7 +198,7 @@ func makeEvidenceSkillCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				if err := validateEvidenceSkillActionable(root, change, def, runVersion); err != nil {
+				if err := validateEvidenceSkillActionable(root, change, def, runVersion, refreshCurrent); err != nil {
 					return err
 				}
 				references = stringutil.UniqueSorted(trimNonEmptyStrings(references))
@@ -362,6 +363,7 @@ func makeEvidenceSkillCmd() *cobra.Command {
 	cmd.Flags().StringArrayVar(&blockers, "blocker", nil, "Verification blocker as code or code:detail; may be repeated")
 	cmd.Flags().StringVar(&notes, "notes", "", "Bounded verification notes")
 	cmd.Flags().StringVar(&notesFile, "notes-file", "", "Workspace-relative file containing verification notes")
+	cmd.Flags().BoolVar(&refreshCurrent, "refresh-current", false, "Intentionally replace already-current passing evidence for a selected S3 review skill")
 
 	return cmd
 }
@@ -2228,7 +2230,7 @@ func restoreVerificationSuffix(err error) string {
 	return fmt.Sprintf("; rollback failed: %v", err)
 }
 
-func validateEvidenceSkillActionable(root string, change model.Change, def skill.Definition, runVersion int) error {
+func validateEvidenceSkillActionable(root string, change model.Change, def skill.Definition, runVersion int, refreshCurrent bool) error {
 	if change.CurrentState == model.StateS3Review {
 		reviewSelection, selectedReviewSkills, err := selectedReviewSkillsForChange(root, change)
 		if err != nil {
@@ -2254,10 +2256,13 @@ func validateEvidenceSkillActionable(root string, change model.Change, def skill
 				if repairActive {
 					return nil
 				}
+				if refreshCurrent {
+					return nil
+				}
 				return newInvalidUsageError(
 					"evidence_skill_not_current",
 					fmt.Sprintf("skill %s already has passing evidence for the current review set", def.Name),
-					"Run `slipway next --json` and record evidence only for a selected review skill that is still missing or stale.",
+					"Run `slipway next --json` and record evidence only for a selected review skill that is still missing or stale. If an operator intentionally reran this selected review skill, rerun with `--refresh-current` to replace the current evidence.",
 					map[string]any{"skill": def.Name},
 				)
 			}

--- a/cmd/evidence_skill_test.go
+++ b/cmd/evidence_skill_test.go
@@ -605,6 +605,7 @@ func TestEvidenceSkillRejectsSelectedReviewerRestampWithValidContextOrigin(t *te
 		cliErr := asCLIError(cmd.Execute())
 		require.NotNil(t, cliErr)
 		assert.Equal(t, "evidence_skill_not_current", cliErr.ErrorCode)
+		assert.Contains(t, cliErr.Remediation, "--refresh-current")
 
 		rec, err := state.LoadVerification(root, slug, progression.SkillSpecComplianceReview)
 		require.NoError(t, err)
@@ -613,6 +614,104 @@ func TestEvidenceSkillRejectsSelectedReviewerRestampWithValidContextOrigin(t *te
 		assert.Equal(t, testSpecContextHandle, handle.Handle)
 		assert.NotEqual(t, "Unexpected spec-compliance review overwrite.", rec.Notes)
 	})
+}
+
+func TestEvidenceSkillRefreshCurrentSelectedReviewerWithValidContextOrigin(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		skillName   string
+		freshHandle string
+		references  []string
+	}{
+		{
+			name:        "spec compliance review",
+			skillName:   progression.SkillSpecComplianceReview,
+			freshHandle: "fresh-spec-compliance-review-context",
+			references: []string{
+				"layer:R0=pass",
+				"scope_contract:pass",
+				"negative_path:pass",
+				model.ContextOriginReferencePrefix + model.StageContextReview + "=fresh-spec-compliance-review-context",
+			},
+		},
+		{
+			name:        "code quality review",
+			skillName:   progression.SkillCodeQualityReview,
+			freshHandle: "fresh-code-quality-review-context",
+			references: []string{
+				"layer:IR1=pass",
+				"layer:IR3=pass",
+				"layer:QUALITY=pass",
+				model.ContextOriginReferencePrefix + model.StageContextReview + "=fresh-code-quality-review-context",
+			},
+		},
+		{
+			name:        "independent review",
+			skillName:   progression.SkillIndependentReview,
+			freshHandle: "fresh-independent-review-context",
+			references: []string{
+				"independent-review:pass",
+				model.ContextOriginReferencePrefix + model.StageContextReview + "=fresh-independent-review-context",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := t.TempDir()
+			withCommandWorkspace(t, root, func() {
+				initTestWorkspace(t, root)
+				slug := createGovernedRequest(t, root, levelNonDiscovery, "evidence skill refreshes current reviewer")
+				setEvidenceSkillChangeState(t, root, slug, model.StateS3Review, model.PlanSubStepNone)
+				writePassingExecutionSummary(t, root, slug, 1, "t-01")
+				writePassingReviewEvidencePack(t, root, slug, 1)
+
+				cmd := commandForRoot(t, root, makeEvidenceCmd())
+				args := []string{
+					"skill",
+					"--json",
+					"--change", slug,
+					"--skill", tt.skillName,
+					"--verdict", model.VerificationVerdictPass,
+					"--refresh-current",
+					"--notes", "Selected reviewer intentionally reran in fresh context.",
+				}
+				for _, ref := range tt.references {
+					args = append(args, "--reference", ref)
+				}
+				cmd.SetArgs(args)
+				var out bytes.Buffer
+				cmd.SetOut(&out)
+				require.NoError(t, cmd.Execute())
+
+				var view evidenceSkillView
+				require.NoError(t, json.Unmarshal(out.Bytes(), &view))
+				assert.Equal(t, tt.skillName, view.SkillName)
+				assert.Equal(t, 1, view.RunVersion)
+				assert.True(t, view.Recorded)
+				assert.True(t, view.Stamped)
+
+				rec, err := state.LoadVerification(root, slug, tt.skillName)
+				require.NoError(t, err)
+				assert.Equal(t, model.VerificationVerdictPass, rec.Verdict)
+				assert.Equal(t, "Selected reviewer intentionally reran in fresh context.", rec.Notes)
+				handle, ok := model.ReviewContextOriginHandleFromVerification(rec)
+				require.True(t, ok)
+				assert.Equal(t, tt.freshHandle, handle.Handle)
+
+				change, err := state.LoadChange(root, slug)
+				require.NoError(t, err)
+				digests, err := state.LoadEvidenceDigestsForChange(root, change)
+				require.NoError(t, err)
+				require.Contains(t, digests.Skills, tt.skillName)
+			})
+		})
+	}
 }
 
 func TestEvidenceSkillRejectsUnselectedSecurityReview(t *testing.T) {

--- a/docs/SURFACE-MANIFEST.json
+++ b/docs/SURFACE-MANIFEST.json
@@ -325,6 +325,13 @@
     },
     {
       "kind": "json-contract",
+      "name": "evidence-skill-refresh-current-json",
+      "source": "cmd/evidence.go",
+      "docs": "docs/reference/commands.md",
+      "token": "slipway evidence skill --skill \u003cname\u003e --verdict pass --refresh-current --json"
+    },
+    {
+      "kind": "json-contract",
       "name": "evidence-task-json",
       "source": "cmd/evidence.go",
       "docs": "docs/reference/commands.md",

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -243,6 +243,7 @@ Stable manifest tokens for JSON contract coverage:
 | delete JSON | `slipway delete --change <slug> --json` |
 | done JSON | `slipway done` |
 | evidence skill JSON | `slipway evidence skill --skill <name> --verdict pass --json` |
+| evidence skill refresh-current JSON | `slipway evidence skill --skill <name> --verdict pass --refresh-current --json` |
 | evidence task JSON | `slipway evidence task --result-file task-result.json [--result-file next-task-result.json ...] --json` |
 | fix JSON | `slipway fix --json` |
 | handoff JSON | `slipway handoff show --json` |

--- a/docs/ja/commands.md
+++ b/docs/ja/commands.md
@@ -145,6 +145,7 @@ JSON コントラクトのカバレッジ向けの安定したマニフェスト
 | delete JSON | `slipway delete --change <slug> --json` |
 | done JSON | `slipway done` |
 | evidence skill JSON | `slipway evidence skill --skill <name> --verdict pass --json` |
+| evidence skill refresh-current JSON | `slipway evidence skill --skill <name> --verdict pass --refresh-current --json` |
 | evidence task JSON | `slipway evidence task --result-file task-result.json [--result-file next-task-result.json ...] --json` |
 | fix JSON | `slipway fix --json` |
 | handoff JSON | `slipway handoff show --json` |

--- a/docs/ja/reference/commands.md
+++ b/docs/ja/reference/commands.md
@@ -67,6 +67,7 @@ slipway delete --change <slug> --json
 slipway repair --json
 slipway evidence task --result-file task-result.json [--result-file next-task-result.json ...] --json
 slipway evidence skill --skill <name> --verdict pass --json
+slipway evidence skill --skill <name> --verdict pass --refresh-current --json
 slipway health --json
 slipway instructions <artifact> --json
 slipway config list --json
@@ -82,6 +83,7 @@ slipway config list --json
 - `slipway handoff show --json` は現在の変更ごとの handoff を構造化して出力します。
 - `slipway evidence task --result-file <path> --json` はコンパクトな実行タスク結果を取り込みます。原子的なバッチにするには `--result-file` を繰り返します。
 - `slipway evidence skill --skill <name> --verdict pass --json` は、そのスキルを所有するステージで統制スキルのエビデンスを記録します。
+- `slipway evidence skill --skill <name> --verdict pass --refresh-current --json` は、選択済み S3 レビュースキルの既に current な passing エビデンスを、意図的な再実行として置き換える場合だけに使います。通常の重複エビデンスは引き続き拒否されます。
 - `slipway status --stats --json` は、廃止されたトップレベルの `stats` コマンドを戻さずにワークスペース診断を報告します。
 - `slipway health --doctor --json` は、ヘルスレポートに修復向けの診断を追加します。
 - `slipway tool <helper>` は生成されたスキルから直接呼び出され、生成されたアダプターのプロンプトサーフェスはありません。

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -64,6 +64,7 @@ slipway delete --change <slug> --json
 slipway repair --json
 slipway evidence task --result-file task-result.json [--result-file next-task-result.json ...] --json
 slipway evidence skill --skill <name> --verdict pass --json
+slipway evidence skill --skill <name> --verdict pass --refresh-current --json
 slipway health --json
 slipway instructions <artifact> --json
 slipway config list --json
@@ -78,6 +79,7 @@ artifact-readiness detail, transition traces, or context-budget diagnostics.
 - `slipway handoff show --json` emits the current per-change handoff in structured form.
 - `slipway evidence task --result-file <path> --json` imports compact executor task results; repeat `--result-file` for an atomic batch.
 - `slipway evidence skill --skill <name> --verdict pass --json` records governed skill evidence at the stage that owns that skill.
+- `slipway evidence skill --skill <name> --verdict pass --refresh-current --json` is only for an intentional rerun that replaces already-current passing evidence for a selected S3 review skill; ordinary duplicate evidence remains rejected.
 - `slipway status --stats --json` reports workspace diagnostics without reviving the retired top-level `stats` command.
 - `slipway health --doctor --json` adds repair-oriented diagnostics to the health report.
 - `slipway tool <helper>` is invoked directly by generated skills and has no generated adapter prompt surface.

--- a/docs/zh/commands.md
+++ b/docs/zh/commands.md
@@ -206,6 +206,7 @@ slipway health --doctor --json
 | delete JSON | `slipway delete --change <slug> --json` |
 | done JSON | `slipway done` |
 | evidence skill JSON | `slipway evidence skill --skill <name> --verdict pass --json` |
+| evidence skill refresh-current JSON | `slipway evidence skill --skill <name> --verdict pass --refresh-current --json` |
 | evidence task JSON | `slipway evidence task --result-file task-result.json [--result-file next-task-result.json ...] --json` |
 | fix JSON | `slipway fix --json` |
 | handoff JSON | `slipway handoff show --json` |

--- a/docs/zh/reference/commands.md
+++ b/docs/zh/reference/commands.md
@@ -63,6 +63,7 @@ slipway delete --change <slug> --json
 slipway repair --json
 slipway evidence task --result-file task-result.json [--result-file next-task-result.json ...] --json
 slipway evidence skill --skill <name> --verdict pass --json
+slipway evidence skill --skill <name> --verdict pass --refresh-current --json
 slipway health --json
 slipway instructions <artifact> --json
 slipway config list --json
@@ -77,6 +78,7 @@ slipway config list --json
 - `slipway handoff show --json` 以结构化形式输出当前变更的 handoff。
 - `slipway evidence task --result-file <path> --json` 导入紧凑的执行任务结果；重复 `--result-file` 可进行原子批量导入。
 - `slipway evidence skill --skill <name> --verdict pass --json` 在拥有该 skill 的阶段记录治理 skill 证据。
+- `slipway evidence skill --skill <name> --verdict pass --refresh-current --json` 只用于把已选 S3 review skill 的当前 passing 证据作为一次明确重跑来替换；普通重复证据仍会被拒绝。
 - `slipway status --stats --json` 报告工作区诊断，不重新引入已退休的顶层 `stats` 命令。
 - `slipway health --doctor --json` 在 health 报告中加入面向修复的诊断。
 - `slipway tool <helper>` 由生成的 skill 直接调用，不生成适配器提示词接入面。

--- a/internal/tmpl/templates/_partials/command-evidence-body.tmpl
+++ b/internal/tmpl/templates/_partials/command-evidence-body.tmpl
@@ -13,6 +13,9 @@ slipway evidence task --result-file <path> [--result-file <path> ...] --json
 
 slipway evidence skill --skill <name> --verdict <pass|fail> \
   --reference "<ref>" --notes-file <path> --json
+
+slipway evidence skill --skill <selected-review-skill> --verdict pass \
+  --refresh-current --reference "<ref>" --notes-file <path> --json
 ```
 
 ## Contract
@@ -33,6 +36,10 @@ slipway evidence skill --skill <name> --verdict <pass|fail> \
 - `evidence skill` validates the requested skill against the current lifecycle
   state and plan substep, and run-summary-bound skills require a ready
   `execution-summary.yaml`.
+- `--refresh-current` is an explicit opt-in replacement path for an
+  already-current passing selected S3 review skill after an operator
+  intentionally reruns that review. Without it, duplicate current review evidence
+  remains fail-closed.
 - `evidence skill` writes the verification record, updates the change evidence
   reference, and does not advance lifecycle state; advance separately with
   `slipway run`.
@@ -58,6 +65,8 @@ slipway evidence skill --skill <name> --verdict <pass|fail> \
 - `--blocker <code[:detail]>`: skill blocker (repeatable)
 - `--notes <text>`: inline verification notes
 - `--notes-file <path>`: file containing verification notes
+- `--refresh-current`: intentionally replace already-current passing evidence
+  for a selected S3 review skill
 - `--json`: JSON output
 - `--change <slug>`: target a specific active change
 {{- end -}}

--- a/internal/toolgen/surface_manifest.go
+++ b/internal/toolgen/surface_manifest.go
@@ -173,6 +173,13 @@ func jsonContractRows() []SurfaceManifestRow {
 					Docs:   "docs/reference/commands.md",
 					Token:  "slipway evidence skill --skill <name> --verdict pass --json",
 				},
+				SurfaceManifestRow{
+					Kind:   "json-contract",
+					Name:   "evidence-skill-refresh-current-json",
+					Source: commandSourcePath(def.ID),
+					Docs:   "docs/reference/commands.md",
+					Token:  "slipway evidence skill --skill <name> --verdict pass --refresh-current --json",
+				},
 			)
 			continue
 		}

--- a/internal/toolgen/surface_manifest_test.go
+++ b/internal/toolgen/surface_manifest_test.go
@@ -106,7 +106,7 @@ func TestBuildSurfaceManifestDerivesRowsFromSlipwayAuthorities(t *testing.T) {
 			continue
 		}
 		if def.ID == "evidence" {
-			for _, id := range []string{"evidence-task-json", "evidence-skill-json"} {
+			for _, id := range []string{"evidence-task-json", "evidence-skill-json", "evidence-skill-refresh-current-json"} {
 				row, ok := rowsByKey["json-contract/"+id]
 				require.Truef(t, ok, "missing json contract row for %s", id)
 				assert.Equal(t, "cmd/evidence.go", row.Source)
@@ -131,6 +131,26 @@ func TestBuildSurfaceManifestDerivesRowsFromSlipwayAuthorities(t *testing.T) {
 		assert.Equal(t, path, row.Docs)
 		assert.Equal(t, path, row.Name)
 	}
+}
+
+func TestSurfaceManifestExposesEvidenceRefreshCurrentJSONContract(t *testing.T) {
+	t.Parallel()
+
+	manifest := BuildSurfaceManifest()
+	for _, row := range manifest.Rows {
+		if row.Kind != "json-contract" || row.Name != "evidence-skill-refresh-current-json" {
+			continue
+		}
+
+		assert.Equal(t, "cmd/evidence.go", row.Source)
+		assert.Equal(t, "docs/reference/commands.md", row.Docs)
+		assert.Equal(t,
+			"slipway evidence skill --skill <name> --verdict pass --refresh-current --json",
+			row.Token)
+		return
+	}
+
+	t.Fatal("surface manifest must expose the evidence skill refresh-current JSON contract")
 }
 
 func TestCommittedSurfaceManifestMatchesBuilder(t *testing.T) {

--- a/internal/toolgen/toolgen.go
+++ b/internal/toolgen/toolgen.go
@@ -342,7 +342,7 @@ var commandRegistry = []CommandDef{
 		Arguments:     "[--json] [--focus <alias>] [--list-focuses] [--format text|json]",
 		Prerequisites: []string{"`.slipway.yaml` must exist (run `slipway init` first)"}},
 	{ID: "evidence", Class: CommandClassMutation, Description: "Record supported runtime and skill verification evidence", Tier: "situational", HasPromptSurface: true,
-		Arguments:     "task --result-file <path> [--result-file <path> ...] [--json] [--change <slug>]; skill --skill <name> --verdict <pass|fail> [--reference <ref> ...] [--blocker <code[:detail]> ...] [--notes <text>|--notes-file <path>] [--json] [--change <slug>]",
+		Arguments:     "task --result-file <path> [--result-file <path> ...] [--json] [--change <slug>]; skill --skill <name> --verdict <pass|fail> [--reference <ref> ...] [--blocker <code[:detail]> ...] [--notes <text>|--notes-file <path>] [--refresh-current] [--json] [--change <slug>]",
 		Prerequisites: []string{"`.slipway.yaml` must exist (run `slipway init` first)", "`task` requires an active governed change in S2_IMPLEMENT with a materialized wave plan.", "`skill` requires an active governed change at the lifecycle state owned by the named governance skill; run-summary-bound skills also require current execution evidence."}},
 	// Helpers (2)
 	{ID: "tool", Class: CommandClassMutation, Description: "Run Slipway helper tools", Tier: "helpers", HasPromptSurface: false,


### PR DESCRIPTION
## Summary

Fixes #384. At `S3_REVIEW`, an operator who intentionally reruns a selected review skill that **already has current passing evidence** hit a dead-end: `slipway evidence skill` refused the fresh review with `evidence_skill_not_current` and offered no actionable path to record the rerun.

This adds an opt-in `--refresh-current` flag to `slipway evidence skill` that lets an operator intentionally replace already-current passing evidence for a **selected S3 review skill**.

## Design (fail-closed preserved)

The flag is tightly scoped — it only relaxes the duplicate-evidence guard, and only when **all** of these hold:
- change is at `S3_REVIEW`,
- the skill is in the selected review set,
- that skill **already has current passing evidence**.

Everything else is unchanged for the refresh path:
- verdict validity, pass-with-blockers rejection, and digest-input freshness still apply;
- the record write + evidence-digest stamp path is reused;
- downstream **cross-stage context-origin distinctness** is still enforced at advance/validate, so a refreshed record must still carry a valid, distinct review handle to keep `can_advance: true`.

Without the flag, duplicate current review evidence remains **fail-closed** and the existing verification record is preserved. The rejection remediation now names `--refresh-current` so the path is discoverable at the point of failure. No bypass / force-close / private-attestation path is introduced.

## Surfaces updated

- `cmd/evidence.go`: `--refresh-current` flag + scoped guard in `validateEvidenceSkillActionable`; updated remediation text.
- Tests: refresh-success across spec-compliance / code-quality / independent review, plus a negative test proving duplicate-without-flag still rejects and preserves the record.
- Discoverability: command-registry arguments, evidence command template, surface manifest (+contract test), and en/ja/zh docs.

## Verification

- `go test ./...`: pass (0 FAIL).
- `golangci-lint run ./...`: 0 issues.
- `gofmt -s`: clean.
- Governed bundle self-dogfooded to done-ready (`can_advance: true`, `evidence_freshness: fresh`, all selected reviewers + ship-verification pass) and finalized via `slipway done`.

## Notes / follow-ups (non-blocking)

- The shared review-skill code path also covers `security-review`; an explicit guardrail-domain refresh test could lock that exact scenario later.
- Refresh replaces the current record rather than storing supplemental review history (accepted in `decision.md` as the smallest fix for #384).

🤖 Generated with [Claude Code](https://claude.com/claude-code)