### PR TITLE
refactor: remove safe dead code

### DIFF
--- a/cmd/abort_test.go
+++ b/cmd/abort_test.go
@@ -127,7 +127,9 @@ func TestAbortPreservesActiveChangeAndMarksInterruptedExecution(t *testing.T) {
 		assert.Equal(t, string(model.ChangeStatusActive), view.Status)
 		assert.Equal(t, string(model.StateS2Implement), view.CurrentState)
 
-		active, err := state.FindActiveChange(root)
+		changes, err := state.ListChanges(root)
+		require.NoError(t, err)
+		active, err := state.SelectActiveChange(changes)
 		require.NoError(t, err)
 		assert.Equal(t, slug, active.Slug)
 

--- a/internal/state/evidence_digests_test.go
+++ b/internal/state/evidence_digests_test.go
@@ -11,12 +11,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSaveLoadEvidenceDigestsRoundTripAndListVerificationsSkipsStore(t *testing.T) {
+func TestSaveLoadEvidenceDigestsRoundTripAndListVerificationsForChangeSkipsStore(t *testing.T) {
 	t.Parallel()
 
 	root := createRuntimeLayout(t)
 	slug := "digest-store"
-	saveActiveChangeForTest(t, root, slug)
+	change := saveActiveChangeForTest(t, root, slug)
 
 	digests := model.EvidenceDigests{
 		Version: model.EvidenceDigestsVersion,
@@ -45,7 +45,7 @@ func TestSaveLoadEvidenceDigestsRoundTripAndListVerificationsSkipsStore(t *testi
 		Blockers:  []model.ReasonCode{},
 		Timestamp: time.Date(2026, 6, 4, 0, 0, 0, 0, time.UTC),
 	})
-	records, err := ListVerifications(root, slug)
+	records, err := ListVerificationsForChange(root, change)
 	require.NoError(t, err)
 	assert.Contains(t, records, "plan-audit")
 	assert.NotContains(t, records, "evidence-digests")

--- a/internal/state/execution_repair.go
+++ b/internal/state/execution_repair.go
@@ -27,10 +27,6 @@ type wavePlanRepairOutcome struct {
 	PreserveHistoricalExecutionEvidence bool
 }
 
-func RepairExecutionState(root string) (ExecutionRepairResult, error) {
-	return RepairExecutionStateAt(root, time.Time{})
-}
-
 func RepairExecutionStateAt(root string, now time.Time) (ExecutionRepairResult, error) {
 	allChanges, _, err := ListChangesBestEffortWithIssues(root)
 	if err != nil {

--- a/internal/state/execution_summary_test.go
+++ b/internal/state/execution_summary_test.go
@@ -1070,11 +1070,9 @@ func TestLoadExecutionSummaryReadsArchivedBundleSummary(t *testing.T) {
 	assert.Equal(t, 3, loaded.RunSummaryVersion)
 	assert.Equal(t, model.ExecutionVerdictPass, loaded.OverallVerdict)
 
-	records, err := ListVerifications(root, change.Slug)
+	record, err := LoadVerification(root, change.Slug, "plan-audit")
 	require.NoError(t, err)
-	if assert.Contains(t, records, "plan-audit") {
-		assert.Equal(t, model.VerificationVerdictPass, records["plan-audit"].Verdict)
-	}
+	assert.Equal(t, model.VerificationVerdictPass, record.Verdict)
 }
 
 func TestArchiveChangeScrubsRuntimeEvidenceRefsFromArchivedExecutionSummary(t *testing.T) {

--- a/internal/state/handoff.go
+++ b/internal/state/handoff.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 	"slices"
 	"strings"
 	"time"
@@ -459,17 +458,4 @@ func compactHandoffLine(line string) string {
 		return line
 	}
 	return strings.TrimSpace(line[:117]) + "..."
-}
-
-func HandoffPathForDisplay(root, path string) string {
-	if rel, err := filepath.Rel(root, path); err == nil && rel != "." && !strings.HasPrefix(rel, "..") {
-		return filepath.ToSlash(rel)
-	}
-	return filepath.ToSlash(path)
-}
-
-func HandoffHeaderKeys() []string {
-	keys := []string{"slug", "generation", "session_owner", "git_branch", "worktree", "updated_at", "staleness"}
-	slices.Sort(keys)
-	return keys
 }

--- a/internal/state/handoff_test.go
+++ b/internal/state/handoff_test.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -102,16 +101,6 @@ func TestHandoffBriefIsBoundedDescriptor(t *testing.T) {
 	assert.Contains(t, brief, "Finish command tests.")
 	assert.NotContains(t, brief, "current_state")
 	assert.NotContains(t, brief, "next_skill")
-}
-
-func TestHandoffHeaderKeysExcludeLifecycleAuthorityFields(t *testing.T) {
-	keys := HandoffHeaderKeys()
-	raw, err := json.Marshal(keys)
-	require.NoError(t, err)
-	assert.NotContains(t, string(raw), "current_state")
-	assert.NotContains(t, string(raw), "substep")
-	assert.NotContains(t, string(raw), "next_skill")
-	assert.NotContains(t, string(raw), "next_command")
 }
 
 func TestWriteHandoffBodyMergesSectionsAndPreservesOthers(t *testing.T) {

--- a/internal/state/lifecycle_event.go
+++ b/internal/state/lifecycle_event.go
@@ -131,29 +131,6 @@ func ReadLifecycleEvents(root string, change model.Change) ([]LifecycleEvent, er
 	return readLifecycleEventsFromPath(path)
 }
 
-// ReadLifecycleEventTail reads at most the last limit lifecycle events. It is
-// intended for display surfaces that only render recent history; full integrity
-// checks should keep using ReadLifecycleEvents.
-func ReadLifecycleEventTail(root string, change model.Change, limit int) ([]LifecycleEvent, error) {
-	if limit <= 0 {
-		return ReadLifecycleEvents(root, change)
-	}
-	path, err := lifecycleEventLogPathForRead(root, change)
-	if err != nil {
-		return nil, err
-	}
-	return ReadLifecycleEventTailFromPath(path, limit)
-}
-
-// ReadLifecycleEventTailFromPath reads at most the last limit lifecycle events
-// from a caller-resolved lifecycle event log path.
-func ReadLifecycleEventTailFromPath(path string, limit int) ([]LifecycleEvent, error) {
-	if limit <= 0 {
-		return readLifecycleEventsFromPath(path)
-	}
-	return readLifecycleEventTailFromPath(path, limit)
-}
-
 // ReadLifecycleEventTailWithPredecessorTransitionFromPath reads the bounded
 // tail plus the nearest earlier state.transitioned event when that predecessor
 // is outside the retained tail. Display surfaces use the predecessor only as
@@ -267,52 +244,6 @@ func readLifecycleEventsFromPath(path string) ([]LifecycleEvent, error) {
 		return nil, err
 	}
 	return events, nil
-}
-
-func readLifecycleEventTailFromPath(path string, limit int) ([]LifecycleEvent, error) {
-	file, err := os.Open(path) // #nosec G304 -- path is resolved from Slipway state/governance authority before this read.
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-	defer file.Close()
-
-	info, err := file.Stat()
-	if err != nil {
-		return nil, err
-	}
-	if info.Size() == 0 {
-		return nil, nil
-	}
-
-	const chunkSize int64 = 64 * 1024
-	offset := info.Size()
-	var tail []byte
-	var lines []string
-	for offset > 0 {
-		readSize := chunkSize
-		if offset < readSize {
-			readSize = offset
-		}
-		offset -= readSize
-
-		chunk := make([]byte, readSize)
-		if _, err := file.ReadAt(chunk, offset); err != nil {
-			return nil, err
-		}
-		tail = append(append([]byte(nil), chunk...), tail...)
-		lines = nonEmptyJSONLLines(tail)
-		if offset == 0 || len(lines) > limit {
-			break
-		}
-	}
-	if len(lines) > limit {
-		lines = lines[len(lines)-limit:]
-	}
-
-	return decodeLifecycleEventLines(lines, "tail")
 }
 
 func readLifecycleEventTailWithPredecessorTransitionFromPath(path string, limit int) ([]LifecycleEvent, error) {

--- a/internal/state/lifecycle_event_test.go
+++ b/internal/state/lifecycle_event_test.go
@@ -66,51 +66,6 @@ func TestReadLifecycleEventsMissingLogIsEmpty(t *testing.T) {
 	assert.Empty(t, events)
 }
 
-func TestReadLifecycleEventTailIgnoresMalformedOlderLines(t *testing.T) {
-	t.Parallel()
-	root := t.TempDir()
-	change := model.NewChange("tail-event-log")
-	require.NoError(t, SaveChange(root, change))
-
-	path, err := LifecycleEventLogPath(root, change)
-	require.NoError(t, err)
-	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
-	payload := "{not-json}\n" +
-		lifecycleEventLine(t, "tail-event-1", change.Slug) +
-		lifecycleEventLine(t, "tail-event-2", change.Slug) +
-		lifecycleEventLine(t, "tail-event-3", change.Slug)
-	require.NoError(t, os.WriteFile(path, []byte(payload), 0o644))
-
-	tail, err := ReadLifecycleEventTail(root, change, 2)
-	require.NoError(t, err)
-	require.Len(t, tail, 2)
-	assert.Equal(t, "tail-event-2", tail[0].EventID)
-	assert.Equal(t, "tail-event-3", tail[1].EventID)
-
-	_, err = ReadLifecycleEvents(root, change)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "line 1")
-}
-
-func TestReadLifecycleEventTailFailsOnMalformedRetainedLine(t *testing.T) {
-	t.Parallel()
-	root := t.TempDir()
-	change := model.NewChange("tail-event-log-malformed")
-	require.NoError(t, SaveChange(root, change))
-
-	path, err := LifecycleEventLogPath(root, change)
-	require.NoError(t, err)
-	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
-	payload := lifecycleEventLine(t, "tail-good-1", change.Slug) +
-		lifecycleEventLine(t, "tail-good-2", change.Slug) +
-		"{not-json}\n"
-	require.NoError(t, os.WriteFile(path, []byte(payload), 0o644))
-
-	_, err = ReadLifecycleEventTail(root, change, 2)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "decode lifecycle event log tail line")
-}
-
 func TestReadLifecycleEventTailWithPredecessorTransitionIncludesContext(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
@@ -204,11 +159,6 @@ func TestReadLifecycleEventTailWithPredecessorTransitionFailsOnMalformedContextL
 	_, err = ReadLifecycleEventTailWithPredecessorTransitionFromPath(path, 2)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "decode lifecycle event log context line")
-}
-
-func lifecycleEventLine(t *testing.T, eventID string, slug string) string {
-	t.Helper()
-	return lifecycleEventLineWithType(t, eventID, slug, "state.transitioned")
 }
 
 func lifecycleEventLineWithType(t *testing.T, eventID string, slug string, eventType string) string {

--- a/internal/state/repair_test.go
+++ b/internal/state/repair_test.go
@@ -221,7 +221,7 @@ func TestRepairExecutionStateUsesEffectiveParallelWhenRecoveringWaveRuns(t *test
 				},
 			}))
 
-			result, err := RepairExecutionState(root)
+			result, err := RepairExecutionStateAt(root, time.Time{})
 			require.NoError(t, err)
 			assert.Contains(t, result.RecoveredWaveRuns, change.Slug)
 

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -677,7 +677,7 @@ func missingBundleAuthorityError(bundleDir string) error {
 }
 
 // SelectActiveChange resolves the single active change from an already-loaded
-// change list. It mirrors FindActiveChange without re-running discovery.
+// change list without re-running change discovery.
 func SelectActiveChange(changes []model.Change) (model.Change, error) {
 	var active []model.Change
 	for _, c := range changes {
@@ -696,8 +696,7 @@ func SelectActiveChange(changes []model.Change) (model.Change, error) {
 }
 
 // SelectActiveChangeForWorktree resolves the active change for worktree from an
-// already-loaded change list. It mirrors FindActiveChangeForWorktree without
-// re-running discovery.
+// already-loaded change list without re-running change discovery.
 func SelectActiveChangeForWorktree(changes []model.Change, currentWorktreePath string) (model.Change, error) {
 	normalizedCurrent, err := NormalizePath(currentWorktreePath)
 	if err != nil {

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -676,16 +676,6 @@ func missingBundleAuthorityError(bundleDir string) error {
 	)
 }
 
-// FindActiveChange finds the single active change. Returns ErrNoActiveChange if none,
-// ErrMultipleActiveChanges if more than one.
-func FindActiveChange(root string) (model.Change, error) {
-	changes, err := ListChanges(root)
-	if err != nil {
-		return model.Change{}, err
-	}
-	return SelectActiveChange(changes)
-}
-
 // SelectActiveChange resolves the single active change from an already-loaded
 // change list. It mirrors FindActiveChange without re-running discovery.
 func SelectActiveChange(changes []model.Change) (model.Change, error) {
@@ -703,15 +693,6 @@ func SelectActiveChange(changes []model.Change) (model.Change, error) {
 		return model.Change{}, ErrMultipleActiveChanges
 	}
 	return active[0], nil
-}
-
-// FindActiveChangeForWorktree finds the active change bound to the given worktree path.
-func FindActiveChangeForWorktree(root, currentWorktreePath string) (model.Change, error) {
-	changes, err := ListChanges(root)
-	if err != nil {
-		return model.Change{}, err
-	}
-	return SelectActiveChangeForWorktree(changes, currentWorktreePath)
 }
 
 // SelectActiveChangeForWorktree resolves the active change for worktree from an

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -239,26 +239,42 @@ active_checkpoint:
 	assert.NotContains(t, err.Error(), "model.alias")
 }
 
-func TestFindActiveChangeSingle(t *testing.T) {
+func selectActiveChangeFromRuntime(root string) (model.Change, error) {
+	changes, err := ListChanges(root)
+	if err != nil {
+		return model.Change{}, err
+	}
+	return SelectActiveChange(changes)
+}
+
+func selectActiveChangeForWorktreeFromRuntime(root, currentWorktreePath string) (model.Change, error) {
+	changes, err := ListChanges(root)
+	if err != nil {
+		return model.Change{}, err
+	}
+	return SelectActiveChangeForWorktree(changes, currentWorktreePath)
+}
+
+func TestSelectActiveChangeFromLoadedChangesSingle(t *testing.T) {
 	t.Parallel()
 	root := createRuntimeLayout(t)
 
 	st := model.NewChange("single-active")
 	require.NoError(t, SaveChange(root, st))
 
-	resolved, err := FindActiveChange(root)
+	resolved, err := selectActiveChangeFromRuntime(root)
 	require.NoError(t, err)
 	assert.Equal(t, "single-active", resolved.Slug)
 }
 
-func TestFindActiveChangeNoActive(t *testing.T) {
+func TestSelectActiveChangeFromLoadedChangesNoActive(t *testing.T) {
 	t.Parallel()
 	root := createRuntimeLayout(t)
-	_, err := FindActiveChange(root)
+	_, err := selectActiveChangeFromRuntime(root)
 	require.ErrorIs(t, err, ErrNoActiveChange)
 }
 
-func TestFindActiveChangeMultipleReturnsError(t *testing.T) {
+func TestSelectActiveChangeFromLoadedChangesMultipleReturnsError(t *testing.T) {
 	t.Parallel()
 	root := createRuntimeLayout(t)
 
@@ -268,7 +284,7 @@ func TestFindActiveChangeMultipleReturnsError(t *testing.T) {
 	b := model.NewChange("change-b")
 	require.NoError(t, SaveChange(root, b))
 
-	_, err := FindActiveChange(root)
+	_, err := selectActiveChangeFromRuntime(root)
 	require.ErrorIs(t, err, ErrMultipleActiveChanges)
 }
 
@@ -285,7 +301,7 @@ func TestListChangesDiagnostics(t *testing.T) {
 	assert.Equal(t, "diag-change", changes[0].Slug)
 }
 
-func TestFindActiveChangeForWorktreeSingleMatch(t *testing.T) {
+func TestSelectActiveChangeForWorktreeSingleMatch(t *testing.T) {
 	t.Parallel()
 	root := createRuntimeRepoLayout(t)
 	worktreeDir := addGitWorktree(t, root, "wt-match-branch")
@@ -294,12 +310,12 @@ func TestFindActiveChangeForWorktreeSingleMatch(t *testing.T) {
 	ch.WorktreePath = worktreeDir
 	require.NoError(t, SaveChange(root, ch))
 
-	resolved, err := FindActiveChangeForWorktree(root, worktreeDir)
+	resolved, err := selectActiveChangeForWorktreeFromRuntime(root, worktreeDir)
 	require.NoError(t, err)
 	assert.Equal(t, "wt-match", resolved.Slug)
 }
 
-func TestFindActiveChangeForWorktreeZeroMatchFallsBackToUnbound(t *testing.T) {
+func TestSelectActiveChangeForWorktreeZeroMatchFallsBackToUnbound(t *testing.T) {
 	t.Parallel()
 	root := createRuntimeLayout(t)
 	queryDir := t.TempDir()
@@ -308,12 +324,12 @@ func TestFindActiveChangeForWorktreeZeroMatchFallsBackToUnbound(t *testing.T) {
 	// No WorktreePath set — unbound active change.
 	require.NoError(t, SaveChange(root, ch))
 
-	resolved, err := FindActiveChangeForWorktree(root, queryDir)
+	resolved, err := selectActiveChangeForWorktreeFromRuntime(root, queryDir)
 	require.NoError(t, err)
 	assert.Equal(t, "unbound-fallback", resolved.Slug)
 }
 
-func TestFindActiveChangeForWorktreeMultipleMatchReturnsError(t *testing.T) {
+func TestSelectActiveChangeForWorktreeMultipleMatchReturnsError(t *testing.T) {
 	t.Parallel()
 	root := createRuntimeRepoLayout(t)
 	worktreeDir := addGitWorktree(t, root, "shared-worktree-branch")
@@ -326,11 +342,11 @@ func TestFindActiveChangeForWorktreeMultipleMatchReturnsError(t *testing.T) {
 	ch2.WorktreePath = worktreeDir
 	require.NoError(t, SaveChange(root, ch2))
 
-	_, err := FindActiveChangeForWorktree(root, worktreeDir)
+	_, err := selectActiveChangeForWorktreeFromRuntime(root, worktreeDir)
 	require.ErrorIs(t, err, ErrMultipleActiveChanges)
 }
 
-func TestFindActiveChangeForWorktreeUnboundFallback(t *testing.T) {
+func TestSelectActiveChangeForWorktreeUnboundFallback(t *testing.T) {
 	t.Parallel()
 	root := createRuntimeLayout(t)
 	queryDir := t.TempDir()
@@ -340,12 +356,12 @@ func TestFindActiveChangeForWorktreeUnboundFallback(t *testing.T) {
 	// WorktreePath intentionally left empty.
 	require.NoError(t, SaveChange(root, ch))
 
-	resolved, err := FindActiveChangeForWorktree(root, queryDir)
+	resolved, err := selectActiveChangeForWorktreeFromRuntime(root, queryDir)
 	require.NoError(t, err)
 	assert.Equal(t, "unbound-change", resolved.Slug)
 }
 
-func TestFindActiveChangeForWorktreeNoMatchNoFallback(t *testing.T) {
+func TestSelectActiveChangeForWorktreeNoMatchNoFallback(t *testing.T) {
 	t.Parallel()
 	root := createRuntimeRepoLayout(t)
 	queryDir := t.TempDir()
@@ -358,7 +374,7 @@ func TestFindActiveChangeForWorktreeNoMatchNoFallback(t *testing.T) {
 	ch2.WorktreePath = addGitWorktree(t, root, "other-b-branch")
 	require.NoError(t, SaveChange(root, ch2))
 
-	_, err := FindActiveChangeForWorktree(root, queryDir)
+	_, err := selectActiveChangeForWorktreeFromRuntime(root, queryDir)
 	var boundErr *ChangeBoundElsewhereError
 	require.ErrorAs(t, err, &boundErr)
 	require.Len(t, boundErr.BoundChanges, 2)
@@ -396,13 +412,13 @@ func TestTwoConcurrentChangesDifferentWorktreesCoexist(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, changes, 2)
 
-	// FindActiveChangeForWorktree with path A returns change A.
-	resolvedA, err := FindActiveChangeForWorktree(root, worktreeA)
+	// SelectActiveChangeForWorktree with path A returns change A.
+	resolvedA, err := selectActiveChangeForWorktreeFromRuntime(root, worktreeA)
 	require.NoError(t, err)
 	assert.Equal(t, "change-alpha", resolvedA.Slug)
 
-	// FindActiveChangeForWorktree with path B returns change B.
-	resolvedB, err := FindActiveChangeForWorktree(root, worktreeB)
+	// SelectActiveChangeForWorktree with path B returns change B.
+	resolvedB, err := selectActiveChangeForWorktreeFromRuntime(root, worktreeB)
 	require.NoError(t, err)
 	assert.Equal(t, "change-beta", resolvedB.Slug)
 

--- a/internal/state/verification.go
+++ b/internal/state/verification.go
@@ -273,19 +273,6 @@ func LoadVerification(root, slug, skillName string) (model.VerificationRecord, e
 	return rec, nil
 }
 
-// ListVerifications reads all verification records for a change.
-// Returns a map of skillName → VerificationRecord.
-func ListVerifications(root, slug string) (map[string]model.VerificationRecord, error) {
-	dir, err := resolveExistingVerificationDir(root, slug)
-	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return map[string]model.VerificationRecord{}, nil
-		}
-		return nil, err
-	}
-	return listVerificationsInDir(dir)
-}
-
 // ListVerificationsForChange reads all verification records for a resolved
 // authoritative change without re-discovering bundle ownership by slug.
 func ListVerificationsForChange(root string, change model.Change) (map[string]model.VerificationRecord, error) {

--- a/internal/state/verification_test.go
+++ b/internal/state/verification_test.go
@@ -184,21 +184,12 @@ func TestLoadVerificationAcceptsStructuredReasonCodes(t *testing.T) {
 	assert.Equal(t, "research.md", loaded.Blockers[0].Detail)
 }
 
-func TestListVerificationsEmpty(t *testing.T) {
-	t.Parallel()
-	root := createRuntimeLayout(t)
-
-	result, err := ListVerifications(root, "no-change")
-	require.NoError(t, err)
-	assert.Empty(t, result)
-}
-
-func TestListVerificationsMultiple(t *testing.T) {
+func TestListVerificationsForChangeMultiple(t *testing.T) {
 	t.Parallel()
 	root := createRuntimeLayout(t)
 	slug := "multi-skill"
 	now := time.Now().UTC()
-	saveActiveChangeForTest(t, root, slug)
+	change := saveActiveChangeForTest(t, root, slug)
 
 	skills := []string{"plan-audit", "research-orchestration", "wave-orchestration"}
 	for _, s := range skills {
@@ -210,7 +201,7 @@ func TestListVerificationsMultiple(t *testing.T) {
 		writeVerificationForTest(t, root, slug, s, rec)
 	}
 
-	result, err := ListVerifications(root, slug)
+	result, err := ListVerificationsForChange(root, change)
 	require.NoError(t, err)
 	assert.Len(t, result, 3)
 	assert.Contains(t, result, "plan-audit")
@@ -218,12 +209,12 @@ func TestListVerificationsMultiple(t *testing.T) {
 	assert.Contains(t, result, "wave-orchestration")
 }
 
-func TestListVerificationsSkipsWavePlanArtifacts(t *testing.T) {
+func TestListVerificationsForChangeSkipsWavePlanArtifacts(t *testing.T) {
 	t.Parallel()
 
 	root := createRuntimeLayout(t)
 	slug := "skip-wave-plan"
-	saveActiveChangeForTest(t, root, slug)
+	change := saveActiveChangeForTest(t, root, slug)
 
 	writeVerificationForTest(t, root, slug, "plan-audit", model.VerificationRecord{
 		Verdict:   model.VerificationVerdictPass,
@@ -250,7 +241,7 @@ func TestListVerificationsSkipsWavePlanArtifacts(t *testing.T) {
 		}},
 	}))
 
-	result, err := ListVerifications(root, slug)
+	result, err := ListVerificationsForChange(root, change)
 	require.NoError(t, err)
 	assert.Len(t, result, 2)
 	assert.Contains(t, result, "plan-audit")
@@ -258,11 +249,11 @@ func TestListVerificationsSkipsWavePlanArtifacts(t *testing.T) {
 	assert.NotContains(t, result, "wave-plan")
 }
 
-func TestListVerificationsRejectsInvalidFiles(t *testing.T) {
+func TestListVerificationsForChangeRejectsInvalidFiles(t *testing.T) {
 	t.Parallel()
 	root := createRuntimeLayout(t)
 	slug := "skip-bad"
-	saveActiveChangeForTest(t, root, slug)
+	change := saveActiveChangeForTest(t, root, slug)
 
 	rec := model.VerificationRecord{
 		Verdict:   model.VerificationVerdictPass,
@@ -278,7 +269,7 @@ func TestListVerificationsRejectsInvalidFiles(t *testing.T) {
 		0o644,
 	))
 
-	_, err := ListVerifications(root, slug)
+	_, err := ListVerificationsForChange(root, change)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "parse verification broken")
 	var loadErr *VerificationLoadError
@@ -345,7 +336,7 @@ func TestSaveVerificationWithReferencesAndRunVersion(t *testing.T) {
 	assert.Equal(t, "All layers pass.", loaded.Notes)
 }
 
-func TestListVerificationsResolvesWorktreeBundleFromProjectRoot(t *testing.T) {
+func TestListVerificationsForChangeResolvesWorktreeBundleFromProjectRoot(t *testing.T) {
 	t.Parallel()
 	root := createRuntimeRepoLayout(t)
 	worktreeRoot := addGitWorktree(t, root, "worktree-verification-branch")
@@ -365,7 +356,7 @@ func TestListVerificationsResolvesWorktreeBundleFromProjectRoot(t *testing.T) {
 	// canonical governed bundle there, not under the project root.
 	writeVerificationForTest(t, worktreeRoot, slug, "plan-audit", rec)
 
-	result, err := ListVerifications(root, slug)
+	result, err := ListVerificationsForChange(root, change)
 	require.NoError(t, err)
 	require.Contains(t, result, "plan-audit")
 }
@@ -390,30 +381,6 @@ timestamp: 2026-04-06T00:00:00Z
 `), 0o644))
 
 	_, err := LoadVerification(root, slug, "plan-audit")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "authoritative bundle")
-}
-
-func TestListVerificationsRejectsHiddenSiblingWorktreeFallback(t *testing.T) {
-	t.Parallel()
-
-	root, worktreeRoot := setupRepoWithWorktree(t)
-	slug := "hidden-worktree-verification-list"
-
-	change := model.NewChange(slug)
-	change.WorktreePath = worktreeRoot
-	change.CurrentState = model.StateS2Implement
-	change.PlanSubStep = model.PlanSubStepNone
-	require.NoError(t, SaveChange(root, change))
-	require.NoError(t, os.Remove(WorkspaceScopeMarkerPath(worktreeRoot)))
-
-	staleRootDir := filepath.Join(root, "artifacts", "changes", slug, "verification")
-	require.NoError(t, os.MkdirAll(staleRootDir, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(staleRootDir, "plan-audit.yaml"), []byte(`verdict: pass
-timestamp: 2026-04-06T00:00:00Z
-`), 0o644))
-
-	_, err := ListVerifications(root, slug)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "authoritative bundle")
 }

--- a/internal/state/worktree_binding.go
+++ b/internal/state/worktree_binding.go
@@ -118,8 +118,8 @@ func readWorktreeBinding(root, slug string) (worktreeBinding, bool) {
 }
 
 // FindActiveChangeByWorktreeBinding resolves the active change bound to the
-// current git worktree using only runtime binding records. Unlike
-// FindActiveChangeForWorktree, it deliberately avoids ListChanges so callers can
+// current git worktree using only runtime binding records. Unlike the
+// ListChanges-based resolvers, it deliberately avoids ListChanges so callers can
 // still prefer the current bound worktree when another workspace has stale
 // orphaned bundle residue.
 func FindActiveChangeByWorktreeBinding(root, currentWorktreePath string) (model.Change, error) {

--- a/internal/state/worktree_binding_test.go
+++ b/internal/state/worktree_binding_test.go
@@ -106,7 +106,7 @@ func TestFindActiveChangeFromInsideWorktreeResolves(t *testing.T) {
 	change.WorktreeBranch = "feature"
 	require.NoError(t, SaveChange(root, change))
 
-	resolved, err := FindActiveChangeForWorktree(worktreeRoot, worktreeRoot)
+	resolved, err := selectActiveChangeForWorktreeFromRuntime(worktreeRoot, worktreeRoot)
 	require.NoError(t, err)
 	assert.Equal(t, change.Slug, resolved.Slug)
 	wantWorktree, err := NormalizePath(worktreeRoot)


### PR DESCRIPTION
## Summary
- Remove production-unreachable state helpers for handoff metadata, lifecycle-event plain tails, execution repair, active-change selection, and verification listing
- Update tests to exercise the retained lower-level selection and verification APIs instead of the removed exported wrappers
- Keep deliberate legacy/test seams such as transaction hook injection, command registry test access, and legacy migration diagnostics out of this cleanup

## Verification
- go test -count=1 ./...
- go build ./...
- go vet ./...
- golangci-lint run ./...
- golangci-lint run --enable-only unused ./...
- deadcode -test ./...
- git diff --check

Note: deadcode ./... now reports only ApplyFileTransactionWithHooks and CommandDefinitions, both intentionally retained.