### PR TITLE
fix(runtime): expose host env contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,9 @@ surfaces:
   [Subagent Configuration](docs/reference/subagents.md).
 - Runtime/host environment variables describe the current AI host session:
   context-window size, host capabilities, handoff owner identity, and similar
-  facts. Discover them with `slipway config list --env`.
+  facts. Discover them with `slipway config list --env`; see
+  [Host Environment Variables](docs/reference/host-environment.md) for the
+  concrete host capability tokens, fallback modes, and unset behavior.
 - Secret environment variables, including GitHub tokens, are environment-only
   and are never representable in `.slipway.yaml`.
 

--- a/artifacts/changes/archived/fix-runtime-host-env-wiring/assurance.md
+++ b/artifacts/changes/archived/fix-runtime-host-env-wiring/assurance.md
@@ -1,0 +1,153 @@
+# Assurance
+
+## Scope Summary
+
+This change repairs GitHub issue #395 by making runtime-host environment wiring
+discoverable from public surfaces instead of source-code inspection. It adds
+structured env contract metadata to `EnvCatalog()`, projects that metadata
+through `slipway config list --env` text and JSON output, and documents host
+integration in public docs.
+
+The core implementation is additive:
+
+- `internal/model.EnvCatalogEntry` now includes `value_syntax`,
+  `accepted_values`, `examples`, and `unset_behavior`.
+- `SLIPWAY_HOST_CAPABILITIES` documents `subagent`, `delegation`, `none`,
+  `unavailable`, and the closed-world handling of unrecognized non-empty tokens.
+- `SLIPWAY_HOST_CAPABILITY_FALLBACKS` documents same-context and manual fallback
+  modes and their case-insensitive token matching.
+- `config list --env` preserves the original table and appends contract details;
+  `config list --env --json` gains only additive `omitempty` fields.
+- Public docs now include `docs/reference/host-environment.md`, README and docs
+  index links, reference-command pointers, and the expanded `docs/commands.md`
+  row that issue #395 identified as ownership-only.
+
+S3 review also found two small runtime/parser mismatches that were better fixed
+than documented around:
+
+- `SLIPWAY_HOST_CAPABILITY_FALLBACKS` now matches fallback tokens
+  case-insensitively while returning canonical mode names.
+- `SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS` now accepts carriage-return separators,
+  matching the catalog/docs and the host capability splitter.
+
+No schema migration, external API shape change, config-file secret storage, or
+credential egress relaxation is part of this work.
+
+## Verification Verdict
+
+Current verdict: ready for terminal ship-verification once the refreshed S3
+review evidence and this assurance artifact are recorded.
+
+Completed peer review evidence to refresh:
+
+- `spec-compliance-review`: pass, including `layer:R0=pass`,
+  `layer:R3=pass`, `scope_contract:pass`, and `negative_path:pass`.
+- `code-quality-review`: pass, including `layer:IR1=pass` and
+  `layer:IR3=pass`.
+- `independent-review`: pass.
+- `security-review`: pass.
+
+Because this host has not declared subagent capability, the S3 peer reviews use
+the explicit `same_context_degraded` fallback with distinct review handles. The
+terminal ship-verification gate must also record the selected fallback and the
+reviewer-independence, assurance, and high-risk safety-baseline attestations.
+
+## Evidence Index
+
+- Public command output:
+  `go run . config list --env` and `go run . config list --env --json` both
+  expose the structured contract fields and updated host capability/fallback
+  text.
+- Full suite:
+  `artifacts/changes/fix-runtime-host-env-wiring/verification/logs/ship-go-test.txt`
+  from `go test ./... -count=1`, exit 0.
+- Lint:
+  `artifacts/changes/fix-runtime-host-env-wiring/verification/logs/ship-golangci-lint.txt`
+  from `golangci-lint run ./... --timeout=5m`, exit 0 when available in this
+  worktree.
+- Coverage:
+  `artifacts/changes/fix-runtime-host-env-wiring/verification/logs/ship-coverage.txt`,
+  `ship-coverage.out`, and `ship-coverage-func.txt` from
+  `go test ./internal/model ./cmd -coverprofile=... -count=1`.
+- SAST baseline:
+  `artifacts/changes/fix-runtime-host-env-wiring/verification/logs/ship-semgrep.txt`
+  and `ship-semgrep.json` from Semgrep `p/gosec` over the changed Go files:
+  `cmd/config.go`, `cmd/config_test.go`, `cmd/tool_github.go`,
+  `cmd/tool_github_test.go`, `internal/engine/capability/resolver.go`,
+  `internal/engine/capability/resolver_test.go`,
+  `internal/model/env_catalog.go`, and `internal/model/env_catalog_test.go`.
+- Stub scan:
+  `artifacts/changes/fix-runtime-host-env-wiring/verification/logs/ship-stub-scan.txt`.
+- Review evidence:
+  `verification/spec-compliance-review.yaml`,
+  `verification/code-quality-review.yaml`,
+  `verification/independent-review.yaml`, and
+  `verification/security-review.yaml`.
+
+## Requirement Coverage
+
+- REQ-001 Structured Env Wiring Catalog:
+  `internal/model/env_catalog.go` exposes structured metadata for all catalog
+  entries, including host capability and fallback tokens. The model tests require
+  value syntax and unset behavior for every catalog entry, scan public env
+  literals, and assert closed-world/fallback wording.
+- REQ-002 Host-Facing Config Output:
+  `cmd/config.go` returns structured JSON directly from `EnvCatalog()` and
+  appends `CONTRACT DETAILS` to text output. Command tests assert raw JSON field
+  names, accepted host tokens, unset behavior, and the concrete subagent
+  declaration.
+- REQ-003 Public Host Integration Documentation:
+  `docs/reference/host-environment.md` maps skill preconditions to
+  `SLIPWAY_HOST_CAPABILITIES=subagent`, explains `delegation`, `none`,
+  `unavailable`, fallback modes, context metrics, handoff owner, GitHub API
+  allowlists, and secret boundaries. README, `docs/index.md`,
+  `docs/reference/commands.md`, and `docs/commands.md` link or describe the new
+  authority.
+- REQ-004 Verification Coverage:
+  Focused tests, full suite, Semgrep SAST, coverage output, stub scan, and four
+  S3 reviews are recorded in the evidence index above.
+
+## Residual Risks and Exceptions
+
+- Text output is more verbose. This is accepted because the original table is
+  preserved, and `--json` remains the stable machine-readable contract.
+- Documentation is English-only in this change. Existing localized docs are not
+  updated; the authoritative command output and primary docs now carry the
+  complete contract.
+- Case-insensitive fallback matching accepts uppercase spellings of existing
+  fallback mode names. This is intentional host interoperability, not a bypass:
+  fallback evidence is still required and unrecognized fallback tokens are still
+  ignored.
+- Carriage-return splitting slightly broadens accepted separator syntax for
+  operator-supplied GitHub API allowlists. URL normalization, exact allowlist
+  matching, and override-token destination checks still gate credential egress.
+
+## Rollback Readiness
+
+Rollback is straightforward and local:
+
+- Revert `internal/model/env_catalog.go`, `internal/model/env_catalog_test.go`,
+  `internal/engine/capability/resolver.go`,
+  `internal/engine/capability/resolver_test.go`, `cmd/config.go`,
+  `cmd/config_test.go`, `cmd/tool_github.go`, `cmd/tool_github_test.go`,
+  `docs/reference/host-environment.md`, `docs/reference/commands.md`,
+  `docs/commands.md`, `docs/index.md`, and `README.md`.
+- Remove this change's governed bundle if the rollback abandons the change.
+- Verify rollback with `go test ./internal/model ./cmd ./internal/engine/capability -count=1`
+  and `go run . validate` in the active worktree.
+
+No schema migration, irreversible state change, external API response shape
+change, or credential-format change is part of this work.
+
+## Archive Decision
+
+Archive decision: not ready to archive until ship-verification records the
+terminal pass evidence, including
+`high_risk_check:external_api_contracts.safety_baseline=pass`,
+`closeout:reviewer_independence=pass`, and
+`closeout:assurance_complete=pass`.
+
+After ship-verification is recorded, `go run . validate` and
+`go run . next --json --diagnostics` must be rerun before declaring done-ready.
+Archived bundles must be treated as frozen records, not revalidated through the
+active validate gate.

--- a/artifacts/changes/archived/fix-runtime-host-env-wiring/change.yaml
+++ b/artifacts/changes/archived/fix-runtime-host-env-wiring/change.yaml
@@ -1,0 +1,62 @@
+version: 1
+slug: fix-runtime-host-env-wiring
+description: fix runtime host env wiring
+status: done
+current_state: DONE
+needs_discovery: true
+complexity_level: complex
+base_ref: HEAD
+created_at: 2026-07-02T07:03:27.865614Z
+guardrail_domain: external_api_contracts
+quality_mode: full
+workflow_profile: code
+workflow_preset: standard
+worktree_branch: feat/fix-runtime-host-env-wiring
+artifact_schema: expanded
+artifacts:
+    assurance:
+        id: assurance
+        path: assurance.md
+        state: frozen
+        content_hash: 65d014b1b08053dcb32ce756a13e73f6c862a86ccf75a32498ccbd439f762b64
+        updated_at: 2026-07-02T09:12:51.5820044Z
+    decision:
+        id: decision
+        path: decision.md
+        state: frozen
+        content_hash: a68d115e19117ba2dfd21eff5884cd72c805eec33ce680465522c2dbe9ea95b9
+        updated_at: 2026-07-02T07:11:01.975306849Z
+    intent:
+        id: intent
+        path: intent.md
+        state: frozen
+        content_hash: 6da77f75107dc4d46677094dcfb733a22bac7059dc06fa5009d10c95ed867981
+        updated_at: 2026-07-02T07:09:37.518797441Z
+    requirements:
+        id: requirements
+        path: requirements.md
+        state: frozen
+        content_hash: 2e1b0bd85bba34192bf8edb21256702282d9c81bb431f3ea9895d9182e554505
+        updated_at: 2026-07-02T07:11:01.974657649Z
+    research:
+        id: research
+        path: research.md
+        state: frozen
+        content_hash: 302eceb7b5db0e34b31ffc4267b1a57b8a5a7243047ff8f509602137f0adf5cd
+        updated_at: 2026-07-02T07:09:29.866134054Z
+    tasks:
+        id: tasks
+        path: tasks.md
+        state: frozen
+        content_hash: 9730bf98be63f5281bb3a3eea227c6d67d108acab615b920a5f3381ff6af3881
+        updated_at: 2026-07-02T08:55:14.943130378Z
+evidence_refs:
+    code-quality-review: .worktrees/fix-runtime-host-env-wiring/artifacts/changes/fix-runtime-host-env-wiring/verification/code-quality-review.yaml
+    independent-review: .worktrees/fix-runtime-host-env-wiring/artifacts/changes/fix-runtime-host-env-wiring/verification/independent-review.yaml
+    intake-clarification: .worktrees/fix-runtime-host-env-wiring/artifacts/changes/fix-runtime-host-env-wiring/verification/intake-clarification.yaml
+    plan-audit: .worktrees/fix-runtime-host-env-wiring/artifacts/changes/fix-runtime-host-env-wiring/verification/plan-audit.yaml
+    research-orchestration: .worktrees/fix-runtime-host-env-wiring/artifacts/changes/fix-runtime-host-env-wiring/verification/research-orchestration.yaml
+    security-review: .worktrees/fix-runtime-host-env-wiring/artifacts/changes/fix-runtime-host-env-wiring/verification/security-review.yaml
+    ship-verification: .worktrees/fix-runtime-host-env-wiring/artifacts/changes/fix-runtime-host-env-wiring/verification/ship-verification.yaml
+    spec-compliance-review: .worktrees/fix-runtime-host-env-wiring/artifacts/changes/fix-runtime-host-env-wiring/verification/spec-compliance-review.yaml
+    wave-orchestration: .worktrees/fix-runtime-host-env-wiring/artifacts/changes/fix-runtime-host-env-wiring/verification/wave-orchestration.yaml

--- a/artifacts/changes/archived/fix-runtime-host-env-wiring/decision.md
+++ b/artifacts/changes/archived/fix-runtime-host-env-wiring/decision.md
@@ -1,0 +1,97 @@
+# Decision
+
+## Alternatives Considered
+
+1. Docs-only repair.
+   - This would add a host integration page explaining
+     `SLIPWAY_HOST_CAPABILITIES=subagent`.
+   - It is too weak because `slipway config list --env --json` would remain
+     unable to tell hosts accepted values, unset behavior, or examples.
+
+2. Skill-remediation repair.
+   - This would patch each affected generated skill to name
+     `SLIPWAY_HOST_CAPABILITIES`.
+   - It crosses the instruction boundary: skills should describe workflow
+     prerequisites and evidence obligations, not become host integration
+     manuals. It also duplicates the same wiring across many stage skills.
+
+3. Structured env catalog repair with doc projection.
+   - This adds optional structured wiring metadata to `EnvCatalogEntry`, fills
+     it for env vars with real contracts, projects it through
+     `config list --env` text/JSON, and adds concise public docs that point back
+     to the catalog.
+   - It is additive, machine-readable, testable, and keeps runtime behavior
+     unchanged.
+
+## Selected Approach
+
+Select alternative 3: extend the env catalog as the single public authority for
+environment-variable contracts, then document host integration around that
+authority.
+
+The concrete design:
+
+- Add optional fields to `internal/model.EnvCatalogEntry`:
+  - `ValueSyntax string` for free-form value shape.
+  - `AcceptedValues []EnvAcceptedValue` for constrained tokens and their
+    behavior.
+  - `Examples []string` for copyable declarations.
+  - `UnsetBehavior string` for unset, empty, malformed, or fallback behavior.
+- Populate these fields for all catalog entries where research found non-obvious
+  wiring: host capabilities, fallback modes, context window/metrics/session
+  owner, and GitHub token/API environment variables.
+- Keep existing fields and runtime behavior unchanged.
+- Update `cmd/config.go` text output so humans see the contract in
+  `config list --env`; JSON output receives the new fields automatically.
+- Add a host environment reference page and link it from existing config and
+  command docs.
+- Add tests that connect the public catalog contract to existing runtime
+  semantics, especially the `subagent` / `delegation` / `none` / `unavailable`
+  behavior.
+
+## Interfaces and Data Flow
+
+Changed public interface:
+
+- `slipway config list --env --json` gains additive optional fields on each env
+  entry. Existing JSON fields remain unchanged.
+- `slipway config list --env` gains human-readable contract columns or detail
+  lines that expose value syntax, accepted values, examples, and unset behavior.
+
+Internal data flow:
+
+1. Runtime code continues to read environment variables from the same call sites.
+2. `EnvCatalog()` records the public contract for those reads.
+3. `runConfigList(..., envFlag=true)` reads `EnvCatalog()` and projects it to
+   JSON/text.
+4. Docs point host integrators to `slipway config list --env` for the current
+   authority.
+
+No persisted change-state format, lifecycle transition, capability resolver, or
+credential routing behavior changes.
+
+## Rollout and Rollback
+
+Rollout:
+
+- Ship additive model fields, output formatting, docs, and tests together.
+- Existing JSON consumers that ignore unknown fields continue to work.
+- Humans get richer text output from the same command.
+
+Rollback:
+
+- Revert changes to `internal/model/env_catalog.go`, `cmd/config.go`, affected
+  tests, and docs.
+- Verify rollback with `go test ./internal/model ./cmd -count=1`.
+
+## Risk
+
+- JSON compatibility risk: mitigated by additive `omitempty` fields only.
+- Text-output churn risk: mitigated by retaining the existing core columns and
+  appending structured contract details rather than changing command semantics.
+- Secret handling risk: mitigated by preserving `Secret=true` and empty
+  `FileConfigKey` for secret entries.
+- Documentation drift risk: mitigated by making the catalog/output the primary
+  authority and testing key host capability wording there.
+- External API contract risk: mitigated by review gates and by avoiding runtime
+  behavior changes.

--- a/artifacts/changes/archived/fix-runtime-host-env-wiring/intent.md
+++ b/artifacts/changes/archived/fix-runtime-host-env-wiring/intent.md
@@ -1,0 +1,84 @@
+# Intent
+
+## Summary
+Fix runtime-host environment wiring discoverability for issue #395, and
+systematically investigate whether similar hidden environment-contract gaps
+exist across Slipway public surfaces.
+
+## Complexity Assessment
+complex
+Rationale: this changes a public host-integration contract surface, may extend
+the env catalog schema/output, requires repo-wide contract-gap research, and
+must preserve existing runtime semantics while improving discoverability.
+
+## Guardrail Domains
+external_api_contracts
+
+## In Scope
+- Investigate and repair the host-facing wiring surface for
+  `SLIPWAY_HOST_CAPABILITIES` and `SLIPWAY_HOST_CAPABILITY_FALLBACKS`.
+- Extend the env catalog or equivalent single-authority surface so
+  `slipway config list --env` JSON/text output can expose accepted values,
+  value-to-behavior mappings, unset behavior, and host integration guidance
+  where an environment variable has a real operational contract.
+- Audit all Slipway environment variables across runtime-host, secret, and
+  repo-policy scopes for the same class of hidden contract gap.
+- Add a host-integration doc that reconciles generated skill preconditions such
+  as "host declared subagent capability" with the concrete env knob.
+- Add contract tests for env catalog completeness, output shape, and the
+  documented host capability wiring.
+
+## Out of Scope
+- Reworking subagent execution, dispatch, or capability-resolution semantics.
+- Changing accepted capability tokens unless research proves the existing
+  runtime contract conflicts with the public contract.
+- Fixing unrelated open issues #371, #361, or #392.
+- Publishing, uploading, or editing README video assets.
+
+## Constraints
+- Preserve existing behavior for all environment variables unless the current
+  behavior is inconsistent with the newly documented public contract.
+- Keep skills focused on agent workflow requirements; put host-integration
+  manuals in catalog/docs surfaces instead of per-stage skill prose.
+- Treat the env catalog as the preferred single public authority for environment
+  variables consumed by Slipway commands.
+
+## Acceptance Signals
+- Without reading Go source, a host integrator can learn from public surfaces how
+  to declare subagent capability, including `SLIPWAY_HOST_CAPABILITIES=subagent`
+  and the behavior of `delegation`, `none`, `unavailable`, empty, and unset.
+- `slipway config list --env` text output and `--json` output expose the
+  relevant env wiring contract for runtime-host variables that have accepted
+  values or non-obvious unset behavior.
+- The same hidden-contract class is investigated across all env vars, with
+  fixed gaps or an explicit no-fix-needed rationale.
+- Tests cover env catalog contract completeness, config env output, and the
+  host capability wiring public contract.
+- Governed plan, implementation evidence, review, and final verification pass.
+
+## Open Questions
+<!-- Track real unknowns as a checklist. An unchecked `- [ ]` item is unresolved
+     and routes intake to S0_INTAKE/research; mark `- [x]` once resolved. Leave the
+     section empty (or write `None`) when there are none. Prose here is
+     documentation, not a blocker — a genuine open question must be a `- [ ]`. -->
+- [x] Which current env vars have accepted values, format constraints, fallback
+  semantics, or behavior mappings that are only discoverable from Go source or
+  tests?
+- [x] Which public surfaces should own the host-integration contract without
+  turning generated workflow skills into host manuals?
+- [x] What schema/output design gives host integrators enough detail while
+  preserving backward-compatible JSON consumers?
+
+## Deferred Ideas
+- A broader redesign of auto mode or plan-audit semantics belongs to #361/#371,
+  not this change.
+- Future CLI affordances may validate env var values directly, but this change
+  focuses on discoverability and contract documentation.
+
+## Approved Summary
+Confirmed by user on 2026-07-02: solve issue #395 and, before designing the
+fix, thoroughly investigate similar hidden environment-contract problems across
+the project. The change will repair host-facing runtime env wiring
+discoverability, especially for host capability declarations, by updating the
+env catalog/config output/docs/tests while preserving runtime behavior and
+leaving unrelated issues #371, #361, and #392 out of scope.

--- a/artifacts/changes/archived/fix-runtime-host-env-wiring/requirements.md
+++ b/artifacts/changes/archived/fix-runtime-host-env-wiring/requirements.md
@@ -1,0 +1,88 @@
+# Requirements
+
+## Requirements
+
+### Requirement: Structured Environment Wiring Catalog
+
+REQ-001: The system MUST expose environment-variable wiring contracts in
+`EnvCatalog()` for variables whose values have accepted tokens, format
+constraints, examples, fallback behavior, or other non-obvious runtime effects.
+
+#### Scenario: host capability tokens are discoverable
+
+GIVEN a host integrator needs to run review or verification skills that require
+subagent capability
+WHEN they inspect `SLIPWAY_HOST_CAPABILITIES` through the env catalog
+THEN the catalog states that `subagent` and `delegation` satisfy the subagent
+capability, `none` and `unavailable` declare it unavailable, and unset or empty
+values remain unknown.
+
+#### Scenario: future env vars cannot hide contracts
+
+GIVEN a production code path reads a public env var with accepted values or
+fallback semantics
+WHEN the env catalog entry omits structured contract detail
+THEN tests MUST fail before the change can pass verification.
+
+### Requirement: Host-Facing Config Output
+
+REQ-002: `slipway config list --env` and `slipway config list --env --json`
+SHALL project the structured env wiring contract without removing or renaming
+existing public output fields.
+
+#### Scenario: JSON consumers receive machine-readable wiring
+
+GIVEN a caller runs `slipway config list --env --json`
+WHEN the response includes `SLIPWAY_HOST_CAPABILITIES`
+THEN the entry includes machine-readable accepted values, examples, and unset
+behavior while retaining existing fields such as `name`, `scope`,
+`description`, and `secret`.
+
+#### Scenario: text output closes the host-integration loop
+
+GIVEN a human runs `slipway config list --env`
+WHEN they inspect runtime-host entries
+THEN the text output includes enough wiring detail to set the environment
+without reading Go source.
+
+### Requirement: Public Host Integration Documentation
+
+REQ-003: The documentation MUST reconcile workflow skill preconditions such as
+"host declared subagent capability" with concrete environment knobs and keep
+host manuals out of per-stage workflow skill bodies.
+
+#### Scenario: public docs explain subagent capability declaration
+
+GIVEN a host integrator reads the public docs
+WHEN they need to declare subagent capability
+THEN the docs show `SLIPWAY_HOST_CAPABILITIES=subagent`, explain the
+`delegation` alias, explain explicit unavailable declarations, and point to
+`slipway config list --env` as the current catalog authority.
+
+#### Scenario: skill boundary remains focused
+
+GIVEN generated review, audit, or verification skills mention host capability
+requirements
+WHEN this change is complete
+THEN those skills remain workflow evidence instructions rather than duplicated
+host environment manuals.
+
+### Requirement: Verification Coverage
+
+REQ-004: The change MUST include tests that prove catalog completeness,
+structured output, and host capability wiring documentation for the guarded
+external API contract surface.
+
+#### Scenario: focused tests cover the repair
+
+GIVEN the implementation is complete
+WHEN focused tests for `internal/model`, `cmd`, and capability resolution run
+THEN they pass and prove the public env contract matches existing runtime
+semantics.
+
+#### Scenario: governed verification can close
+
+GIVEN the governed change reaches review
+WHEN validation, selected reviews, and final verification run
+THEN they use fresh evidence and do not rely on stale or hand-edited readiness
+state.

--- a/artifacts/changes/archived/fix-runtime-host-env-wiring/research.md
+++ b/artifacts/changes/archived/fix-runtime-host-env-wiring/research.md
@@ -1,0 +1,149 @@
+# Research
+
+## Alternatives Considered
+
+### Architecture
+- Affected modules: `internal/model/env_catalog.go`, `cmd/config.go`,
+  `cmd/config_test.go`, `internal/model/env_catalog_test.go`, docs under
+  `docs/`, and generated skill source templates that mention host capability
+  preconditions.
+- Dependency chains: production env reads flow from command/runtime code into
+  behavior (`cmd/next.go`, `cmd/context_pressure_hook.go`,
+  `cmd/next_context_budget.go`, `cmd/tool_github.go`,
+  `internal/state/handoff.go`); `internal/model/env_catalog.go` is the curated
+  public env authority; `cmd/config.go` projects that authority through
+  `slipway config list --env`; docs and command help point users back to that
+  command.
+- Blast radius: additive model/output/docs/tests. No lifecycle state file,
+  capability resolver, subagent dispatch, or credential destination semantics
+  need to change.
+- Constraints: JSON output is public, so the design must add `omitempty` fields
+  without removing or renaming existing fields. Secrets must remain env-only.
+  Workflow skills should keep capability prerequisites, not become host manuals.
+
+Env contract audit:
+
+| Env var | Hidden contract found | Current public surface | Fix decision |
+| --- | --- | --- | --- |
+| `SLIPWAY_HOST_CAPABILITIES` | Accepted tokens `subagent`, `delegation`, `none`, `unavailable`; unset/empty means unknown and triggers a continuable authorization prerequisite; non-matching declared tokens mean unavailable. | Catalog only says "tokens"; skills say "host with subagent capability"; no public token mapping. | Fix in env catalog JSON/text and host-env doc. |
+| `SLIPWAY_HOST_CAPABILITY_FALLBACKS` | Accepted values are the fallback modes declared on selected host-capability contracts, e.g. `manual_plan_audit`, `manual_independent_review`, `manual_security_review`, `manual_spec_compliance_review`, `manual_code_quality_review`, `manual_ship_verification`, `same_context_degraded`. | Catalog only says "fallbacks"; skills mention modes locally. | Fix in env catalog JSON/text and host-env doc. |
+| `SLIPWAY_CONTEXT_WINDOW_TOKENS` | Positive integer only; malformed, zero, or negative values are ignored; default is 200000 tokens. | `next --help` documents this; catalog omits syntax/default behavior. | Add catalog structured syntax/unset behavior for single-source discovery. |
+| `SLIPWAY_CONTEXT_METRICS_PATH` | Optional JSON metrics file path for context-pressure hook. Metrics may use `tokens_used` + `context_window`, `used_pct`, `used_percentage`, or `remaining_percentage`; stale metrics older than 60s are ignored; unset falls back to sanitized session temp files and transcript tail. | Catalog only names path. | Add catalog/doc metadata for path, accepted JSON fields, and unset fallback. |
+| `SLIPWAY_SESSION_OWNER` | First non-empty owner wins from `SLIPWAY_SESSION_OWNER`, `USER`, `USERNAME`, hostname, then `unknown`. | `handoff --help` and catalog mention part of this. | Add precise catalog unset behavior. |
+| `USER` / `USERNAME` | Ambient fallback only for handoff owner. | Catalog names fallback. | No structural accepted values needed; add unset behavior only if schema requires consistency. |
+| `SLIPWAY_GITHUB_API_URL` | HTTPS GitHub REST/GraphQL base URL, normalized; env > file > default; override must be allowlisted. | GitHub helper help and README explain this; catalog has default/file key. | Add value syntax/unset behavior to catalog, but no runtime change. |
+| `SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS` | Comma/space/semicolon/newline/tab separated HTTPS API base URLs, normalized; env list overrides file allowlist and confirms token egress for file-configured override URLs. | GitHub helper help and README explain this. | Add value syntax/unset behavior to catalog. |
+| `SLIPWAY_GITHUB_API_TOKEN` | Env-only token sent only to allowlisted override host; ambient tokens are not sent to override hosts. | GitHub helper help and README explain this. | Add catalog unset behavior; preserve secret handling. |
+| `GH_TOKEN` / `GITHUB_TOKEN` | Ambient tokens used only for default `https://api.github.com`; `GH_TOKEN` wins over fallback. | GitHub helper help and README explain this. | Add catalog unset behavior; preserve secret handling. |
+
+### Patterns
+- Existing config catalog pattern: `internal/model/config_catalog.go` uses
+  `AllowedValues []string` for constrained `.slipway.yaml` keys and
+  `cmd/config.go` renders those values in text output. Env catalog currently has
+  no equivalent.
+- Existing env coverage pattern:
+  `internal/model/env_catalog_test.go:TestEnvCatalogCoversEveryGetenv` scans
+  production source literals and fails if a public env var is read without a
+  catalog entry. This is the right test to extend from "listed" to "listed with
+  contract detail when needed".
+- Existing command-help pattern: `cmd/tool_github.go` has rich command-local env
+  help for GitHub helpers; `cmd/next.go` and `cmd/handoff.go` include narrower
+  env help. The catalog should not depend on every command duplicating the same
+  full contract.
+- Existing generated-skill pattern: skill frontmatter and remediation name host
+  capability requirements/fallback evidence, while resolver behavior and
+  next/validate projections own availability. Do not duplicate env knob manuals
+  into every skill template.
+
+### Risks
+- Technical risk, medium: widening `EnvCatalogEntry` changes public JSON shape.
+  Mitigation: add only optional fields and keep existing field names.
+- Technical risk, medium: a free-form string-only fix could pass tests but fail
+  machine consumers. Mitigation: use structured fields for value syntax,
+  accepted values with descriptions, examples, and unset behavior.
+- Security risk, low: documenting secrets must not imply they can be persisted
+  to `.slipway.yaml`. Mitigation: preserve `secret=true`, keep `file_config_key`
+  empty for secret entries, and explicitly describe env-only behavior.
+- Guardrail domain: external API contract. The change affects public host
+  integration behavior and must fail closed to review and evidence.
+- Reversibility: additive catalog/docs/tests are straightforward to revert; no
+  persisted user state migration is involved.
+
+### Test Strategy
+- Existing coverage: `internal/model/env_catalog_test.go` covers source env
+  usage and entry well-formedness; `cmd/config_test.go` covers env text/JSON
+  output; `internal/engine/capability/resolver_test.go` covers capability token
+  runtime semantics.
+- New coverage: require non-empty contract metadata for env vars with accepted
+  values or non-obvious behavior; assert `SLIPWAY_HOST_CAPABILITIES` JSON
+  includes accepted token mappings; assert text output includes contract fields;
+  assert docs mention the concrete subagent declaration knob.
+- Verification approach: run focused Go tests for `./internal/model`, `./cmd`,
+  and `./internal/engine/capability`, then full `go test ./...` plus governed
+  validation.
+
+### Options
+- Option A: Add structured env catalog wiring metadata and project it through
+  `config list --env`, then add a concise host environment doc.
+  - Pros: single authority, machine-readable JSON, human-readable text, catches
+    future drift with tests, satisfies #395 without changing runtime behavior.
+  - Cons: slightly expands public JSON shape and text output.
+- Option B: Add only a host-integration doc.
+  - Pros: smallest implementation.
+  - Cons: leaves `config list --env --json` incomplete and does not prevent the
+    same bug for future env vars.
+- Option C: Patch every affected generated skill remediation to name
+  `SLIPWAY_HOST_CAPABILITIES`.
+  - Pros: users may see the knob near the blocker.
+  - Cons: crosses the instruction boundary, duplicates host manuals across
+    skills, and still leaves the env catalog incomplete.
+- Selected: Option A. The user asked for the optimal design after a thorough
+  investigation, and the evidence shows the env catalog is already the intended
+  discovery authority. A concise doc can explain host integration, but the
+  catalog/output must carry the structured contract.
+
+## Unknowns
+
+- Resolved: Which env vars have hidden accepted values, fallback semantics, or
+  behavior mappings? -> See the env contract audit table above. Host capability
+  env vars are the highest-impact hidden contract; context and GitHub vars also
+  merit structured catalog detail.
+- Resolved: Which public surface should own host-integration wiring? ->
+  `EnvCatalog()` / `slipway config list --env` should own the machine-readable
+  contract; docs should explain integration; per-stage skills should remain
+  workflow instructions.
+- Resolved: What schema/output design is best? -> Optional additive fields on
+  `EnvCatalogEntry`: value syntax, accepted values with behavior descriptions,
+  examples, and unset behavior. Text output should expose the same contract
+  without removing existing columns.
+- Remaining: None.
+
+## Assumptions
+
+- Existing runtime behavior is correct and should not change. Evidence:
+  `internal/engine/capability/resolver.go`, `cmd/context_pressure_hook.go`,
+  `cmd/next_context_budget.go`, `cmd/tool_github.go`.
+- Additive JSON fields are acceptable for public command output. Evidence:
+  existing `ConfigCatalogEntry` and `EnvCatalogEntry` structs use `omitempty`
+  optional fields, and current tests assert required fields without forbidding
+  additional fields.
+- English docs are sufficient for this change's primary host-integration
+  closure; localized command summaries can remain general unless the repo has a
+  generation path for translated prose. Evidence: issue #395 asks for a public
+  host-facing surface and acceptance is centered on `config list --env`.
+
+## Canonical References
+
+- `internal/model/env_catalog.go`
+- `internal/model/env_catalog_test.go`
+- `cmd/config.go`
+- `cmd/config_test.go`
+- `internal/engine/capability/resolver.go`
+- `internal/engine/capability/resolver_test.go`
+- `cmd/next.go`
+- `cmd/context_pressure_hook.go`
+- `cmd/next_context_budget.go`
+- `cmd/tool_github.go`
+- `internal/state/handoff.go`
+- `README.md`
+- `docs/reference/subagents.md`

--- a/artifacts/changes/archived/fix-runtime-host-env-wiring/tasks.md
+++ b/artifacts/changes/archived/fix-runtime-host-env-wiring/tasks.md
@@ -1,0 +1,27 @@
+# Tasks
+
+## Task List
+
+- [x] `t-01` Add structured env wiring metadata to the catalog, runtime contracts, and model tests.
+  - depends_on: []
+  - target_files: [`internal/model/env_catalog.go`, `internal/model/env_catalog_test.go`, `internal/engine/capability/resolver.go`, `internal/engine/capability/resolver_test.go`]
+  - task_kind: code
+  - covers: [REQ-001, REQ-004]
+
+- [x] `t-02` Project env wiring metadata through `config list --env` text/JSON and command tests.
+  - depends_on: [`t-01`]
+  - target_files: [`cmd/config.go`, `cmd/config_test.go`, `cmd/tool_github.go`, `cmd/tool_github_test.go`]
+  - task_kind: code
+  - covers: [REQ-002, REQ-004]
+
+- [x] `t-03` Add host environment documentation and link it from public reference surfaces.
+  - depends_on: [`t-01`, `t-02`]
+  - target_files: [`docs/reference/host-environment.md`, `docs/reference/commands.md`, `docs/commands.md`, `docs/index.md`, `README.md`]
+  - task_kind: doc
+  - covers: [REQ-003]
+
+- [x] `t-04` Run focused and full verification for the env contract repair.
+  - depends_on: [`t-01`, `t-02`, `t-03`]
+  - target_files: [`artifacts/changes/fix-runtime-host-env-wiring/verification/wave-verification-notes.md`]
+  - task_kind: verification
+  - covers: [REQ-001, REQ-002, REQ-003, REQ-004]

--- a/artifacts/codebase/ARCHITECTURE.md
+++ b/artifacts/codebase/ARCHITECTURE.md
@@ -1,40 +1,35 @@
 # Architecture
 
-- Question: Which public lifecycle surfaces need additive route, freshness, and
-  host-capability metadata so agents can recover from non-success states without
-  parsing prose or relying on private resolver knowledge?
-- Route entry points: `CLIError` now has an optional `invocation_route`
-  payload (`cmd/errors.go:46`), and common route builders cover diagnostic
-  paths for `no_active`, `multi_active`, `explicit_missing`, and
-  `bound_elsewhere` (`cmd/common.go:56`, `cmd/common.go:80`,
-  `cmd/common.go:91`, `cmd/common.go:102`, `cmd/common.go:113`). Existing
-  successful route assembly remains centralized in `buildInvocationRouteView`
-  (`cmd/common.go:1184`), with local archived worktrees distinguished as
-  `archived_local` (`cmd/common.go:1211`).
-- Command collaborators: `status` attaches route data to diagnostic summaries
-  and explicit-missing errors (`cmd/status.go:322`, `cmd/status.go:603`);
-  `validate` carries route data from resolution errors into diagnostics
-  (`cmd/validate.go:180`); `next` and `done` reuse active-change resolution and
-  CLIError route payloads rather than adding separate route grammars.
-- Freshness entry points: `nextView` and default handoff views now expose
-  execution, governance, and overall readiness freshness (`cmd/next.go:55`,
-  `cmd/next_handoff.go:22`), while `doneView` reports the same pre-archive
-  concepts plus diagnostics (`cmd/done.go:32`). Shared projection helpers live
-  in `cmd/status_view_build.go:206`, `cmd/status_view_build.go:238`, and
-  `cmd/status_view_build.go:266`.
-- Human status rendering remains the text projection of the same readiness
-  model: it falls back to the legacy single value only when split fields are
-  absent, then prints explicit execution/governance/overall labels
-  (`cmd/status_render.go:145`, `cmd/status_render.go:157`).
-- Host capability authority moves from resolver-only hardcoding to registry
-  metadata. `Skill.HostCapabilities` and validation live in
-  `internal/engine/capability/registry.go:88` and
-  `internal/engine/capability/registry.go:249`; the independent-review
-  contract is declared by the default registry
-  (`internal/engine/capability/registry_default.go:47`); the resolver consumes
-  registry data through `ResolveHostCapabilityRequirementFromRegistry`
-  (`internal/engine/capability/resolver.go:96`).
-- Blast radius: the repair stays in public command JSON/text projections,
-  capability registry/template metadata, and tests. It does not change
-  lifecycle mutation ordering, durable state formats, or GitHub protection
-  settings.
+- Question: Which public surfaces own environment-variable and host-capability
+  contracts so host integrators can wire Slipway without reading Go source?
+- Environment catalog authority: `internal/model/env_catalog.go` defines
+  `EnvCatalogEntry` and `EnvCatalog()`, and `cmd/config.go` projects it through
+  `slipway config list --env` text and JSON. This is the right single authority
+  for env contract metadata because `internal/model/env_catalog_test.go` already
+  scans source literals to ensure every `SLIPWAY_*`, token, and username fallback
+  read by production Go code is cataloged.
+- Runtime-host consumers: `cmd/next.go` reads `SLIPWAY_HOST_CAPABILITIES` and
+  `SLIPWAY_HOST_CAPABILITY_FALLBACKS` for host capability gate projection;
+  `cmd/next_context_budget.go` and `cmd/context_pressure_hook.go` read
+  `SLIPWAY_CONTEXT_WINDOW_TOKENS`; `cmd/context_pressure_hook.go` reads
+  `SLIPWAY_CONTEXT_METRICS_PATH`; `internal/state/handoff.go` reads
+  `SLIPWAY_SESSION_OWNER`, `USER`, and `USERNAME`.
+- Host capability semantics: `internal/engine/capability/resolver.go` maps
+  `subagent` and `delegation` to available subagent capability, `none` and
+  `unavailable` to unavailable, empty/unset to unknown, and configured fallback
+  modes to explicit degraded operation. Current catalog output does not expose
+  those tokens or their behavior.
+- Existing partial public surfaces: command help for GitHub API helpers already
+  explains `SLIPWAY_GITHUB_API_URL`,
+  `SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS`, `SLIPWAY_GITHUB_API_TOKEN`, and
+  `GH_TOKEN`/`GITHUB_TOKEN`; `next --help` explains
+  `SLIPWAY_CONTEXT_WINDOW_TOKENS`; `handoff --help` explains
+  `SLIPWAY_SESSION_OWNER`. These are command-local hints, not the complete env
+  catalog contract.
+- Generated skill boundary: stage skills correctly declare/remediate required
+  host capabilities as workflow prerequisites, but they do not name env knobs.
+  Per instruction-boundary rules, host wiring belongs in `config list --env` and
+  a host-integration doc, not repeated inside every per-stage skill.
+- Blast radius: additive model fields, config output, documentation, and tests.
+  No lifecycle state schema, capability runtime semantics, or subagent dispatch
+  semantics need to change.

--- a/artifacts/codebase/CONCERNS.md
+++ b/artifacts/codebase/CONCERNS.md
@@ -1,30 +1,16 @@
 # Concerns
 
-- Public JSON compatibility risk: route and freshness fields are public command
-  surface. The repair must add fields without removing or renaming existing
-  fields; `nextView`, `doneView`, status/validate diagnostics, and CLIError
-  therefore keep legacy `evidence_freshness` while adding split fields
-  (`cmd/next.go:55`, `cmd/done.go:32`, `cmd/errors.go:46`).
-- Lifecycle execution safety risk: diagnostic route kinds must not imply
-  executable lifecycle authority. No-active, multi-active, explicit-missing,
-  and bound-elsewhere routes explicitly set local/effective lifecycle execution
-  disabled unless the existing successful explicit route permits it
-  (`cmd/common.go:56`, `cmd/common.go:113`, `cmd/common.go:1184`).
-- Freshness truthfulness risk: host capability blockers are appended late in
-  `next` construction, so overall readiness freshness must be recomputed after
-  those blockers are added (`cmd/next.go:500`,
-  `cmd/status_view_build.go:244`). Otherwise `next`/`run` could report stale or
-  misleading readiness.
-- Human status risk: printing one line as `Evidence Freshness: fresh` can hide
-  stale governance evidence. Text output must show execution, governance, and
-  overall readiness separately (`cmd/status_render.go:145`,
-  `cmd/status_render.go:157`).
-- Host capability fail-closed risk: independent-review must continue to block
-  when the host cannot provide fresh subagent review. Registry metadata can make
-  the requirement discoverable, but fallback remains explicit and bounded
-  (`internal/engine/capability/registry_default.go:47`,
-  `internal/engine/capability/resolver.go:140`).
-- Template drift risk: generated skills are public agent contracts. The
-  independent-review source template and registry must stay mirrored through
-  `TestFrontmatterMirrorsRegistryHostCapabilities`
-  (`internal/engine/capability/gates_test.go:76`).
+- JSON compatibility: `config list --env --json` is public. Additive
+  `omitempty` fields are acceptable; removing or renaming existing fields is not.
+- Contract drift: the hidden-contract bug recurs if future env vars can be added
+  with only a one-line description. Tests should fail when scoped variables with
+  meaningful format, accepted values, or fallback semantics omit structured
+  wiring metadata.
+- Over-documentation risk: not every env var has enumerated accepted values.
+  The schema should distinguish accepted token lists from free-form value syntax
+  and unset behavior.
+- Security boundary: secret env vars must not imply values can be written to
+  `.slipway.yaml`; catalog wording and tests should preserve env-only handling.
+- Skill boundary: generated workflow skills should continue to name capability
+  prerequisites and evidence fallbacks, but host-integration wiring should stay
+  in catalog/docs surfaces to avoid duplicating host manuals across skills.

--- a/artifacts/codebase/STRUCTURE.md
+++ b/artifacts/codebase/STRUCTURE.md
@@ -1,38 +1,28 @@
 # Structure
 
-- `cmd/common.go`
-  - Owns shared command helpers such as `resolveActiveChangeRef`,
-    `resolveExplicitChange`, execution-summary loading, and invocation route
-    decoration helpers used by public lifecycle commands.
-- `cmd/status.go`
-  - Owns the public `status` command route order: explicit `--change`,
-    current-worktree binding, current-worktree archived fallback, then global
-    active-change summary.
-- `cmd/status_view_build.go`
-  - Owns status JSON/prose projection, evidence pointers, freshness fields,
-    gate display, and lifecycle timeline rendering.
-- `cmd/next.go` and `cmd/next_context_build.go`
-  - Own `next` command routing, read-only preview behavior, next-skill view
-    construction, input context, and handoff context projection.
-- `cmd/validate.go`
-  - Owns validate JSON projection, artifact contract display, readiness
-    projection, and route metadata for validation callers.
-- `internal/state/store.go`
-  - Owns active bundle discovery across visible workspace roots, strict
-    `change.yaml` loading, worktree visibility checks, and persistence
-    transaction ops.
-- `internal/state/worktree_binding.go`
-  - Owns git-local `worktree-binding.yaml` records used to resolve dedicated
-    worktree authority without persisting absolute paths into tracked bundles.
-- `internal/state/paths.go`
-  - Owns canonical path derivation for runtime evidence, governed bundles,
-    archive paths, and codebase map locations.
-- `internal/state/verification.go`
-  - Owns verification directory resolution, strict verification YAML loading,
-    and resolved-change verification inventory helpers.
-- `internal/state/lifecycle_event.go`
-  - Owns lifecycle event path resolution, append/readback, full-log reads, and
-    the new status-tail read surface planned by this change.
-- `internal/engine/progression/readiness.go`
-  - Owns governance readiness projection. It may accept preloaded verification
-    records if needed, but `internal/state` must not import engine packages.
+- `internal/model/env_catalog.go`
+  - Owns `EnvCatalogEntry`, env scopes, and the curated `EnvCatalog()` list
+    surfaced by `slipway config list --env`.
+- `internal/model/env_catalog_test.go`
+  - Owns source-scan coverage for production env reads and well-formedness
+    checks for env catalog entries.
+- `cmd/config.go`
+  - Owns `config list` / `config list --env` JSON and text projections.
+- `cmd/config_test.go`
+  - Owns command-level assertions for config catalog and env catalog output
+    shape.
+- `internal/engine/capability/resolver.go`
+  - Owns runtime interpretation of host capability tokens and fallback modes.
+- `cmd/next.go` and `cmd/validate.go`
+  - Own host capability requirement projection into `next` and `validate`
+    views; they should consume existing runtime semantics unchanged.
+- `cmd/context_pressure_hook.go` and `cmd/next_context_budget.go`
+  - Own context metric/window env behavior that the catalog must describe.
+- `cmd/tool_github.go`
+  - Owns GitHub API env resolution, allowlist parsing, and token destination
+    safety.
+- `internal/state/handoff.go`
+  - Owns handoff session-owner fallback order.
+- `docs/reference/commands.md`, `docs/index.md`, and `README.md`
+  - Own public navigation into configuration and host environment reference
+    docs.

--- a/artifacts/codebase/TESTING.md
+++ b/artifacts/codebase/TESTING.md
@@ -1,31 +1,21 @@
 # Testing
 
-- Question: Which tests prove additive public surface repair without weakening
-  lifecycle fail-closed behavior?
-- Route coverage: `cmd/active_change_resolution_test.go` now verifies
-  bound-elsewhere CLIError route data, no-active status/validate/next/done
-  routes, multi-active status summary routes, explicit-missing routes, and
-  `archived_local` routing (`cmd/active_change_resolution_test.go:40`,
-  `cmd/active_change_resolution_test.go:123`,
-  `cmd/active_change_resolution_test.go:173`,
-  `cmd/active_change_resolution_test.go:297`).
-- Freshness coverage: next/run/validate handoff views assert split freshness and
-  blocked overall readiness for host-capability blockers
-  (`cmd/progression_next_test.go:1239`, `cmd/progression_next_test.go:1275`,
-  `cmd/progression_next_test.go:1291`); done JSON asserts pre-archive freshness
-  and diagnostics (`cmd/lifecycle_commands_test.go:128`); status text asserts
-  split labels and absence of the old single-line misleading claim
-  (`cmd/status_render_test.go:60`).
-- Capability coverage: registry behavior and bounded alias handling are tested
-  in `TestResolveHostCapabilityRequirementUsesRegistryContract`
-  (`internal/engine/capability/resolver_test.go:175`), and template/registry
-  drift is guarded by `TestFrontmatterMirrorsRegistryHostCapabilities`
-  (`internal/engine/capability/gates_test.go:76`).
-- Integration commands already run for this repair: focused `cmd` route and
-  freshness tests, focused capability tests, `go test ./cmd -count=1`,
-  `go test ./internal/engine/capability ./internal/tmpl ./internal/toolgen
-  -count=1`, `git diff --check`, `go test ./... -count=1`,
-  `just coverage-gate`, and the state-read performance baseline check.
-- Final verification must be refreshed after any remaining artifact/evidence
-  edits: at minimum rerun validation/status/next and rerun the full suite or the
-  relevant gates if code changes after this research evidence.
+- Env source coverage: extend `internal/model/env_catalog_test.go`, which
+  already enforces `EnvCatalog()` coverage for production env reads, to require
+  structured contract fields for env vars with accepted tokens, format
+  constraints, or non-obvious unset behavior.
+- Config output coverage: extend `cmd/config_test.go` so
+  `config list --env --json` exposes structured wiring metadata and
+  `config list --env` text includes human-readable contract fields for
+  `SLIPWAY_HOST_CAPABILITIES`.
+- Capability behavior coverage: existing capability resolver tests in
+  `internal/engine/capability/resolver_test.go` already prove the runtime
+  behavior for `subagent`, `delegation`, `none`, unknown, and fallback modes.
+  New catalog tests should align the public contract with those semantics
+  instead of duplicating runtime resolution logic.
+- Documentation coverage: add or update docs tests/manifest checks only if the
+  repo already enforces the new doc path. At minimum, focused tests should make
+  the command/catalog output self-sufficient even if prose docs drift.
+- Verification stack for this change: focused `go test ./internal/model
+  ./cmd ./internal/engine/capability -count=1`, then full `go test ./...`, plus
+  governed `validate`/`next` evidence before closeout.

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/signalridge/slipway/internal/model"
@@ -57,7 +58,8 @@ original key ordering are not preserved.
   config list --env [--json]
                            Enumerate the environment-variable surface (name,
                            scope, secret, default, file-config-key,
-                           description).
+                           description, value syntax, accepted values,
+                           examples, unset behavior).
   config get <key> [--json]
                            Print the resolved effective value for a file key.
   config set <key> <value> Validate and persist a file key to .slipway.yaml.`,
@@ -85,7 +87,8 @@ func makeConfigListCmd() *cobra.Command {
 With --env, list the environment-variable surface instead: the SLIPWAY_* (and
 ambient GitHub token) variables Slipway reads, each with its scope (repo-policy,
 runtime-host, or secret), default, the .slipway.yaml key it overrides (for
-repo-policy variables), and a description. The environment value overrides the
+repo-policy variables), value syntax, accepted values when constrained,
+examples, unset behavior, and a description. The environment value overrides the
 matching file value (env > file > default).`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -180,7 +183,75 @@ func writeEnvCatalogText(cmd *cobra.Command, entries []model.EnvCatalogEntry) er
 			return err
 		}
 	}
-	return tw.Flush()
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+	if !envCatalogHasContractDetails(entries) {
+		return nil
+	}
+	if _, err := fmt.Fprintln(cmd.OutOrStdout()); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(cmd.OutOrStdout(), "CONTRACT DETAILS"); err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if !envCatalogEntryHasContractDetails(entry) {
+			continue
+		}
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "%s\n", entry.Name); err != nil {
+			return err
+		}
+		if entry.ValueSyntax != "" {
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "  VALUE: %s\n", entry.ValueSyntax); err != nil {
+				return err
+			}
+		}
+		if len(entry.AcceptedValues) > 0 {
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "  ACCEPTED: %s\n", formatEnvAcceptedValues(entry.AcceptedValues)); err != nil {
+				return err
+			}
+		}
+		if len(entry.Examples) > 0 {
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "  EXAMPLES: %s\n", strings.Join(entry.Examples, "; ")); err != nil {
+				return err
+			}
+		}
+		if entry.UnsetBehavior != "" {
+			if _, err := fmt.Fprintf(cmd.OutOrStdout(), "  UNSET: %s\n", entry.UnsetBehavior); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func envCatalogHasContractDetails(entries []model.EnvCatalogEntry) bool {
+	for _, entry := range entries {
+		if envCatalogEntryHasContractDetails(entry) {
+			return true
+		}
+	}
+	return false
+}
+
+func envCatalogEntryHasContractDetails(entry model.EnvCatalogEntry) bool {
+	return entry.ValueSyntax != "" ||
+		len(entry.AcceptedValues) > 0 ||
+		len(entry.Examples) > 0 ||
+		entry.UnsetBehavior != ""
+}
+
+func formatEnvAcceptedValues(values []model.EnvAcceptedValue) string {
+	parts := make([]string, 0, len(values))
+	for _, value := range values {
+		if value.Description == "" {
+			parts = append(parts, value.Value)
+			continue
+		}
+		parts = append(parts, value.Value+"="+value.Description)
+	}
+	return strings.Join(parts, "; ")
 }
 
 func writeConfigCatalogText(cmd *cobra.Command, catalog []model.ConfigCatalogEntry) error {

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -127,6 +127,10 @@ func TestConfigListEnvJSONShape(t *testing.T) {
 		out, errOut, err := runConfigCmd(t, root, "list", "--env", "--json")
 		require.NoError(t, err)
 		assert.Empty(t, errOut)
+		assert.Contains(t, out, `"value_syntax"`)
+		assert.Contains(t, out, `"accepted_values"`)
+		assert.Contains(t, out, `"examples"`)
+		assert.Contains(t, out, `"unset_behavior"`)
 
 		var entries []model.EnvCatalogEntry
 		require.NoError(t, json.Unmarshal([]byte(out), &entries))
@@ -141,12 +145,47 @@ func TestConfigListEnvJSONShape(t *testing.T) {
 		assert.Equal(t, model.EnvScopeRepoPolicy, apiURL.Scope)
 		assert.Equal(t, "github.api_url", apiURL.FileConfigKey)
 		assert.False(t, apiURL.Secret)
+		assert.NotEmpty(t, apiURL.ValueSyntax)
+		assert.NotEmpty(t, apiURL.UnsetBehavior)
 
 		token, ok := byName["GH_TOKEN"]
 		require.True(t, ok)
 		assert.Equal(t, model.EnvScopeSecret, token.Scope)
 		assert.True(t, token.Secret)
 		assert.Empty(t, token.FileConfigKey)
+		assert.NotEmpty(t, token.ValueSyntax)
+		assert.NotEmpty(t, token.UnsetBehavior)
+
+		hostCapabilities, ok := byName["SLIPWAY_HOST_CAPABILITIES"]
+		require.True(t, ok)
+		assert.NotEmpty(t, hostCapabilities.Examples)
+		assert.Contains(t, hostCapabilities.UnsetBehavior, "unknown")
+		accepted := map[string]string{}
+		for _, value := range hostCapabilities.AcceptedValues {
+			accepted[value.Value] = value.Description
+		}
+		assert.Contains(t, accepted["subagent"], "available")
+		assert.Contains(t, accepted["delegation"], "available")
+		assert.Contains(t, accepted["none"], "unavailable")
+	})
+}
+
+func TestConfigListEnvTextShowsWiringContractDetails(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+
+		out, errOut, err := runConfigCmd(t, root, "list", "--env")
+		require.NoError(t, err)
+		assert.Empty(t, errOut)
+		assert.Contains(t, out, "CONTRACT DETAILS")
+		assert.Contains(t, out, "SLIPWAY_HOST_CAPABILITIES")
+		assert.Contains(t, out, "subagent=")
+		assert.Contains(t, out, "delegation=")
+		assert.Contains(t, out, "none=")
+		assert.Contains(t, out, "UNSET:")
+		assert.Contains(t, out, "SLIPWAY_HOST_CAPABILITIES=subagent")
 	})
 }
 
@@ -162,6 +201,13 @@ func TestConfigHelpDisclosesSetRewrite(t *testing.T) {
 		assert.Contains(t, out, "rewrites .slipway.yaml as deterministic YAML")
 		assert.Contains(t, out, "comments and the")
 		assert.Contains(t, out, "original key ordering are not preserved")
+
+		listOut, listErrOut, err := runConfigCmd(t, root, "list", "--help")
+		require.NoError(t, err)
+		assert.Empty(t, listErrOut)
+		assert.Contains(t, listOut, "value syntax")
+		assert.Contains(t, listOut, "accepted values")
+		assert.Contains(t, listOut, "unset behavior")
 	})
 }
 

--- a/cmd/context_pressure_hook.go
+++ b/cmd/context_pressure_hook.go
@@ -13,13 +13,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/signalridge/slipway/internal/model"
 	"github.com/signalridge/slipway/internal/state"
 	"github.com/spf13/cobra"
 )
 
 const contextPressureMetricMaxAge = 60 * time.Second
 const contextPressureTranscriptTailBytes = 1 << 20
-const contextPressureDefaultWindowTokens = 200000
 
 type contextPressureState string
 
@@ -406,7 +406,7 @@ func contextPressureWindowTokens() int {
 			return parsed
 		}
 	}
-	return contextPressureDefaultWindowTokens
+	return model.DefaultContextWindowTokens
 }
 
 func firstNumericField(raw map[string]any, keys ...string) (float64, bool) {

--- a/cmd/next_context_budget.go
+++ b/cmd/next_context_budget.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/signalridge/slipway/internal/model"
 	"github.com/signalridge/slipway/internal/tmpl"
 )
 
@@ -22,7 +23,6 @@ func estimateContextBudget(root string, skill *nextSkillView, inputContext nextC
 	}
 
 	const bytesPerToken = 4
-	const defaultContextWindowTokens = 200000
 	const warnRemainingPercent = 50.0
 	const stopRemainingPercent = 35.0
 
@@ -79,7 +79,7 @@ func estimateContextBudget(root string, skill *nextSkillView, inputContext nextC
 		return nil
 	}
 
-	assumedContextWindow := defaultContextWindowTokens
+	assumedContextWindow := model.DefaultContextWindowTokens
 	// Honor a valid SLIPWAY_CONTEXT_WINDOW_TOKENS override; a malformed or
 	// non-positive value falls through to the default window. Mirrors
 	// contextPressureWindowTokens.

--- a/cmd/next_context_budget_test.go
+++ b/cmd/next_context_budget_test.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"errors"
 	"testing"
+
+	"github.com/signalridge/slipway/internal/model"
 )
 
 func TestEstimateContextBudgetFallsBackWhenMarshalFails(t *testing.T) {
@@ -32,7 +34,6 @@ func TestEstimateContextBudgetFallsBackWhenMarshalFails(t *testing.T) {
 // non-positive — a malformed override must not silently weaken the context
 // hard-stop guard.
 func TestEstimateContextBudgetEnvWindow(t *testing.T) {
-	const defaultWindow = 200000
 	skill := &nextSkillView{Name: "plan-audit"}
 	ctx := nextContext{WorkspaceRoot: "/tmp/workspace", ArtifactBundle: "artifacts/changes/demo"}
 
@@ -42,9 +43,9 @@ func TestEstimateContextBudgetEnvWindow(t *testing.T) {
 		want    int
 	}{
 		{"valid override honored", "300000", 300000},
-		{"malformed override falls back to default", "bad", defaultWindow},
-		{"non-positive override falls back to default", "0", defaultWindow},
-		{"unset falls back to default", "", defaultWindow},
+		{"malformed override falls back to default", "bad", model.DefaultContextWindowTokens},
+		{"non-positive override falls back to default", "0", model.DefaultContextWindowTokens},
+		{"unset falls back to default", "", model.DefaultContextWindowTokens},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/tool_github.go
+++ b/cmd/tool_github.go
@@ -523,7 +523,12 @@ func githubAPIBaseURLAllowed(baseURL string, fileCfg model.ConfigGitHub) (github
 
 func parseGitHubAPIAllowedBaseURLs(raw string) ([]string, error) {
 	parts := strings.FieldsFunc(raw, func(r rune) bool {
-		return r == ',' || r == ';' || r == '\n' || r == '\t' || r == ' '
+		switch r {
+		case ',', ';', ' ', '\t', '\n', '\r':
+			return true
+		default:
+			return false
+		}
 	})
 	out := make([]string, 0, len(parts))
 	for _, part := range parts {

--- a/cmd/tool_github_test.go
+++ b/cmd/tool_github_test.go
@@ -124,3 +124,20 @@ func TestAddGitHubPaginationParams(t *testing.T) {
 		})
 	}
 }
+
+func TestParseGitHubAPIAllowedBaseURLsSplitsCarriageReturn(t *testing.T) {
+	t.Parallel()
+
+	got, err := parseGitHubAPIAllowedBaseURLs("https://github.example.com/api/v3\rhttps://ghe.example.com/api/v3")
+	if err != nil {
+		t.Fatalf("parseGitHubAPIAllowedBaseURLs returned error: %v", err)
+	}
+
+	want := []string{
+		"https://github.example.com/api/v3",
+		"https://ghe.example.com/api/v3",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseGitHubAPIAllowedBaseURLs = %v, want %v", got, want)
+	}
+}

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -180,7 +180,7 @@ codebase-map advisory.
 | Command | Class | Purpose |
 | --- | --- | --- |
 | `slipway init` | mutation | Initialize `.slipway.yaml`, the repo-local runtime layout, and optional AI-tool adapters. |
-| `slipway config [list\|get\|set]` | mutation | Inspect and update repo-level `.slipway.yaml` keys; `config list --env` lists runtime/secret environment variables and their ownership. CLI-only; no generated adapter prompt surface. |
+| `slipway config [list\|get\|set]` | mutation | Inspect and update repo-level `.slipway.yaml` keys; `config list --env [--json]` lists runtime/secret environment variables with ownership, value syntax, accepted values, examples, and unset behavior. CLI-only; no generated adapter prompt surface. |
 
 `docs/SURFACE-MANIFEST.json` is the committed generated-surface inventory for
 adapter, command, skill, JSON, and documentation rows. The manifest is rebuilt

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ Documentation is organized by Diataxis so each page has one job.
 | --- | --- | --- |
 | Tutorials | You want a guided path with commands and prompts to copy. | [First governed change](tutorials/first-governed-change.md), [Onboarding an existing codebase](tutorials/onboarding-existing-codebase.md) |
 | How-to | You need to complete a specific operational task. | [Install and refresh adapters](how-to/install-and-refresh-adapters.md), [Recover and troubleshoot](how-to/recover-and-troubleshoot.md) |
-| Reference | You need authoritative command, adapter, configuration, and contributor facts. | [Commands](reference/commands.md), [Subagents](reference/subagents.md), [AI tool adapters](reference/ai-tools.md), [Contributing](contributing.md) |
+| Reference | You need authoritative command, adapter, configuration, and contributor facts. | [Commands](reference/commands.md), [Host environment](reference/host-environment.md), [Subagents](reference/subagents.md), [AI tool adapters](reference/ai-tools.md), [Contributing](contributing.md) |
 | Explanation | You want the design reasoning behind the workflow. | [Design](explanation/design.md), [Workflow](explanation/workflow.md) |
 
 ## Mental Model

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -84,7 +84,7 @@ artifact-readiness detail, transition traces, or context-budget diagnostics.
 - `slipway health --doctor --json` adds repair-oriented diagnostics to the health report.
 - `slipway tool <helper>` is invoked directly by generated skills and has no generated adapter prompt surface.
 - `slipway hook session-start` and `slipway hook context-pressure` are invoked directly by generated host hook configuration; hook helpers fail silent so automatic hooks cannot block the user.
-- `slipway config`, `slipway config list --json`, `slipway config list --env [--json]`, `slipway config get <key> --json`, and `slipway config set <key> <value>` inspect `.slipway.yaml` keys and the runtime/secret environment surface; only file keys can be updated. `config` is intentionally CLI-only and has no generated adapter prompt surface.
+- `slipway config`, `slipway config list --json`, `slipway config list --env [--json]`, `slipway config get <key> --json`, and `slipway config set <key> <value>` inspect `.slipway.yaml` keys and the runtime/secret environment surface; only file keys can be updated. `config list --env` carries value syntax, accepted values, examples, and unset behavior for host-facing environment variables; see [Host Environment Variables](host-environment.md). `config` is intentionally CLI-only and has no generated adapter prompt surface.
 - `subagents.*` config controls slot-based delegation targets for `plan_audit`, `executor`, `review`, `fix`, and `verify`; see [Subagent Configuration](subagents.md).
 
 ## Read-Only Authority

--- a/docs/reference/host-environment.md
+++ b/docs/reference/host-environment.md
@@ -1,0 +1,110 @@
+# Host Environment Variables
+
+Slipway keeps repository policy, runtime host facts, and secrets on separate
+surfaces. Use `.slipway.yaml` for version-controlled repo policy. Use
+environment variables for facts supplied by the current host session and for
+secrets that must never be written to project config.
+
+The current machine-readable authority is:
+
+```bash
+slipway config list --env
+slipway config list --env --json
+```
+
+The JSON form includes each variable's scope, secret status, value syntax,
+accepted values when constrained, examples, and unset behavior.
+
+## Runtime Host Scope
+
+Runtime-host variables describe the current AI host session. They have no
+`.slipway.yaml` key because they describe host capability or identity, not repo
+policy.
+
+### Declaring Subagent Capability
+
+Some governed skills require fresh subagent or delegated execution to preserve
+independent review evidence. When a skill says the host must declare subagent
+capability, the host-facing knob is:
+
+```bash
+SLIPWAY_HOST_CAPABILITIES=subagent
+```
+
+Accepted `SLIPWAY_HOST_CAPABILITIES` tokens:
+
+| Token | Meaning |
+| --- | --- |
+| `subagent` | Declares subagent dispatch capability available. |
+| `delegation` | Alias that also satisfies the subagent capability. |
+| `none` | Explicitly declares the capability unavailable. |
+| `unavailable` | Explicitly declares the capability unavailable. |
+
+The value is a comma, semicolon, space, tab, newline, or carriage-return
+separated token list. Capability token matching is case-insensitive. Empty or
+unset does not mean unavailable; it means unknown. In that state `next`, `run`,
+or `validate` can surface a delegation authorization prerequisite plus named
+fallback options. Any other non-empty token still declares the host capability
+space; if it does not satisfy the required capability, Slipway treats that
+capability as unavailable rather than unknown.
+
+When a host intentionally runs degraded same-context evidence, declare the
+fallback separately and record fallback evidence with the governed skill:
+
+```bash
+SLIPWAY_HOST_CAPABILITY_FALLBACKS=same_context_degraded
+```
+
+Skill-specific manual fallbacks include `manual_plan_audit`,
+`manual_spec_compliance_review`, `manual_code_quality_review`,
+`manual_security_review`, `manual_independent_review`, and
+`manual_ship_verification`. Fallback token matching is case-insensitive, and
+unrecognized fallback tokens are ignored. Fallback selection does not replace
+evidence requirements; it only makes the degradation explicit.
+
+### Context Budget And Pressure
+
+`SLIPWAY_CONTEXT_WINDOW_TOKENS` overrides the assumed context-window size used
+by `next` diagnostics and context-pressure hooks. It must be a positive integer.
+Malformed, zero, or negative values are ignored and Slipway falls back to the
+built-in `200000` token window.
+
+`SLIPWAY_CONTEXT_METRICS_PATH` points the context-pressure hook at a JSON metrics
+file written by the host. Supported metric shapes are:
+
+- `tokens_used` with `context_window` or `context_window_size`
+- `used_pct`
+- `used_percentage`
+- `remaining_percentage`
+
+Metrics older than the freshness window are ignored. When the path is unset,
+Slipway checks sanitized session temp metric paths and then the transcript tail.
+
+### Handoff Owner
+
+`SLIPWAY_SESSION_OWNER` sets the owner label recorded in handoff notes. When it
+is unset, empty, or whitespace-only, Slipway falls back to `USER`, then
+`USERNAME`, then machine hostname, then `unknown`.
+
+## Repo Policy And Secret Scope
+
+Some repo policy has both a file key and an environment override. For GitHub
+Enterprise API routing, environment values win over file config, and file config
+wins over defaults:
+
+| Environment | File key | Notes |
+| --- | --- | --- |
+| `SLIPWAY_GITHUB_API_URL` | `github.api_url` | HTTPS GitHub REST/GraphQL API base URL. Defaults to `https://api.github.com`. |
+| `SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS` | `github.api_allowed_base_urls` | Comma, semicolon, space, tab, newline, or carriage-return separated HTTPS allowlist for override hosts. |
+
+Secrets stay environment-only:
+
+| Environment | Notes |
+| --- | --- |
+| `GH_TOKEN` | Ambient token for `https://api.github.com`; preferred over `GITHUB_TOKEN`. |
+| `GITHUB_TOKEN` | Ambient fallback token for `https://api.github.com`. |
+| `SLIPWAY_GITHUB_API_TOKEN` | Token for an allowlisted override host only. |
+
+Ambient `GH_TOKEN` and `GITHUB_TOKEN` are not sent to override hosts.
+`SLIPWAY_GITHUB_API_TOKEN` is sent only after the override host is allowlisted
+and operator-confirmed.

--- a/internal/engine/capability/resolver.go
+++ b/internal/engine/capability/resolver.go
@@ -201,17 +201,17 @@ func hostCapabilityAvailability(tokens []string, capabilityName string) string {
 }
 
 func selectedFallbackMode(tokens []string, fallbackModes []string) (string, bool) {
-	allowed := make(map[string]struct{}, len(fallbackModes))
+	allowed := make(map[string]string, len(fallbackModes))
 	for _, mode := range fallbackModes {
 		mode = strings.TrimSpace(mode)
 		if mode != "" {
-			allowed[mode] = struct{}{}
+			allowed[strings.ToLower(mode)] = mode
 		}
 	}
 	for _, token := range tokens {
-		token = strings.TrimSpace(token)
-		if _, ok := allowed[token]; ok {
-			return token, true
+		token = strings.TrimSpace(strings.ToLower(token))
+		if mode, ok := allowed[token]; ok {
+			return mode, true
 		}
 	}
 	return "", false

--- a/internal/engine/capability/resolver_test.go
+++ b/internal/engine/capability/resolver_test.go
@@ -162,6 +162,16 @@ func TestResolveHostCapabilityRequirement(t *testing.T) {
 			wantFallbackMode: "same_context_degraded",
 		},
 		{
+			name: "same-context degraded fallback is matched case-insensitively and returned canonical",
+			signals: Signals{
+				HostCapabilities: []string{"none"},
+				Fallbacks:        []string{"Same_Context_Degraded"},
+			},
+			wantAvailability: "unavailable",
+			wantFallback:     true,
+			wantFallbackMode: "same_context_degraded",
+		},
+		{
 			name: "fallback tokens are matched case-insensitively and returned canonical",
 			signals: Signals{
 				HostCapabilities: []string{"none"},
@@ -215,10 +225,12 @@ func TestEnvCatalogHostCapabilityFallbacksMirrorContracts(t *testing.T) {
 	want := map[string]bool{}
 	reg := DefaultRegistry()
 	for _, skill := range reg.All() {
-		for _, contract := range skill.HostCapabilities {
-			for _, mode := range contract.FallbackModes {
-				want[mode] = true
-			}
+		contract, ok := resolveHostCapabilityContract(reg, skill.ID)
+		if !ok {
+			continue
+		}
+		for _, mode := range contract.FallbackModes {
+			want[mode] = true
 		}
 	}
 	for _, skillID := range []string{"plan-audit", "spec-compliance-review", "code-quality-review", "ship-verification"} {
@@ -297,6 +309,18 @@ func TestResolveHostCapabilitySubagentDispatchLever(t *testing.T) {
 		assert.Equal(t, "unavailable", req.Availability)
 		assert.Contains(t, req.Remediation, "context_origin:stage=review=<handle>")
 		assert.Contains(t, req.Remediation, "fallback:<mode>")
+	})
+
+	t.Run("security-review same-context degraded fallback is case-insensitive", func(t *testing.T) {
+		t.Parallel()
+		req := ResolveHostCapabilityRequirement("security-review", Signals{
+			HostCapabilities: []string{"none"},
+			Fallbacks:        []string{"Same_Context_Degraded"},
+		})
+		require.NotNil(t, req, "security-review must carry a registry host-capability contract")
+		assert.Equal(t, "unavailable", req.Availability)
+		assert.True(t, req.FallbackSelected)
+		assert.Equal(t, "same_context_degraded", req.FallbackMode)
 	})
 
 	t.Run("skills without any contract still resolve to nil", func(t *testing.T) {

--- a/internal/engine/capability/resolver_test.go
+++ b/internal/engine/capability/resolver_test.go
@@ -4,6 +4,7 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/signalridge/slipway/internal/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -134,6 +135,13 @@ func TestResolveHostCapabilityRequirement(t *testing.T) {
 			wantAvailability: "unavailable",
 		},
 		{
+			name: "unrecognized non-empty capability token is closed-world unavailable",
+			signals: Signals{
+				HostCapabilities: []string{"tools"},
+			},
+			wantAvailability: "unavailable",
+		},
+		{
 			name: "manual independent review fallback is explicit",
 			signals: Signals{
 				HostCapabilities: []string{"none"},
@@ -152,6 +160,16 @@ func TestResolveHostCapabilityRequirement(t *testing.T) {
 			wantAvailability: "unavailable",
 			wantFallback:     true,
 			wantFallbackMode: "same_context_degraded",
+		},
+		{
+			name: "fallback tokens are matched case-insensitively and returned canonical",
+			signals: Signals{
+				HostCapabilities: []string{"none"},
+				Fallbacks:        []string{"MANUAL_INDEPENDENT_REVIEW"},
+			},
+			wantAvailability: "unavailable",
+			wantFallback:     true,
+			wantFallbackMode: "manual_independent_review",
 		},
 	}
 
@@ -174,6 +192,44 @@ func TestResolveHostCapabilityRequirement(t *testing.T) {
 			assert.Contains(t, req.Remediation, "fallback:<mode>")
 		})
 	}
+}
+
+func TestEnvCatalogHostCapabilityFallbacksMirrorContracts(t *testing.T) {
+	t.Parallel()
+
+	entries := model.EnvCatalog()
+	var fallbackEntry model.EnvCatalogEntry
+	for _, entry := range entries {
+		if entry.Name == "SLIPWAY_HOST_CAPABILITY_FALLBACKS" {
+			fallbackEntry = entry
+			break
+		}
+	}
+	require.NotEmpty(t, fallbackEntry.Name)
+
+	got := map[string]bool{}
+	for _, value := range fallbackEntry.AcceptedValues {
+		got[value.Value] = true
+	}
+
+	want := map[string]bool{}
+	reg := DefaultRegistry()
+	for _, skill := range reg.All() {
+		for _, contract := range skill.HostCapabilities {
+			for _, mode := range contract.FallbackModes {
+				want[mode] = true
+			}
+		}
+	}
+	for _, skillID := range []string{"plan-audit", "spec-compliance-review", "code-quality-review", "ship-verification"} {
+		contract, ok := resolveHostCapabilityContract(reg, skillID)
+		require.True(t, ok, "missing host capability contract for %s", skillID)
+		for _, mode := range contract.FallbackModes {
+			want[mode] = true
+		}
+	}
+
+	assert.Equal(t, want, got)
 }
 
 // TestResolveHostCapabilitySubagentDispatchLever covers the built-in

--- a/internal/model/env_catalog.go
+++ b/internal/model/env_catalog.go
@@ -42,6 +42,23 @@ type EnvCatalogEntry struct {
 	// Secret reports whether the value is a credential that must not be logged or
 	// written to a file.
 	Secret bool `json:"secret,omitempty"`
+	// ValueSyntax describes the expected value shape, such as a positive integer,
+	// an HTTPS URL, or a separated token list.
+	ValueSyntax string `json:"value_syntax,omitempty"`
+	// AcceptedValues describes constrained tokens and their runtime meaning.
+	AcceptedValues []EnvAcceptedValue `json:"accepted_values,omitempty"`
+	// Examples lists copyable declarations with placeholder values where needed.
+	Examples []string `json:"examples,omitempty"`
+	// UnsetBehavior describes the fallback path when the environment variable is
+	// unset, empty, malformed, or intentionally omitted.
+	UnsetBehavior string `json:"unset_behavior,omitempty"`
+}
+
+// EnvAcceptedValue describes one accepted token or literal value for an
+// environment variable whose value space is constrained.
+type EnvAcceptedValue struct {
+	Value       string `json:"value"`
+	Description string `json:"description"`
 }
 
 // EnvCatalog returns the curated, name-sorted catalog of environment variables
@@ -56,65 +73,116 @@ func EnvCatalog() []EnvCatalogEntry {
 			Default:       "https://api.github.com",
 			FileConfigKey: "github.api_url",
 			Description:   "GitHub REST/GraphQL API base URL for the token-backed HTTP backend; overrides github.api_url.",
+			ValueSyntax:   "HTTPS GitHub REST/GraphQL API base URL.",
+			Examples:      []string{"SLIPWAY_GITHUB_API_URL=https://github.example.com/api/v3"},
+			UnsetBehavior: "Falls back to github.api_url from .slipway.yaml; if that is unset, uses https://api.github.com.",
 		},
 		{
 			Name:          "SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS",
 			Scope:         EnvScopeRepoPolicy,
 			FileConfigKey: "github.api_allowed_base_urls",
-			Description:   "Comma/space/semicolon separated HTTPS API base URLs allowed for a GitHub API override; overrides github.api_allowed_base_urls and confirms file-configured token destinations.",
+			Description:   "Comma, semicolon, space, tab, newline, or carriage-return separated HTTPS API base URLs allowed for a GitHub API override; overrides github.api_allowed_base_urls and confirms file-configured token destinations.",
+			ValueSyntax:   "Comma, semicolon, space, tab, newline, or carriage-return separated HTTPS GitHub API base URLs.",
+			Examples:      []string{"SLIPWAY_GITHUB_API_ALLOWED_BASE_URLS=https://github.example.com/api/v3"},
+			UnsetBehavior: "Falls back to github.api_allowed_base_urls from .slipway.yaml; an override URL still must be allowlisted before override-token egress.",
 		},
 		{
-			Name:        "SLIPWAY_GITHUB_API_TOKEN",
-			Scope:       EnvScopeSecret,
-			Secret:      true,
-			Description: "Token used only for an allowlisted and env-confirmed GitHub API override host; never read from .slipway.yaml.",
+			Name:          "SLIPWAY_GITHUB_API_TOKEN",
+			Scope:         EnvScopeSecret,
+			Secret:        true,
+			Description:   "Token used only for an allowlisted and env-confirmed GitHub API override host; never read from .slipway.yaml.",
+			ValueSyntax:   "GitHub API token string for an allowlisted override host.",
+			Examples:      []string{"SLIPWAY_GITHUB_API_TOKEN=<token>"},
+			UnsetBehavior: "No override-host token is available; ambient GH_TOKEN/GITHUB_TOKEN are not sent to override hosts.",
 		},
 		{
-			Name:        "SLIPWAY_CONTEXT_WINDOW_TOKENS",
-			Scope:       EnvScopeRuntimeHost,
-			Description: "Host model context-window size (tokens) used to estimate context-budget pressure.",
+			Name:          "SLIPWAY_CONTEXT_WINDOW_TOKENS",
+			Scope:         EnvScopeRuntimeHost,
+			Description:   "Host model context-window size (tokens) used to estimate context-budget pressure.",
+			ValueSyntax:   "Positive integer token count.",
+			Examples:      []string{"SLIPWAY_CONTEXT_WINDOW_TOKENS=200000"},
+			UnsetBehavior: "Uses the built-in 200000-token context window; malformed, zero, or negative values are ignored and also fall back to 200000.",
 		},
 		{
-			Name:        "SLIPWAY_CONTEXT_METRICS_PATH",
-			Scope:       EnvScopeRuntimeHost,
-			Description: "Path the host writes live context-usage metrics to for the context-pressure hook.",
+			Name:          "SLIPWAY_CONTEXT_METRICS_PATH",
+			Scope:         EnvScopeRuntimeHost,
+			Description:   "Path the host writes live context-usage metrics to for the context-pressure hook.",
+			ValueSyntax:   "Filesystem path to a JSON object with tokens_used plus context_window/context_window_size, or used_pct/used_percentage/remaining_percentage.",
+			Examples:      []string{"SLIPWAY_CONTEXT_METRICS_PATH=/tmp/slipway-context.json"},
+			UnsetBehavior: "The context-pressure hook checks sanitized session temp metric paths and then the transcript tail; missing, malformed, or stale metrics are ignored.",
 		},
 		{
-			Name:        "SLIPWAY_SESSION_OWNER",
-			Scope:       EnvScopeRuntimeHost,
-			Description: "Session identity recorded on handoff notes; falls back to USER/USERNAME when unset.",
+			Name:          "SLIPWAY_SESSION_OWNER",
+			Scope:         EnvScopeRuntimeHost,
+			Description:   "Session identity recorded on handoff notes; falls back to USER/USERNAME when unset, empty, or whitespace.",
+			ValueSyntax:   "Non-empty session owner label.",
+			Examples:      []string{"SLIPWAY_SESSION_OWNER=agent-codex"},
+			UnsetBehavior: "Unset, empty, or whitespace-only values fall back to USER, then USERNAME, then machine hostname, then unknown.",
 		},
 		{
 			Name:        "SLIPWAY_HOST_CAPABILITIES",
 			Scope:       EnvScopeRuntimeHost,
 			Description: "Host-advertised capability tokens (e.g. subagent fan-out) the engine reads when shaping dispatch.",
+			ValueSyntax: "Comma, semicolon, space, tab, newline, or carriage-return separated host capability tokens; token matching is case-insensitive.",
+			AcceptedValues: []EnvAcceptedValue{
+				{Value: "subagent", Description: "Declares subagent dispatch capability available."},
+				{Value: "delegation", Description: "Alias that declares subagent dispatch capability available."},
+				{Value: "none", Description: "Declares host capability unavailable."},
+				{Value: "unavailable", Description: "Declares host capability unavailable."},
+			},
+			Examples:      []string{"SLIPWAY_HOST_CAPABILITIES=subagent", "SLIPWAY_HOST_CAPABILITIES=none"},
+			UnsetBehavior: "Empty or unset means capability availability is unknown; any non-empty unrecognized token declares the host capability space and leaves unsatisfied capabilities unavailable rather than unknown.",
 		},
 		{
 			Name:        "SLIPWAY_HOST_CAPABILITY_FALLBACKS",
 			Scope:       EnvScopeRuntimeHost,
 			Description: "Host-advertised capability fallbacks applied when a primary capability is unavailable.",
+			ValueSyntax: "Comma, semicolon, space, tab, newline, or carriage-return separated fallback-mode tokens; token matching is case-insensitive.",
+			AcceptedValues: []EnvAcceptedValue{
+				{Value: "manual_plan_audit", Description: "Explicit degraded fallback for plan-audit."},
+				{Value: "manual_spec_compliance_review", Description: "Explicit degraded fallback for spec-compliance-review."},
+				{Value: "manual_code_quality_review", Description: "Explicit degraded fallback for code-quality-review."},
+				{Value: "manual_security_review", Description: "Explicit degraded fallback for security-review."},
+				{Value: "manual_independent_review", Description: "Explicit degraded fallback for independent-review."},
+				{Value: "manual_ship_verification", Description: "Explicit degraded fallback for ship-verification."},
+				{Value: "same_context_degraded", Description: "Generic degraded fallback accepted by subagent-required governance skills; record fallback evidence when used."},
+			},
+			Examples:      []string{"SLIPWAY_HOST_CAPABILITY_FALLBACKS=same_context_degraded"},
+			UnsetBehavior: "No recognized degraded fallback is selected; unavailable required capabilities remain blocked and unknown capabilities require authorization.",
 		},
 		{
-			Name:        "GH_TOKEN",
-			Scope:       EnvScopeSecret,
-			Secret:      true,
-			Description: "Ambient GitHub token sent only to https://api.github.com (and honored by the gh backend); never read from .slipway.yaml.",
+			Name:          "GH_TOKEN",
+			Scope:         EnvScopeSecret,
+			Secret:        true,
+			Description:   "Ambient GitHub token sent only to https://api.github.com (and honored by the gh backend); never read from .slipway.yaml.",
+			ValueSyntax:   "GitHub token string for the default https://api.github.com API host.",
+			Examples:      []string{"GH_TOKEN=<token>"},
+			UnsetBehavior: "Falls back to GITHUB_TOKEN for the API backend; if both are unset, token-backed default API calls fail unless the gh backend supplies auth.",
 		},
 		{
-			Name:        "GITHUB_TOKEN",
-			Scope:       EnvScopeSecret,
-			Secret:      true,
-			Description: "Ambient GitHub token fallback sent only to https://api.github.com; never read from .slipway.yaml.",
+			Name:          "GITHUB_TOKEN",
+			Scope:         EnvScopeSecret,
+			Secret:        true,
+			Description:   "Ambient GitHub token fallback sent only to https://api.github.com; never read from .slipway.yaml.",
+			ValueSyntax:   "GitHub token string for the default https://api.github.com API host.",
+			Examples:      []string{"GITHUB_TOKEN=<token>"},
+			UnsetBehavior: "No ambient fallback token is available when GH_TOKEN is also unset; token-backed default API calls fail unless the gh backend supplies auth.",
 		},
 		{
-			Name:        "USER",
-			Scope:       EnvScopeRuntimeHost,
-			Description: "Ambient OS username fallback for handoff session owner when SLIPWAY_SESSION_OWNER is unset.",
+			Name:          "USER",
+			Scope:         EnvScopeRuntimeHost,
+			Description:   "Ambient OS username fallback for handoff session owner when SLIPWAY_SESSION_OWNER is unset.",
+			ValueSyntax:   "Non-empty ambient OS username.",
+			Examples:      []string{"USER=<username>"},
+			UnsetBehavior: "Falls back to USERNAME for handoff ownership when SLIPWAY_SESSION_OWNER is unset.",
 		},
 		{
-			Name:        "USERNAME",
-			Scope:       EnvScopeRuntimeHost,
-			Description: "Ambient OS username fallback for handoff session owner when SLIPWAY_SESSION_OWNER and USER are unset.",
+			Name:          "USERNAME",
+			Scope:         EnvScopeRuntimeHost,
+			Description:   "Ambient OS username fallback for handoff session owner when SLIPWAY_SESSION_OWNER and USER are unset.",
+			ValueSyntax:   "Non-empty ambient OS username.",
+			Examples:      []string{"USERNAME=<username>"},
+			UnsetBehavior: "Falls back to machine hostname, then unknown, when SLIPWAY_SESSION_OWNER and USER are unset.",
 		},
 	}
 	sort.Slice(entries, func(i, j int) bool { return entries[i].Name < entries[j].Name })

--- a/internal/model/env_catalog.go
+++ b/internal/model/env_catalog.go
@@ -1,6 +1,13 @@
 package model
 
-import "sort"
+import (
+	"sort"
+	"strconv"
+)
+
+// DefaultContextWindowTokens is the assumed host context window when no valid
+// SLIPWAY_CONTEXT_WINDOW_TOKENS override is provided.
+const DefaultContextWindowTokens = 200000
 
 // Environment-variable scopes classify how a SLIPWAY_* (or ambient) variable
 // relates to the file config surface. The scope tells an operator whether the
@@ -23,8 +30,8 @@ const (
 // EnvCatalogEntry describes one environment variable Slipway reads, giving the
 // runtime env surface the same discoverability the file config surface gets from
 // ConfigCatalog(). Unlike file keys, env vars are not derivable by reflection, so
-// this catalog is curated; a contract test (TestEnvCatalogCoversEveryGetenv)
-// asserts every SLIPWAY_* name read in source has an entry here.
+// this catalog is curated; TestEnvCatalogCoversPublicEnvLiterals asserts public
+// env names read in source have entries here.
 type EnvCatalogEntry struct {
 	// Name is the environment variable name, e.g. "SLIPWAY_GITHUB_API_URL".
 	Name string `json:"name"`
@@ -66,6 +73,7 @@ type EnvAcceptedValue struct {
 // operator can see the env > file > default relationship at a glance. Ambient
 // fallback variables are included even though they are not SLIPWAY_-prefixed.
 func EnvCatalog() []EnvCatalogEntry {
+	defaultContextWindow := strconv.Itoa(DefaultContextWindowTokens)
 	entries := []EnvCatalogEntry{
 		{
 			Name:          "SLIPWAY_GITHUB_API_URL",
@@ -100,8 +108,8 @@ func EnvCatalog() []EnvCatalogEntry {
 			Scope:         EnvScopeRuntimeHost,
 			Description:   "Host model context-window size (tokens) used to estimate context-budget pressure.",
 			ValueSyntax:   "Positive integer token count.",
-			Examples:      []string{"SLIPWAY_CONTEXT_WINDOW_TOKENS=200000"},
-			UnsetBehavior: "Uses the built-in 200000-token context window; malformed, zero, or negative values are ignored and also fall back to 200000.",
+			Examples:      []string{"SLIPWAY_CONTEXT_WINDOW_TOKENS=" + defaultContextWindow},
+			UnsetBehavior: "Uses the built-in " + defaultContextWindow + "-token context window; malformed, zero, or negative values are ignored and also fall back to " + defaultContextWindow + ".",
 		},
 		{
 			Name:          "SLIPWAY_CONTEXT_METRICS_PATH",

--- a/internal/model/env_catalog_test.go
+++ b/internal/model/env_catalog_test.go
@@ -79,13 +79,14 @@ func scanEnvUsages(t *testing.T, root string) map[string]string {
 	return found
 }
 
-// TestEnvCatalogCoversEveryGetenv is the drift guard for the runtime env
-// surface: every SLIPWAY_* env var plus ambient token/username fallback read
-// anywhere in source must have an EnvCatalog() entry. Reading a new env var
-// without cataloguing it FAILS here and names the missing variable and the file
-// that reads it — the env-side mirror of
-// TestConfigCatalogCoversEveryStructLeaf.
-func TestEnvCatalogCoversEveryGetenv(t *testing.T) {
+// TestEnvCatalogCoversPublicEnvLiterals is the drift guard for the runtime env
+// surface: every public env-var literal in the SLIPWAY_ namespace plus ambient
+// token/username fallbacks must have an EnvCatalog() entry. Reading a new env
+// var through a string literal or shared const without cataloguing it FAILS here
+// and names the missing variable and source file. This intentionally scans
+// literals rather than only os.Getenv call arguments so const-backed reads are
+// still covered.
+func TestEnvCatalogCoversPublicEnvLiterals(t *testing.T) {
 	have := map[string]bool{}
 	for _, entry := range EnvCatalog() {
 		have[entry.Name] = true
@@ -127,6 +128,25 @@ func TestEnvCatalogEntriesAreWellFormed(t *testing.T) {
 		if strings.TrimSpace(entry.Description) == "" {
 			t.Errorf("env catalog entry %q has empty description", entry.Name)
 		}
+		if strings.TrimSpace(entry.ValueSyntax) == "" {
+			t.Errorf("env catalog entry %q has empty value_syntax", entry.Name)
+		}
+		if strings.TrimSpace(entry.UnsetBehavior) == "" {
+			t.Errorf("env catalog entry %q has empty unset_behavior", entry.Name)
+		}
+		for _, accepted := range entry.AcceptedValues {
+			if strings.TrimSpace(accepted.Value) == "" {
+				t.Errorf("env catalog entry %q has accepted value with empty value", entry.Name)
+			}
+			if strings.TrimSpace(accepted.Description) == "" {
+				t.Errorf("env catalog entry %q accepted value %q has empty description", entry.Name, accepted.Value)
+			}
+		}
+		for _, example := range entry.Examples {
+			if strings.TrimSpace(example) == "" {
+				t.Errorf("env catalog entry %q has empty example", entry.Name)
+			}
+		}
 		switch entry.Scope {
 		case EnvScopeRepoPolicy:
 			if entry.FileConfigKey == "" {
@@ -150,6 +170,58 @@ func TestEnvCatalogEntriesAreWellFormed(t *testing.T) {
 			}
 		default:
 			t.Errorf("env catalog entry %q has unknown scope %q", entry.Name, entry.Scope)
+		}
+	}
+}
+
+func TestEnvCatalogHostCapabilityWiringContract(t *testing.T) {
+	entries := EnvCatalog()
+	byName := map[string]EnvCatalogEntry{}
+	for _, entry := range entries {
+		byName[entry.Name] = entry
+	}
+
+	capabilities, ok := byName["SLIPWAY_HOST_CAPABILITIES"]
+	if !ok {
+		t.Fatal("SLIPWAY_HOST_CAPABILITIES missing from env catalog")
+	}
+	if capabilities.ValueSyntax == "" {
+		t.Fatal("SLIPWAY_HOST_CAPABILITIES must describe token syntax")
+	}
+	if capabilities.UnsetBehavior == "" {
+		t.Fatal("SLIPWAY_HOST_CAPABILITIES must describe unset behavior")
+	}
+	if !strings.Contains(capabilities.UnsetBehavior, "unrecognized") {
+		t.Fatal("SLIPWAY_HOST_CAPABILITIES must describe closed-world handling for unrecognized tokens")
+	}
+	if len(capabilities.Examples) == 0 {
+		t.Fatal("SLIPWAY_HOST_CAPABILITIES must include at least one host declaration example")
+	}
+
+	accepted := map[string]string{}
+	for _, value := range capabilities.AcceptedValues {
+		accepted[value.Value] = value.Description
+	}
+	for _, token := range []string{"subagent", "delegation", "none", "unavailable"} {
+		if strings.TrimSpace(accepted[token]) == "" {
+			t.Fatalf("SLIPWAY_HOST_CAPABILITIES accepted values missing %q with description: %#v", token, accepted)
+		}
+	}
+
+	fallbacks, ok := byName["SLIPWAY_HOST_CAPABILITY_FALLBACKS"]
+	if !ok {
+		t.Fatal("SLIPWAY_HOST_CAPABILITY_FALLBACKS missing from env catalog")
+	}
+	if !strings.Contains(fallbacks.ValueSyntax, "case-insensitive") {
+		t.Fatal("SLIPWAY_HOST_CAPABILITY_FALLBACKS must describe case-insensitive token matching")
+	}
+	fallbackTokens := map[string]bool{}
+	for _, value := range fallbacks.AcceptedValues {
+		fallbackTokens[value.Value] = true
+	}
+	for _, token := range []string{"same_context_degraded", "manual_plan_audit", "manual_security_review"} {
+		if !fallbackTokens[token] {
+			t.Fatalf("SLIPWAY_HOST_CAPABILITY_FALLBACKS accepted values missing %q: %#v", token, fallbackTokens)
 		}
 	}
 }

--- a/internal/model/env_catalog_test.go
+++ b/internal/model/env_catalog_test.go
@@ -1,21 +1,25 @@
 package model
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 )
 
-// envLiteral matches environment-variable names Slipway treats as public
-// runtime/config surface: SLIPWAY_* names, ambient token fallbacks, and ambient
-// username fallbacks. Scanning string literals (rather than only
-// os.Getenv("...") call sites) catches vars read via const identifiers and
-// simple fallback slices.
-var envLiteral = regexp.MustCompile(`"(SLIPWAY_[A-Z0-9_]+|[A-Z][A-Z0-9_]*_TOKEN|GH_TOKEN|USER|USERNAME)"`)
+// publicEnvLiteral matches environment-variable names Slipway treats as public
+// runtime/config surface when they appear as source string literals:
+// SLIPWAY_* names, ambient token fallbacks, and ambient username fallbacks.
+// Scanning string literals catches vars read via const identifiers and simple
+// fallback slices.
+var publicEnvLiteral = regexp.MustCompile(`^(SLIPWAY_[A-Z0-9_]+|[A-Z][A-Z0-9_]*_TOKEN|GH_TOKEN|USER|USERNAME)$`)
 
 // repoRootForTest resolves the repository root from this test's package
 // directory (internal/model => ../..). Walking from here keeps the source scan
@@ -58,19 +62,32 @@ func scanEnvUsages(t *testing.T, root string) map[string]string {
 		if name == "env_catalog.go" {
 			return nil
 		}
-		data, readErr := os.ReadFile(path) // #nosec G304 -- test-only scan of in-repo source.
-		if readErr != nil {
-			return readErr
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			rel = path
 		}
-		for _, m := range envLiteral.FindAllStringSubmatch(string(data), -1) {
-			rel, relErr := filepath.Rel(root, path)
-			if relErr != nil {
-				rel = path
-			}
-			if _, ok := found[m[1]]; !ok {
-				found[m[1]] = rel
-			}
+		fileSet := token.NewFileSet()
+		file, parseErr := parser.ParseFile(fileSet, path, nil, 0)
+		if parseErr != nil {
+			return parseErr
 		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			switch node := n.(type) {
+			case *ast.BasicLit:
+				if node.Kind != token.STRING {
+					return true
+				}
+				value, err := strconv.Unquote(node.Value)
+				if err == nil && publicEnvLiteral.MatchString(value) {
+					recordEnvUsage(found, value, rel)
+				}
+			case *ast.CallExpr:
+				if name, ok := directEnvReadLiteral(node); ok {
+					recordEnvUsage(found, name, rel)
+				}
+			}
+			return true
+		})
 		return nil
 	})
 	if err != nil {
@@ -79,13 +96,44 @@ func scanEnvUsages(t *testing.T, root string) map[string]string {
 	return found
 }
 
+func recordEnvUsage(found map[string]string, name, rel string) {
+	if _, ok := found[name]; !ok {
+		found[name] = rel
+	}
+}
+
+func directEnvReadLiteral(call *ast.CallExpr) (string, bool) {
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || len(call.Args) != 1 {
+		return "", false
+	}
+	pkg, ok := selector.X.(*ast.Ident)
+	if !ok || pkg.Name != "os" {
+		return "", false
+	}
+	switch selector.Sel.Name {
+	case "Getenv", "LookupEnv":
+	default:
+		return "", false
+	}
+	lit, ok := call.Args[0].(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return "", false
+	}
+	name, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return "", false
+	}
+	name = strings.TrimSpace(name)
+	return name, name != ""
+}
+
 // TestEnvCatalogCoversPublicEnvLiterals is the drift guard for the runtime env
 // surface: every public env-var literal in the SLIPWAY_ namespace plus ambient
-// token/username fallbacks must have an EnvCatalog() entry. Reading a new env
-// var through a string literal or shared const without cataloguing it FAILS here
-// and names the missing variable and source file. This intentionally scans
-// literals rather than only os.Getenv call arguments so const-backed reads are
-// still covered.
+// token/username fallback, and every direct os.Getenv/os.LookupEnv string
+// argument, must have an EnvCatalog() entry. Reading a new env var through a
+// string literal, shared const, or direct env call without cataloguing it FAILS
+// here and names the missing variable and source file.
 func TestEnvCatalogCoversPublicEnvLiterals(t *testing.T) {
 	have := map[string]bool{}
 	for _, entry := range EnvCatalog() {
@@ -223,6 +271,36 @@ func TestEnvCatalogHostCapabilityWiringContract(t *testing.T) {
 		if !fallbackTokens[token] {
 			t.Fatalf("SLIPWAY_HOST_CAPABILITY_FALLBACKS accepted values missing %q: %#v", token, fallbackTokens)
 		}
+	}
+}
+
+func TestEnvCatalogContextWindowDefaultMirrorsRuntimeConstant(t *testing.T) {
+	defaultWindow := strconv.Itoa(DefaultContextWindowTokens)
+	entries := EnvCatalog()
+	for _, entry := range entries {
+		if entry.Name != "SLIPWAY_CONTEXT_WINDOW_TOKENS" {
+			continue
+		}
+		if !strings.Contains(entry.UnsetBehavior, defaultWindow) {
+			t.Fatalf("SLIPWAY_CONTEXT_WINDOW_TOKENS unset behavior %q does not mention default %s", entry.UnsetBehavior, defaultWindow)
+		}
+		if len(entry.Examples) == 0 || !strings.Contains(entry.Examples[0], defaultWindow) {
+			t.Fatalf("SLIPWAY_CONTEXT_WINDOW_TOKENS examples %#v do not mention default %s", entry.Examples, defaultWindow)
+		}
+		return
+	}
+	t.Fatal("SLIPWAY_CONTEXT_WINDOW_TOKENS missing from env catalog")
+}
+
+func TestHostEnvironmentDocsMirrorContextWindowDefault(t *testing.T) {
+	defaultWindow := strconv.Itoa(DefaultContextWindowTokens)
+	path := filepath.Join(repoRootForTest(t), "docs", "reference", "host-environment.md")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read host environment docs: %v", err)
+	}
+	if !strings.Contains(string(content), "`"+defaultWindow+"`") {
+		t.Fatalf("host environment docs must mention default context window %s", defaultWindow)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add structured env contract metadata to `EnvCatalog()` and expose it through `config list --env` text/JSON
- document host runtime env variables, subagent capability declarations, fallback modes, context metrics, handoff owner fallback, and GitHub override token boundaries
- align runtime parsing with the documented contract for fallback token case and GitHub API allowlist carriage-return separators
- archive the completed Slipway change bundle for `fix-runtime-host-env-wiring`

Fixes #395.

## Verification

- `go test ./internal/model -count=1`
- `go test ./internal/engine/capability -count=1`
- `go test ./cmd -count=1`
- `go test ./... -count=1`
- `golangci-lint run ./... --timeout=5m`
- `semgrep --config p/gosec --metrics=off` over the 8 changed Go files
- `git diff --check`
- `go run . validate`
- `go run . done`