### PR TITLE
fix(evidence): require review context origin before persistence

### DIFF
--- a/artifacts/changes/archived/fix-s3-review-evidence-guard/assurance.md
+++ b/artifacts/changes/archived/fix-s3-review-evidence-guard/assurance.md
@@ -1,0 +1,88 @@
+# Assurance
+
+## Scope Summary
+
+This change fixes issue #394 by failing closed at the `slipway evidence skill`
+write boundary for passing selected S3 review evidence that does not include
+exactly one valid `context_origin:stage=review=<handle>` reference. The scope
+also updates generated/public guidance so selected-review pass commands include
+the review context-origin handle, a `*-notes.md` notes file, and degraded
+fallback as an additional structured reference rather than as a replacement for
+the review handle.
+
+The implementation is intentionally limited to `evidence skill` record-time
+validation, the reusable context-origin parser helper, focused command/model
+tests, capability/next/template/toolgen surfaces, and localized command docs.
+It does not redesign S3 review selection, subagent dispatch, or task/wave proof
+Markdown handling.
+
+## Verification Verdict
+
+Pass. The implementation, generated surfaces, review evidence, and terminal
+verification commands all support the acceptance criteria. Passing selected S3
+review evidence now rejects missing, malformed, conflicting duplicate, and
+identical duplicate review context-origin references before reviewer YAML is
+written. Valid selected-review pass evidence still records successfully, and
+fail verdicts remain recordable without a review context-origin handle.
+
+## Evidence Index
+
+- `artifacts/changes/fix-s3-review-evidence-guard/verification/intake-clarification.yaml`
+- `artifacts/changes/fix-s3-review-evidence-guard/verification/research-orchestration.yaml`
+- `artifacts/changes/fix-s3-review-evidence-guard/verification/plan-audit.yaml`
+- `artifacts/changes/fix-s3-review-evidence-guard/verification/wave-orchestration.yaml`
+- `artifacts/changes/fix-s3-review-evidence-guard/verification/final-focused-verification.md`
+- `artifacts/changes/fix-s3-review-evidence-guard/verification/spec-compliance-review.yaml`
+- `artifacts/changes/fix-s3-review-evidence-guard/verification/code-quality-review.yaml`
+- `artifacts/changes/fix-s3-review-evidence-guard/verification/independent-review.yaml`
+- `artifacts/changes/fix-s3-review-evidence-guard/verification/security-review.yaml`
+- `artifacts/changes/fix-s3-review-evidence-guard/verification/logs/ship-coverage-gate.txt`
+- `artifacts/changes/fix-s3-review-evidence-guard/verification/logs/ship-go-vet.txt`
+- `artifacts/changes/fix-s3-review-evidence-guard/verification/logs/ship-testlint.txt`
+- `artifacts/changes/fix-s3-review-evidence-guard/verification/logs/ship-golangci-lint.txt`
+- `artifacts/changes/fix-s3-review-evidence-guard/verification/logs/ship-diff-check.txt`
+- `artifacts/changes/fix-s3-review-evidence-guard/verification/logs/ship-manifest-check.txt`
+
+## Requirement Coverage
+
+- REQ-001: Covered by the pre-persistence candidate validation in
+  `cmd/evidence.go`, exact-one review handle parsing in
+  `internal/model/context_attestation.go`, and negative command tests that
+  assert no reviewer YAML is written for invalid selected-review pass evidence.
+- REQ-002: Covered by the guard's pass-only and selected-review-only scope and
+  by the fail-verdict test that records selected-review fail evidence without a
+  review context-origin handle.
+- REQ-003: Covered by the evidence command partial, review skill templates,
+  capability remediation, `next` confirmation text, surface manifest, and
+  English/Chinese/Japanese command docs.
+- REQ-004: Covered by focused command tests, parser tests, generated-surface
+  tests, capability tests, and the affected package suite.
+
+## Residual Risks and Exceptions
+
+- `same_context_degraded` was used for S3 peer review and ship verification
+  because the current host did not provide an explicitly user-requested
+  subagent delegation flow. The degraded mode is explicitly recorded in review
+  evidence and does not replace distinct review context-origin handles.
+- Existing invalid selected-review YAML from before this change is not migrated.
+  The existing readiness/ship gate still rejects such records as defense in
+  depth; new invalid pass submissions are blocked before persistence.
+- No guardrail domain was set for this change. The security review found no
+  auth/authz, secrets, injection, SSRF, XSS, dependency, or infrastructure
+  security impact.
+
+## Rollback Readiness
+
+Rollback is a normal code revert of the command guard, parser helper, tests, and
+surface/docs updates. No data migration or state migration is required. After a
+rollback, rerun the same command-boundary, model, template/toolgen/capability,
+full-suite, static-check, and coverage-gate commands listed in the evidence
+index before shipping the rollback.
+
+## Archive Decision
+
+Ready to archive after `ship-verification` passes and active `slipway validate`
+is captured immediately before `done`. The active validation proof belongs to
+the live governed worktree and will be cited by ship-verification; archived
+bundles are retained records and are not revalidated through the active validate
+gate after archival.

--- a/artifacts/changes/archived/fix-s3-review-evidence-guard/change.yaml
+++ b/artifacts/changes/archived/fix-s3-review-evidence-guard/change.yaml
@@ -1,0 +1,61 @@
+version: 1
+slug: fix-s3-review-evidence-guard
+description: fix S3 review evidence guard
+status: done
+current_state: DONE
+needs_discovery: true
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-06-30T16:20:32.237594Z
+quality_mode: standard
+workflow_profile: code
+workflow_preset: standard
+worktree_branch: feat/fix-s3-review-evidence-guard
+artifact_schema: expanded
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: cc563e6c816f05fcb1ffad45a84d8325df961d390657cfbb246dbdae5c38d38a
+        updated_at: 2026-06-30T17:12:56.35107155Z
+    decision:
+        id: decision
+        path: decision.md
+        state: frozen
+        content_hash: 3baa86c885e299640b8d67cf210e2a9ec23e0b7a2a18f9b471203dbfd78a3f85
+        updated_at: 2026-06-30T16:35:57.948073742Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: 6a72dec28519c489c1756e2b6fe7ba601efb86e4838eaf73d3dd333fb06bab76
+        updated_at: 2026-06-30T16:34:33.12326498Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: 05aa1ad73950a45b634e9223fe53ae99ea1d02b60cdcfca9b30212c9b342c253
+        updated_at: 2026-06-30T16:35:38.132121036Z
+    research:
+        id: research
+        path: research.md
+        state: frozen
+        content_hash: ea4fd7de84259308c0cc3ceb2f7cd0b8b301bd3b3e06106563e23f6068c885da
+        updated_at: 2026-06-30T16:34:25.82669102Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: 8a7af7c2b79ed8a8f96bdfabd3c93face01fc3db9c778feea30767d5ab73a69a
+        updated_at: 2026-06-30T16:53:49.589169976Z
+evidence_refs:
+    code-quality-review: .worktrees/fix-s3-review-evidence-guard/artifacts/changes/fix-s3-review-evidence-guard/verification/code-quality-review.yaml
+    independent-review: .worktrees/fix-s3-review-evidence-guard/artifacts/changes/fix-s3-review-evidence-guard/verification/independent-review.yaml
+    intake-clarification: .worktrees/fix-s3-review-evidence-guard/artifacts/changes/fix-s3-review-evidence-guard/verification/intake-clarification.yaml
+    plan-audit: .worktrees/fix-s3-review-evidence-guard/artifacts/changes/fix-s3-review-evidence-guard/verification/plan-audit.yaml
+    research-orchestration: .worktrees/fix-s3-review-evidence-guard/artifacts/changes/fix-s3-review-evidence-guard/verification/research-orchestration.yaml
+    security-review: .worktrees/fix-s3-review-evidence-guard/artifacts/changes/fix-s3-review-evidence-guard/verification/security-review.yaml
+    ship-verification: .worktrees/fix-s3-review-evidence-guard/artifacts/changes/fix-s3-review-evidence-guard/verification/ship-verification.yaml
+    spec-compliance-review: .worktrees/fix-s3-review-evidence-guard/artifacts/changes/fix-s3-review-evidence-guard/verification/spec-compliance-review.yaml
+    wave-orchestration: .worktrees/fix-s3-review-evidence-guard/artifacts/changes/fix-s3-review-evidence-guard/verification/wave-orchestration.yaml

--- a/artifacts/changes/archived/fix-s3-review-evidence-guard/decision.md
+++ b/artifacts/changes/archived/fix-s3-review-evidence-guard/decision.md
@@ -1,0 +1,81 @@
+# Decision
+
+## Alternatives Considered
+
+### Option A: Keep Validation Only In Ship/Readiness
+The existing `context_origin_handle_invalid` readiness blocker already rejects
+passing selected-review YAML without a valid review context-origin handle.
+
+Tradeoff: zero write-path churn, but it preserves the false-completion state
+from issue #394 because invalid `verdict: pass` YAML can still be persisted.
+
+### Option B: Add Record-Time Validation In `evidence skill`
+Build the candidate `VerificationRecord` before persistence, validate selected
+S3 review pass evidence against a model-level exact-one review context-origin
+parser helper, then write only structurally valid records.
+
+Tradeoff: small command and parser change, but it closes the bug at the point
+where the false authority record would otherwise be created. This keeps the
+later readiness gate as defense in depth.
+
+### Option C: Centralize Candidate Validation In Progression Authority
+Move the selected-review pass candidate through progression authority before
+writing evidence.
+
+Tradeoff: maximally centralized, but it couples command candidate validation to
+broader readiness evaluation and is more invasive than the bug requires.
+
+## Selected Approach
+
+Select Option B.
+
+The selected design adds a targeted record-time guard in `cmd/evidence.go` and
+a parser helper in `internal/model/context_attestation.go`. The guard applies
+only when all of these are true:
+
+- the active change is in `S3_REVIEW`;
+- the target skill is currently selected as an S3 review skill;
+- the submitted verdict is `pass`;
+- the submitted references do not contain exactly one valid
+  `context_origin:stage=review=<handle>` token.
+
+The guard runs before reference de-duplication and before
+`state.SaveVerification`, so malformed records cannot be persisted and duplicate
+identical context-origin tokens are not hidden by CLI normalization.
+
+## Interfaces and Data Flow
+
+- CLI input: `slipway evidence skill --skill <selected-review-skill>
+  --verdict pass --reference "context_origin:stage=review=<handle>"
+  --notes-file artifacts/changes/<slug>/verification/<skill>-notes.md`.
+- Command flow: parse flags -> validate stage/actionability -> build candidate
+  `VerificationRecord` from raw references -> validate exact-one review
+  context-origin for selected S3 reviewer passes -> de-duplicate references ->
+  run digest checks -> save YAML -> stamp digest/change evidence refs.
+- Parser flow: `ExactlyOneReviewContextOriginHandleFromVerification` reuses the
+  model context-origin token grammar and rejects missing, malformed, conflicting,
+  or repeated review-stage handles for record-time validation.
+- Documentation flow: generated evidence command surfaces, review skill
+  templates, capability remediations, surface manifest, and command reference
+  docs show the safe selected-review pass shape.
+
+## Rollout and Rollback
+
+Rollout is additive in the current codebase. No state migration is required.
+Existing invalid YAML remains rejected later by readiness; new invalid pass
+submissions are blocked earlier.
+
+Rollback is a code revert of the command guard, parser helper, and surface docs.
+Verification command: rerun the focused `cmd`, `internal/model`,
+`internal/tmpl`, `internal/toolgen`, and `internal/engine/capability` tests, then
+the broader package suite before shipping.
+
+## Risk
+
+- Existing agents that omit the review context-origin handle will fail earlier.
+  This is intentional and provides the remediation command shape.
+- The exact-one helper is stricter than the readiness parser for duplicate
+  identical review handles. The stricter behavior is scoped to selected-review
+  pass evidence at record time.
+- Public docs in English, Chinese, and Japanese must stay aligned with the
+  manifest token. The change updates all current command reference surfaces.

--- a/artifacts/changes/archived/fix-s3-review-evidence-guard/intent.md
+++ b/artifacts/changes/archived/fix-s3-review-evidence-guard/intent.md
@@ -1,0 +1,78 @@
+# Intent
+
+## Summary
+fix S3 review evidence guard
+## Complexity Assessment
+complex
+<!-- Rationale: provide justification for the assessed complexity level -->
+
+## Guardrail Domains
+<!-- none detected -->
+
+## In Scope
+- Add record-time validation to `slipway evidence skill` so a passing selected
+  S3 review skill cannot persist without exactly one valid
+  `context_origin:stage=review=<handle>` reference.
+- Cover all selected S3 review skills, including `spec-compliance-review`,
+  `code-quality-review`, `independent-review`, and `security-review` when
+  selected for the active change.
+- Add focused command-boundary tests for missing, malformed, and duplicate
+  review context-origin references.
+- Keep existing ship/readiness validation as defense in depth.
+- Update generated review skill or recovery examples so passing selected-review
+  evidence uses `*-notes.md` and includes the context-origin reference.
+
+## Out of Scope
+- Do not implement or rely on the #384 refresh/restamp path.
+- Do not ban ordinary task, wave, or targeted verification Markdown under
+  `verification/`.
+- Do not redesign S3 review selection or subagent dispatch.
+- Do not clean unrelated worktrees, active changes, or root checkout dirt.
+
+## Constraints
+- Reuse the existing context-origin parsing/readiness contract instead of
+  ad hoc string checks.
+- Fail before writing YAML evidence when the selected-review pass record is
+  structurally invalid.
+- Preserve archived and non-selected evidence behavior unless it conflicts with
+  the fail-closed selected-review contract.
+
+## Acceptance Signals
+- A `slipway evidence skill --skill independent-review --verdict pass` attempt
+  for an active selected S3 reviewer fails before writing YAML when the
+  context-origin reference is missing.
+- The same boundary rejects malformed and duplicate review-stage context-origin
+  references for selected S3 review skills.
+- Passing selected-review evidence with exactly one valid review-stage
+  context-origin reference still records successfully.
+- Focused tests and the relevant Go package tests pass in the governed
+  worktree.
+- `slipway status --json`, `slipway validate`, and lifecycle readiness agree
+  that this change is ready for review/ship when implementation is complete.
+
+## Open Questions
+<!-- Track real unknowns as a checklist. An unchecked `- [ ]` item is unresolved
+     and routes intake to S0_INTAKE/research; mark `- [x]` once resolved. Leave the
+     section empty (or write `None`) when there are none. Prose here is
+     documentation, not a blocker — a genuine open question must be a `- [ ]`. -->
+
+- [x] Locate the evidence command write path, the selected-review skill
+  selection source, and the reusable context-origin parser.
+- [x] Identify which generated skill/recovery text surfaces produce passing
+  selected-review evidence examples.
+
+## Deferred Ideas
+<!-- Identified but postponed ideas -->
+- Warning-level health/validate detection for visually misleading
+  `verification/<review-skill>.md` sibling files may be added only if it is
+  small and does not distract from the fail-closed write boundary.
+
+## Approved Summary
+- Approved 2026-06-30T16:25:00Z by user instruction to proceed without further
+  questions if the fix is straightforward. This change will fail closed at
+  `slipway evidence skill` record time for passing selected S3 reviewer
+  evidence that lacks exactly one valid `context_origin:stage=review=<handle>`
+  reference, add focused tests, and tighten generated/recovery examples to use
+  `*-notes.md` plus the structured context-origin token. It explicitly excludes
+  #384 refresh/restamp behavior, broad S3 review redesign, and any ban on
+  ordinary task or wave proof Markdown.

--- a/artifacts/changes/archived/fix-s3-review-evidence-guard/requirements.md
+++ b/artifacts/changes/archived/fix-s3-review-evidence-guard/requirements.md
@@ -1,0 +1,58 @@
+# Requirements
+
+## Requirements
+
+### Requirement: Selected Review Pass Evidence Fails Before Persistence
+REQ-001: The system MUST reject `slipway evidence skill --verdict pass` for a
+selected S3 review skill before writing verification YAML unless the submitted
+references contain exactly one valid `context_origin:stage=review=<handle>`
+token.
+
+#### Scenario: Missing context-origin does not write YAML
+GIVEN an active governed change in `S3_REVIEW` with `independent-review`
+selected
+WHEN `slipway evidence skill --skill independent-review --verdict pass` omits
+`context_origin:stage=review=<handle>`
+THEN the command fails with an actionable error and no
+`verification/independent-review.yaml` is written.
+
+#### Scenario: Malformed or duplicate review context-origin does not write YAML
+GIVEN an active selected S3 reviewer
+WHEN pass evidence includes a malformed review context-origin token or more
+than one review-stage context-origin token
+THEN the command rejects the record before persistence.
+
+### Requirement: Non-Completion Evidence Paths Stay Usable
+REQ-002: The system MUST keep non-pass reviewer evidence, non-selected review
+evidence handling, task evidence, wave evidence, and ordinary task/wave
+Markdown proof behavior outside the selected-review pass hard blocker.
+
+#### Scenario: Fail verdict remains recordable
+GIVEN an active selected S3 reviewer
+WHEN `slipway evidence skill` records `--verdict fail` with blockers and no
+review context-origin pass handle
+THEN the fail record remains valid command-boundary evidence.
+
+### Requirement: Agent-Facing Examples Teach Structured Review Evidence
+REQ-003: Generated command surfaces, review skill templates, capability
+remediation, and command reference docs MUST show passing selected-review
+evidence with `context_origin:stage=review=<handle>` and
+`verification/<skill>-notes.md`, and MUST describe degraded fallback mode as an
+additional structured reference rather than a substitute for the review handle.
+
+#### Scenario: Generated examples are safe to follow
+GIVEN an agent reads generated evidence or review skill instructions
+WHEN the instructions show a passing selected-review evidence command
+THEN the command includes a review context-origin reference and the `*-notes.md`
+notes-file convention.
+
+### Requirement: Regression Coverage Pins The Boundary
+REQ-004: The change MUST add focused tests that prove missing, malformed, and
+duplicate selected-review context-origin references fail before persistence,
+while a valid selected-review pass still records successfully.
+
+#### Scenario: Focused tests cover issue #394
+GIVEN the command-boundary and parser tests
+WHEN the focused test suite runs
+THEN it proves the selected-review fail-fast behavior and preserves existing
+defense-in-depth readiness behavior.

--- a/artifacts/changes/archived/fix-s3-review-evidence-guard/research.md
+++ b/artifacts/changes/archived/fix-s3-review-evidence-guard/research.md
@@ -1,0 +1,139 @@
+# Research
+
+## Alternatives Considered
+
+### Architecture
+- Affected modules:
+  - `cmd/evidence.go`: `evidence skill` builds the candidate
+    `VerificationRecord` before `state.SaveVerification`, which is the correct
+    fail-before-persistence seam for issue #394 (`cmd/evidence.go:193`,
+    `cmd/evidence.go:204`, `cmd/evidence.go:212`).
+  - `internal/model/context_attestation.go`: owns the reusable
+    `context_origin:stage=<stage>=<handle>` parser and existing review-handle
+    extraction (`internal/model/context_attestation.go:154`).
+  - `internal/engine/progression/authority.go`: remains the later S3
+    readiness defense-in-depth gate for invalid selected-review context-origin
+    evidence (`internal/engine/progression/authority.go:687`).
+  - `internal/tmpl/templates/_partials/command-evidence-body.tmpl`,
+    `internal/tmpl/templates/skills/*review*/SKILL.md.tmpl`,
+    `internal/toolgen/surface_manifest.go`, and `docs/**/commands.md` are the
+    public/agent-facing evidence examples that must not teach invalid pass
+    evidence.
+- Dependency chains:
+  - CLI command -> model parser -> state verification write -> progression
+    digest stamp.
+  - Template/toolgen source -> generated command/skill docs -> agent command
+    examples.
+- Blast radius: low-to-medium. The runtime behavior changes only for passing
+  selected S3 review skills at record time. Fail verdicts, non-review skills,
+  unselected review skills, task evidence, and task/wave Markdown proof remain
+  outside the hard blocker.
+- Constraints:
+  - The command must validate before `SaveVerification`, not after
+    ship/readiness evaluation.
+  - The check must run before CLI reference de-duplication, otherwise duplicate
+    identical review handles become invisible.
+
+### Patterns
+- Existing conventions:
+  - `cmd/evidence.go` already validates stage/actionability before writing and
+    returns structured `newInvalidUsageError` values with actionable
+    remediation.
+  - `internal/model/context_attestation.go` keeps the attestation grammar free
+    of command/template imports.
+  - Existing tests use command-level fixtures in `cmd/evidence_skill_test.go`
+    to assert whether YAML is written.
+- Reusable abstractions:
+  - Add a model-level exact-one parser helper for review context-origin handles
+    instead of command-local string checks.
+  - Reuse `selectedReviewSkillsForChange` to scope the guard to the active
+    selected review set.
+- Convention deviations: None required. The fix is additive and follows the
+  existing CLI error/test patterns.
+
+### Risks
+- Technical risks:
+  - Medium: rejecting selected-review pass evidence could block old agent
+    workflows that relied on malformed records. This is desired fail-closed
+    behavior for issue #394.
+  - Low: duplicate identical context-origin references were previously
+    idempotent in the readiness parser. The stricter helper is used only at
+    record time for selected S3 review passes, preserving the broader parser's
+    defense-in-depth behavior.
+  - Low: docs and generated skill examples may drift. Template, toolgen, and
+    capability tests now pin the context-origin and notes-file examples.
+- Guardrail domains: none. This is governance/evidence integrity, not auth,
+  secrets, PII, finance, schema migration, or irreversible operations.
+- Reversibility: straightforward. The command guard, parser helper, and docs
+  are additive and can be reverted without state migration.
+
+### Test Strategy
+- Existing coverage:
+  - `cmd/evidence_skill_test.go` already exercises S3 selected-review evidence
+    ordering, restamp, refresh-current, and unselected security-review behavior.
+  - `internal/model/context_attestation_test.go` covers context-origin parser
+    behavior.
+  - `internal/tmpl/templates_test.go`, `internal/toolgen/surface_manifest_test.go`,
+    and capability tests cover generated/public surfaces.
+- Infrastructure needs: no new harness. Existing command fixtures can create an
+  active S3 change, write execution summary evidence, run the command, and
+  assert the YAML path remains absent.
+- Verification approach:
+  - Command-boundary tests for missing, malformed, duplicate conflicting, and
+    duplicate identical review context-origin references.
+  - Success test that keeps selected reviews unordered while requiring a valid
+    context-origin handle.
+  - Fail-verdict test proving the hard guard applies only to pass records.
+  - Template/toolgen/capability tests proving examples and fallback text teach
+    `context_origin:stage=review=<handle>`, `*-notes.md`, and fallback
+    references.
+
+### Options
+- Option A: rely on the existing ship/readiness `context_origin_handle_invalid`
+  blocker only.
+  - Tradeoff: no code churn, but preserves the false-completion affordance:
+    invalid pass YAML can still be written.
+- Option B: add record-time validation in `cmd/evidence.go` backed by a
+  model-level exact-one review context-origin parser helper, plus focused tests
+  and public-surface updates.
+  - Tradeoff: small command/parser change and doc churn, but it fails before
+    persistence and directly satisfies the issue.
+- Option C: move the entire selected-review evidence validation into the
+  progression authority layer and call it from `evidence skill`.
+  - Tradeoff: centralizes all review authority checks, but risks broader
+    coupling and makes the record-time "candidate before persistence" path more
+    complex than needed.
+- Selected: Option B. It is the smallest fail-closed change at the write
+  boundary, reuses the existing parser layer, keeps the later readiness gate as
+  defense in depth, and updates the agent-facing examples that contributed to
+  the bug.
+
+## Unknowns
+- Resolved: Locate the evidence write path, selected-review selection source,
+  and reusable parser -> `cmd/evidence.go`, `cmd/next_skill_view.go`, and
+  `internal/model/context_attestation.go`.
+- Resolved: Identify generated/recovery text surfaces -> command evidence
+  partial, S3 review skill templates, capability remediations, surface manifest,
+  and command docs.
+- Remaining: None.
+
+## Assumptions
+- A failing selected review may still be recorded without a context-origin
+  handle because the fail record is not a passing selected-review completion
+  claim. Evidence: the issue acceptance criteria explicitly target
+  `--verdict pass`, and command tests cover fail verdicts separately.
+- Duplicate identical review context-origin references should fail at record
+  time even though the readiness parser treats identical repeats as idempotent,
+  because issue #394 asks for exactly one valid reference and the command would
+  otherwise de-duplicate them before persistence.
+
+## Canonical References
+- `cmd/evidence.go:193`
+- `cmd/evidence.go:204`
+- `cmd/evidence.go:212`
+- `cmd/evidence.go:1537`
+- `internal/model/context_attestation.go:154`
+- `internal/model/context_attestation.go:168`
+- `internal/engine/progression/authority.go:687`
+- `cmd/evidence_skill_test.go:531`
+- `internal/tmpl/templates/_partials/command-evidence-body.tmpl:17`

--- a/artifacts/changes/archived/fix-s3-review-evidence-guard/tasks.md
+++ b/artifacts/changes/archived/fix-s3-review-evidence-guard/tasks.md
@@ -1,0 +1,24 @@
+# Tasks
+
+## Task List
+
+- [x] `t-01` enforce selected-review evidence context-origin before persistence
+  - depends_on: []
+  - target_files: ["cmd/evidence.go", "cmd/evidence_skill_test.go", "internal/model/context_attestation.go", "internal/model/context_attestation_test.go"]
+  - task_kind: code
+  - covers: [REQ-001, REQ-002, REQ-004]
+  - acceptance: focused `go test ./cmd` evidence-skill tests and `go test ./internal/model` context-attestation tests pass; invalid selected-review pass evidence leaves no reviewer YAML.
+
+- [x] `t-02` update agent-facing selected-review evidence surfaces
+  - depends_on: []
+  - target_files: ["cmd/next.go", "cmd/progression_next_test.go", "internal/engine/capability/resolver.go", "internal/engine/capability/resolver_test.go", "internal/engine/capability/registry_default.go", "internal/engine/capability/registry_scale_foundation.go", "internal/tmpl/templates/_partials/command-evidence-body.tmpl", "internal/tmpl/templates/skills/code-quality-review/SKILL.md.tmpl", "internal/tmpl/templates/skills/spec-compliance-review/SKILL.md.tmpl", "internal/tmpl/templates/skills/independent-review/SKILL.md", "internal/tmpl/templates/skills/independent-review/SKILL.md.tmpl", "internal/tmpl/templates/skills/security-review/SKILL.md", "internal/tmpl/templates/skills/security-review/SKILL.md.tmpl", "internal/tmpl/templates_test.go", "internal/toolgen/surface_manifest.go", "internal/toolgen/surface_manifest_test.go", "docs/SURFACE-MANIFEST.json", "docs/reference/commands.md", "docs/commands.md", "docs/zh/reference/commands.md", "docs/zh/commands.md", "docs/ja/reference/commands.md", "docs/ja/commands.md"]
+  - task_kind: code
+  - covers: [REQ-003, REQ-004]
+  - acceptance: template, toolgen, capability, and next-surface tests pass and generated examples include context-origin, fallback reference, and `*-notes.md`.
+
+- [x] `t-03` verify issue 394 acceptance boundary
+  - depends_on: [t-01, t-02]
+  - target_files: ["cmd/evidence_skill_test.go", "cmd/evidence_task_test.go", "cmd/progression_next_test.go", "internal/model/context_attestation_test.go", "internal/engine/capability/resolver_test.go", "internal/tmpl/templates_test.go", "internal/toolgen/surface_manifest_test.go", "artifacts/changes/fix-s3-review-evidence-guard/verification/final-focused-verification.md"]
+  - task_kind: verification
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004]
+  - acceptance: final focused verification, package tests, `git diff --check`, `slipway validate`, and readiness checks pass with fresh evidence.

--- a/cmd/evidence.go
+++ b/cmd/evidence.go
@@ -201,7 +201,18 @@ func makeEvidenceSkillCmd() *cobra.Command {
 				if err := validateEvidenceSkillActionable(root, change, def, runVersion, refreshCurrent); err != nil {
 					return err
 				}
-				references = stringutil.UniqueSorted(trimNonEmptyStrings(references))
+				candidateReferences := trimNonEmptyStrings(references)
+				candidateRecord := model.VerificationRecord{
+					Verdict:    verdict,
+					Blockers:   blockerCodes,
+					RunVersion: runVersion,
+					References: candidateReferences,
+					Notes:      notesText,
+				}
+				if err := validateSelectedReviewPassContextOrigin(root, change, def, candidateRecord); err != nil {
+					return err
+				}
+				references = stringutil.UniqueSorted(candidateReferences)
 
 				if verdict == model.VerificationVerdictPass {
 					if err := progression.CheckEvidenceDigestInputsForSkill(root, change, skillName, digestSummary); err != nil {
@@ -1521,6 +1532,43 @@ func currentS3ReviewAlignmentActive(root string, change model.Change) (bool, err
 
 func selectedReviewContextOriginRefreshRequired(root string, change model.Change, skillName string) (bool, error) {
 	return progression.SelectedReviewContextOriginInvalid(root, change, skillName)
+}
+
+func validateSelectedReviewPassContextOrigin(
+	root string,
+	change model.Change,
+	def skill.Definition,
+	record model.VerificationRecord,
+) error {
+	if change.CurrentState != model.StateS3Review || !record.IsPassing() {
+		return nil
+	}
+	_, selectedReviewSkills, err := selectedReviewSkillsForChange(root, change)
+	if err != nil {
+		return err
+	}
+	if !stringInSlice(selectedReviewSkills, def.Name) {
+		return nil
+	}
+	if _, ok := model.ExactlyOneReviewContextOriginHandleFromVerification(record); ok {
+		return nil
+	}
+	notesPath := "artifacts/changes/" + change.Slug + "/verification/" + def.Name + "-notes.md"
+	return newInvalidUsageError(
+		"evidence_skill_review_context_origin_missing",
+		fmt.Sprintf("selected S3 review evidence for %s must include exactly one context_origin:stage=review=<handle> reference", def.Name),
+		fmt.Sprintf(
+			"Re-run %s in a fresh subagent, or explicitly select a degraded fallback, then record evidence with --reference \"context_origin:stage=review=<handle>\" and --notes-file %s. Fallback mode is not a substitute for the review-stage context handle; record it as an additional reference such as --reference \"fallback:same_context_degraded\".",
+			def.Name,
+			notesPath,
+		),
+		map[string]any{
+			"skill":                  def.Name,
+			"selected_review_skills": selectedReviewSkills,
+			"state":                  string(change.CurrentState),
+			"notes_file":             notesPath,
+		},
+	)
 }
 
 func evidenceTaskWrongStateRemediation(_ string, _ model.Change) string {

--- a/cmd/evidence_skill_test.go
+++ b/cmd/evidence_skill_test.go
@@ -501,6 +501,7 @@ func TestEvidenceSkillRecordsSelectedReviewPeerWithoutSpecPredecessor(t *testing
 			"--skill", progression.SkillCodeQualityReview,
 			"--verdict", model.VerificationVerdictPass,
 			"--reference", "code-quality:pass",
+			"--reference", model.ContextOriginReferencePrefix + model.StageContextReview + "=code-quality-review-context",
 			"--notes", "Quality review passed.",
 		})
 		var out bytes.Buffer
@@ -517,10 +518,117 @@ func TestEvidenceSkillRecordsSelectedReviewPeerWithoutSpecPredecessor(t *testing
 		require.NoError(t, err)
 		assert.Equal(t, model.VerificationVerdictPass, rec.Verdict)
 		assert.Equal(t, 1, rec.RunVersion)
+		handle, ok := model.ReviewContextOriginHandleFromVerification(rec)
+		require.True(t, ok)
+		assert.Equal(t, "code-quality-review-context", handle.Handle)
 
 		_, err = os.Stat(filepath.Join(state.VerificationDir(root, slug), progression.SkillSpecComplianceReview+".yaml"))
 		require.Error(t, err)
 		assert.True(t, os.IsNotExist(err))
+	})
+}
+
+func TestEvidenceSkillRejectsSelectedReviewPassWithoutReviewContextOrigin(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		skillName  string
+		references []string
+	}{
+		{
+			name:       "missing review context origin",
+			skillName:  progression.SkillIndependentReview,
+			references: []string{"independent-review:pass"},
+		},
+		{
+			name:       "malformed review context origin",
+			skillName:  progression.SkillCodeQualityReview,
+			references: []string{"code-quality:pass", model.ContextOriginReferencePrefix + model.StageContextReview},
+		},
+		{
+			name:      "duplicate conflicting review context origin",
+			skillName: progression.SkillSpecComplianceReview,
+			references: []string{
+				"spec-compliance:pass",
+				model.ContextOriginReferencePrefix + model.StageContextReview + "=spec-review-a",
+				model.ContextOriginReferencePrefix + model.StageContextReview + "=spec-review-b",
+			},
+		},
+		{
+			name:      "duplicate identical review context origin",
+			skillName: progression.SkillIndependentReview,
+			references: []string{
+				"independent-review:pass",
+				model.ContextOriginReferencePrefix + model.StageContextReview + "=same-review-handle",
+				model.ContextOriginReferencePrefix + model.StageContextReview + "=same-review-handle",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := t.TempDir()
+			withCommandWorkspace(t, root, func() {
+				initTestWorkspace(t, root)
+				slug := createGovernedRequest(t, root, levelNonDiscovery, "evidence skill requires review origin")
+				setEvidenceSkillChangeState(t, root, slug, model.StateS3Review, model.PlanSubStepNone)
+				writePassingExecutionSummary(t, root, slug, 1, "t-01")
+
+				cmd := commandForRoot(t, root, makeEvidenceCmd())
+				args := []string{
+					"skill",
+					"--change", slug,
+					"--skill", tt.skillName,
+					"--verdict", model.VerificationVerdictPass,
+					"--notes", "Review passed without a valid context-origin handle.",
+				}
+				for _, ref := range tt.references {
+					args = append(args, "--reference", ref)
+				}
+				cmd.SetArgs(args)
+				cliErr := asCLIError(cmd.Execute())
+				require.NotNil(t, cliErr)
+				assert.Equal(t, "evidence_skill_review_context_origin_missing", cliErr.ErrorCode)
+				assert.Equal(t, tt.skillName, cliErr.Details["skill"])
+				assert.Contains(t, cliErr.Remediation, `--reference "context_origin:stage=review=<handle>"`)
+				assert.Contains(t, cliErr.Remediation, "verification/"+tt.skillName+"-notes.md")
+
+				_, err := os.Stat(filepath.Join(state.VerificationDir(root, slug), tt.skillName+".yaml"))
+				require.Error(t, err)
+				assert.True(t, os.IsNotExist(err))
+			})
+		})
+	}
+}
+
+func TestEvidenceSkillSelectedReviewContextOriginGuardSkipsFailVerdict(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "evidence skill allows review fail without origin")
+		setEvidenceSkillChangeState(t, root, slug, model.StateS3Review, model.PlanSubStepNone)
+		writePassingExecutionSummary(t, root, slug, 1, "t-01")
+
+		cmd := commandForRoot(t, root, makeEvidenceCmd())
+		cmd.SetArgs([]string{
+			"skill",
+			"--change", slug,
+			"--skill", progression.SkillIndependentReview,
+			"--verdict", model.VerificationVerdictFail,
+			"--blocker", "review_blocked:manual-check-failed",
+			"--notes", "Independent review failed before a fresh context-origin pass.",
+		})
+		require.NoError(t, cmd.Execute())
+
+		rec, err := state.LoadVerification(root, slug, progression.SkillIndependentReview)
+		require.NoError(t, err)
+		assert.Equal(t, model.VerificationVerdictFail, rec.Verdict)
 	})
 }
 

--- a/cmd/evidence_task_test.go
+++ b/cmd/evidence_task_test.go
@@ -1186,6 +1186,7 @@ func TestEvidenceSkillRecordsCLIStampedVerificationAndDigest(t *testing.T) {
 			"--verdict", "pass",
 			"--reference", "layer:R0=pass",
 			"--reference", "scope_contract:pass",
+			"--reference", model.ContextOriginReferencePrefix + model.StageContextReview + "=cli-stamped-spec-review",
 			"--notes-file", "review-notes.md",
 		})
 		var out bytes.Buffer
@@ -1207,7 +1208,11 @@ func TestEvidenceSkillRecordsCLIStampedVerificationAndDigest(t *testing.T) {
 		assert.Equal(t, 2, rec.RunVersion)
 		assert.False(t, rec.Timestamp.IsZero())
 		assert.Equal(t, "review notes from disk", rec.Notes)
-		assert.Equal(t, []string{"layer:R0=pass", "scope_contract:pass"}, rec.References)
+		assert.Equal(t, []string{
+			model.ContextOriginReferencePrefix + model.StageContextReview + "=cli-stamped-spec-review",
+			"layer:R0=pass",
+			"scope_contract:pass",
+		}, rec.References)
 
 		digests, err := state.LoadOptionalEvidenceDigestsForChange(root, change)
 		require.NoError(t, err)

--- a/cmd/next.go
+++ b/cmd/next.go
@@ -1153,7 +1153,8 @@ func withSubagentDelegationPrerequisite(req confirmationRequirement, view nextVi
 	req.NextAction = strings.TrimRight(strings.TrimSpace(req.NextAction), ".") +
 		". Host subagent delegation is a prerequisite the host has not declared available: authorize subagent dispatch, " +
 		"or explicitly select a named degraded fallback (e.g. same_context_degraded) and record fresh evidence for each listed skill " +
-		"(see host_capabilities[] and recovery for the per-skill fallback names)"
+		"(see host_capabilities[] and recovery for the per-skill fallback names). For S3 review skills, record exactly one " +
+		"context_origin:stage=review=<handle> reference and an additional fallback:<mode> reference when degraded"
 	return req
 }
 

--- a/cmd/progression_next_test.go
+++ b/cmd/progression_next_test.go
@@ -1480,6 +1480,8 @@ func TestReviewBatchHostSubagentDelegationSurfacedAcrossCapabilityStates(t *test
 	assert.Equal(t, "review_batch", unknownHandoff.Confirmation.NextActionKind)
 	assert.Contains(t, unknownHandoff.Confirmation.NextAction, "Host subagent delegation is a prerequisite")
 	assert.Contains(t, unknownHandoff.Confirmation.NextAction, "same_context_degraded")
+	assert.Contains(t, unknownHandoff.Confirmation.NextAction, "context_origin:stage=review=<handle>")
+	assert.Contains(t, unknownHandoff.Confirmation.NextAction, "fallback:<mode>")
 	assert.Equal(t, "blocked", unknownHandoff.OverallReadinessFreshness)
 	require.NotNil(t, unknownHandoff.Recovery)
 	assert.NotEmpty(t, unknownHandoff.Recovery.Steps)

--- a/docs/SURFACE-MANIFEST.json
+++ b/docs/SURFACE-MANIFEST.json
@@ -328,7 +328,7 @@
       "name": "evidence-skill-refresh-current-json",
       "source": "cmd/evidence.go",
       "docs": "docs/reference/commands.md",
-      "token": "slipway evidence skill --skill \u003cname\u003e --verdict pass --refresh-current --json"
+      "token": "slipway evidence skill --skill \u003cselected-review-skill\u003e --verdict pass --refresh-current --reference \"context_origin:stage=review=\u003chandle\u003e\" --notes-file artifacts/changes/\u003cslug\u003e/verification/\u003cselected-review-skill\u003e-notes.md --json"
     },
     {
       "kind": "json-contract",

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -243,7 +243,7 @@ Stable manifest tokens for JSON contract coverage:
 | delete JSON | `slipway delete --change <slug> --json` |
 | done JSON | `slipway done` |
 | evidence skill JSON | `slipway evidence skill --skill <name> --verdict pass --json` |
-| evidence skill refresh-current JSON | `slipway evidence skill --skill <name> --verdict pass --refresh-current --json` |
+| evidence skill refresh-current JSON | `slipway evidence skill --skill <selected-review-skill> --verdict pass --refresh-current --reference "context_origin:stage=review=<handle>" --notes-file artifacts/changes/<slug>/verification/<selected-review-skill>-notes.md --json` |
 | evidence task JSON | `slipway evidence task --result-file task-result.json [--result-file next-task-result.json ...] --json` |
 | fix JSON | `slipway fix --json` |
 | handoff JSON | `slipway handoff show --json` |

--- a/docs/ja/commands.md
+++ b/docs/ja/commands.md
@@ -145,7 +145,7 @@ JSON コントラクトのカバレッジ向けの安定したマニフェスト
 | delete JSON | `slipway delete --change <slug> --json` |
 | done JSON | `slipway done` |
 | evidence skill JSON | `slipway evidence skill --skill <name> --verdict pass --json` |
-| evidence skill refresh-current JSON | `slipway evidence skill --skill <name> --verdict pass --refresh-current --json` |
+| evidence skill refresh-current JSON | `slipway evidence skill --skill <selected-review-skill> --verdict pass --refresh-current --reference "context_origin:stage=review=<handle>" --notes-file artifacts/changes/<slug>/verification/<selected-review-skill>-notes.md --json` |
 | evidence task JSON | `slipway evidence task --result-file task-result.json [--result-file next-task-result.json ...] --json` |
 | fix JSON | `slipway fix --json` |
 | handoff JSON | `slipway handoff show --json` |

--- a/docs/ja/reference/commands.md
+++ b/docs/ja/reference/commands.md
@@ -67,7 +67,7 @@ slipway delete --change <slug> --json
 slipway repair --json
 slipway evidence task --result-file task-result.json [--result-file next-task-result.json ...] --json
 slipway evidence skill --skill <name> --verdict pass --json
-slipway evidence skill --skill <name> --verdict pass --refresh-current --json
+slipway evidence skill --skill <selected-review-skill> --verdict pass --refresh-current --reference "context_origin:stage=review=<handle>" --notes-file artifacts/changes/<slug>/verification/<selected-review-skill>-notes.md --json
 slipway health --json
 slipway instructions <artifact> --json
 slipway config list --json
@@ -83,7 +83,7 @@ slipway config list --json
 - `slipway handoff show --json` は現在の変更ごとの handoff を構造化して出力します。
 - `slipway evidence task --result-file <path> --json` はコンパクトな実行タスク結果を取り込みます。原子的なバッチにするには `--result-file` を繰り返します。
 - `slipway evidence skill --skill <name> --verdict pass --json` は、そのスキルを所有するステージで統制スキルのエビデンスを記録します。
-- `slipway evidence skill --skill <name> --verdict pass --refresh-current --json` は、選択済み S3 レビュースキルの既に current な passing エビデンスを、意図的な再実行として置き換える場合だけに使います。通常の重複エビデンスは引き続き拒否されます。
+- `slipway evidence skill --skill <selected-review-skill> --verdict pass --refresh-current --reference "context_origin:stage=review=<handle>" --notes-file artifacts/changes/<slug>/verification/<selected-review-skill>-notes.md --json` は、選択済み S3 レビュースキルの既に current な passing エビデンスを、意図的な再実行として置き換える場合だけに使います。通常の重複エビデンスは引き続き拒否されます。
 - `slipway status --stats --json` は、廃止されたトップレベルの `stats` コマンドを戻さずにワークスペース診断を報告します。
 - `slipway health --doctor --json` は、ヘルスレポートに修復向けの診断を追加します。
 - `slipway tool <helper>` は生成されたスキルから直接呼び出され、生成されたアダプターのプロンプトサーフェスはありません。

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -64,7 +64,7 @@ slipway delete --change <slug> --json
 slipway repair --json
 slipway evidence task --result-file task-result.json [--result-file next-task-result.json ...] --json
 slipway evidence skill --skill <name> --verdict pass --json
-slipway evidence skill --skill <name> --verdict pass --refresh-current --json
+slipway evidence skill --skill <selected-review-skill> --verdict pass --refresh-current --reference "context_origin:stage=review=<handle>" --notes-file artifacts/changes/<slug>/verification/<selected-review-skill>-notes.md --json
 slipway health --json
 slipway instructions <artifact> --json
 slipway config list --json
@@ -79,7 +79,7 @@ artifact-readiness detail, transition traces, or context-budget diagnostics.
 - `slipway handoff show --json` emits the current per-change handoff in structured form.
 - `slipway evidence task --result-file <path> --json` imports compact executor task results; repeat `--result-file` for an atomic batch.
 - `slipway evidence skill --skill <name> --verdict pass --json` records governed skill evidence at the stage that owns that skill.
-- `slipway evidence skill --skill <name> --verdict pass --refresh-current --json` is only for an intentional rerun that replaces already-current passing evidence for a selected S3 review skill; ordinary duplicate evidence remains rejected.
+- `slipway evidence skill --skill <selected-review-skill> --verdict pass --refresh-current --reference "context_origin:stage=review=<handle>" --notes-file artifacts/changes/<slug>/verification/<selected-review-skill>-notes.md --json` is only for an intentional rerun that replaces already-current passing evidence for a selected S3 review skill; ordinary duplicate evidence remains rejected.
 - `slipway status --stats --json` reports workspace diagnostics without reviving the retired top-level `stats` command.
 - `slipway health --doctor --json` adds repair-oriented diagnostics to the health report.
 - `slipway tool <helper>` is invoked directly by generated skills and has no generated adapter prompt surface.

--- a/docs/zh/commands.md
+++ b/docs/zh/commands.md
@@ -206,7 +206,7 @@ slipway health --doctor --json
 | delete JSON | `slipway delete --change <slug> --json` |
 | done JSON | `slipway done` |
 | evidence skill JSON | `slipway evidence skill --skill <name> --verdict pass --json` |
-| evidence skill refresh-current JSON | `slipway evidence skill --skill <name> --verdict pass --refresh-current --json` |
+| evidence skill refresh-current JSON | `slipway evidence skill --skill <selected-review-skill> --verdict pass --refresh-current --reference "context_origin:stage=review=<handle>" --notes-file artifacts/changes/<slug>/verification/<selected-review-skill>-notes.md --json` |
 | evidence task JSON | `slipway evidence task --result-file task-result.json [--result-file next-task-result.json ...] --json` |
 | fix JSON | `slipway fix --json` |
 | handoff JSON | `slipway handoff show --json` |

--- a/docs/zh/reference/commands.md
+++ b/docs/zh/reference/commands.md
@@ -63,7 +63,7 @@ slipway delete --change <slug> --json
 slipway repair --json
 slipway evidence task --result-file task-result.json [--result-file next-task-result.json ...] --json
 slipway evidence skill --skill <name> --verdict pass --json
-slipway evidence skill --skill <name> --verdict pass --refresh-current --json
+slipway evidence skill --skill <selected-review-skill> --verdict pass --refresh-current --reference "context_origin:stage=review=<handle>" --notes-file artifacts/changes/<slug>/verification/<selected-review-skill>-notes.md --json
 slipway health --json
 slipway instructions <artifact> --json
 slipway config list --json
@@ -78,7 +78,7 @@ slipway config list --json
 - `slipway handoff show --json` 以结构化形式输出当前变更的 handoff。
 - `slipway evidence task --result-file <path> --json` 导入紧凑的执行任务结果；重复 `--result-file` 可进行原子批量导入。
 - `slipway evidence skill --skill <name> --verdict pass --json` 在拥有该 skill 的阶段记录治理 skill 证据。
-- `slipway evidence skill --skill <name> --verdict pass --refresh-current --json` 只用于把已选 S3 review skill 的当前 passing 证据作为一次明确重跑来替换；普通重复证据仍会被拒绝。
+- `slipway evidence skill --skill <selected-review-skill> --verdict pass --refresh-current --reference "context_origin:stage=review=<handle>" --notes-file artifacts/changes/<slug>/verification/<selected-review-skill>-notes.md --json` 只用于把已选 S3 review skill 的当前 passing 证据作为一次明确重跑来替换；普通重复证据仍会被拒绝。
 - `slipway status --stats --json` 报告工作区诊断，不重新引入已退休的顶层 `stats` 命令。
 - `slipway health --doctor --json` 在 health 报告中加入面向修复的诊断。
 - `slipway tool <helper>` 由生成的 skill 直接调用，不生成适配器提示词接入面。

--- a/internal/engine/capability/registry_default.go
+++ b/internal/engine/capability/registry_default.go
@@ -50,7 +50,7 @@ func independentReview() Skill {
 				Required:            true,
 				FallbackModes:       []string{"manual_independent_review", "same_context_degraded"},
 				EvidenceRequirement: "record independent-review evidence from a fresh independent reviewer context",
-				Remediation:         "Run independent-review in a host with subagent capability, or explicitly select manual_independent_review / same_context_degraded fallback and record fresh reviewer evidence.",
+				Remediation:         "Run independent-review in a host with subagent capability, or explicitly select manual_independent_review / same_context_degraded fallback and record fresh reviewer evidence with context_origin:stage=review=<handle> plus a fallback:<mode> reference when degraded.",
 			},
 		},
 	}

--- a/internal/engine/capability/registry_scale_foundation.go
+++ b/internal/engine/capability/registry_scale_foundation.go
@@ -62,7 +62,7 @@ func securityReview() Skill {
 				Required:            true,
 				FallbackModes:       []string{"manual_security_review", "same_context_degraded"},
 				EvidenceRequirement: "record security-review evidence from a fresh independent reviewer context",
-				Remediation:         "Run security-review in a host with subagent capability, or explicitly select manual_security_review / same_context_degraded fallback and record fresh reviewer evidence.",
+				Remediation:         "Run security-review in a host with subagent capability, or explicitly select manual_security_review / same_context_degraded fallback and record fresh reviewer evidence with context_origin:stage=review=<handle> plus a fallback:<mode> reference when degraded.",
 			},
 		},
 		HydrateReferences: []HydrateReference{

--- a/internal/engine/capability/resolver.go
+++ b/internal/engine/capability/resolver.go
@@ -156,14 +156,14 @@ var builtinSubagentDispatchContracts = map[string]HostCapabilityContract{
 		Required:            true,
 		FallbackModes:       []string{"manual_spec_compliance_review", "same_context_degraded"},
 		EvidenceRequirement: "record spec-compliance-review evidence from a fresh independent reviewer context",
-		Remediation:         "Run spec-compliance-review in a host with subagent capability, or explicitly select manual_spec_compliance_review / same_context_degraded fallback and record fresh reviewer evidence.",
+		Remediation:         "Run spec-compliance-review in a host with subagent capability, or explicitly select manual_spec_compliance_review / same_context_degraded fallback and record fresh reviewer evidence with context_origin:stage=review=<handle> plus a fallback:<mode> reference when degraded.",
 	},
 	"code-quality-review": {
 		Capability:          "subagent",
 		Required:            true,
 		FallbackModes:       []string{"manual_code_quality_review", "same_context_degraded"},
 		EvidenceRequirement: "record code-quality-review evidence from a fresh independent reviewer context",
-		Remediation:         "Run code-quality-review in a host with subagent capability, or explicitly select manual_code_quality_review / same_context_degraded fallback and record fresh reviewer evidence.",
+		Remediation:         "Run code-quality-review in a host with subagent capability, or explicitly select manual_code_quality_review / same_context_degraded fallback and record fresh reviewer evidence with context_origin:stage=review=<handle> plus a fallback:<mode> reference when degraded.",
 	},
 	"ship-verification": {
 		Capability:          "subagent",

--- a/internal/engine/capability/resolver_test.go
+++ b/internal/engine/capability/resolver_test.go
@@ -170,6 +170,8 @@ func TestResolveHostCapabilityRequirement(t *testing.T) {
 			assert.Equal(t, tt.wantFallbackMode, req.FallbackMode)
 			assert.NotEmpty(t, req.EvidenceRequirement)
 			assert.NotEmpty(t, req.Remediation)
+			assert.Contains(t, req.Remediation, "context_origin:stage=review=<handle>")
+			assert.Contains(t, req.Remediation, "fallback:<mode>")
 		})
 	}
 }
@@ -200,6 +202,10 @@ func TestResolveHostCapabilitySubagentDispatchLever(t *testing.T) {
 			assert.False(t, req.FallbackSelected)
 			assert.NotEmpty(t, req.EvidenceRequirement)
 			assert.NotEmpty(t, req.Remediation)
+			if hostCapabilityTestIsSelectedReviewSkill(skillID) {
+				assert.Contains(t, req.Remediation, "context_origin:stage=review=<handle>")
+				assert.Contains(t, req.Remediation, "fallback:<mode>")
+			}
 		})
 		t.Run(skillID+"/explicit none is unavailable", func(t *testing.T) {
 			t.Parallel()
@@ -233,6 +239,8 @@ func TestResolveHostCapabilitySubagentDispatchLever(t *testing.T) {
 		require.NotNil(t, req, "security-review must carry a registry host-capability contract")
 		assert.Equal(t, "subagent", req.Capability)
 		assert.Equal(t, "unavailable", req.Availability)
+		assert.Contains(t, req.Remediation, "context_origin:stage=review=<handle>")
+		assert.Contains(t, req.Remediation, "fallback:<mode>")
 	})
 
 	t.Run("skills without any contract still resolve to nil", func(t *testing.T) {
@@ -240,6 +248,15 @@ func TestResolveHostCapabilitySubagentDispatchLever(t *testing.T) {
 		assert.Nil(t, ResolveHostCapabilityRequirement("context-assembly", Signals{}))
 		assert.Nil(t, ResolveHostCapabilityRequirement("no-such-skill", Signals{}))
 	})
+}
+
+func hostCapabilityTestIsSelectedReviewSkill(skillID string) bool {
+	switch skillID {
+	case "spec-compliance-review", "code-quality-review", "independent-review", "security-review":
+		return true
+	default:
+		return false
+	}
 }
 
 func TestResolveHostCapabilityRequirementUsesRegistryContract(t *testing.T) {

--- a/internal/model/context_attestation.go
+++ b/internal/model/context_attestation.go
@@ -165,6 +165,41 @@ func ReviewContextOriginHandleFromVerification(record VerificationRecord) (Conte
 	return handle, true
 }
 
+// ExactlyOneReviewContextOriginHandleFromVerification extracts the selected S3
+// reviewer handle only when the record carries exactly one well-formed
+// context_origin:stage=review=<handle> reference. Unlike
+// ReviewContextOriginHandleFromVerification, this rejects repeated identical
+// review handles so record-time evidence validation can fail before CLI
+// reference de-duplication hides a duplicate submission.
+func ExactlyOneReviewContextOriginHandleFromVerification(record VerificationRecord) (ContextOriginHandle, bool) {
+	var found ContextOriginHandle
+	count := 0
+	for _, ref := range record.References {
+		raw := strings.Trim(strings.TrimSpace(ref), "\"'`.,;()[]{}")
+		if !strings.HasPrefix(raw, ContextOriginReferencePrefix) {
+			continue
+		}
+		rest := strings.TrimPrefix(raw, ContextOriginReferencePrefix)
+		stage, _, _ := strings.Cut(rest, "=")
+		if strings.TrimSpace(stage) != StageContextReview {
+			continue
+		}
+		stage, handle, ok := parseContextOriginReference(ref)
+		if !ok {
+			return ContextOriginHandle{}, false
+		}
+		count++
+		if count > 1 {
+			return ContextOriginHandle{}, false
+		}
+		found = ContextOriginHandle{Stage: stage, Handle: handle}
+	}
+	if count != 1 {
+		return ContextOriginHandle{}, false
+	}
+	return found, true
+}
+
 // FixContextOriginHandleSetFromVerification flattens every
 // context_origin:stage=fix=<handle> reference a record attests into a deduped
 // set of fix context handles. The fix stage is multi-valued — a reviewer's

--- a/internal/model/context_attestation_test.go
+++ b/internal/model/context_attestation_test.go
@@ -360,6 +360,88 @@ func TestReviewContextOriginHandleFromVerification(t *testing.T) {
 	}
 }
 
+func TestExactlyOneReviewContextOriginHandleFromVerification(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		record     VerificationRecord
+		wantOK     bool
+		wantHandle string
+	}{
+		{
+			name: "single valid review origin token",
+			record: VerificationRecord{
+				References: []string{"context_origin:stage=review=ctx-reviewer"},
+			},
+			wantOK:     true,
+			wantHandle: "ctx-reviewer",
+		},
+		{
+			name: "missing review origin token",
+			record: VerificationRecord{
+				References: []string{"independent-review:pass"},
+			},
+			wantOK: false,
+		},
+		{
+			name: "malformed review origin token",
+			record: VerificationRecord{
+				References: []string{"context_origin:stage=review"},
+			},
+			wantOK: false,
+		},
+		{
+			name: "duplicate identical review origin token is rejected",
+			record: VerificationRecord{
+				References: []string{
+					"context_origin:stage=review=ctx-reviewer",
+					"context_origin:stage=review=ctx-reviewer",
+				},
+			},
+			wantOK: false,
+		},
+		{
+			name: "duplicate conflicting review origin token is rejected",
+			record: VerificationRecord{
+				References: []string{
+					"context_origin:stage=review=ctx-reviewer-a",
+					"context_origin:stage=review=ctx-reviewer-b",
+				},
+			},
+			wantOK: false,
+		},
+		{
+			name: "single review handle may coexist with fix handles",
+			record: VerificationRecord{
+				References: []string{
+					"context_origin:stage=review=ctx-reviewer",
+					"context_origin:stage=fix=ctx-fix-1",
+					"context_origin:stage=fix=ctx-fix-2",
+				},
+			},
+			wantOK:     true,
+			wantHandle: "ctx-reviewer",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := ExactlyOneReviewContextOriginHandleFromVerification(tt.record)
+			require.Equal(t, tt.wantOK, ok)
+			if !tt.wantOK {
+				assert.Equal(t, ContextOriginHandle{}, got)
+				return
+			}
+			assert.Equal(t, StageContextReview, got.Stage)
+			assert.Equal(t, tt.wantHandle, got.Handle)
+		})
+	}
+}
+
 func TestFixContextOriginHandleSetFromVerification(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tmpl/templates/_partials/command-evidence-body.tmpl
+++ b/internal/tmpl/templates/_partials/command-evidence-body.tmpl
@@ -15,7 +15,12 @@ slipway evidence skill --skill <name> --verdict <pass|fail> \
   --reference "<ref>" --notes-file <path> --json
 
 slipway evidence skill --skill <selected-review-skill> --verdict pass \
-  --refresh-current --reference "<ref>" --notes-file <path> --json
+  --reference "context_origin:stage=review=<handle>" \
+  --notes-file artifacts/changes/<slug>/verification/<selected-review-skill>-notes.md --json
+
+slipway evidence skill --skill <selected-review-skill> --verdict pass \
+  --refresh-current --reference "context_origin:stage=review=<handle>" \
+  --notes-file artifacts/changes/<slug>/verification/<selected-review-skill>-notes.md --json
 ```
 
 ## Contract
@@ -40,6 +45,13 @@ slipway evidence skill --skill <selected-review-skill> --verdict pass \
   already-current passing selected S3 review skill after an operator
   intentionally reruns that review. Without it, duplicate current review evidence
   remains fail-closed.
+- A passing selected S3 review skill must include exactly one
+  `--reference "context_origin:stage=review=<handle>"` before YAML is written;
+  malformed, missing, or duplicate review-stage handles fail closed. Use
+  `artifacts/changes/<slug>/verification/<skill>-notes.md` for review notes.
+- A degraded fallback is an additional structured reference, for example
+  `--reference "fallback:same_context_degraded"`; fallback prose in Markdown is
+  not a substitute for the review-stage context handle.
 - `evidence skill` writes the verification record, updates the change evidence
   reference, and does not advance lifecycle state; advance separately with
   `slipway run`.

--- a/internal/tmpl/templates/skills/code-quality-review/SKILL.md.tmpl
+++ b/internal/tmpl/templates/skills/code-quality-review/SKILL.md.tmpl
@@ -121,7 +121,10 @@ host has not declared subagent capability available, `slipway next`/`run` surfac
 a subagent-delegation prerequisite plus a named degraded fallback for this review:
 authorize subagent dispatch, or explicitly select the named fallback (for example
 `same_context_degraded`) and record fresh reviewer evidence for the degraded run —
-do not review inline without recording the selected fallback.
+do not review inline without recording the selected fallback. The fallback is an
+additional structured reference such as
+`--reference "fallback:same_context_degraded"`; it does not replace the required
+`context_origin:stage=review=<handle>` reference.
 
 Record this review's per-stage context identifier as
 `context_origin:stage=review=<handle>`, where `<handle>` is the dispatched

--- a/internal/tmpl/templates/skills/independent-review/SKILL.md
+++ b/internal/tmpl/templates/skills/independent-review/SKILL.md
@@ -20,7 +20,7 @@ host_capabilities:
       - manual_independent_review
       - same_context_degraded
     evidence_requirement: "record independent-review evidence from a fresh independent reviewer context"
-    remediation: "Run independent-review in a host with subagent capability, or explicitly select manual_independent_review / same_context_degraded fallback and record fresh reviewer evidence."
+    remediation: "Run independent-review in a host with subagent capability, or explicitly select manual_independent_review / same_context_degraded fallback and record fresh reviewer evidence with context_origin:stage=review=<handle> plus a fallback:<mode> reference when degraded."
 ---
 
 # Independent Review

--- a/internal/tmpl/templates/skills/independent-review/SKILL.md.tmpl
+++ b/internal/tmpl/templates/skills/independent-review/SKILL.md.tmpl
@@ -9,7 +9,7 @@ host_capabilities:
       - manual_independent_review
       - same_context_degraded
     evidence_requirement: "record independent-review evidence from a fresh independent reviewer context"
-    remediation: "Run independent-review in a host with subagent capability, or explicitly select manual_independent_review / same_context_degraded fallback and record fresh reviewer evidence."
+    remediation: "Run independent-review in a host with subagent capability, or explicitly select manual_independent_review / same_context_degraded fallback and record fresh reviewer evidence with context_origin:stage=review=<handle> plus a fallback:<mode> reference when degraded."
 ---
 
 # Independent Review
@@ -104,7 +104,10 @@ subagent capability available, `slipway next`/`run` surfaces a subagent-delegati
 prerequisite plus a named degraded fallback for this review: authorize subagent
 dispatch, or explicitly select the named fallback (for example
 `same_context_degraded`) and record fresh reviewer evidence for the degraded run —
-do not review inline without recording the selected fallback.
+do not review inline without recording the selected fallback. The fallback is an
+additional structured reference such as
+`--reference "fallback:same_context_degraded"`; it does not replace the required
+`context_origin:stage=review=<handle>` reference.
 
 Record this review's context identifier as
 `context_origin:stage=review=<handle>`, where `<handle>` is the dispatched

--- a/internal/tmpl/templates/skills/security-review/SKILL.md
+++ b/internal/tmpl/templates/skills/security-review/SKILL.md
@@ -23,7 +23,7 @@ host_capabilities:
       - manual_security_review
       - same_context_degraded
     evidence_requirement: "record security-review evidence from a fresh independent reviewer context"
-    remediation: "Run security-review in a host with subagent capability, or explicitly select manual_security_review / same_context_degraded fallback and record fresh reviewer evidence."
+    remediation: "Run security-review in a host with subagent capability, or explicitly select manual_security_review / same_context_degraded fallback and record fresh reviewer evidence with context_origin:stage=review=<handle> plus a fallback:<mode> reference when degraded."
 hydrate_references:
   - name: authentication.md
     reason: "Password storage / session / MFA / recovery secure-default rules"

--- a/internal/tmpl/templates/skills/security-review/SKILL.md.tmpl
+++ b/internal/tmpl/templates/skills/security-review/SKILL.md.tmpl
@@ -9,7 +9,7 @@ host_capabilities:
       - manual_security_review
       - same_context_degraded
     evidence_requirement: "record security-review evidence from a fresh independent reviewer context"
-    remediation: "Run security-review in a host with subagent capability, or explicitly select manual_security_review / same_context_degraded fallback and record fresh reviewer evidence."
+    remediation: "Run security-review in a host with subagent capability, or explicitly select manual_security_review / same_context_degraded fallback and record fresh reviewer evidence with context_origin:stage=review=<handle> plus a fallback:<mode> reference when degraded."
 hydrate_references:
   - name: authentication.md
     reason: "Password storage / session / MFA / recovery secure-default rules"
@@ -113,7 +113,10 @@ prerequisite plus a named degraded fallback for this review: authorize subagent
 dispatch, or explicitly select the named fallback (for example
 `manual_security_review` or `same_context_degraded`) and record fresh reviewer
 evidence for the degraded run — do not review inline without recording the
-selected fallback.
+selected fallback. The fallback is an additional structured reference such as
+`--reference "fallback:same_context_degraded"` or the skill-specific manual
+fallback token; it does not replace the required
+`context_origin:stage=review=<handle>` reference.
 
 Record this review's context identifier as
 `context_origin:stage=review=<handle>`, where `<handle>` is the dispatched

--- a/internal/tmpl/templates/skills/spec-compliance-review/SKILL.md.tmpl
+++ b/internal/tmpl/templates/skills/spec-compliance-review/SKILL.md.tmpl
@@ -149,7 +149,10 @@ host has not declared subagent capability available, `slipway next`/`run` surfac
 a subagent-delegation prerequisite plus a named degraded fallback for this review:
 authorize subagent dispatch, or explicitly select the named fallback (for example
 `same_context_degraded`) and record fresh reviewer evidence for the degraded run —
-do not review inline without recording the selected fallback.
+do not review inline without recording the selected fallback. The fallback is an
+additional structured reference such as
+`--reference "fallback:same_context_degraded"`; it does not replace the required
+`context_origin:stage=review=<handle>` reference.
 
 Record this review's per-stage context identifier as
 `context_origin:stage=review=<handle>`, where `<handle>` is the dispatched

--- a/internal/tmpl/templates_test.go
+++ b/internal/tmpl/templates_test.go
@@ -1296,6 +1296,8 @@ func TestS3ReviewTemplateContractsStayLiveAndSynchronized(t *testing.T) {
 			for _, requiredReference := range tt.requiredReferences {
 				assert.Contains(t, recordVerification, requiredReference)
 			}
+			assert.Contains(t, content, `--reference "fallback:same_context_degraded"`)
+			assert.Contains(t, content, "`context_origin:stage=review=<handle>`")
 		})
 	}
 }
@@ -1398,6 +1400,12 @@ func TestEvidenceCommandEntryUsesResultFileOnlyTaskSurface(t *testing.T) {
 	content := renderPromptSurfaceForTest(t, "commands/command-entry.md.tmpl", "evidence", "command-evidence-body", "claude")
 	assert.Contains(t, content, "slipway evidence task --result-file",
 		"evidence command body should teach result-file task evidence import")
+	assert.Contains(t, content, `--reference "context_origin:stage=review=<handle>"`,
+		"evidence command body should teach selected-review context-origin evidence")
+	assert.Contains(t, content, "artifacts/changes/<slug>/verification/<selected-review-skill>-notes.md",
+		"evidence command body should teach selected-review notes-file convention")
+	assert.Contains(t, content, `--reference "fallback:same_context_degraded"`,
+		"evidence command body should teach degraded fallback as a structured reference")
 	assert.Equal(t, 1, strings.Count(content, "slipway evidence task --help"),
 		"evidence command body should have exactly one manual fallback breadcrumb")
 

--- a/internal/toolgen/surface_manifest.go
+++ b/internal/toolgen/surface_manifest.go
@@ -178,7 +178,7 @@ func jsonContractRows() []SurfaceManifestRow {
 					Name:   "evidence-skill-refresh-current-json",
 					Source: commandSourcePath(def.ID),
 					Docs:   "docs/reference/commands.md",
-					Token:  "slipway evidence skill --skill <name> --verdict pass --refresh-current --json",
+					Token:  "slipway evidence skill --skill <selected-review-skill> --verdict pass --refresh-current --reference \"context_origin:stage=review=<handle>\" --notes-file artifacts/changes/<slug>/verification/<selected-review-skill>-notes.md --json",
 				},
 			)
 			continue

--- a/internal/toolgen/surface_manifest_test.go
+++ b/internal/toolgen/surface_manifest_test.go
@@ -145,7 +145,7 @@ func TestSurfaceManifestExposesEvidenceRefreshCurrentJSONContract(t *testing.T) 
 		assert.Equal(t, "cmd/evidence.go", row.Source)
 		assert.Equal(t, "docs/reference/commands.md", row.Docs)
 		assert.Equal(t,
-			"slipway evidence skill --skill <name> --verdict pass --refresh-current --json",
+			"slipway evidence skill --skill <selected-review-skill> --verdict pass --refresh-current --reference \"context_origin:stage=review=<handle>\" --notes-file artifacts/changes/<slug>/verification/<selected-review-skill>-notes.md --json",
 			row.Token)
 		return
 	}


### PR DESCRIPTION
## Summary

- Fail selected S3 review pass evidence before persistence unless it carries exactly one valid `context_origin:stage=review=<handle>` reference.
- Add the shared model helper and focused coverage for missing, malformed, conflicting duplicate, and duplicate-identical review context-origin refs.
- Update evidence remediation, generated command/skill surfaces, localized docs, and the committed surface manifest.
- Archive the governed Slipway change bundle for `fix-s3-review-evidence-guard`.

Fixes #394

## Verification

- `go test ./cmd -run 'TestEvidenceSkillRecordsCLIStampedVerificationAndDigest|TestEvidenceSkill(RecordsSelectedReviewPeerWithoutSpecPredecessor|RejectsSelectedReviewPassWithoutReviewContextOrigin|SelectedReviewContextOriginGuardSkipsFailVerdict|AllowsSelectedReviewerRestampForInvalidContextOrigin|RefreshCurrentSelectedReviewerWithValidContextOrigin)$' -count=1`
- `go test ./internal/toolgen -run 'TestSurfaceManifestExposesEvidenceRefreshCurrentJSONContract|TestCommittedSurfaceManifestMatchesBuilder|TestSurfaceManifestDocsTokensExist' -count=1`
- `go test ./cmd ./internal/model ./internal/engine/capability ./internal/tmpl ./internal/toolgen -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- `go run ./internal/testlint/cmd/testlint ./...`
- `golangci-lint run --timeout 5m`
- `just coverage-gate`
- `go run ./internal/toolgen/cmd/gen-surface-manifest --check`
- `git diff --check`
- `SLIPWAY_HOST_CAPABILITY_FALLBACKS=same_context_degraded go run . validate`
- `SLIPWAY_HOST_CAPABILITY_FALLBACKS=same_context_degraded go run . done`
