### PR TITLE
refactor: behavior-preserving optimization and correctness hardening

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -536,7 +536,7 @@ func resolveExplicitChangeWithReadContext(readCtx *stateReadContext, slug string
 						"status":       string(archived.Status),
 					},
 				)
-				cliErr.InvocationRoute = buildInvocationRouteView(root, archived, root, true)
+				cliErr.InvocationRoute = buildInvocationRouteViewWithReadContext(readCtx, archived, root, true)
 				return changeRef{}, cliErr
 			}
 			// No archived record was found. Only os.ErrNotExist (no bundle at all)
@@ -573,7 +573,7 @@ func resolveExplicitChangeWithReadContext(readCtx *stateReadContext, slug string
 				"status": string(change.Status),
 			},
 		)
-		cliErr.InvocationRoute = buildInvocationRouteView(root, change, root, true)
+		cliErr.InvocationRoute = buildInvocationRouteViewWithReadContext(readCtx, change, root, true)
 		return changeRef{}, cliErr
 	}
 	if err := state.ValidateChangeSlug(change.Slug); err != nil {
@@ -702,26 +702,10 @@ func classifyOrphanBundlesWith(root string, orphans []string, match slugWorktree
 	return class
 }
 
-func unmanagedOrphanSlugs(orphans []unmanagedOrphan) []string {
+func orphanSlugs[T any](orphans []T, slug func(T) string) []string {
 	slugs := make([]string, 0, len(orphans))
 	for _, o := range orphans {
-		slugs = append(slugs, o.Slug)
-	}
-	return slugs
-}
-
-func unknownOrphanSlugs(orphans []unknownOrphan) []string {
-	slugs := make([]string, 0, len(orphans))
-	for _, o := range orphans {
-		slugs = append(slugs, o.Slug)
-	}
-	return slugs
-}
-
-func archivedResidueOrphanSlugs(orphans []archivedResidueOrphan) []string {
-	slugs := make([]string, 0, len(orphans))
-	for _, o := range orphans {
-		slugs = append(slugs, o.Slug)
+		slugs = append(slugs, slug(o))
 	}
 	return slugs
 }
@@ -793,9 +777,9 @@ func orphanedChangeBundleError(root, slug string) *CLIError {
 			remediation = unmanagedWorktreeOrphanRemediation(primary.Slug, primary.Match)
 			details["unmanaged_worktree_path"] = primary.Match.WorktreePath
 			details["unmanaged_worktree_branch"] = primary.Match.Branch
-			details["unmanaged_worktree_orphans"] = unmanagedOrphanSlugs(class.Unmanaged)
+			details["unmanaged_worktree_orphans"] = orphanSlugs(class.Unmanaged, func(o unmanagedOrphan) string { return o.Slug })
 			if len(class.Unknown) > 0 {
-				unknown := unknownOrphanSlugs(class.Unknown)
+				unknown := orphanSlugs(class.Unknown, func(o unknownOrphan) string { return o.Slug })
 				details["ownership_unknown_orphans"] = unknown
 				remediation += fmt.Sprintf(" Ownership could not be verified for: %s (git worktree cross-check failed); inspect those for live worktrees and preserve any unmerged work before discarding anything.", strings.Join(unknown, ", "))
 			}
@@ -805,7 +789,7 @@ func orphanedChangeBundleError(root, slug string) *CLIError {
 			primarySlug = primary.Slug
 			message = fmt.Sprintf("governed bundle %q lost its change.yaml authority and its git worktree ownership could not be verified", primary.Slug)
 			remediation = ownershipUnknownOrphanRemediation(primary.Slug, primary.Err)
-			details["ownership_unknown_orphans"] = unknownOrphanSlugs(class.Unknown)
+			details["ownership_unknown_orphans"] = orphanSlugs(class.Unknown, func(o unknownOrphan) string { return o.Slug })
 		}
 		if len(class.Plain) > 0 {
 			details["orphaned_change_bundles"] = class.Plain
@@ -813,7 +797,7 @@ func orphanedChangeBundleError(root, slug string) *CLIError {
 		}
 		if len(class.ArchivedResidue) > 0 {
 			archived := class.ArchivedResidue[0]
-			details["orphaned_active_residue_archived_changes"] = archivedResidueOrphanSlugs(class.ArchivedResidue)
+			details["orphaned_active_residue_archived_changes"] = orphanSlugs(class.ArchivedResidue, func(o archivedResidueOrphan) string { return o.Slug })
 			details["archive_path"] = archived.ArchivePath
 			remediation += " Separately, " + archivedActiveResidueRemediation(archived)
 		}
@@ -833,11 +817,11 @@ func orphanedChangeBundleError(root, slug string) *CLIError {
 		message := fmt.Sprintf("active-state residue for archived change %q is missing its change.yaml authority", primary.Slug)
 		remediation := archivedActiveResidueRemediation(primary)
 		if len(class.ArchivedResidue) > 1 {
-			message = "active-state residue remains for archived changes: " + strings.Join(archivedResidueOrphanSlugs(class.ArchivedResidue), ", ")
+			message = "active-state residue remains for archived changes: " + strings.Join(orphanSlugs(class.ArchivedResidue, func(o archivedResidueOrphan) string { return o.Slug }), ", ")
 			remediation = fmt.Sprintf("Discard each stale active-state residue with `slipway delete --change <slug>`; first suggested command: `slipway delete --change %s`. Archived records and source commits are not deletion targets.", primary.Slug)
 		}
 		details := map[string]any{
-			"orphaned_active_residue_archived_changes": archivedResidueOrphanSlugs(class.ArchivedResidue),
+			"orphaned_active_residue_archived_changes": orphanSlugs(class.ArchivedResidue, func(o archivedResidueOrphan) string { return o.Slug }),
 			"archive_path": primary.ArchivePath,
 		}
 		if len(class.Plain) > 0 {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -280,14 +280,7 @@ func writeConfigCatalogText(cmd *cobra.Command, catalog []model.ConfigCatalogEnt
 }
 
 func joinConfigAllowed(values []string) string {
-	out := ""
-	for i, v := range values {
-		if i > 0 {
-			out += "|"
-		}
-		out += v
-	}
-	return out
+	return strings.Join(values, "|")
 }
 
 func runConfigGet(cmd *cobra.Command, key string, jsonFlag bool) error {

--- a/cmd/done.go
+++ b/cmd/done.go
@@ -120,28 +120,45 @@ func doneWorktreeDirtyState(root string, change model.Change) (string, []string)
 	return doneWorktreeDirtyWarning, files
 }
 
-func detectRemediationSources(root string, change model.Change) []model.ArchiveReference {
+func detectRemediationSources(root string, change model.Change) ([]model.ArchiveReference, error) {
 	paths, err := state.ResolveChangePaths(root, change)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	refs := []model.ArchiveReference{}
-	_ = filepath.WalkDir(paths.GovernedBundleDir, func(path string, entry fs.DirEntry, err error) error {
-		if err != nil || entry.IsDir() {
+	walkErr := filepath.WalkDir(paths.GovernedBundleDir, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
 			return nil
 		}
 		name := entry.Name()
 		if !strings.HasSuffix(name, ".md") && !strings.HasSuffix(name, ".yaml") && !strings.HasSuffix(name, ".yml") {
 			return nil
 		}
+		// Skip symlinks and other non-regular entries: ReadFileNoSymlink
+		// intentionally refuses them, and that refusal is a deliberate skip
+		// rather than an unreadable-file failure. WalkDir does not follow
+		// symlinks, so they arrive here with a nil walk error and a
+		// symlink-typed entry.
+		if !entry.Type().IsRegular() {
+			return nil
+		}
 		data, readErr := fsutil.ReadFileNoSymlink(path)
 		if readErr != nil {
-			return nil
+			return readErr
 		}
 		refs = append(refs, archiveReferencesFromText(string(data))...)
 		return nil
 	})
-	return mergeArchiveReferences(nil, existingArchiveReferences(root, refs))
+	// A missing GovernedBundleDir is tolerated (baseline behavior): there is
+	// simply nothing to detect. Genuine read/permission errors on existing
+	// files still surface (C3), so only the not-exist case is skipped.
+	if walkErr != nil && !errors.Is(walkErr, fs.ErrNotExist) {
+		return nil, walkErr
+	}
+	return mergeArchiveReferences(nil, existingArchiveReferences(root, refs)), nil
 }
 
 func archiveReferencesFromText(text string) []model.ArchiveReference {
@@ -300,20 +317,14 @@ func makeDoneCmd() *cobra.Command {
 						nil,
 					)
 				}
-				worktreeDirtyWarning, worktreeDirtyFiles := doneWorktreeDirtyState(root, change)
-				if err := reconcileDoneFilesystemState(root, &change); err != nil {
-					return err
-				}
-				if err := validateGovernedDoneArtifacts(root, change); err != nil {
-					return err
-				}
-				shipEval, shipBlocked, err := refreshDoneShipGate(root, &change)
+				prep, _, err := prepareDoneFinalize(root, &change)
 				if err != nil {
 					return err
 				}
-				if shipBlocked {
-					return shipGateBlockedError(root, change, shipEval)
+				if prep.shipBlocked {
+					return shipGateBlockedError(root, change, prep.shipEval)
 				}
+				worktreeDirtyWarning, worktreeDirtyFiles := prep.worktreeDirtyWarning, prep.worktreeDirtyFiles
 				doneFreshnessChange := change
 				doneExecCtx, err := loadExecutionContext(root, change)
 				if err != nil {
@@ -336,9 +347,13 @@ func makeDoneCmd() *cobra.Command {
 				}
 				beforeChange := change
 				markChangeDone(&change)
+				detectedRemediation, err := detectRemediationSources(root, change)
+				if err != nil {
+					return err
+				}
 				change.RemediationSources = mergeArchiveReferences(
 					change.RemediationSources,
-					detectRemediationSources(root, change),
+					detectedRemediation,
 				)
 
 				if err := appendCLILifecycleEvent(root, change, state.LifecycleEvent{
@@ -497,25 +512,26 @@ func archiveSingleDoneReady(root, slug string, change model.Change) doneBulkItem
 	if !action.CanFinalizeDone(change.CurrentState) {
 		return newDoneBulkSkipped(slug, string(change.CurrentState), "not_done_ready")
 	}
-	worktreeDirtyWarning, worktreeDirtyFiles := doneWorktreeDirtyState(root, change)
-	if err := reconcileDoneFilesystemState(root, &change); err != nil {
-		return newDoneBulkFailed(slug, "artifact_reconcile_failed", err.Error())
-	}
-	if err := validateGovernedDoneArtifacts(root, change); err != nil {
-		return newDoneBulkFailed(slug, "artifact_validation_failed", err.Error())
-	}
-	shipEval, shipBlocked, err := refreshDoneShipGate(root, &change)
+	prep, step, err := prepareDoneFinalize(root, &change)
 	if err != nil {
-		return doneBulkFailedFromError(slug, err)
+		switch step {
+		case doneFinalizeStepReconcile:
+			return newDoneBulkFailed(slug, "artifact_reconcile_failed", err.Error())
+		case doneFinalizeStepValidate:
+			return newDoneBulkFailed(slug, "artifact_validation_failed", err.Error())
+		default:
+			return doneBulkFailedFromError(slug, err)
+		}
 	}
-	if shipBlocked {
+	if prep.shipBlocked {
 		return newDoneBulkSkippedWithReasonCodes(
 			slug,
 			string(change.CurrentState),
 			"ship_gate_blocked",
-			append([]model.ReasonCode(nil), shipEval.ReasonCodes...),
+			append([]model.ReasonCode(nil), prep.shipEval.ReasonCodes...),
 		)
 	}
+	worktreeDirtyWarning, worktreeDirtyFiles := prep.worktreeDirtyWarning, prep.worktreeDirtyFiles
 	beforeChange := change
 	markChangeDone(&change)
 
@@ -566,6 +582,56 @@ func refreshDoneShipGate(root string, change *model.Change) (gate.GateEvaluation
 		return eval, false, nil
 	}
 	return eval, true, nil
+}
+
+// doneFinalizeStep identifies which step of the shared pre-archive finalize
+// sequence failed, so each caller can surface the failure in its own error
+// shape (a raw error propagated by interactive `done`, or a reason-coded bulk
+// item emitted by `--all-ready`).
+type doneFinalizeStep int
+
+const (
+	doneFinalizeStepNone doneFinalizeStep = iota
+	doneFinalizeStepReconcile
+	doneFinalizeStepValidate
+	doneFinalizeStepShipGate
+)
+
+// doneFinalizePrep carries the results of the shared pre-archive finalize
+// sequence back to each call site.
+type doneFinalizePrep struct {
+	worktreeDirtyWarning string
+	worktreeDirtyFiles   []string
+	shipEval             gate.GateEvaluation
+	shipBlocked          bool
+}
+
+// prepareDoneFinalize runs the finalize steps shared by interactive `done` and
+// bulk `--all-ready` archive: it snapshots the dirty-worktree advisory,
+// reconciles the governed bundle to the filesystem, validates governed
+// artifacts, and refreshes the ship gate. change is mutated exactly as the
+// inline sequences did (reconcile persists the reconciled bundle; ship-gate
+// refresh re-evaluates against it). On failure it returns the raw underlying
+// error together with the step that failed, leaving error-to-surface mapping to
+// each caller. On success step is doneFinalizeStepNone and prep.shipBlocked
+// reports whether the refreshed ship gate blocks finalization (prep.shipEval
+// carries the evaluation).
+func prepareDoneFinalize(root string, change *model.Change) (doneFinalizePrep, doneFinalizeStep, error) {
+	prep := doneFinalizePrep{}
+	prep.worktreeDirtyWarning, prep.worktreeDirtyFiles = doneWorktreeDirtyState(root, *change)
+	if err := reconcileDoneFilesystemState(root, change); err != nil {
+		return prep, doneFinalizeStepReconcile, err
+	}
+	if err := validateGovernedDoneArtifacts(root, *change); err != nil {
+		return prep, doneFinalizeStepValidate, err
+	}
+	shipEval, shipBlocked, err := refreshDoneShipGate(root, change)
+	if err != nil {
+		return prep, doneFinalizeStepShipGate, err
+	}
+	prep.shipEval = shipEval
+	prep.shipBlocked = shipBlocked
+	return prep, doneFinalizeStepNone, nil
 }
 
 func shipGateBlockedError(root string, change model.Change, eval gate.GateEvaluation) error {

--- a/cmd/done_test.go
+++ b/cmd/done_test.go
@@ -1,0 +1,98 @@
+package cmd
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/signalridge/slipway/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDetectRemediationSourcesSurfacesUnreadableBundleFile proves that an
+// unreadable (permission-denied) regular file in the governed bundle causes the
+// walk/read error to be surfaced instead of silently dropping remediation
+// references.
+//
+// RED rationale: before the fix, detectRemediationSources discarded the
+// filepath.WalkDir result and returned nil on per-file read errors, so this
+// call returned no error and the reference in the unreadable file was silently
+// omitted — require.Error would FAIL. After the fix, the per-file read error is
+// returned from the walk callback and threaded out, so this call returns a
+// non-nil error — require.Error PASSES.
+func TestDetectRemediationSourcesSurfacesUnreadableBundleFile(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod-based unreadable-file simulation is not portable on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses file permission bits; cannot simulate an unreadable file")
+	}
+
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "fix archived workflow feedback")
+		change, err := state.LoadChange(root, slug)
+		require.NoError(t, err)
+
+		paths, err := state.ResolveChangePaths(root, change)
+		require.NoError(t, err)
+
+		// A regular bundle file that carries a remediation reference the scan
+		// would otherwise pick up, then made unreadable.
+		unreadable := filepath.Join(paths.GovernedBundleDir, "remediation-source.md")
+		require.NoError(t, os.WriteFile(
+			unreadable,
+			[]byte("Remediates artifacts/changes/archived/source-archived-workflow/workflow-feedback.md\n"),
+			0o644,
+		))
+		require.NoError(t, os.Chmod(unreadable, 0o000))
+		// Restore permissions so the temp-dir cleanup can remove the file.
+		t.Cleanup(func() { _ = os.Chmod(unreadable, 0o644) })
+
+		refs, err := detectRemediationSources(root, change)
+		require.Error(t, err, "unreadable bundle file must surface the read error, not be silently dropped")
+		assert.ErrorIs(t, err, fs.ErrPermission)
+		assert.Nil(t, refs)
+	})
+}
+
+// TestDetectRemediationSourcesSkipsSymlinkWithoutError guards the behavior-
+// preserving boundary: a symlinked bundle file is an intentional skip (matching
+// ReadFileNoSymlink's refusal), not an unreadable-file failure, so the scan must
+// still succeed with no error even though genuine read failures now surface.
+func TestDetectRemediationSourcesSkipsSymlinkWithoutError(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "fix archived workflow feedback")
+		change, err := state.LoadChange(root, slug)
+		require.NoError(t, err)
+
+		paths, err := state.ResolveChangePaths(root, change)
+		require.NoError(t, err)
+
+		external := filepath.Join(t.TempDir(), "outside.md")
+		require.NoError(t, os.WriteFile(
+			external,
+			[]byte("Remediates artifacts/changes/archived/source-archived-workflow/workflow-feedback.md\n"),
+			0o644,
+		))
+		link := filepath.Join(paths.GovernedBundleDir, "linked-source.md")
+		if err := os.Symlink(external, link); err != nil {
+			t.Skipf("symlink unavailable: %v", err)
+		}
+
+		_, err = detectRemediationSources(root, change)
+		require.NoError(t, err)
+	})
+}

--- a/cmd/next.go
+++ b/cmd/next.go
@@ -476,21 +476,7 @@ func buildNextViewForCommandWithReadContext(readCtx *stateReadContext, ref chang
 	}
 	command = strings.TrimSpace(command)
 
-	view := nextView{
-		Command:                     command,
-		Slug:                        ref.Slug,
-		Phase:                       model.PhasePlanning,
-		EvidenceFreshness:           "unknown",
-		ExecutionEvidenceFreshness:  "unknown",
-		GovernanceEvidenceFreshness: "unknown",
-		OverallReadinessFreshness:   "unknown",
-		ConfirmationRequirement:     confirmationNoBoundary("initializing"),
-		auto:                        auto,
-		config:                      cfg,
-		InputContext: nextContext{
-			WorkspaceRoot: root,
-		},
-	}
+	view := newBaseNextView(root, cfg, command, ref, auto)
 	if shouldExposeAdvancedSummaryToCaller(advanced) {
 		view.Advanced = &advanced
 	}
@@ -515,84 +501,14 @@ func buildNextViewForCommandWithReadContext(readCtx *stateReadContext, ref chang
 		// under auto. buildNextContextByMode does not set this field.
 		view.GuardrailDomain = strings.TrimSpace(governedChange.GuardrailDomain)
 	}
-	finalize := func() (nextView, error) {
-		applyReadyAdvanceDiagnostics(root, governedChange, &view)
-		applyHostCapabilityContractToNext(&view)
-		refreshOverallReadinessFreshnessForNext(&view)
-		view.ConfirmationRequirement = deriveConfirmationRequirement(view)
-		view.CurrentActionKind = view.ConfirmationRequirement.NextActionKind
-		view.CurrentActionCommand = view.ConfirmationRequirement.NextCommand
-		view.Recovery = model.BuildRecovery(view.Blockers)
-		return view, nil
-	}
 	view.Phase = model.PhaseFor(view.CurrentState)
 	var nextSkillEvidence map[string]model.VerificationRecord
 	var nextSkillArtifactProjection *progression.ArtifactProjection
 	if governedChange != nil {
-		presetFields, err := buildWorkflowPresetView(root, *governedChange)
+		nextSkillEvidence, nextSkillArtifactProjection, err = applyGovernedReadinessToNextView(root, readCtx, &view, ref, *governedChange, execCtx)
 		if err != nil {
 			return nextView{}, err
 		}
-		view.WorkflowPreset = presetFields.WorkflowPreset
-		view.SuggestedWorkflowPreset = presetFields.SuggestedWorkflowPreset
-		view.EffectiveWorkflowPreset = presetFields.EffectiveWorkflowPreset
-		view.PresetConfirmationPending = presetFields.PresetConfirmationPending
-		view.PresetUpgradeReasons = presetFields.PresetUpgradeReasons
-		view.GovernanceForecast = presetFields.GovernanceForecast
-
-		verificationRecords, err := readCtx.verificationRecords(*governedChange)
-		if err != nil {
-			return nextView{}, wrapGovernanceReadinessError("evaluate next skill evidence", ref.Slug, err)
-		}
-		readiness, err := progression.EvaluateGovernanceReadiness(
-			root,
-			*governedChange,
-			progression.GovernanceReadinessOptions{
-				IncludeGateEvaluations: true,
-				// Next needs projected artifact context for rendering, but keeps the
-				// reconcile read-only by requesting only the in-memory projection.
-				IncludeArtifactProjection: true,
-				VerificationRecords:       verificationRecords,
-			},
-		)
-		if err != nil {
-			return nextView{}, wrapGovernanceReadinessError("evaluate next skill evidence", ref.Slug, err)
-		}
-		view.Warnings = append(view.Warnings, readiness.Diagnostics...)
-		view.Blockers = appendReasonCodes(view.Blockers, readiness.Blockers)
-		// Capture the genuine dead-end reason codes of the gate that OWNS
-		// advancement out of the current (state, plan substep) when that gate is
-		// blocked. They are applied later in applyReadyAdvanceDiagnostics, bounded
-		// to the no-skill ready/run-to-advance posture, so a dead-end (e.g.
-		// plan_audit_origin_invalid) stops `next` advertising the step ready to
-		// advance while the gate that owns advancement is blocked (#382). PACING
-		// blocks (required-skill handoffs and other host-handoff ride-along codes)
-		// are filtered out here so they keep riding the normal handoff/run guidance;
-		// surfacing every blocked visible gate over-surfaced that pacing work and
-		// erased the no_skill_required / run_slipway_run_to_advance guidance.
-		if owning := progression.OwningAdvanceGateID(view.CurrentState, governedChange.PlanSubStep); owning != "" {
-			if eval, ok := readiness.GateEvaluations[gate.GateID(owning)]; ok && eval.Status == model.GateStatusBlocked {
-				for _, rc := range eval.ReasonCodes {
-					if !progression.HostHandoffBlockerCanRide(rc) {
-						view.ownedAdvanceGateDeadEndBlockers = append(view.ownedAdvanceGateDeadEndBlockers, rc)
-					}
-				}
-			}
-		}
-		view.FreshnessDiagnostics = attachFreshnessDiagnostics(readiness.FreshnessDiagnostics)
-		var summary *model.ExecutionSummary
-		if execCtx != nil {
-			summary = execCtx.Summary
-		}
-		applyReadinessFreshnessToNext(root, &view, *governedChange, summary, readiness)
-		if readiness.ArtifactProjection != nil && len(readiness.ArtifactProjection.Amendments) > 0 {
-			view.ArtifactAmendments = append([]artifact.AmendmentEvent(nil), readiness.ArtifactProjection.Amendments...)
-		}
-		nextSkillEvidence = readiness.PassingSkills
-		nextSkillArtifactProjection = readiness.ArtifactProjection
-		applyReadinessToNextContext(&view, readiness)
-		applyGovernanceSurfaceToNext(readiness, &view)
-		view.planLocked = planLockedFromGates(readiness)
 	}
 
 	// Attach wave plan when at S2_IMPLEMENT for governed changes.
@@ -603,7 +519,7 @@ func buildNextViewForCommandWithReadContext(readCtx *stateReadContext, ref chang
 	if view.CurrentState == model.StateDone {
 		view.NextSkill = nil
 		view.Blockers = []model.ReasonCode{model.NewReasonCode("change_is_done", "")}
-		return finalize()
+		return finalizeNextView(root, governedChange, view)
 	}
 	if err := projectDoneReadyForReadOnlyQuery(root, governedChange, &advanced); err != nil {
 		return nextView{}, err
@@ -616,7 +532,7 @@ func buildNextViewForCommandWithReadContext(readCtx *stateReadContext, ref chang
 			return nextView{}, err
 		}
 		view.Warnings = append(view.Warnings, warnings...)
-		return finalize()
+		return finalizeNextView(root, governedChange, view)
 	}
 
 	if skipAutoPass && governedChange != nil {
@@ -630,7 +546,128 @@ func buildNextViewForCommandWithReadContext(readCtx *stateReadContext, ref chang
 		return nextView{}, err
 	}
 
-	return finalize()
+	return finalizeNextView(root, governedChange, view)
+}
+
+// newBaseNextView constructs the initial next-view scaffold shared by every
+// build path: identity, the planning-phase default, "unknown" freshness fields,
+// the initializing confirmation requirement, and the unexported auto/config
+// carriers. Downstream steps overwrite these fields as governance context
+// resolves.
+func newBaseNextView(root string, cfg model.Config, command string, ref changeRef, auto bool) nextView {
+	return nextView{
+		Command:                     command,
+		Slug:                        ref.Slug,
+		Phase:                       model.PhasePlanning,
+		EvidenceFreshness:           "unknown",
+		ExecutionEvidenceFreshness:  "unknown",
+		GovernanceEvidenceFreshness: "unknown",
+		OverallReadinessFreshness:   "unknown",
+		ConfirmationRequirement:     confirmationNoBoundary("initializing"),
+		auto:                        auto,
+		config:                      cfg,
+		InputContext: nextContext{
+			WorkspaceRoot: root,
+		},
+	}
+}
+
+// applyGovernedReadinessToNextView evaluates governance readiness for a governed
+// change and folds the result into the view: preset fields, readiness
+// diagnostics and blockers, the owning-advance-gate dead-end capture (#382),
+// freshness diagnostics and readiness freshness, artifact amendments, the
+// readiness-derived context and governance surface, and the plan-locked flag. It
+// returns the passing-skill evidence and artifact projection the skill-view
+// assembly consumes. It performs the same reads and view mutations, in the same
+// order, as the inline block it was extracted from.
+func applyGovernedReadinessToNextView(
+	root string,
+	readCtx *stateReadContext,
+	view *nextView,
+	ref changeRef,
+	governedChange model.Change,
+	execCtx *executionContext,
+) (map[string]model.VerificationRecord, *progression.ArtifactProjection, error) {
+	presetFields, err := buildWorkflowPresetView(root, governedChange)
+	if err != nil {
+		return nil, nil, err
+	}
+	view.WorkflowPreset = presetFields.WorkflowPreset
+	view.SuggestedWorkflowPreset = presetFields.SuggestedWorkflowPreset
+	view.EffectiveWorkflowPreset = presetFields.EffectiveWorkflowPreset
+	view.PresetConfirmationPending = presetFields.PresetConfirmationPending
+	view.PresetUpgradeReasons = presetFields.PresetUpgradeReasons
+	view.GovernanceForecast = presetFields.GovernanceForecast
+
+	verificationRecords, err := readCtx.verificationRecords(governedChange)
+	if err != nil {
+		return nil, nil, wrapGovernanceReadinessError("evaluate next skill evidence", ref.Slug, err)
+	}
+	readiness, err := progression.EvaluateGovernanceReadiness(
+		root,
+		governedChange,
+		progression.GovernanceReadinessOptions{
+			IncludeGateEvaluations: true,
+			// Next needs projected artifact context for rendering, but keeps the
+			// reconcile read-only by requesting only the in-memory projection.
+			IncludeArtifactProjection: true,
+			VerificationRecords:       verificationRecords,
+		},
+	)
+	if err != nil {
+		return nil, nil, wrapGovernanceReadinessError("evaluate next skill evidence", ref.Slug, err)
+	}
+	view.Warnings = append(view.Warnings, readiness.Diagnostics...)
+	view.Blockers = appendReasonCodes(view.Blockers, readiness.Blockers)
+	// Capture the genuine dead-end reason codes of the gate that OWNS
+	// advancement out of the current (state, plan substep) when that gate is
+	// blocked. They are applied later in applyReadyAdvanceDiagnostics, bounded
+	// to the no-skill ready/run-to-advance posture, so a dead-end (e.g.
+	// plan_audit_origin_invalid) stops `next` advertising the step ready to
+	// advance while the gate that owns advancement is blocked (#382). PACING
+	// blocks (required-skill handoffs and other host-handoff ride-along codes)
+	// are filtered out here so they keep riding the normal handoff/run guidance;
+	// surfacing every blocked visible gate over-surfaced that pacing work and
+	// erased the no_skill_required / run_slipway_run_to_advance guidance.
+	if owning := progression.OwningAdvanceGateID(view.CurrentState, governedChange.PlanSubStep); owning != "" {
+		if eval, ok := readiness.GateEvaluations[gate.GateID(owning)]; ok && eval.Status == model.GateStatusBlocked {
+			for _, rc := range eval.ReasonCodes {
+				if !progression.HostHandoffBlockerCanRide(rc) {
+					view.ownedAdvanceGateDeadEndBlockers = append(view.ownedAdvanceGateDeadEndBlockers, rc)
+				}
+			}
+		}
+	}
+	view.FreshnessDiagnostics = attachFreshnessDiagnostics(readiness.FreshnessDiagnostics)
+	var summary *model.ExecutionSummary
+	if execCtx != nil {
+		summary = execCtx.Summary
+	}
+	applyReadinessFreshnessToNext(root, view, governedChange, summary, readiness)
+	if readiness.ArtifactProjection != nil && len(readiness.ArtifactProjection.Amendments) > 0 {
+		view.ArtifactAmendments = append([]artifact.AmendmentEvent(nil), readiness.ArtifactProjection.Amendments...)
+	}
+	applyReadinessToNextContext(view, readiness)
+	applyGovernanceSurfaceToNext(readiness, view)
+	view.planLocked = planLockedFromGates(readiness)
+	return readiness.PassingSkills, readiness.ArtifactProjection, nil
+}
+
+// finalizeNextView applies the terminal read-only diagnostics shared by every
+// return path — ready-advance diagnostics, the host-capability contract, overall
+// readiness freshness, the derived confirmation requirement and its mirrored
+// current-action fields, and the recovery summary — then returns the completed
+// view. It is a pure projection over the accumulated view state and carries no
+// advancement side effects.
+func finalizeNextView(root string, governedChange *model.Change, view nextView) (nextView, error) {
+	applyReadyAdvanceDiagnostics(root, governedChange, &view)
+	applyHostCapabilityContractToNext(&view)
+	refreshOverallReadinessFreshnessForNext(&view)
+	view.ConfirmationRequirement = deriveConfirmationRequirement(view)
+	view.CurrentActionKind = view.ConfirmationRequirement.NextActionKind
+	view.CurrentActionCommand = view.ConfirmationRequirement.NextCommand
+	view.Recovery = model.BuildRecovery(view.Blockers)
+	return view, nil
 }
 
 // advanceIfReadyAuto attempts state advancement unless in preview mode. When
@@ -939,10 +976,10 @@ func applyHostCapabilityContractToValidate(view *validateView, skills []string) 
 	view.HostCapabilities = hostCapabilityViewsForSkills(skills)
 	for _, req := range view.HostCapabilities {
 		if code := hostCapabilityBlockerCode(req); code != "" {
-			view.Blockers = model.NormalizeReasonCodes(append(
+			view.Blockers = appendReasonCodes(
 				view.Blockers,
-				model.NewReasonCode(code, req.SkillName+":"+req.Capability),
-			))
+				[]model.ReasonCode{model.NewReasonCode(code, req.SkillName+":"+req.Capability)},
+			)
 		}
 	}
 	view.CanAdvance = len(view.Blockers) == 0

--- a/cmd/repair.go
+++ b/cmd/repair.go
@@ -87,9 +87,8 @@ func makeRepairCmd() *cobra.Command {
 				}
 				summary.CleanedAtomicTemps = cleaned
 
-				if backupPath, err := state.RepairCorruptConfig(root, now); err == nil {
-					summary.ConfigBackupPath = backupPath
-				}
+				backupPath, configRepairErr := state.RepairCorruptConfig(root, now)
+				applyConfigRepairResult(&summary, backupPath, configRepairErr)
 				worktreeScopeRepairs, err := state.RepairBoundWorktreeScopeMetadata(root)
 				if err != nil {
 					return err
@@ -101,9 +100,24 @@ func makeRepairCmd() *cobra.Command {
 				}
 				summary.RemovedEmptyOrphanBundles = removedEmptyOrphans
 
-				cfg, err := loadConfigAtRoot(root)
-				if err != nil {
-					return err
+				cfg, cfgErr := loadConfigAtRoot(root)
+				if cfgErr != nil {
+					// The config is still unreadable after the RepairCorruptConfig
+					// attempt above. Hard-returning here would discard the whole
+					// summary — including any config-repair finding just recorded —
+					// and leave the operator with a bare config_parse_failure that
+					// says to run `slipway repair` right after they ran it (REQ-002).
+					// Surface the unreadable config as a non-repairable finding and
+					// fall back to default lock settings (as loadRepairLockConfigAtRoot
+					// already does) so the remaining repairs and the summary complete.
+					summary.NonRepairableFindings = append(
+						summary.NonRepairableFindings,
+						fmt.Sprintf(
+							"config unreadable after repair; correct or remove %s manually: %v",
+							state.ConfigPath(root), cfgErr,
+						),
+					)
+					cfg = model.DefaultConfig()
 				}
 
 				allChanges, changeIssues, err := state.ListChangesBestEffortWithIssues(root)
@@ -267,6 +281,23 @@ func makeRepairCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&listFocuses, "list-focuses", false, "List public --focus aliases for this command and exit")
 	cmd.Flags().StringVar(&discoveryFormat, "format", "text", "Output format for --list-focuses: text|json")
 	return cmd
+}
+
+// applyConfigRepairResult records the outcome of state.RepairCorruptConfig on
+// the summary. A successful repair records the backup path (empty when the
+// config was already valid or was recreated from missing). A non-nil error is a
+// config-repair FAILURE that must surface as a non-repairable finding for the
+// operator rather than being swallowed as success: the backup or rewrite did
+// not complete, so the on-disk config is still broken.
+func applyConfigRepairResult(summary *repairSummary, backupPath string, err error) {
+	if err != nil {
+		summary.NonRepairableFindings = append(
+			summary.NonRepairableFindings,
+			fmt.Sprintf("config repair failed: %v", err),
+		)
+		return
+	}
+	summary.ConfigBackupPath = backupPath
 }
 
 func writeRepairText(w io.Writer, summary repairSummary) error {

--- a/cmd/repair_test.go
+++ b/cmd/repair_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -60,6 +61,76 @@ func TestWriteRepairTextDoesNotReportNoopWhenUnrepairedDriftExists(t *testing.T)
 	assert.Contains(t, text, "Unrepaired drift:")
 	assert.Contains(t, text, state.StalePlanningEvidenceBlockerToken)
 	assert.NotContains(t, text, "No repairs were needed")
+}
+
+func TestApplyConfigRepairResultSurfacesFailureAsNonRepairableFinding(t *testing.T) {
+	t.Parallel()
+
+	// RED rationale: the pre-fix call site was
+	//   `if backupPath, err := state.RepairCorruptConfig(...); err == nil { ... }`
+	// which took the success branch and SWALLOWED a non-nil error — a config
+	// repair FAILURE produced no finding and no ConfigBackupPath, making it
+	// indistinguishable from "nothing to repair". `loadConfigAtRoot` re-reads the
+	// same config immediately after and early-returns on any on-disk state that
+	// makes RepairCorruptConfig fail, so the error branch is unreachable through
+	// the full command; this exercises the extracted seam directly. After the fix
+	// a non-nil error must surface as a non-repairable finding and must NOT record
+	// a (success-only) backup path.
+	failure := repairSummary{}
+	applyConfigRepairResult(&failure, "unused-success-backup-path", errors.New("backup write failed"))
+
+	require.Len(t, failure.NonRepairableFindings, 1)
+	assert.Contains(t, failure.NonRepairableFindings[0], "config repair failed")
+	assert.Contains(t, failure.NonRepairableFindings[0], "backup write failed")
+	assert.Empty(t, failure.ConfigBackupPath, "a failed config repair must not report a success-path backup")
+
+	// The success path is preserved: a nil error records the backup path and adds
+	// no finding (behavior-preserving guarantee for the unchanged happy path).
+	success := repairSummary{}
+	backupPath := "/backups/slipway.yaml.broken.20260704T000000Z.yaml"
+	applyConfigRepairResult(&success, backupPath, nil)
+	assert.Equal(t, backupPath, success.ConfigBackupPath)
+	assert.Empty(t, success.NonRepairableFindings)
+}
+
+// TestRepairSurfacesUnrepairableConfigInsteadOfHardFailing covers the full
+// `slipway repair --json` command path that the seam test above cannot reach: a
+// config that stays unreadable after RepairCorruptConfig fails must surface as a
+// non-repairable finding in the summary, not early-return config_parse_failure
+// with an empty stdout that tells the operator to run the command they just ran
+// (REQ-002).
+func TestRepairSurfacesUnrepairableConfigInsteadOfHardFailing(t *testing.T) {
+	root := t.TempDir()
+	withWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+
+		// Corrupt the config so it no longer parses, then block the config backup
+		// directory by planting a regular file at its path so RepairCorruptConfig
+		// cannot back up + rewrite it. The config therefore stays unreadable for
+		// the whole command.
+		require.NoError(t, os.WriteFile(state.ConfigPath(root), []byte("broken: [unterminated\n"), 0o644))
+		backupDir := state.ConfigBackupDir(root)
+		require.NoError(t, os.MkdirAll(filepath.Dir(backupDir), 0o755))
+		require.NoError(t, os.WriteFile(backupDir, []byte("blocker"), 0o644))
+
+		var out bytes.Buffer
+		cmd := makeRepairCmd()
+		cmd.SetArgs([]string{"--json"})
+		cmd.SetOut(&out)
+
+		// Must NOT hard-fail: the summary has to reach stdout so the operator sees
+		// the finding rather than a bare config_parse_failure.
+		require.NoError(t, cmd.Execute())
+
+		var summary repairSummary
+		require.NoError(t, json.Unmarshal(out.Bytes(), &summary))
+
+		joined := strings.Join(summary.NonRepairableFindings, "\n")
+		assert.Contains(t, joined, "config unreadable after repair",
+			"expected the unrepairable-config finding in the repair summary")
+		assert.Contains(t, joined, "manually",
+			"config finding must direct the operator to manual correction, not a repair re-run")
+	})
 }
 
 func TestRepairRestoresMissingBoundWorktreeScopeMetadata(t *testing.T) {

--- a/cmd/tool_actions.go
+++ b/cmd/tool_actions.go
@@ -11,6 +11,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// usesRe and shaRe are compiled once at package load and shared across the
+// pin-actions helpers below. The patterns are identical to the previous
+// per-call regexp.MustCompile calls, and a *regexp.Regexp is safe for
+// concurrent use by multiple goroutines.
+var (
+	usesRe = regexp.MustCompile(`^(\s*-?\s*uses:\s*)([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)@([^\s#]+)(.*)$`)
+	shaRe  = regexp.MustCompile(`^[0-9a-f]{40}$`)
+)
+
 func makePinActionsCmd() *cobra.Command {
 	var mappingPath string
 	cmd := &cobra.Command{
@@ -69,7 +78,6 @@ func loadActionPinMapping(path string) (map[string]string, error) {
 	}
 	defer file.Close()
 
-	shaRe := regexp.MustCompile(`^[0-9a-f]{40}$`)
 	out := map[string]string{}
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
@@ -131,8 +139,6 @@ func planActionPinsRewrite(file string, mapping map[string]string) (actionPinRew
 		return actionPinRewritePlan{}, err
 	}
 
-	usesRe := regexp.MustCompile(`^(\s*-?\s*uses:\s*)([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)@([^\s#]+)(.*)$`)
-	shaRe := regexp.MustCompile(`^[0-9a-f]{40}$`)
 	lines := strings.SplitAfter(string(raw), "\n")
 	var b strings.Builder
 	for _, lineWithEnd := range lines {

--- a/cmd/tool_github.go
+++ b/cmd/tool_github.go
@@ -879,14 +879,13 @@ type githubGraphQLEnvelope struct {
 	Errors []githubGraphQLError `json:"errors"`
 }
 
-// postGraphQLChecked decodes the {data, errors} envelope. A non-empty errors
-// array fails with a precondition error quoting the messages. On success the
-// raw data payload is returned for the caller to decode.
-func (c githubHTTPClient) postGraphQLChecked(query string, variables map[string]any) (json.RawMessage, error) {
-	var env githubGraphQLEnvelope
-	if err := c.postGraphQL(query, variables, &env); err != nil {
-		return nil, err
-	}
+// checkGraphQLEnvelope inspects a decoded {data, errors} GraphQL envelope. A
+// non-empty errors array fails with a precondition error quoting the messages;
+// an empty or null data payload fails with a no-data precondition error;
+// otherwise the raw data payload is returned for the caller to decode. Both the
+// HTTP and CLI clients had byte-identical baseline bodies (errors guard + no-data
+// guard), so both route through this shared helper with identical behavior.
+func checkGraphQLEnvelope(env githubGraphQLEnvelope) (json.RawMessage, error) {
 	if len(env.Errors) > 0 {
 		messages := make([]string, 0, len(env.Errors))
 		for _, e := range env.Errors {
@@ -914,6 +913,17 @@ func (c githubHTTPClient) postGraphQLChecked(query string, variables map[string]
 		)
 	}
 	return env.Data, nil
+}
+
+// postGraphQLChecked decodes the {data, errors} envelope. A non-empty errors
+// array fails with a precondition error quoting the messages. On success the
+// raw data payload is returned for the caller to decode.
+func (c githubHTTPClient) postGraphQLChecked(query string, variables map[string]any) (json.RawMessage, error) {
+	var env githubGraphQLEnvelope
+	if err := c.postGraphQL(query, variables, &env); err != nil {
+		return nil, err
+	}
+	return checkGraphQLEnvelope(env)
 }
 
 type githubCLIClient struct {
@@ -997,33 +1007,8 @@ func (c githubCLIClient) postGraphQLChecked(query string, variables map[string]a
 	if err := json.Unmarshal(raw, &env); err != nil {
 		return nil, err
 	}
-	if len(env.Errors) > 0 {
-		messages := make([]string, 0, len(env.Errors))
-		for _, e := range env.Errors {
-			msg := strings.TrimSpace(e.Message)
-			if msg == "" {
-				msg = "unspecified GraphQL error"
-			}
-			messages = append(messages, msg)
-		}
-		return nil, newPreconditionError(
-			"github_graphql_errors",
-			"GitHub GraphQL returned errors: "+strings.Join(messages, "; "),
-			"Resolve the GraphQL errors (permissions, ids, or schema) and retry.",
-			"",
-			map[string]any{"errors": messages},
-		)
-	}
-	if len(bytes.TrimSpace(env.Data)) == 0 || string(env.Data) == "null" {
-		return nil, newPreconditionError(
-			"github_graphql_no_data",
-			"GitHub GraphQL response carried no data payload",
-			"The mutation or query returned a null payload; verify the request and retry.",
-			"",
-			nil,
-		)
-	}
-	return env.Data, nil
+	// CLI path rejects empty/null data, matching its baseline behavior.
+	return checkGraphQLEnvelope(env)
 }
 
 func (c githubCLIClient) api(path string) ([]byte, error) {

--- a/internal/engine/artifact/manager.go
+++ b/internal/engine/artifact/manager.go
@@ -132,9 +132,18 @@ func BuildStaleGraph(schema []ArtifactSpec) map[string][]string {
 	return graph
 }
 
-// DefaultStaleGraph returns the stale graph for the expanded schema.
-func DefaultStaleGraph() map[string][]string {
+// defaultStaleGraph memoizes the expanded-schema stale graph. It is derived only
+// from the immutable expandedSchema, so it is built once and shared. Every caller
+// passes it to stalePropagationOrderFromGraph, which reads the map and copies each
+// adjacency slice before sorting, so the shared instance is never mutated.
+var defaultStaleGraph = sync.OnceValue(func() map[string][]string {
 	return BuildStaleGraph(expandedSchema)
+})
+
+// DefaultStaleGraph returns the stale graph for the expanded schema. The returned
+// map is a shared, memoized, read-only instance; callers must not mutate it.
+func DefaultStaleGraph() map[string][]string {
+	return defaultStaleGraph()
 }
 
 func requiredSectionsForArtifact(name string) []string {

--- a/internal/engine/artifact/requirements_contract.go
+++ b/internal/engine/artifact/requirements_contract.go
@@ -47,8 +47,18 @@ func EvaluateRequirementsContract(bundleDir string) (RequirementsContractResult,
 		}, nil
 	}
 
-	content := source.Content
-	requirementCount := len(ParseRequirementBlocks(content))
+	// Parse the requirement blocks once and drive every downstream check
+	// (count, missing stable IDs, substance) from the same parse.
+	// splitRequirementBlocksForSubstance yields, per block, the same name and
+	// first stable REQ-* ID that ParseRequirementBlocks and
+	// RequirementBlocksMissingStableIDs derive — both compute firstRequirementID
+	// over the identical block text of the comment-stripped content — plus the
+	// statement/scenario regions the substance check needs. One parse therefore
+	// feeds all three consumers with byte-identical data and ordering.
+	strippedContent := stripRequirementGuidanceComments(source.Content)
+	blocks := splitRequirementBlocksForSubstance(strippedContent)
+
+	requirementCount := len(blocks)
 	if requirementCount == 0 {
 		return RequirementsContractResult{
 			Status:  RequirementsContractStatusInvalid,
@@ -57,7 +67,7 @@ func EvaluateRequirementsContract(bundleDir string) (RequirementsContractResult,
 		}, nil
 	}
 
-	missingStableIDs := RequirementBlocksMissingStableIDs(content)
+	missingStableIDs := requirementBlocksMissingStableIDs(blocks)
 	if len(missingStableIDs) > 0 {
 		return RequirementsContractResult{
 			Status: RequirementsContractStatusInvalid,
@@ -69,7 +79,7 @@ func EvaluateRequirementsContract(bundleDir string) (RequirementsContractResult,
 		}, nil
 	}
 
-	if substanceBlockers := RequirementSubstanceBlockers(content); len(substanceBlockers) > 0 {
+	if substanceBlockers := requirementSubstanceBlockersFrom(strippedContent, blocks); len(substanceBlockers) > 0 {
 		return RequirementsContractResult{
 			Status: RequirementsContractStatusInvalid,
 			Source: source.Path,
@@ -100,13 +110,35 @@ func EvaluateRequirementsContract(bundleDir string) (RequirementsContractResult,
 // in "pending investigation" status — is not false-flagged (issue #91: avoid
 // false positives that block real work).
 func RequirementSubstanceBlockers(content string) []string {
-	content = stripRequirementGuidanceComments(content)
+	strippedContent := stripRequirementGuidanceComments(content)
+	return requirementSubstanceBlockersFrom(strippedContent, splitRequirementBlocksForSubstance(strippedContent))
+}
+
+// requirementBlocksMissingStableIDs returns the names of parsed blocks that lack a
+// stable REQ-* ID, in block order. It mirrors RequirementBlocksMissingStableIDs but
+// operates on an already-parsed block slice, so EvaluateRequirementsContract can
+// reuse a single parse across the count, missing-ID, and substance checks.
+func requirementBlocksMissingStableIDs(blocks []requirementSubstanceBlock) []string {
+	missing := make([]string, 0)
+	for _, block := range blocks {
+		if strings.TrimSpace(block.stableID) == "" {
+			missing = append(missing, block.name)
+		}
+	}
+	return missing
+}
+
+// requirementSubstanceBlockersFrom evaluates the substance problems described by
+// RequirementSubstanceBlockers from already comment-stripped content and its parsed
+// substance blocks. Separating the parse from the evaluation lets both
+// RequirementSubstanceBlockers and EvaluateRequirementsContract feed it — the latter
+// reusing the single parse it also uses for the count and missing-ID checks.
+func requirementSubstanceBlockersFrom(strippedContent string, blocks []requirementSubstanceBlock) []string {
 	var blockers []string
-	if LooksLikeRequirementsPlaceholder(content) {
+	if LooksLikeRequirementsPlaceholder(strippedContent) {
 		blockers = append(blockers,
 			"contains template/seed placeholder content; author concrete requirements")
 	}
-	blocks := splitRequirementBlocksForSubstance(content)
 	if len(blocks) == 0 {
 		blockers = append(blockers, "requirements.md declares no Requirement blocks; author concrete requirements")
 	}

--- a/internal/engine/capability/registry.go
+++ b/internal/engine/capability/registry.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"sync"
 )
 
 // Tier names the semantic role of a catalog skill.
@@ -147,35 +148,65 @@ func NewRegistry(skills ...Skill) (*Registry, error) {
 	return reg, nil
 }
 
-// DefaultRegistry returns the shipped catalog registry in deterministic order.
-func DefaultRegistry() *Registry {
+// defaultRegistry memoizes the shipped catalog registry. Sharing one instance
+// is safe: byID is never written after NewRegistry, no method mutates it, and
+// Lookup/All hand back cloned skills so a caller cannot mutate the shared state.
+var defaultRegistry = sync.OnceValue(func() *Registry {
 	reg, err := NewRegistry(defaultSkills()...)
 	if err != nil {
 		// defaultSkills is table data, any error is a programmer bug.
 		panic(err)
 	}
 	return reg
+})
+
+// DefaultRegistry returns the shipped catalog registry in deterministic order.
+func DefaultRegistry() *Registry {
+	return defaultRegistry()
 }
 
-// Lookup returns the skill with the given id. The second return value is
-// false when the id is not registered.
+// clone returns a copy of the skill whose mutable slice fields — Bindings,
+// HydrateReferences, HostCapabilities, and each HostCapabilityContract's nested
+// FallbackModes — are independently allocated, so a caller mutating the result
+// cannot reach back into the memoized registry's stored skills. Every other
+// field is a scalar or string (EvidenceContract is a string) and needs no copy.
+func (s Skill) clone() Skill {
+	s.Bindings = slices.Clone(s.Bindings)
+	s.HydrateReferences = slices.Clone(s.HydrateReferences)
+	if s.HostCapabilities != nil {
+		caps := slices.Clone(s.HostCapabilities)
+		for i := range caps {
+			caps[i].FallbackModes = slices.Clone(caps[i].FallbackModes)
+		}
+		s.HostCapabilities = caps
+	}
+	return s
+}
+
+// Lookup returns the skill with the given id. The second return value is false
+// when the id is not registered. The returned skill is an independent copy;
+// mutating its slice fields does not affect the shared registry.
 func (r *Registry) Lookup(id string) (Skill, bool) {
 	if r == nil {
 		return Skill{}, false
 	}
 	sk, ok := r.byID[id]
-	return sk, ok
+	if !ok {
+		return Skill{}, false
+	}
+	return sk.clone(), true
 }
 
-// All returns every registered skill sorted by id. The returned slice is
-// freshly allocated and safe for the caller to mutate.
+// All returns every registered skill sorted by id. The returned slice and each
+// skill's mutable slice fields are freshly allocated, so the caller may mutate
+// the result without affecting the shared registry.
 func (r *Registry) All() []Skill {
 	if r == nil {
 		return nil
 	}
 	out := make([]Skill, 0, len(r.byID))
 	for _, sk := range r.byID {
-		out = append(out, sk)
+		out = append(out, sk.clone())
 	}
 	slices.SortFunc(out, func(a, b Skill) int {
 		switch {

--- a/internal/engine/capability/registry_test.go
+++ b/internal/engine/capability/registry_test.go
@@ -150,3 +150,49 @@ func TestDefaultSkillsDoNotUseRemovedCommandViewBindings(t *testing.T) {
 		}
 	}
 }
+
+// TestDefaultRegistryReturnsMutationIsolatedSkills guards the mutation isolation
+// that the sync.OnceValue memoization of DefaultRegistry could otherwise break:
+// every caller shares one *Registry, so Lookup and All must return skills whose
+// mutable slice fields are independent copies. Without that, a caller mutating a
+// returned skill would silently poison every later lookup in the process.
+// independent-review carries a Bindings entry plus a HostCapabilities entry with
+// a nested FallbackModes slice, so it exercises the shallow and the nested field.
+func TestDefaultRegistryReturnsMutationIsolatedSkills(t *testing.T) {
+	const id = "independent-review"
+
+	first, ok := DefaultRegistry().Lookup(id)
+	require.True(t, ok)
+	require.NotEmpty(t, first.Bindings, "fixture skill must expose a binding")
+	require.NotEmpty(t, first.HostCapabilities, "fixture skill must expose a host capability")
+	require.NotEmpty(t, first.HostCapabilities[0].FallbackModes, "fixture must expose nested fallback modes")
+
+	wantTarget := first.Bindings[0].Target
+	wantFallback := first.HostCapabilities[0].FallbackModes[0]
+
+	// Mutate the copy returned by Lookup, including the nested FallbackModes.
+	first.Bindings[0].Target = "__mutated_target__"
+	first.HostCapabilities[0].FallbackModes[0] = "__mutated_fallback__"
+
+	afterLookup, ok := DefaultRegistry().Lookup(id)
+	require.True(t, ok)
+	assert.Equal(t, wantTarget, afterLookup.Bindings[0].Target,
+		"Lookup mutation leaked into the shared registry")
+	assert.Equal(t, wantFallback, afterLookup.HostCapabilities[0].FallbackModes[0],
+		"nested FallbackModes mutation via Lookup leaked into the shared registry")
+
+	// All must isolate the same way.
+	for _, sk := range DefaultRegistry().All() {
+		if sk.ID != id {
+			continue
+		}
+		sk.Bindings[0].Target = "__mutated_via_all__"
+		sk.HostCapabilities[0].FallbackModes[0] = "__mutated_via_all__"
+	}
+	afterAll, ok := DefaultRegistry().Lookup(id)
+	require.True(t, ok)
+	assert.Equal(t, wantTarget, afterAll.Bindings[0].Target,
+		"All mutation leaked into the shared registry")
+	assert.Equal(t, wantFallback, afterAll.HostCapabilities[0].FallbackModes[0],
+		"nested FallbackModes mutation via All leaked into the shared registry")
+}

--- a/internal/engine/capability/resolver.go
+++ b/internal/engine/capability/resolver.go
@@ -269,8 +269,9 @@ func collectSupports(reg *Registry, sig Signals, route *RouteSelection) []Attach
 		skill Skill
 		mode  AttachmentMode
 	}
-	var matches []match
-	for _, sk := range reg.All() {
+	all := reg.All()
+	matches := make([]match, 0, len(all))
+	for _, sk := range all {
 		if sk.ID == routeID {
 			continue
 		}

--- a/internal/engine/capability/surfaces.go
+++ b/internal/engine/capability/surfaces.go
@@ -3,6 +3,7 @@ package capability
 import (
 	"sort"
 	"strings"
+	"sync"
 )
 
 // SurfaceClass classifies a public surface record. Two classes remain:
@@ -158,16 +159,28 @@ func LookupFocus(command, alias string) (SurfaceRecord, bool) {
 	return SurfaceRecord{}, false
 }
 
-// ExplicitFocusBackingIDs returns the set of catalog skill IDs that back
-// any public `--focus` alias. Resolver uses this set to suppress hydrate
-// emission on implicit paths (route-surface plan §6: explicit-focus skills
-// hydrate only under explicit selection).
-func ExplicitFocusBackingIDs() map[string]struct{} {
+// explicitFocusBackingIDs memoizes the scan over surfacePolicy for the set of
+// catalog skill IDs backing any public `--focus` alias.
+var explicitFocusBackingIDs = sync.OnceValue(func() map[string]struct{} {
 	out := make(map[string]struct{})
 	for _, s := range surfacePolicy {
 		if s.Class == SurfaceExplicitFocus {
 			out[s.BackingID] = struct{}{}
 		}
+	}
+	return out
+})
+
+// ExplicitFocusBackingIDs returns the set of catalog skill IDs that back
+// any public `--focus` alias. Resolver uses this set to suppress hydrate
+// emission on implicit paths (route-surface plan §6: explicit-focus skills
+// hydrate only under explicit selection). The returned map is a fresh copy the
+// caller may mutate freely.
+func ExplicitFocusBackingIDs() map[string]struct{} {
+	memo := explicitFocusBackingIDs()
+	out := make(map[string]struct{}, len(memo))
+	for id := range memo {
+		out[id] = struct{}{}
 	}
 	return out
 }

--- a/internal/engine/governance/traceability.go
+++ b/internal/engine/governance/traceability.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/signalridge/slipway/internal/engine/artifact"
@@ -424,30 +425,67 @@ func extractRequirementBlocks(content string, reqIDs []string) map[string]string
 // extractBlocksByID splits content into per-ID blocks using the given prefix.
 // Each block spans from the matching marker to the next marker with the same prefix or end of content.
 func extractBlocksByID(content string, ids []string, prefix string) map[string]string {
+	// Index every requested marker's occurrences in one up-front pass, then
+	// resolve each block from that index instead of re-scanning the text for
+	// every id pair (which was O(ids^2) string searches).
+	//
+	// Semantics preserved exactly: a block runs from the first occurrence of its
+	// own marker to the nearest following occurrence of a *different* requested
+	// id's marker that begins at or after the end of the own marker, or to the
+	// end of content. Occurrences of the id's own marker never delimit it, and
+	// only requested ids act as boundaries. All occurrences (not just the first)
+	// are indexed so a boundary marker whose first occurrence precedes the own
+	// marker is still found via its later occurrence.
+	type occurrence struct {
+		pos int
+		id  string
+	}
+	var occurrences []occurrence
+	firstPos := make(map[string]int, len(ids))
+	seen := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		marker := prefix + id
+		first := -1
+		for start := 0; start <= len(content); {
+			rel := strings.Index(content[start:], marker)
+			if rel < 0 {
+				break
+			}
+			pos := start + rel
+			if first < 0 {
+				first = pos
+			}
+			occurrences = append(occurrences, occurrence{pos: pos, id: id})
+			start = pos + 1
+		}
+		firstPos[id] = first
+	}
+	sort.Slice(occurrences, func(i, j int) bool { return occurrences[i].pos < occurrences[j].pos })
+
 	blocks := make(map[string]string, len(ids))
 	for _, id := range ids {
-		marker := prefix + id
-		idx := strings.Index(content, marker)
-		if idx < 0 {
+		idx, ok := firstPos[id]
+		if !ok || idx < 0 {
 			blocks[id] = ""
 			continue
 		}
-		// Find the extent: from this marker to the next marker with the same prefix or end.
-		rest := content[idx:]
-		endIdx := len(rest)
-		for _, otherID := range ids {
-			if otherID == id {
-				continue
-			}
-			otherMarker := prefix + otherID
-			if pos := strings.Index(rest[len(marker):], otherMarker); pos >= 0 {
-				candidate := len(marker) + pos
-				if candidate < endIdx {
-					endIdx = candidate
-				}
+		// Boundary: the first occurrence of any *other* requested id's marker at
+		// or after the end of this id's own marker (matching the original search
+		// that started past the current marker), else end of content.
+		threshold := idx + len(prefix) + len(id)
+		end := len(content)
+		lo := sort.Search(len(occurrences), func(i int) bool { return occurrences[i].pos >= threshold })
+		for i := lo; i < len(occurrences); i++ {
+			if occurrences[i].id != id {
+				end = occurrences[i].pos
+				break
 			}
 		}
-		blocks[id] = rest[:endIdx]
+		blocks[id] = content[idx:end]
 	}
 	return blocks
 }

--- a/internal/engine/progression/advance_governed.go
+++ b/internal/engine/progression/advance_governed.go
@@ -61,43 +61,12 @@ func AdvanceGoverned(root, slug string, opts ...AdvanceOptions) (summary Advance
 	// blocked CLI view. Under --auto, a pending preset is auto-confirmed
 	// UPGRADE-ONLY to the suggested/effective preset and advancement continues;
 	// this never downgrades and never bypasses a downstream evidence gate.
-	if blockers := PresetConfirmationBlockers(change); len(blockers) > 0 {
-		confirmed, err := autoConfirmPendingPreset(root, &change, options.Auto, presetPolicy, options.Command)
-		if err != nil {
-			return AdvanceSummary{}, err
-		}
-		if !confirmed {
-			return blockedAdvanceSummary(fromState, model.ReasonCodesFromSpecs(blockers)), nil
-		}
-		// The confirmed preset may change effective governance posture; re-resolve
-		// so the rest of advancement runs under the now-confirmed preset.
-		presetPolicy, err = governance.ResolvePresetPolicy(root, change)
-		if err != nil {
-			return AdvanceSummary{}, err
-		}
+	if handled, summary, err := advancePresetConfirmationGate(root, &change, &presetPolicy, options, fromState); handled {
+		return summary, err
 	}
 
-	if target, ok, err := staleEvidenceRepairTarget(root, change); err != nil {
-		return AdvanceSummary{}, err
-	} else if ok {
-		if staleEvidenceRepairDeferredToReview(change, target) {
-			// S2 owns implementation evidence. Upstream intake/planning drift is
-			// reviewed at S3 as plan/code/evidence alignment; requiring an S0/S1
-			// evidence replay here creates an impossible forward-only dead end.
-		} else if fromState != model.StateS3Review {
-			// Pre-S3 (S0_INTAKE / S1_PLAN / S2_IMPLEMENT) the owning stage still
-			// holds this evidence (e.g. a stale intake-clarification or
-			// wave-orchestration authority). Surface its blockers directly — whose
-			// remediation is the state-valid `slipway run` / `slipway evidence
-			// skill` — instead of the review-alignment path, which maps to the
-			// S3-only `slipway fix` and would yield fix_state_invalid here. This
-			// only changes the recommended command; the stale-evidence gate stays
-			// fail-closed. Only S3, where review owns plan/code/evidence alignment,
-			// keeps the forward-only review-alignment path below (issues #324, #376).
-			return blockedAdvanceSummary(fromState, target.Blockers), nil
-		} else {
-			return forwardOnlyStaleEvidenceSummary(fromState, target), nil
-		}
+	if handled, summary, err := advanceStaleEvidenceGate(root, change, fromState); handled {
+		return summary, err
 	}
 
 	// 1. S0_INTAKE: lightweight path — no bundle, no worktree, no wave sync.
@@ -110,81 +79,19 @@ func AdvanceGoverned(root, slug string, opts ...AdvanceOptions) (summary Advance
 	// instead of a hollow `slipway repair` dead-end. Only a pure branch mismatch on
 	// an otherwise-valid dedicated worktree is reconciled; every other authenticity
 	// failure stays fail-closed in the bundle/worktree gates below.
-	if fromState == model.StateS2Implement && strings.TrimSpace(change.WorktreePath) != "" {
-		reconciled, err := state.ReconcileWorktreeBranchBinding(root, &change)
-		if err != nil {
-			return AdvanceSummary{}, err
-		}
-		if reconciled {
-			if err := state.SaveChange(root, change); err != nil {
-				return AdvanceSummary{}, err
-			}
-		}
+	if err := reconcileWorktreeBranchBindingIfBound(root, &change, fromState); err != nil {
+		return AdvanceSummary{}, err
 	}
 
-	// 2. Bundle precondition check.
-	// Skip at S1_PLAN/research with NeedsDiscovery — research runs before
-	// the full bundle is populated.
-	skipBundleCheck := fromState == model.StateS1Plan &&
-		change.PlanSubStep == model.PlanSubStepResearch &&
-		change.NeedsDiscovery
-	if ShouldCheckGovernedBundle(change) && !skipBundleCheck {
-		bundleBlockers := GovernedBundleBlockers(root, change)
-		if len(bundleBlockers) > 0 {
-			return blockedAdvanceSummary(fromState, model.ReasonCodesFromSpecs(bundleBlockers)), nil
-		}
-	}
-	assuranceBlockers := AssuranceContractBlockers(root, change)
-	if len(assuranceBlockers) > 0 {
-		return blockedAdvanceSummary(fromState, model.ReasonCodesFromSpecs(assuranceBlockers)), nil
+	// 2. Bundle precondition and assurance contract checks.
+	if handled, summary := advanceBundleAndAssuranceGate(root, change, fromState); handled {
+		return summary, nil
 	}
 
-	// 3. Wave synchronization at S2_IMPLEMENT and S3_REVIEW.
-	//
-	// At S2 this is the implement-stage sync. At S3 it is the in-place review
-	// convergence path: when the author discovers more work at review and edits
-	// tasks.md (for example adds a task), the wave plan re-materializes IN PLACE
-	// from the current tasks.md at the SAME run version, folding the delta into
-	// the review instead of forcing a backward rescope re-walk. Unchanged-task
-	// evidence is preserved; a newly added or structurally changed task surfaces
-	// as still-required work and blocks S3->S4 until its evidence is recorded
-	// (fail-closed). The lifecycle state is never regressed to S1/S2.
-	runWaveSync := fromState == model.StateS2Implement
-	if fromState == model.StateS3Review {
-		// Only re-sync at review when there is genuine convergence work to absorb:
-		// either tasks.md drifted from the materialized wave plan (the author added
-		// a task at review → re-materialize), or the per-task evidence ledger
-		// advanced past the persisted execution summary (a folded-in task's
-		// evidence was just recorded → rebuild the summary so its
-		// incomplete_execution_task blocker clears). A settled review keeps the
-		// existing read-only S3 behavior so done-ready, light-preset, and other
-		// settled review flows are not perturbed by an unconditional re-sync.
-		pending, err := reviewConvergencePending(root, change)
-		if err != nil {
-			return AdvanceSummary{}, err
-		}
-		runWaveSync = pending
-	}
-	if runWaveSync {
-		syncResult, err := SyncGovernedWaveExecution(root, change)
-		if err != nil {
-			return AdvanceSummary{}, err
-		}
-		blockers := syncResult.Blockers
-		if fromState == model.StateS3Review {
-			// S3 absorbs the re-materialized plan delta in place: plan/evidence
-			// drift on already-evidenced tasks is realigned through the diff-scoped
-			// reviewers (who re-certify against the current plan), not replayed as a
-			// backward gate — the same drift tokens blockingExecutionSummaryIssues
-			// treats as review input. Genuinely missing or non-passing work
-			// (incomplete tasks, failed verdicts, safety-net violations) still fails
-			// closed here, so a task newly discovered at review cannot reach S4
-			// without its own evidence.
-			blockers = absorbedAtReviewWaveBlockers(blockers)
-		}
-		if len(blockers) > 0 {
-			return blockedAdvanceSummary(fromState, blockers), nil
-		}
+	// 3. Wave synchronization at S2_IMPLEMENT and S3_REVIEW (in-place review
+	// convergence). See advanceWaveSyncGate for the S3 fold-in rationale.
+	if handled, summary, err := advanceWaveSyncGate(root, change, fromState); handled {
+		return summary, err
 	}
 
 	executionSummaryCtx, err := state.LoadRelevantExecutionSummaryContext(root, change)
@@ -384,20 +291,9 @@ func AdvanceGoverned(root, slug string, opts ...AdvanceOptions) (summary Advance
 	}
 
 	// G_scope gate: validates research.md structure and discovery evidence at
-	// S1_PLAN/research before allowing progression to bundle. Without this,
-	// discovery changes could skip research validation entirely.
-	isResearchGate := fromState == model.StateS1Plan && change.PlanSubStep == model.PlanSubStepResearch && change.NeedsDiscovery
-	if isResearchGate {
-		scopeResult, err := EvaluateScopeGate(root, change, passingSkills, researchDiscoveryEvidence)
-		if err != nil {
-			return AdvanceSummary{}, err
-		}
-		if scopeResult.Status == model.GateStatusBlocked {
-			summary := blockedAdvanceSummary(fromState, scopeResult.ReasonCodes)
-			summary.SideEffects = append(summary.SideEffects, preTransitionSideEffects...)
-			summary.SkillEvidence = append(summary.SkillEvidence, preTransitionSkillEvidence...)
-			return saveChangeAndReturn(root, change, summary)
-		}
+	// S1_PLAN/research before allowing progression to bundle.
+	if handled, summary, err := advanceScopeGate(root, change, fromState, passingSkills, researchDiscoveryEvidence, preTransitionSideEffects, preTransitionSkillEvidence); handled {
+		return summary, err
 	}
 
 	isPlanAuditGate := fromState == model.StateS1Plan && change.PlanSubStep == model.PlanSubStepAudit
@@ -420,30 +316,240 @@ func AdvanceGoverned(root, slug string, opts ...AdvanceOptions) (summary Advance
 		preTransitionSideEffects = append(preTransitionSideEffects, sideEffects...)
 	}
 
-	if fromState == model.StateS3Review {
-		shipAuthority, err := EvaluateShipAuthority(root, change)
-		if err != nil {
-			return AdvanceSummary{}, err
-		}
-		if shipAuthority.Result.Status == model.GateStatusBlocked {
-			summary := blockedAdvanceSummary(fromState, shipAuthority.Result.ReasonCodes)
-			summary.SideEffects = append(summary.SideEffects, preTransitionSideEffects...)
-			summary.SkillEvidence = append(summary.SkillEvidence, preTransitionSkillEvidence...)
-			return saveChangeAndReturn(root, change, summary)
-		}
-		stampResult, err := stampPassingSkillDigests(root, change, shipAuthorityPassingSkills(shipAuthority))
-		if err != nil {
-			return AdvanceSummary{}, err
-		}
-		if len(stampResult.Blockers) > 0 {
-			summary := blockedAdvanceSummary(fromState, model.ReasonCodesFromSpecs(stampResult.Blockers))
-			summary.SideEffects = append(summary.SideEffects, preTransitionSideEffects...)
-			summary.SkillEvidence = append(summary.SkillEvidence, preTransitionSkillEvidence...)
-			return saveChangeAndReturn(root, change, summary)
-		}
+	if handled, summary, err := advanceShipAuthorityGate(root, change, fromState, preTransitionSideEffects, preTransitionSkillEvidence); handled {
+		return summary, err
 	}
 
-	// 7. State transition
+	// 7. State transition.
+	return advanceGovernedTransition(root, &change, fromState, toState, passingSkills, preTransitionSideEffects, preTransitionSkillEvidence)
+}
+
+// advancePresetConfirmationGate runs the preset-confirmation gate that must
+// precede all advancement. When a preset confirmation is pending it is
+// auto-confirmed UPGRADE-ONLY under --auto (re-resolving presetPolicy so the
+// rest of advancement runs under the confirmed preset) or otherwise blocks. It
+// reports handled=true when the caller must return the given summary/err; on the
+// confirmed path it reports handled=false and advancement continues.
+func advancePresetConfirmationGate(
+	root string,
+	change *model.Change,
+	presetPolicy *governance.PresetPolicy,
+	options AdvanceOptions,
+	fromState model.WorkflowState,
+) (bool, AdvanceSummary, error) {
+	blockers := PresetConfirmationBlockers(*change)
+	if len(blockers) == 0 {
+		return false, AdvanceSummary{}, nil
+	}
+	confirmed, err := autoConfirmPendingPreset(root, change, options.Auto, *presetPolicy, options.Command)
+	if err != nil {
+		return true, AdvanceSummary{}, err
+	}
+	if !confirmed {
+		return true, blockedAdvanceSummary(fromState, model.ReasonCodesFromSpecs(blockers)), nil
+	}
+	// The confirmed preset may change effective governance posture; re-resolve
+	// so the rest of advancement runs under the now-confirmed preset.
+	resolved, err := governance.ResolvePresetPolicy(root, *change)
+	if err != nil {
+		return true, AdvanceSummary{}, err
+	}
+	*presetPolicy = resolved
+	return false, AdvanceSummary{}, nil
+}
+
+// advanceStaleEvidenceGate routes stale skill evidence discovered before the
+// primary gates. S2-owned implementation drift is deferred to S3 review
+// alignment (fall through); pre-S3 the owning stage surfaces its blockers
+// directly (state-valid `slipway run` / `slipway evidence skill`); only S3 keeps
+// the forward-only review-alignment path. It reports handled=true when the
+// caller must return the given summary/err.
+func advanceStaleEvidenceGate(root string, change model.Change, fromState model.WorkflowState) (bool, AdvanceSummary, error) {
+	target, ok, err := staleEvidenceRepairTarget(root, change)
+	if err != nil {
+		return true, AdvanceSummary{}, err
+	}
+	if !ok {
+		return false, AdvanceSummary{}, nil
+	}
+	if staleEvidenceRepairDeferredToReview(change, target) {
+		// S2 owns implementation evidence. Upstream intake/planning drift is
+		// reviewed at S3 as plan/code/evidence alignment; requiring an S0/S1
+		// evidence replay here creates an impossible forward-only dead end.
+		return false, AdvanceSummary{}, nil
+	}
+	if fromState != model.StateS3Review {
+		// Pre-S3 the owning stage still holds this evidence; its remediation is the
+		// state-valid `slipway run` / `slipway evidence skill`, not the S3-only
+		// `slipway fix`. Only the recommended command differs; the stale-evidence
+		// gate stays fail-closed (issues #324, #376).
+		return true, blockedAdvanceSummary(fromState, target.Blockers), nil
+	}
+	return true, forwardOnlyStaleEvidenceSummary(fromState, target), nil
+}
+
+// reconcileWorktreeBranchBindingIfBound reconciles a bound S2 worktree whose
+// recorded branch drifted from its actual git branch (no git mutation), so a
+// branch mismatch resolves via `slipway run` instead of a hollow repair
+// dead-end. Only a pure branch mismatch on an otherwise-valid dedicated worktree
+// is reconciled; every other authenticity failure stays fail-closed downstream.
+func reconcileWorktreeBranchBindingIfBound(root string, change *model.Change, fromState model.WorkflowState) error {
+	if fromState != model.StateS2Implement || strings.TrimSpace(change.WorktreePath) == "" {
+		return nil
+	}
+	reconciled, err := state.ReconcileWorktreeBranchBinding(root, change)
+	if err != nil {
+		return err
+	}
+	if reconciled {
+		if err := state.SaveChange(root, *change); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// advanceBundleAndAssuranceGate runs the bundle precondition and assurance
+// contract checks. The bundle check is skipped at S1_PLAN/research with
+// NeedsDiscovery — research runs before the full bundle is populated. It reports
+// handled=true when the caller must return the given blocked summary.
+func advanceBundleAndAssuranceGate(root string, change model.Change, fromState model.WorkflowState) (bool, AdvanceSummary) {
+	skipBundleCheck := fromState == model.StateS1Plan &&
+		change.PlanSubStep == model.PlanSubStepResearch &&
+		change.NeedsDiscovery
+	if ShouldCheckGovernedBundle(change) && !skipBundleCheck {
+		bundleBlockers := GovernedBundleBlockers(root, change)
+		if len(bundleBlockers) > 0 {
+			return true, blockedAdvanceSummary(fromState, model.ReasonCodesFromSpecs(bundleBlockers))
+		}
+	}
+	assuranceBlockers := AssuranceContractBlockers(root, change)
+	if len(assuranceBlockers) > 0 {
+		return true, blockedAdvanceSummary(fromState, model.ReasonCodesFromSpecs(assuranceBlockers))
+	}
+	return false, AdvanceSummary{}
+}
+
+// advanceWaveSyncGate runs wave synchronization at S2_IMPLEMENT and, when there
+// is genuine convergence work to absorb, at S3_REVIEW (in-place review
+// convergence: a tasks.md delta re-materializes the wave plan at the SAME run
+// version, folding the delta into review instead of a backward rescope re-walk;
+// unchanged-task evidence is preserved and the lifecycle state is never
+// regressed). At S3 the in-place-absorbed plan/evidence drift tokens are dropped
+// while hard blockers (incomplete tasks, non-pass verdicts, safety-net
+// violations) still fail closed. It reports handled=true when the caller must
+// return the given summary/err.
+func advanceWaveSyncGate(root string, change model.Change, fromState model.WorkflowState) (bool, AdvanceSummary, error) {
+	runWaveSync := fromState == model.StateS2Implement
+	if fromState == model.StateS3Review {
+		pending, err := reviewConvergencePending(root, change)
+		if err != nil {
+			return true, AdvanceSummary{}, err
+		}
+		runWaveSync = pending
+	}
+	if runWaveSync {
+		syncResult, err := SyncGovernedWaveExecution(root, change)
+		if err != nil {
+			return true, AdvanceSummary{}, err
+		}
+		blockers := syncResult.Blockers
+		if fromState == model.StateS3Review {
+			blockers = absorbedAtReviewWaveBlockers(blockers)
+		}
+		if len(blockers) > 0 {
+			return true, blockedAdvanceSummary(fromState, blockers), nil
+		}
+	}
+	return false, AdvanceSummary{}, nil
+}
+
+// advanceScopeGate evaluates G_scope at S1_PLAN/research (discovery), validating
+// research.md structure and discovery evidence before progression to bundle. A
+// blocked gate persists the change and returns; otherwise it falls through. It
+// reports handled=true when the caller must return the given summary/err.
+func advanceScopeGate(
+	root string,
+	change model.Change,
+	fromState model.WorkflowState,
+	passingSkills map[string]model.VerificationRecord,
+	researchDiscoveryEvidence gate.DiscoveryEvidenceState,
+	preTransitionSideEffects []SideEffect,
+	preTransitionSkillEvidence []SkillEvidenceTrace,
+) (bool, AdvanceSummary, error) {
+	if fromState != model.StateS1Plan || change.PlanSubStep != model.PlanSubStepResearch || !change.NeedsDiscovery {
+		return false, AdvanceSummary{}, nil
+	}
+	scopeResult, err := EvaluateScopeGate(root, change, passingSkills, researchDiscoveryEvidence)
+	if err != nil {
+		return true, AdvanceSummary{}, err
+	}
+	if scopeResult.Status == model.GateStatusBlocked {
+		summary := blockedAdvanceSummary(fromState, scopeResult.ReasonCodes)
+		summary.SideEffects = append(summary.SideEffects, preTransitionSideEffects...)
+		summary.SkillEvidence = append(summary.SkillEvidence, preTransitionSkillEvidence...)
+		s, err := saveChangeAndReturn(root, change, summary)
+		return true, s, err
+	}
+	return false, AdvanceSummary{}, nil
+}
+
+// advanceShipAuthorityGate evaluates ship authority at S3_REVIEW and stamps the
+// passing ship-skill digests. A blocked authority or a stamp blocker persists
+// the change and returns a blocked summary; otherwise it falls through. It
+// reports handled=true when the caller must return the given summary/err. The
+// ship-authority computation here is intentionally independent of the
+// EvaluateShipGate path and is left recomputed.
+func advanceShipAuthorityGate(
+	root string,
+	change model.Change,
+	fromState model.WorkflowState,
+	preTransitionSideEffects []SideEffect,
+	preTransitionSkillEvidence []SkillEvidenceTrace,
+) (bool, AdvanceSummary, error) {
+	if fromState != model.StateS3Review {
+		return false, AdvanceSummary{}, nil
+	}
+	shipAuthority, err := EvaluateShipAuthority(root, change)
+	if err != nil {
+		return true, AdvanceSummary{}, err
+	}
+	if shipAuthority.Result.Status == model.GateStatusBlocked {
+		summary := blockedAdvanceSummary(fromState, shipAuthority.Result.ReasonCodes)
+		summary.SideEffects = append(summary.SideEffects, preTransitionSideEffects...)
+		summary.SkillEvidence = append(summary.SkillEvidence, preTransitionSkillEvidence...)
+		s, err := saveChangeAndReturn(root, change, summary)
+		return true, s, err
+	}
+	stampResult, err := stampPassingSkillDigests(root, change, shipAuthorityPassingSkills(shipAuthority))
+	if err != nil {
+		return true, AdvanceSummary{}, err
+	}
+	if len(stampResult.Blockers) > 0 {
+		summary := blockedAdvanceSummary(fromState, model.ReasonCodesFromSpecs(stampResult.Blockers))
+		summary.SideEffects = append(summary.SideEffects, preTransitionSideEffects...)
+		summary.SkillEvidence = append(summary.SkillEvidence, preTransitionSkillEvidence...)
+		s, err := saveChangeAndReturn(root, change, summary)
+		return true, s, err
+	}
+	return false, AdvanceSummary{}, nil
+}
+
+// advanceGovernedTransition performs the terminal state-transition phase of
+// AdvanceGoverned: S1_PLAN substep progression, the post-audit inline validation
+// edge, the done-ready hand-off, wave-plan materialization on entry to
+// S2_IMPLEMENT, and the final state transition. It always returns the advance
+// result (or an error) and mutates change in place so the caller's deferred
+// lifecycle-event recording observes the transitioned change.
+func advanceGovernedTransition(
+	root string,
+	change *model.Change,
+	fromState model.WorkflowState,
+	toState model.WorkflowState,
+	passingSkills map[string]model.VerificationRecord,
+	preTransitionSideEffects []SideEffect,
+	preTransitionSkillEvidence []SkillEvidenceTrace,
+) (AdvanceSummary, error) {
 	// S1_PLAN substep progression: advance within planning before leaving to S2_IMPLEMENT.
 	if fromState == model.StateS1Plan {
 		fromSub := string(change.PlanSubStep)
@@ -454,7 +560,7 @@ func AdvanceGoverned(root, slug string, opts ...AdvanceOptions) (summary Advance
 			var sideEffects []SideEffect
 			transactionOps := make([]fsutil.FileTransactionOp, 0, 2)
 			if nextSub == model.PlanSubStepBundle {
-				scaffoldOps, err := governedBundleScaffoldTransactionOps(root, &change)
+				scaffoldOps, err := governedBundleScaffoldTransactionOps(root, change)
 				if err != nil {
 					return AdvanceSummary{}, err
 				}
@@ -464,7 +570,7 @@ func AdvanceGoverned(root, slug string, opts ...AdvanceOptions) (summary Advance
 					Detail: "governed bundle artifacts created or verified",
 				})
 			}
-			if err := applyGovernedChangeTransaction(root, change, transactionOps); err != nil {
+			if err := applyGovernedChangeTransaction(root, *change, transactionOps); err != nil {
 				return AdvanceSummary{}, err
 			}
 			sideEffects = append(append([]SideEffect(nil), preTransitionSideEffects...), sideEffects...)
@@ -487,10 +593,10 @@ func AdvanceGoverned(root, slug string, opts ...AdvanceOptions) (summary Advance
 		// inline before entering S2_IMPLEMENT. If validation fails, the change
 		// persists at S1_PLAN/validate as a recovery-only substep.
 		if change.PlanSubStep == model.PlanSubStepAudit {
-			planResult := ValidatePlanningReadiness(root, change)
+			planResult := ValidatePlanningReadiness(root, *change)
 			if len(planResult.Blockers) > 0 {
 				change.AdvancePlanSubStep(model.PlanSubStepValidate)
-				if err := state.SaveChange(root, change); err != nil {
+				if err := state.SaveChange(root, *change); err != nil {
 					return AdvanceSummary{}, err
 				}
 				summary := blockedAdvanceSummary(fromState, planResult.Blockers)
@@ -511,7 +617,7 @@ func AdvanceGoverned(root, slug string, opts ...AdvanceOptions) (summary Advance
 		summary := doneReadyAdvanceSummary(fromState, "All governance gates passed. Run `slipway done` to finalize.")
 		summary.SideEffects = append(summary.SideEffects, preTransitionSideEffects...)
 		summary.SkillEvidence = append(summary.SkillEvidence, preTransitionSkillEvidence...)
-		return saveChangeAndReturn(root, change, summary)
+		return saveChangeAndReturn(root, *change, summary)
 	}
 
 	sideEffects := append([]SideEffect(nil), preTransitionSideEffects...)
@@ -521,7 +627,7 @@ func AdvanceGoverned(root, slug string, opts ...AdvanceOptions) (summary Advance
 		if planAudit, ok := passingSkills[SkillPlanAudit]; ok && !planAudit.Timestamp.IsZero() {
 			generatedAt = planAudit.Timestamp
 		}
-		_, wavePlanOp, err := state.MaterializeWavePlanTransactionOpAt(root, change, generatedAt)
+		_, wavePlanOp, err := state.MaterializeWavePlanTransactionOpAt(root, *change, generatedAt)
 		if err != nil {
 			return AdvanceSummary{}, err
 		}
@@ -542,11 +648,11 @@ func AdvanceGoverned(root, slug string, opts ...AdvanceOptions) (summary Advance
 		cleared = append(cleared, "last_auto_passed_states")
 	}
 	if len(transactionOps) > 0 {
-		if err := applyGovernedChangeTransaction(root, change, transactionOps); err != nil {
+		if err := applyGovernedChangeTransaction(root, *change, transactionOps); err != nil {
 			return AdvanceSummary{}, err
 		}
 	} else {
-		if err := state.SaveChange(root, change); err != nil {
+		if err := state.SaveChange(root, *change); err != nil {
 			return AdvanceSummary{}, err
 		}
 	}

--- a/internal/engine/progression/autopass.go
+++ b/internal/engine/progression/autopass.go
@@ -32,14 +32,23 @@ func attemptAutoPassSequence(
 	}
 	candidate.CurrentState = startState
 
-	eligible, reason, err := autoPassReviewEligible(root, candidate, policy)
+	// Review authority is a pure function of (root, change-on-disk) and no state
+	// mutation occurs before the review-skill stamp below, so it is computed once
+	// here and threaded through both the eligibility check and the stamp rather
+	// than recomputed inside each.
+	reviewAuthority, err := EvaluateReviewAuthority(root, candidate)
+	if err != nil {
+		return AdvanceSummary{}, false, err
+	}
+
+	eligible, reason, err := autoPassReviewEligible(root, candidate, policy, reviewAuthority)
 	if err != nil {
 		return AdvanceSummary{}, false, err
 	}
 	if !eligible {
 		return AdvanceSummary{}, false, nil
 	}
-	stampResult, err := stampAutoPassedSkillDigests(root, candidate)
+	stampResult, err := stampAutoPassedSkillDigests(root, candidate, reviewAuthority)
 	if err != nil {
 		return AdvanceSummary{}, false, err
 	}
@@ -53,10 +62,15 @@ func attemptAutoPassSequence(
 		Reason: reason,
 	})
 
-	shipEligible, shipReason, err := autoPassShipEligible(root, candidate, policy)
+	// Ship authority is likewise pure. The only barrier between here and the
+	// ship-skill stamp below is the review stamp already applied above, so it is
+	// computed once and reused for both the eligibility check and the stamp.
+	shipAuthority, err := EvaluateShipAuthority(root, candidate)
 	if err != nil {
 		return AdvanceSummary{}, false, err
 	}
+
+	shipEligible, shipReason := autoPassShipEligible(policy, shipAuthority)
 	if !shipEligible {
 		candidate.CurrentState = model.StateS3Review
 		candidate.LastAutoPassedStates = autoPassed
@@ -69,10 +83,6 @@ func attemptAutoPassSequence(
 			AutoPassedStates: autoPassed,
 		})
 		return summary, true, err
-	}
-	shipAuthority, err := EvaluateShipAuthority(root, candidate)
-	if err != nil {
-		return AdvanceSummary{}, false, err
 	}
 	stampResult, err = stampPassingSkillDigests(root, candidate, shipAuthorityPassingSkills(shipAuthority))
 	if err != nil {
@@ -115,28 +125,29 @@ func AutoPassEligibility(root string, change model.Change) ([]model.AutoPassedSt
 	var eligible []model.AutoPassedState
 	candidate := change
 	candidate.CurrentState = change.CurrentState
-	ok, reason, err := autoPassReviewEligible(root, candidate, policy)
+	reviewAuthority, err := EvaluateReviewAuthority(root, candidate)
+	if err != nil {
+		return nil, err
+	}
+	ok, reason, err := autoPassReviewEligible(root, candidate, policy, reviewAuthority)
 	if err != nil {
 		return nil, err
 	}
 	if ok {
 		eligible = append(eligible, model.AutoPassedState{State: model.StateS3Review, Reason: reason})
 	}
-	ok, reason, err = autoPassShipEligible(root, candidate, policy)
+	shipAuthority, err := EvaluateShipAuthority(root, candidate)
 	if err != nil {
 		return nil, err
 	}
+	ok, reason = autoPassShipEligible(policy, shipAuthority)
 	if ok {
 		eligible = append(eligible, model.AutoPassedState{State: model.StateS3Review, Reason: reason})
 	}
 	return eligible, nil
 }
 
-func autoPassReviewEligible(root string, change model.Change, policy governance.PresetPolicy) (bool, string, error) {
-	reviewAuthority, err := EvaluateReviewAuthority(root, change)
-	if err != nil {
-		return false, "", err
-	}
+func autoPassReviewEligible(root string, change model.Change, policy governance.PresetPolicy, reviewAuthority ReviewAuthority) (bool, string, error) {
 	readiness, err := EvaluateGovernanceReadiness(root, change, GovernanceReadinessOptions{})
 	if err != nil {
 		return false, "", err
@@ -150,26 +161,18 @@ func autoPassReviewEligible(root string, change model.Change, policy governance.
 	return true, autoPassReasonNoBlockingReviewObligations, nil
 }
 
-func autoPassShipEligible(root string, change model.Change, policy governance.PresetPolicy) (bool, string, error) {
-	shipAuthority, err := EvaluateShipAuthority(root, change)
-	if err != nil {
-		return false, "", err
-	}
+func autoPassShipEligible(policy governance.PresetPolicy, shipAuthority ShipAuthority) (bool, string) {
 	if !policy.VerifyAutoPassEnabled || hasUnsatisfiedBlockingAction(shipAuthority.Actions, model.ControlScopeRelease) {
-		return false, "", nil
+		return false, ""
 	}
 	if shipAuthority.Result.Status != model.GateStatusApproved {
-		return false, "", nil
+		return false, ""
 	}
-	return true, autoPassReasonNoBlockingReleaseObligations, nil
+	return true, autoPassReasonNoBlockingReleaseObligations
 }
 
-func stampAutoPassedSkillDigests(root string, change model.Change) (skillDigestStampResult, error) {
+func stampAutoPassedSkillDigests(root string, change model.Change, reviewAuthority ReviewAuthority) (skillDigestStampResult, error) {
 	if change.CurrentState == model.StateS3Review {
-		reviewAuthority, err := EvaluateReviewAuthority(root, change)
-		if err != nil {
-			return skillDigestStampResult{}, err
-		}
 		result, err := stampPassingSkillDigests(root, change, reviewAuthority.PassingSkills)
 		if err != nil {
 			return skillDigestStampResult{}, err

--- a/internal/engine/progression/evidence_repair.go
+++ b/internal/engine/progression/evidence_repair.go
@@ -397,36 +397,40 @@ func staleEvidenceAuthorityLabel(workflowState model.WorkflowState, subStep mode
 // ready, the change has not yet reached S2_IMPLEMENT, evaluation errors are
 // surfaced elsewhere, or the contract passes.
 func scopeContractRepairTarget(root string, change model.Change, summary *model.ExecutionSummary) (EvidenceRepairTarget, error) {
-	if !state.ExecutionSummaryReady(summary) {
-		return EvidenceRepairTarget{}, nil
-	}
-	if compareStaleEvidencePosition(
-		currentStaleEvidencePosition(change),
-		staleEvidencePositionFor(model.StateS2Implement, model.PlanSubStepNone),
-	) < 0 {
-		return EvidenceRepairTarget{}, nil
-	}
-	paths, err := state.ResolveChangePaths(root, change)
-	if err != nil {
-		return EvidenceRepairTarget{}, err
-	}
-	report, err := scopecontract.EvaluateBundleWithChangedFiles(
-		paths.GovernedBundleDir,
-		summary,
-		scopeContractWorkspaceChangedFiles(paths),
-	)
-	if err != nil || len(report.Blockers) == 0 {
-		return EvidenceRepairTarget{}, nil
-	}
-	return EvidenceRepairTarget{
-		SkillName:   SkillWaveOrchestration,
-		State:       model.StateS2Implement,
-		PlanSubStep: model.PlanSubStepNone,
-		Blockers:    report.Blockers,
-	}, nil
+	return executionSummaryRepairTarget(root, change, summary, func(paths state.ResolvedChangePaths) []model.ReasonCode {
+		report, err := scopecontract.EvaluateBundleWithChangedFiles(
+			paths.GovernedBundleDir,
+			summary,
+			scopeContractWorkspaceChangedFiles(paths),
+		)
+		if err != nil {
+			return nil
+		}
+		return report.Blockers
+	})
 }
 
 func sensitiveEvidenceRepairTarget(root string, change model.Change, summary *model.ExecutionSummary) (EvidenceRepairTarget, error) {
+	return executionSummaryRepairTarget(root, change, summary, func(paths state.ResolvedChangePaths) []model.ReasonCode {
+		return sensitiveevidence.Evaluate(summary, scopeContractWorkspaceChangedFiles(paths)).Blockers
+	})
+}
+
+// executionSummaryRepairTarget factors the shared S2_IMPLEMENT repair-target
+// sequence used by scopeContractRepairTarget and sensitiveEvidenceRepairTarget:
+// require a ready execution summary, require the change to have reached
+// S2_IMPLEMENT, resolve the change paths, then build a wave-orchestration repair
+// target from the blockers the supplied evaluator reports. evaluate is the only
+// behavioral difference between the two callers; it receives the resolved paths
+// (closing over the summary) and returns the blockers to repair, empty when there
+// is nothing to repair. A non-nil error is returned only when path resolution
+// fails; a non-zero target only when evaluate yields at least one blocker.
+func executionSummaryRepairTarget(
+	root string,
+	change model.Change,
+	summary *model.ExecutionSummary,
+	evaluate func(paths state.ResolvedChangePaths) []model.ReasonCode,
+) (EvidenceRepairTarget, error) {
 	if !state.ExecutionSummaryReady(summary) {
 		return EvidenceRepairTarget{}, nil
 	}
@@ -440,14 +444,14 @@ func sensitiveEvidenceRepairTarget(root string, change model.Change, summary *mo
 	if err != nil {
 		return EvidenceRepairTarget{}, err
 	}
-	report := sensitiveevidence.Evaluate(summary, scopeContractWorkspaceChangedFiles(paths))
-	if len(report.Blockers) == 0 {
+	blockers := evaluate(paths)
+	if len(blockers) == 0 {
 		return EvidenceRepairTarget{}, nil
 	}
 	return EvidenceRepairTarget{
 		SkillName:   SkillWaveOrchestration,
 		State:       model.StateS2Implement,
 		PlanSubStep: model.PlanSubStepNone,
-		Blockers:    report.Blockers,
+		Blockers:    blockers,
 	}, nil
 }

--- a/internal/engine/progression/readiness.go
+++ b/internal/engine/progression/readiness.go
@@ -3,7 +3,6 @@ package progression
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -689,28 +688,9 @@ func evaluateArtifactReadinessWithContext(root string, change model.Change, ctx 
 	for _, spec := range ctx.resolution.Schema {
 		specByName[spec.Name] = spec
 	}
-	eligibleByLevel := map[string]struct{}{}
 	for _, name := range required {
-		eligibleByLevel[name] = struct{}{}
-	}
-	requiredSet := map[string]struct{}{}
-	for _, name := range required {
-		requiredSet[name] = struct{}{}
-	}
-	for _, name := range required {
-		spec, ok := specByName[name]
-		if !ok {
+		if _, ok := specByName[name]; !ok {
 			result.Blockers = append(result.Blockers, model.NewReasonCode("required_artifact_schema_missing", name))
-			continue
-		}
-		for _, dep := range spec.DependsOn {
-			if _, inLevel := eligibleByLevel[dep]; !inLevel {
-				continue
-			}
-			if _, ok := requiredSet[dep]; ok {
-				continue
-			}
-			result.Blockers = append(result.Blockers, model.NewReasonCode("required_artifact_dependency_missing", fmt.Sprintf("%s->%s", name, dep)))
 		}
 	}
 

--- a/internal/engine/progression/validation.go
+++ b/internal/engine/progression/validation.go
@@ -579,26 +579,9 @@ func GovernedBundleBlockers(root string, change model.Change) []string {
 	for _, spec := range resolution.Schema {
 		specByName[spec.Name] = spec
 	}
-	eligibleByLevel := map[string]struct{}{}
 	for _, name := range required {
-		eligibleByLevel[name] = struct{}{}
-	}
-	requiredSet := map[string]struct{}{}
-	for _, name := range required {
-		requiredSet[name] = struct{}{}
-	}
-	for _, name := range required {
-		spec, ok := specByName[name]
-		if !ok {
+		if _, ok := specByName[name]; !ok {
 			return []string{"required_artifact_schema_missing:" + name}
-		}
-		for _, dep := range spec.DependsOn {
-			if _, inLevel := eligibleByLevel[dep]; !inLevel {
-				continue
-			}
-			if _, exists := requiredSet[dep]; !exists {
-				return []string{fmt.Sprintf("required_artifact_dependency_missing:%s->%s", name, dep)}
-			}
 		}
 	}
 

--- a/internal/model/change.go
+++ b/internal/model/change.go
@@ -252,13 +252,15 @@ func (c Change) EffectiveWorkflowProfile() WorkflowProfile {
 }
 
 func (c Change) MarshalYAML() (interface{}, error) {
-	normalized := c
-	normalized.Normalize()
+	// The value receiver already hands us a private copy of the Change, so we can
+	// normalize it in place without mutating the caller's value; no extra copy is
+	// required to keep marshaling side-effect free.
+	c.Normalize()
 	// WorktreePath carries yaml:"-", so it is dropped from every Change YAML write
 	// (active SaveChange, archive snapshot, repair rewrite) without an explicit
 	// strip here.
 	type alias Change
-	return alias(normalized), nil
+	return alias(c), nil
 }
 
 func (c *Change) UnmarshalYAML(unmarshal func(interface{}) error) error {

--- a/internal/model/config_catalog.go
+++ b/internal/model/config_catalog.go
@@ -4,9 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 
 	"gopkg.in/yaml.v3"
 )
@@ -154,7 +156,29 @@ func configDescriptions() map[string]string {
 // keys. It is derived by walking the Config struct's yaml tags (the same shape
 // strict decoding sees), so adding a struct field surfaces here automatically.
 // A completeness test asserts every strict-decoded leaf has an entry.
+//
+// The reflection walk is memoized (see configCatalogOnce) and each call returns
+// a fresh clone, so callers keep the independently-owned slice they have always
+// received while the catalog is built only once.
 func ConfigCatalog() []ConfigCatalogEntry {
+	master := configCatalogOnce()
+	out := make([]ConfigCatalogEntry, len(master))
+	for i, entry := range master {
+		// Clone the only reference-typed field so a caller mutating the returned
+		// entry's AllowedValues cannot corrupt the memoized master. slices.Clone
+		// preserves nil, keeping the nil-vs-populated distinction intact.
+		entry.AllowedValues = slices.Clone(entry.AllowedValues)
+		out[i] = entry
+	}
+	return out
+}
+
+// configCatalogOnce memoizes the reflection-built catalog so the Config struct
+// walk runs a single time; DefaultConfig() is deterministic, so the built value
+// is identical on every call.
+var configCatalogOnce = sync.OnceValue(buildConfigCatalog)
+
+func buildConfigCatalog() []ConfigCatalogEntry {
 	defaults := DefaultConfig()
 	// Normalize so Normalize()-derived effective defaults (e.g. artifact_schema
 	// => expanded) appear in the DEFAULT column instead of rendering blank.

--- a/internal/model/reason_code.go
+++ b/internal/model/reason_code.go
@@ -859,7 +859,15 @@ func NormalizeReasonCodes(reasons []ReasonCode) []ReasonCode {
 	if len(reasons) == 0 {
 		return nil
 	}
-	out := make([]ReasonCode, 0, len(reasons))
+	// Decorate each retained reason with the sort key already computed for
+	// deduplication so the comparator compares precomputed keys instead of
+	// recomputing Key() on every comparison. Keys are unique after dedup, so the
+	// resulting order matches the previous key-comparing comparator exactly.
+	type keyedReason struct {
+		key    string
+		reason ReasonCode
+	}
+	decorated := make([]keyedReason, 0, len(reasons))
 	seen := map[string]struct{}{}
 	for _, reason := range reasons {
 		reason.Normalize()
@@ -868,13 +876,17 @@ func NormalizeReasonCodes(reasons []ReasonCode) []ReasonCode {
 			continue
 		}
 		seen[key] = struct{}{}
-		out = append(out, reason)
+		decorated = append(decorated, keyedReason{key: key, reason: reason})
 	}
-	slices.SortFunc(out, func(a, b ReasonCode) int {
-		return strings.Compare(a.Key(), b.Key())
-	})
-	if len(out) == 0 {
+	if len(decorated) == 0 {
 		return nil
+	}
+	slices.SortFunc(decorated, func(a, b keyedReason) int {
+		return strings.Compare(a.key, b.key)
+	})
+	out := make([]ReasonCode, len(decorated))
+	for i := range decorated {
+		out[i] = decorated[i].reason
 	}
 	return out
 }

--- a/internal/tmpl/templates.go
+++ b/internal/tmpl/templates.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"path"
 	"strings"
+	"sync"
 	"text/template"
 )
 
@@ -60,15 +61,85 @@ func ContentIfExists(name string) (content string, exists bool, err error) {
 
 const maxIncludeDepth = 16
 
+// partialsGlob matches the embedded partial templates.
+const partialsGlob = "templates/_partials/*.tmpl"
+
+// partialsRootName owns the parsed templates/_partials/*.tmpl definition set.
+// It is never executed and never referenced by any template, so its presence
+// in the namespace cannot change a rendered byte; it exists only to carry the
+// shared partial definitions that named templates invoke via
+// {{ template "partial-name" . }} or {{ include "name" . }}.
+const partialsRootName = "__slipway_partials_root__"
+
+// embeddedPartials parses the embedded _partials set exactly once. The result
+// is a master template that Render clones (never executing or mutating it)
+// before each render, so the re-glob + re-parse of every partial no longer
+// happens per call and per-render include state cannot leak between renders.
+var embeddedPartials = sync.OnceValues(func() (*template.Template, error) {
+	return parsePartialSet(embeddedTemplates)
+})
+
 // Render parses a template file as a Go text/template and executes it with the given data.
 // Use for .tmpl files that contain {{.Variable}} placeholders.
 // Partials from templates/_partials/*.tmpl are automatically available via
 // {{ template "partial-name" . }} or the include helper {{ include "name" . }}.
 func Render(name string, data any) (string, error) {
-	return renderFS(embeddedTemplates, name, data)
+	master, err := embeddedPartials()
+	if err != nil {
+		return "", err
+	}
+	// Clone the once-parsed partial set so all per-render funcs and state land
+	// on the clone; the shared master is never executed or mutated.
+	base, err := master.Clone()
+	if err != nil {
+		return "", fmt.Errorf("template %q clone: %w", name, err)
+	}
+	return renderNamed(base, embeddedTemplates, name, data)
 }
 
 func renderFS(templateFS fs.FS, name string, data any) (string, error) {
+	base, err := parsePartialSet(templateFS)
+	if err != nil {
+		return "", err
+	}
+	return renderNamed(base, templateFS, name, data)
+}
+
+// parsePartialSet builds a template that owns every templates/_partials/*.tmpl
+// definition in templateFS. The include helper is registered before Parse so
+// partials that call {{ include ... }} parse cleanly; because the partials are
+// {{define}}-only, none of them replaces the root body. The result carries
+// definitions only: callers add the named template as an associated template
+// and execute that, never this root.
+func parsePartialSet(templateFS fs.FS) (*template.Template, error) {
+	// The include closure intentionally captures t; the nil guard defends
+	// against future reorderings.
+	var t *template.Template
+	var includeStack []string
+
+	funcMap := template.FuncMap{"include": newIncludeFunc(&t, &includeStack)}
+	t = template.New(partialsRootName).Funcs(funcMap)
+
+	// Load partials from _partials/ directory if they exist.
+	partials, _ := fs.Glob(templateFS, partialsGlob)
+	for _, pp := range partials {
+		pb, readErr := fs.ReadFile(templateFS, pp)
+		if readErr != nil {
+			continue
+		}
+		if _, parseErr := t.Parse(normalizeTemplateLineEndings(string(pb))); parseErr != nil {
+			return nil, fmt.Errorf("partial %q parse: %w", pp, parseErr)
+		}
+	}
+	return t, nil
+}
+
+// renderNamed parses the named template as an associated template of base
+// (which already owns the _partials set), registers a fresh per-render include
+// helper on the set, executes the named template, and returns normalized
+// output. base must be caller-owned (a clone for the embedded path, or a
+// freshly parsed set for an arbitrary FS) and must never be the shared master.
+func renderNamed(base *template.Template, templateFS fs.FS, name string, data any) (string, error) {
 	p := templatePath(name)
 	b, err := fs.ReadFile(templateFS, p)
 	if err != nil {
@@ -82,21 +153,9 @@ func renderFS(templateFS fs.FS, name string, data any) (string, error) {
 
 	funcMap := template.FuncMap{"include": newIncludeFunc(&t, &includeStack)}
 
-	t, err = template.New(name).Funcs(funcMap).Parse(normalizeTemplateLineEndings(string(b)))
+	t, err = base.New(name).Funcs(funcMap).Parse(normalizeTemplateLineEndings(string(b)))
 	if err != nil {
 		return "", fmt.Errorf("template %q parse: %w", name, err)
-	}
-
-	// Load partials from _partials/ directory if they exist.
-	partials, _ := fs.Glob(templateFS, "templates/_partials/*.tmpl")
-	for _, pp := range partials {
-		pb, readErr := fs.ReadFile(templateFS, pp)
-		if readErr != nil {
-			continue
-		}
-		if _, parseErr := t.Parse(normalizeTemplateLineEndings(string(pb))); parseErr != nil {
-			return "", fmt.Errorf("partial %q parse: %w", pp, parseErr)
-		}
 	}
 
 	var buf bytes.Buffer

--- a/internal/toolgen/toolgen.go
+++ b/internal/toolgen/toolgen.go
@@ -1,6 +1,7 @@
 package toolgen
 
 import (
+	"cmp"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 	"runtime/debug"
 	"slices"
 	"strings"
+	"sync"
 
 	"github.com/signalridge/slipway/internal/engine/capability"
 	"github.com/signalridge/slipway/internal/fsutil"
@@ -487,12 +489,19 @@ var promptSurfaceIDs = func() []string {
 	return out
 }()
 
-// commandIDs returns the prompt surface IDs that have user-facing command entries (sorted).
-func commandIDs() []string {
+// sortedCommandIDs memoizes the sorted prompt surface IDs. The sort input
+// (promptSurfaceIDs) is fixed at package init, so the ordering never changes;
+// commandIDs clones this per call so callers keep an independently mutable slice.
+var sortedCommandIDs = sync.OnceValue(func() []string {
 	out := make([]string, len(promptSurfaceIDs))
 	copy(out, promptSurfaceIDs)
 	slices.Sort(out)
 	return out
+})
+
+// commandIDs returns the prompt surface IDs that have user-facing command entries (sorted).
+func commandIDs() []string {
+	return slices.Clone(sortedCommandIDs())
 }
 
 const workflowSkillID = "workflow"
@@ -797,13 +806,7 @@ func Registry() []ToolConfig {
 		out = append(out, cfg)
 	}
 	slices.SortFunc(out, func(a, b ToolConfig) int {
-		if a.ID < b.ID {
-			return -1
-		}
-		if a.ID > b.ID {
-			return 1
-		}
-		return 0
+		return cmp.Compare(a.ID, b.ID)
 	})
 	return out
 }
@@ -1031,21 +1034,77 @@ func generateForTool(root string, cfg ToolConfig, refresh bool, closure skillIns
 		}()
 	}
 
-	if refresh {
-		// Purge direct command prompt surfaces before rewrite (project-local only).
-		if cfg.CommandsDir != "" {
-			if err := purgeCommandPromptSurfaces(root, cfg, plan); err != nil {
-				return err
-			}
-		}
+	if err := prepareRefreshRewrite(root, cfg, refresh, hadGeneratedAdapter, plan, closure); err != nil {
+		return err
+	}
 
-		if err := cleanupStaleGeneratedArtifacts(root, cfg, hadGeneratedAdapter, plan, closure); err != nil {
+	if err := emitStaticGovernanceSkills(root, cfg, refresh, plan, closure); err != nil {
+		return err
+	}
+
+	if err := emitTemplatedGovernanceSkills(root, cfg, refresh, plan, closure); err != nil {
+		return err
+	}
+
+	reg := capability.DefaultRegistry()
+	if err := emitCatalogSkills(root, cfg, refresh, plan, closure, reg); err != nil {
+		return err
+	}
+
+	if err := emitStandaloneSkills(root, cfg, refresh, plan, closure); err != nil {
+		return err
+	}
+
+	if err := emitTechniqueSkills(root, cfg, refresh, plan, closure); err != nil {
+		return err
+	}
+
+	if err := emitRouterSkills(root, cfg, refresh, plan, closure); err != nil {
+		return err
+	}
+
+	if err := emitCommandPromptSurfaces(root, cfg, refresh, plan); err != nil {
+		return err
+	}
+
+	if err := emitCommandSkillSurfaces(root, cfg, refresh, plan, closure); err != nil {
+		return err
+	}
+
+	if err := registerHostSettingsSurfaces(root, cfg, refresh, plan); err != nil {
+		return err
+	}
+
+	if err := emitWorkflowSkillIndex(root, cfg, refresh, plan, closure, reg); err != nil {
+		return err
+	}
+
+	return commitGeneratedSentinel(sentinelPath, plan)
+}
+
+// prepareRefreshRewrite purges direct command prompt surfaces and cleans up
+// stale generated artifacts before a rewrite. It is a no-op outside refresh.
+func prepareRefreshRewrite(root string, cfg ToolConfig, refresh bool, hadGeneratedAdapter bool, plan *toolRefreshPlan, closure skillInstallClosure) error {
+	if !refresh {
+		return nil
+	}
+	// Purge direct command prompt surfaces before rewrite (project-local only).
+	if cfg.CommandsDir != "" {
+		if err := purgeCommandPromptSurfaces(root, cfg, plan); err != nil {
 			return err
 		}
 	}
 
-	// Governance skills (static content)
-	// Includes both registry governance skills and standalone governance guidance skills.
+	if err := cleanupStaleGeneratedArtifacts(root, cfg, hadGeneratedAdapter, plan, closure); err != nil {
+		return err
+	}
+	return nil
+}
+
+// emitStaticGovernanceSkills writes the static-content governance skills,
+// including both registry governance skills and standalone governance guidance
+// skills.
+func emitStaticGovernanceSkills(root string, cfg ToolConfig, refresh bool, plan *toolRefreshPlan, closure skillInstallClosure) error {
 	allStaticGovernance := append([]string{}, GovernanceSkillNames...)
 	allStaticGovernance = append(allStaticGovernance, standaloneGovernanceNames...)
 	for _, name := range allStaticGovernance {
@@ -1068,8 +1127,12 @@ func generateForTool(root string, cfg ToolConfig, refresh bool, closure skillIns
 			return fmt.Errorf("emit support files for governance skill %q (%s): %w", name, cfg.ID, err)
 		}
 	}
+	return nil
+}
 
-	// Templated governance skills (tool-aware host templates)
+// emitTemplatedGovernanceSkills writes the tool-aware host-templated governance
+// skills.
+func emitTemplatedGovernanceSkills(root string, cfg ToolConfig, refresh bool, plan *toolRefreshPlan, closure skillInstallClosure) error {
 	for _, name := range TemplatedGovernanceSkillNames {
 		if !closure.includesHostSkill(name) {
 			continue
@@ -1086,10 +1149,12 @@ func generateForTool(root string, cfg ToolConfig, refresh bool, closure skillIns
 			return fmt.Errorf("emit support files for templated governance skill %q (%s): %w", name, cfg.ID, err)
 		}
 	}
+	return nil
+}
 
-	// Catalog skills (registry-owned, assembled from SKILL.md plus optional
-	// typed templates in fixed order).
-	reg := capability.DefaultRegistry()
+// emitCatalogSkills writes the registry-owned catalog skills, assembled from
+// SKILL.md plus optional typed templates in fixed order.
+func emitCatalogSkills(root string, cfg ToolConfig, refresh bool, plan *toolRefreshPlan, closure skillInstallClosure, reg *capability.Registry) error {
 	for _, id := range catalogSkillIDs {
 		if !closure.includesHostSkill(id) {
 			continue
@@ -1116,8 +1181,13 @@ func generateForTool(root string, cfg ToolConfig, refresh bool, closure skillIns
 			return fmt.Errorf("emit support files for catalog skill %q (%s): %w", id, cfg.ID, err)
 		}
 	}
+	return nil
+}
 
-	// Standalone skills (static content, not governance, not technique)
+// emitStandaloneSkills writes standalone skills (static content, not governance,
+// not technique), including the special-cased workflow skill and its command
+// reference.
+func emitStandaloneSkills(root string, cfg ToolConfig, refresh bool, plan *toolRefreshPlan, closure skillInstallClosure) error {
 	for _, name := range standaloneNames {
 		if !closure.includesHostSkill(name) {
 			continue
@@ -1162,8 +1232,11 @@ func generateForTool(root string, cfg ToolConfig, refresh bool, closure skillIns
 			return fmt.Errorf("emit support files for standalone skill %q (%s): %w", name, cfg.ID, err)
 		}
 	}
+	return nil
+}
 
-	// Technique skills (static content)
+// emitTechniqueSkills writes the static-content technique skills.
+func emitTechniqueSkills(root string, cfg ToolConfig, refresh bool, plan *toolRefreshPlan, closure skillInstallClosure) error {
 	for _, name := range techniqueNames {
 		if !closure.includesHostSkill(name) {
 			continue
@@ -1187,10 +1260,13 @@ func generateForTool(root string, cfg ToolConfig, refresh bool, closure skillIns
 			return fmt.Errorf("emit support files for technique skill %q (%s): %w", name, cfg.ID, err)
 		}
 	}
+	return nil
+}
 
-	// Namespace router skills keep the eager skill list small for profile-based
-	// installs. They point agents back to command/host surfaces and never own
-	// lifecycle transitions or evidence gates.
+// emitRouterSkills writes the namespace router skills that keep the eager skill
+// list small for profile-based installs. They point agents back to
+// command/host surfaces and never own lifecycle transitions or evidence gates.
+func emitRouterSkills(root string, cfg ToolConfig, refresh bool, plan *toolRefreshPlan, closure skillInstallClosure) error {
 	for _, router := range closure.routerDefinitions() {
 		content, err := renderSurfaceRouterSkill(cfg, router)
 		if err != nil {
@@ -1200,49 +1276,62 @@ func generateForTool(root string, cfg ToolConfig, refresh bool, closure skillIns
 			return err
 		}
 	}
+	return nil
+}
 
-	// Command prompt surfaces (inline command prompts for prompt-backed adapters).
-	// Skip when CommandsDir is empty (Codex uses command skills instead).
-	if cfg.CommandsDir != "" {
-		for _, id := range commandIDs() {
-			content, err := renderCommandEntry(cfg, id)
-			if err != nil {
-				return fmt.Errorf("render command prompt %q for %s: %w", id, cfg.ID, err)
-			}
-			if err := writeDeterministicWithPlan(plan, commandEntryPath(root, cfg, id), content, refresh); err != nil {
-				return err
-			}
+// emitCommandPromptSurfaces writes the inline command prompts for prompt-backed
+// adapters. It is skipped when CommandsDir is empty (Codex uses command skills
+// instead).
+func emitCommandPromptSurfaces(root string, cfg ToolConfig, refresh bool, plan *toolRefreshPlan) error {
+	if cfg.CommandsDir == "" {
+		return nil
+	}
+	for _, id := range commandIDs() {
+		content, err := renderCommandEntry(cfg, id)
+		if err != nil {
+			return fmt.Errorf("render command prompt %q for %s: %w", id, cfg.ID, err)
+		}
+		if err := writeDeterministicWithPlan(plan, commandEntryPath(root, cfg, id), content, refresh); err != nil {
+			return err
 		}
 	}
+	return nil
+}
 
-	// Command skill surfaces (Codex): one discoverable skill per command under
-	// SkillsDir.
-	if cfg.CommandSkillSurface {
-		for _, id := range commandIDs() {
-			if !closure.includesCommandSkill(id) {
-				continue
-			}
-			content, err := renderCommandSkill(cfg, id)
-			if err != nil {
-				return fmt.Errorf("render command skill %q for %s: %w", id, cfg.ID, err)
-			}
-			if err := writeDeterministicWithPlan(plan, filepath.Join(root, SkillPath(cfg, id)), content, refresh); err != nil {
-				return err
-			}
+// emitCommandSkillSurfaces writes one discoverable command skill per command
+// under SkillsDir (Codex).
+func emitCommandSkillSurfaces(root string, cfg ToolConfig, refresh bool, plan *toolRefreshPlan, closure skillInstallClosure) error {
+	if !cfg.CommandSkillSurface {
+		return nil
+	}
+	for _, id := range commandIDs() {
+		if !closure.includesCommandSkill(id) {
+			continue
+		}
+		content, err := renderCommandSkill(cfg, id)
+		if err != nil {
+			return fmt.Errorf("render command skill %q for %s: %w", id, cfg.ID, err)
+		}
+		if err := writeDeterministicWithPlan(plan, filepath.Join(root, SkillPath(cfg, id)), content, refresh); err != nil {
+			return err
 		}
 	}
+	return nil
+}
 
-	// Settings registration is keyed on whether the host owns a settings.json.
-	//
-	//   - Settings-capable hosts (claude, qwen): register each hook event as a
-	//     bare inline `slipway hook <subcommand>` command directly in
-	//     settings.json. No launcher script files are written, and on refresh any
-	//     previously generated launcher files are pruned.
-	//   - Pi registers generated skills/prompts in settings.json without hook
-	//     semantics.
-	//   - Settings-less hosts (cursor, opencode): keep emitting the advisory
-	//     session-start launcher files (extensionless + .ps1 + .cmd), since they
-	//     have no settings.json to register an inline command in.
+// registerHostSettingsSurfaces registers settings-based host surfaces. Behavior
+// is keyed on whether the host owns a settings.json.
+//
+//   - Settings-capable hosts (claude, qwen): register each hook event as a
+//     bare inline `slipway hook <subcommand>` command directly in
+//     settings.json. No launcher script files are written, and on refresh any
+//     previously generated launcher files are pruned.
+//   - Pi registers generated skills/prompts in settings.json without hook
+//     semantics.
+//   - Settings-less hosts (cursor, opencode): keep emitting the advisory
+//     session-start launcher files (extensionless + .ps1 + .cmd), since they
+//     have no settings.json to register an inline command in.
+func registerHostSettingsSurfaces(root string, cfg ToolConfig, refresh bool, plan *toolRefreshPlan) error {
 	if strings.TrimSpace(cfg.SettingsPath) != "" {
 		switch cfg.SettingsKind {
 		case settingsKindPiRegistration:
@@ -1283,10 +1372,14 @@ func generateForTool(root string, cfg ToolConfig, refresh bool, closure skillIns
 			}
 		}
 	}
+	return nil
+}
 
-	// Workflow skill index (read by external agents; not consumed by the
-	// Slipway kernel). Regenerated deterministically from the Go-owned
-	// capability registry so every adapter sees direct host skill paths.
+// emitWorkflowSkillIndex writes the workflow skill index (read by external
+// agents; not consumed by the Slipway kernel). It is regenerated
+// deterministically from the Go-owned capability registry so every adapter sees
+// direct host skill paths.
+func emitWorkflowSkillIndex(root string, cfg ToolConfig, refresh bool, plan *toolRefreshPlan, closure skillInstallClosure, reg *capability.Registry) error {
 	exportedReg, err := exportedCapabilityRegistryForInstallClosure(reg, closure)
 	if err != nil {
 		return err
@@ -1298,8 +1391,12 @@ func generateForTool(root string, cfg ToolConfig, refresh bool, closure skillIns
 	if err := writeDeterministicWithPlan(plan, indexPath, index, refresh); err != nil {
 		return err
 	}
+	return nil
+}
 
-	// Write sentinel last — a missing sentinel means the tree is invalid.
+// commitGeneratedSentinel writes the sentinel last — a missing sentinel means
+// the tree is invalid.
+func commitGeneratedSentinel(sentinelPath string, plan *toolRefreshPlan) error {
 	if plan != nil {
 		return plan.commit(sentinelPath, []byte("generated\n"))
 	}
@@ -2421,13 +2518,10 @@ func renderSurfaceRouterSkill(cfg ToolConfig, def namespaceRouterDefinition) (st
 	return tmpl.Render(sourceSkillTemplatePath("surface", hostSkillTemplateSourceFile), data)
 }
 
-// renderCommandEntry renders an inline command prompt from the appropriate template.
-func renderCommandEntry(cfg ToolConfig, id string) (string, error) {
-	meta, err := buildCommandRenderData(id)
-	if err != nil {
-		return "", err
-	}
-	data := map[string]any{
+// baseCommandRenderData builds the render map keys shared by renderCommandEntry
+// and renderCommandSkill. Callers add any surface-specific keys after.
+func baseCommandRenderData(cfg ToolConfig, id string, meta commandRenderData) map[string]any {
+	return map[string]any{
 		"CommandID":     meta.ID,
 		"ToolID":        cfg.ID,
 		"Trigger":       commandTrigger(cfg, meta.ID),
@@ -2437,8 +2531,17 @@ func renderCommandEntry(cfg ToolConfig, id string) (string, error) {
 		"Arguments":     meta.Arguments,
 		"Prerequisites": meta.Prerequisites,
 		"Tier":          meta.Tier,
-		"Surface":       "adapter",
 	}
+}
+
+// renderCommandEntry renders an inline command prompt from the appropriate template.
+func renderCommandEntry(cfg ToolConfig, id string) (string, error) {
+	meta, err := buildCommandRenderData(id)
+	if err != nil {
+		return "", err
+	}
+	data := baseCommandRenderData(cfg, id, meta)
+	data["Surface"] = "adapter"
 	tmplName := "command-entry.md.tmpl"
 	if cfg.CommandFormat == "toml" {
 		tmplName = "command-entry.toml.tmpl"
@@ -2455,17 +2558,7 @@ func renderCommandSkill(cfg ToolConfig, id string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	data := map[string]any{
-		"CommandID":     meta.ID,
-		"ToolID":        cfg.ID,
-		"Trigger":       commandTrigger(cfg, meta.ID),
-		"Class":         meta.Class,
-		"Description":   meta.Description,
-		"BodyTemplate":  "command-" + id + "-body",
-		"Arguments":     meta.Arguments,
-		"Prerequisites": meta.Prerequisites,
-		"Tier":          meta.Tier,
-	}
+	data := baseCommandRenderData(cfg, id, meta)
 	raw, err := tmpl.Render(path.Join("commands", "command-skill.md.tmpl"), data)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## What

A behavior-preserving optimization and correctness-hardening pass (dimensions **A–G**) across the engine, CLI, and generated surfaces. **No public CLI command, flag, JSON schema, generated-skill, or gate-outcome change** — the global invariant (REQ-007). Existing public-contract tests pass unmodified.

## Why

A 6-agent read of the codebase surfaced a set of unreachable branches, swallowed errors, redundant I/O/allocations, and long functions worth hardening — none of which should alter observable behavior. Bundled as one governed change so the behavior-preservation invariant is enforced end-to-end.

## Changes

**Correctness (C1–C4)**
- **C1 (REQ-001):** delete the unreachable `required_artifact_dependency_missing` branch in `readiness.go` / `validation.go` (`eligibleByLevel` and `requiredSet` carry identical keys, so the branch can never fire).
- **C2 (REQ-002):** surface `state.RepairCorruptConfig` failures in `slipway repair` instead of swallowing them; still emit a summary (exit 0) when the config stays unreadable, consistent with other non-repairable findings.
- **C3 (REQ-003):** surface directory-walk read errors in `slipway done` `detectRemediationSources` instead of silently skipping them (the `IsRegular()` guard keeps the intentional symlink skip).
- **C4 (REQ-004):** safe blocker aggregation via `appendReasonCodes` in `next.go` (no shared-slice aliasing).

**Mechanical, output-identical (B, D, F, G — REQ-005)**
- **B:** `sync.OnceValue` memoization of immutable derived state with clone-on-return isolation (capability `registry`/`resolver`/`surfaces`).
- **D:** parse-once artifact I/O (`artifact` manager / `requirements_contract`).
- **F:** linear `extractBlocksByID` dedup (governance `traceability`).
- **G:** micro-optimizations (`config` / `tool_github` / `reason_code` and peers).

**Structural refactors, outcome-preserving (A, E — REQ-006)**
- **A:** request-scoped resolution/config context threading (extends the existing `ctx.resolution` seam).
- **E:** pure extraction of `AdvanceGoverned` / `generateForTool` / `buildNextView` into focused helpers (`advance_governed` / `autopass` / `toolgen` / `next` / `templates`); authority is computed once per phase around a single stamp write, so no memoized value is reused across its own mutation.

## Verification

Driven through the Slipway governed lifecycle: S1 plan-audit → S2 dependency-ordered waves → S3 spec-compliance / code-quality / independent / security reviews + terminal ship-verification → `done`. All gates green:

- `go build ./...`, `go vet ./...`
- `gofmt -s` clean
- `go test ./...` — all packages `ok`
- `golangci-lint run` — 0 issues

New regression tests lock the correctness fixes: `TestRepairSurfacesUnrepairableConfigInsteadOfHardFailing` (C2), `detectRemediationSources` read-error surfacing (C3), and `TestDefaultRegistryReturnsMutationIsolatedSkills` (B clone isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
