### PR TITLE
refactor: complete deferred optimization residual from PR #414

### DIFF
--- a/cmd/done.go
+++ b/cmd/done.go
@@ -97,6 +97,47 @@ func markChangeDone(change *model.Change) {
 	change.CurrentState = model.StateDone
 }
 
+// doneArchiveStep identifies which step of the shared done-archive helper failed,
+// so each caller can surface the failure in its own shape: interactive `done`
+// propagates the raw error, while `--all-ready` maps the step to a distinct
+// reason-coded bulk item.
+type doneArchiveStep int
+
+const (
+	doneArchiveStepNone doneArchiveStep = iota
+	doneArchiveStepLifecycleEvent
+	doneArchiveStepArchive
+)
+
+// finalizeDoneArchive performs the terminal done transition shared by interactive
+// `done` and bulk `--all-ready`: it marks the change done, emits the canonical
+// `done.marked` lifecycle event (snapshotting the pre-mark state for BeforeState),
+// and archives the change, returning the archived snapshot. Callers own their own
+// surrounding concerns — remediation merge, display-path resolution, and
+// error-to-surface mapping — before and after this call. On failure it returns the
+// raw underlying error together with the step that failed.
+func finalizeDoneArchive(root string, change *model.Change) (model.Change, doneArchiveStep, error) {
+	beforeState := change.CurrentState
+	markChangeDone(change)
+	if err := appendCLILifecycleEvent(root, *change, state.LifecycleEvent{
+		Command:     "done",
+		EventType:   "done.marked",
+		Action:      "archived",
+		Reason:      "operator_finalized_done_ready",
+		Result:      string(model.ChangeStatusDone),
+		GateID:      string(gate.GateShip),
+		BeforeState: beforeState,
+		AfterState:  change.CurrentState,
+	}); err != nil {
+		return model.Change{}, doneArchiveStepLifecycleEvent, err
+	}
+	archived, err := state.ArchiveChange(root, *change, model.ChangeStatusDone)
+	if err != nil {
+		return model.Change{}, doneArchiveStepArchive, err
+	}
+	return archived, doneArchiveStepNone, nil
+}
+
 const doneWorktreeDirtyWarning = "worktree has uncommitted non-bundle changes; commit them together with the archived bundle before removing the worktree"
 
 // doneWorktreeDirtyState reports uncommitted non-bundle worktree changes as a
@@ -345,8 +386,6 @@ func makeDoneCmd() *cobra.Command {
 				if err != nil {
 					return wrapGovernanceReadinessError("evaluate done freshness", change.Slug, err)
 				}
-				beforeChange := change
-				markChangeDone(&change)
 				detectedRemediation, err := detectRemediationSources(root, change)
 				if err != nil {
 					return err
@@ -355,24 +394,11 @@ func makeDoneCmd() *cobra.Command {
 					change.RemediationSources,
 					detectedRemediation,
 				)
-
-				if err := appendCLILifecycleEvent(root, change, state.LifecycleEvent{
-					Command:     "done",
-					EventType:   "done.marked",
-					Action:      "archived",
-					Reason:      "operator_finalized_done_ready",
-					Result:      string(model.ChangeStatusDone),
-					GateID:      string(gate.GateShip),
-					BeforeState: beforeChange.CurrentState,
-					AfterState:  change.CurrentState,
-				}); err != nil {
-					return err
-				}
 				archivePaths, err := state.ResolveChangePaths(root, change)
 				if err != nil {
 					return err
 				}
-				archived, err := state.ArchiveChange(root, change, model.ChangeStatusDone)
+				archived, _, err := finalizeDoneArchive(root, &change)
 				if err != nil {
 					return err
 				}
@@ -532,22 +558,10 @@ func archiveSingleDoneReady(root, slug string, change model.Change) doneBulkItem
 		)
 	}
 	worktreeDirtyWarning, worktreeDirtyFiles := prep.worktreeDirtyWarning, prep.worktreeDirtyFiles
-	beforeChange := change
-	markChangeDone(&change)
-
-	if err := appendCLILifecycleEvent(root, change, state.LifecycleEvent{
-		Command:     "done",
-		EventType:   "done.marked",
-		Action:      "archived",
-		Reason:      "operator_finalized_done_ready",
-		Result:      string(model.ChangeStatusDone),
-		GateID:      string(gate.GateShip),
-		BeforeState: beforeChange.CurrentState,
-		AfterState:  change.CurrentState,
-	}); err != nil {
-		return newDoneBulkFailed(slug, "lifecycle_event_write_failed", err.Error())
-	}
-	if _, err := state.ArchiveChange(root, change, model.ChangeStatusDone); err != nil {
+	if _, step, err := finalizeDoneArchive(root, &change); err != nil {
+		if step == doneArchiveStepLifecycleEvent {
+			return newDoneBulkFailed(slug, "lifecycle_event_write_failed", err.Error())
+		}
 		return newDoneBulkFailed(slug, "archive_failed", err.Error())
 	}
 	item := newDoneBulkArchived(slug)

--- a/cmd/evidence.go
+++ b/cmd/evidence.go
@@ -416,8 +416,8 @@ func makeEvidenceTaskCmd() *cobra.Command {
 			}
 
 			return withChangeStateLock(root, ref.Slug, "evidence task", func() error {
-				change, err := loadActiveChange(
-					root,
+				change, err := loadActiveChangeWithReadContext(
+					readCtx,
 					ref.Slug,
 					"cannot record task evidence for governed status %q",
 					"Task evidence can only be recorded for an active governed change.",
@@ -425,7 +425,7 @@ func makeEvidenceTaskCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				route := commandInvocationRoute(cmd, root, change, strings.TrimSpace(changeSlug) != "")
+				route := commandInvocationRouteWithReadContext(cmd, readCtx, change, strings.TrimSpace(changeSlug) != "")
 				if change.CurrentState != model.StateS2Implement && change.CurrentState != model.StateS3Review {
 					remediation := evidenceTaskWrongStateRemediation(root, change)
 					return newInvalidUsageError(
@@ -727,6 +727,28 @@ func normalizeEvidenceTaskResultFileArgs(resultFiles []string) []string {
 	return normalized
 }
 
+// loadActiveChangeWithReadContext mirrors loadActiveChange but resolves the
+// change through the shared read-context, reusing the change already loaded
+// during active-ref resolution instead of reading change.yaml again uncached.
+func loadActiveChangeWithReadContext(readCtx *stateReadContext, slug, inactiveMessage, remediation string) (model.Change, error) {
+	change, err := readCtx.loadChange(slug)
+	if err != nil {
+		return model.Change{}, newChangeStateLoadFailedError(slug, err)
+	}
+	if change.Status != model.ChangeStatusActive {
+		return model.Change{}, newPreconditionError(
+			"not_active",
+			fmt.Sprintf(inactiveMessage, change.Status),
+			remediation,
+			slug,
+			map[string]any{
+				"status": string(change.Status),
+			},
+		)
+	}
+	return change, nil
+}
+
 func recordEvidenceTaskResultFiles(
 	cmd *cobra.Command,
 	root string,
@@ -765,7 +787,7 @@ func recordEvidenceTaskResultFiles(
 			map[string]any{"path": state.WavePlanPathForRead(root, change.Slug)},
 		)
 	}
-	runSummary, err := deriveEvidenceTaskRunSummaryVersion(root, change, wavePlan)
+	runSummary, existingTaskEvidencePaths, err := deriveEvidenceTaskRunSummaryVersion(root, change, wavePlan)
 	if err != nil {
 		return err
 	}
@@ -773,7 +795,7 @@ func recordEvidenceTaskResultFiles(
 		return err
 	}
 
-	prepared, err := prepareEvidenceTaskResultFiles(root, change, wavePlan, runSummary, resultFiles, time.Now().UTC())
+	prepared, err := prepareEvidenceTaskResultFiles(root, change, wavePlan, runSummary, resultFiles, time.Now().UTC(), existingTaskEvidencePaths)
 	if err != nil {
 		return err
 	}
@@ -873,6 +895,7 @@ func prepareEvidenceTaskResultFiles(
 	runSummary int,
 	resultFiles []string,
 	commandCapturedAt time.Time,
+	existingTaskEvidencePaths []string,
 ) ([]preparedEvidenceTaskResult, error) {
 	seenTasks := map[string]string{}
 	prepared := make([]preparedEvidenceTaskResult, 0, len(resultFiles))
@@ -1039,7 +1062,7 @@ func prepareEvidenceTaskResultFiles(
 			},
 		})
 	}
-	if err := rejectDuplicateEvidenceTaskResultSessions(root, change, runSummary, prepared); err != nil {
+	if err := rejectDuplicateEvidenceTaskResultSessions(root, change, runSummary, prepared, existingTaskEvidencePaths); err != nil {
 		return nil, err
 	}
 	return prepared, nil
@@ -1050,13 +1073,13 @@ type evidenceTaskResultSessionOwner struct {
 	resultFile string
 }
 
-func rejectDuplicateEvidenceTaskResultSessions(root string, change model.Change, runSummary int, prepared []preparedEvidenceTaskResult) error {
+func rejectDuplicateEvidenceTaskResultSessions(root string, change model.Change, runSummary int, prepared []preparedEvidenceTaskResult, existingTaskEvidencePaths []string) error {
 	replacedTasks := map[string]struct{}{}
 	for _, item := range prepared {
 		replacedTasks[item.payload.TaskID] = struct{}{}
 	}
 
-	sessionOwners, err := existingEvidenceTaskResultSessionOwners(root, change, runSummary, replacedTasks)
+	sessionOwners, err := existingEvidenceTaskResultSessionOwners(root, change, runSummary, replacedTasks, existingTaskEvidencePaths)
 	if err != nil {
 		return err
 	}
@@ -1092,28 +1115,10 @@ func existingEvidenceTaskResultSessionOwners(
 	change model.Change,
 	runSummary int,
 	replacedTasks map[string]struct{},
+	paths []string,
 ) (map[string]evidenceTaskResultSessionOwner, error) {
-	dir := state.EvidenceTasksDir(root, change.Slug)
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return map[string]evidenceTaskResultSessionOwner{}, nil
-		}
-		return nil, newStateIntegrityError(
-			"evidence_task_existing_evidence_load_failed",
-			fmt.Sprintf("failed to read existing task evidence %q: %v", state.DisplayPath(root, dir), err),
-			"Repair the runtime task evidence before importing task result evidence.",
-			change.Slug,
-			map[string]any{"path": state.DisplayPath(root, dir)},
-		)
-	}
-
 	sessionOwners := map[string]evidenceTaskResultSessionOwner{}
-	for _, entry := range entries {
-		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
-			continue
-		}
-		path := filepath.Join(dir, entry.Name())
+	for _, path := range paths {
 		task, _, sessionID, err := progression.ParseTaskEvidence(root, path, runSummary)
 		if err != nil {
 			var versionMismatch progression.TaskEvidenceRunVersionMismatchError
@@ -2075,9 +2080,9 @@ func resolveEvidenceTaskResultPath(root string, change model.Change, resultFile 
 	return resolvedPath, nil
 }
 
-func deriveEvidenceTaskRunSummaryVersion(root string, change model.Change, wavePlan model.WavePlan) (int, error) {
+func deriveEvidenceTaskRunSummaryVersion(root string, change model.Change, wavePlan model.WavePlan) (int, []string, error) {
 	if wavePlan.RunSummaryVersion < 1 {
-		return 0, newStateIntegrityError(
+		return 0, nil, newStateIntegrityError(
 			"evidence_task_run_summary_version_unavailable",
 			fmt.Sprintf("current wave plan for %q has invalid run_summary_version %d", change.Slug, wavePlan.RunSummaryVersion),
 			"Rematerialize the S2 wave plan before importing task result evidence.",
@@ -2085,12 +2090,12 @@ func deriveEvidenceTaskRunSummaryVersion(root string, change model.Change, waveP
 			map[string]any{"run_summary_version": wavePlan.RunSummaryVersion},
 		)
 	}
-	versions, err := existingEvidenceTaskRunSummaryVersions(root, change.Slug)
+	versions, paths, err := existingEvidenceTaskRunSummaryVersions(root, change.Slug)
 	if err != nil {
-		return 0, err
+		return 0, nil, err
 	}
 	if len(versions) > 1 {
-		return 0, newInvalidUsageError(
+		return 0, nil, newInvalidUsageError(
 			"evidence_task_run_summary_version_ambiguous",
 			"task evidence contains multiple run_summary_version values",
 			"Clear, repair, or re-record task evidence so every task belongs to the active execution run before importing more results.",
@@ -2103,7 +2108,7 @@ func deriveEvidenceTaskRunSummaryVersion(root string, change model.Change, waveP
 	}
 	for version := range versions {
 		if version > wavePlan.RunSummaryVersion {
-			return 0, newInvalidUsageError(
+			return 0, nil, newInvalidUsageError(
 				"evidence_task_run_summary_version_ambiguous",
 				"task evidence contains a run_summary_version newer than the active wave plan",
 				"Clear, repair, or re-record task evidence so every task belongs to the active execution run before importing more results.",
@@ -2116,17 +2121,34 @@ func deriveEvidenceTaskRunSummaryVersion(root string, change model.Change, waveP
 			)
 		}
 	}
-	return wavePlan.RunSummaryVersion, nil
+	return wavePlan.RunSummaryVersion, paths, nil
 }
 
-func existingEvidenceTaskRunSummaryVersions(root, slug string) (map[int]struct{}, error) {
-	versions, scanErr := scanEvidenceTaskRunSummaryVersions(root, slug)
+// existingEvidenceTaskRunSummaryVersions enumerates the evidence-tasks directory
+// once, returning both the set of existing run_summary_version values and the
+// sorted list of task-evidence file paths it walked so the same listing can feed
+// the session-owner scan without walking the directory a second time.
+func existingEvidenceTaskRunSummaryVersions(root, slug string) (map[int]struct{}, []string, error) {
+	dir := state.EvidenceTasksDir(root, slug)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil, nil
+		}
+		return nil, nil, newStateIntegrityError(
+			"evidence_task_existing_evidence_load_failed",
+			fmt.Sprintf("failed to read existing task evidence %q: %v", state.DisplayPath(root, dir), err),
+			"Repair the runtime task evidence before importing task result evidence.",
+			slug,
+			map[string]any{"path": state.DisplayPath(root, dir)},
+		)
+	}
+	paths := evidenceTaskJSONPaths(dir, entries)
+	versions, scanErr := runSummaryVersionsFromPaths(paths)
 	if scanErr != nil {
 		switch scanErr.Kind {
-		case evidenceTaskRunSummaryVersionsMissingDir:
-			return nil, nil
-		case evidenceTaskRunSummaryVersionsReadDir, evidenceTaskRunSummaryVersionsReadFile:
-			return nil, newStateIntegrityError(
+		case evidenceTaskRunSummaryVersionsReadFile:
+			return nil, nil, newStateIntegrityError(
 				"evidence_task_existing_evidence_load_failed",
 				fmt.Sprintf("failed to read existing task evidence %q: %v", state.DisplayPath(root, scanErr.Path), scanErr.Err),
 				"Repair the runtime task evidence before importing task result evidence.",
@@ -2134,7 +2156,7 @@ func existingEvidenceTaskRunSummaryVersions(root, slug string) (map[int]struct{}
 				map[string]any{"path": state.DisplayPath(root, scanErr.Path)},
 			)
 		case evidenceTaskRunSummaryVersionsParseFile:
-			return nil, newStateIntegrityError(
+			return nil, nil, newStateIntegrityError(
 				"evidence_task_existing_evidence_invalid",
 				fmt.Sprintf("failed to parse existing task evidence %q: %v", state.DisplayPath(root, scanErr.Path), scanErr.Err),
 				"Repair or remove malformed task evidence before importing task result evidence.",
@@ -2142,7 +2164,7 @@ func existingEvidenceTaskRunSummaryVersions(root, slug string) (map[int]struct{}
 				map[string]any{"path": state.DisplayPath(root, scanErr.Path)},
 			)
 		case evidenceTaskRunSummaryVersionsInvalidVersion:
-			return nil, newStateIntegrityError(
+			return nil, nil, newStateIntegrityError(
 				"evidence_task_existing_evidence_invalid",
 				fmt.Sprintf("existing task evidence %q has invalid run_summary_version %d", state.DisplayPath(root, scanErr.Path), scanErr.RunSummaryVersion),
 				"Repair or remove invalid task evidence before importing task result evidence.",
@@ -2151,7 +2173,7 @@ func existingEvidenceTaskRunSummaryVersions(root, slug string) (map[int]struct{}
 			)
 		}
 	}
-	return versions, nil
+	return versions, paths, nil
 }
 
 const (
@@ -2186,13 +2208,29 @@ func scanEvidenceTaskRunSummaryVersions(root, slug string) (map[int]struct{}, *e
 			Err:  err,
 		}
 	}
+	return runSummaryVersionsFromPaths(evidenceTaskJSONPaths(dir, entries))
+}
 
-	versions := map[int]struct{}{}
+// evidenceTaskJSONPaths projects the already-enumerated directory entries into the
+// sorted list of task-evidence file paths, preserving os.ReadDir ordering and the
+// directory/.json filtering both evidence-tasks scans applied independently before.
+func evidenceTaskJSONPaths(dir string, entries []os.DirEntry) []string {
+	paths := make([]string, 0, len(entries))
 	for _, entry := range entries {
 		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
 			continue
 		}
-		path := filepath.Join(dir, entry.Name())
+		paths = append(paths, filepath.Join(dir, entry.Name()))
+	}
+	return paths
+}
+
+// runSummaryVersionsFromPaths collects the set of run_summary_version values from
+// the given task-evidence file paths. It is the per-file version scan shared by the
+// wave-orchestration path and the single-walk result-import path.
+func runSummaryVersionsFromPaths(paths []string) (map[int]struct{}, *evidenceTaskRunSummaryVersionsError) {
+	versions := map[int]struct{}{}
+	for _, path := range paths {
 		raw, err := os.ReadFile(path) // #nosec G304 -- path is resolved from Slipway runtime evidence authority.
 		if err != nil {
 			return nil, &evidenceTaskRunSummaryVersionsError{

--- a/cmd/evidence.go
+++ b/cmd/evidence.go
@@ -727,11 +727,12 @@ func normalizeEvidenceTaskResultFileArgs(resultFiles []string) []string {
 	return normalized
 }
 
-// loadActiveChangeWithReadContext mirrors loadActiveChange but resolves the
-// change through the shared read-context, reusing the change already loaded
-// during active-ref resolution instead of reading change.yaml again uncached.
+// loadActiveChangeWithReadContext mirrors loadActiveChange but keeps the shared
+// read-context authoritative after active-ref resolution. Callers that acquire a
+// state lock after resolving the active ref must reload change.yaml here instead
+// of reusing a pre-lock cache entry.
 func loadActiveChangeWithReadContext(readCtx *stateReadContext, slug, inactiveMessage, remediation string) (model.Change, error) {
-	change, err := readCtx.loadChange(slug)
+	change, err := readCtx.reloadChange(slug)
 	if err != nil {
 		return model.Change{}, newChangeStateLoadFailedError(slug, err)
 	}

--- a/cmd/evidence_test.go
+++ b/cmd/evidence_test.go
@@ -141,3 +141,34 @@ func TestEvidenceTaskWrongStateBeforeImplement(t *testing.T) {
 		assert.Contains(t, cliErr.Remediation, "S3_REVIEW")
 	})
 }
+
+func TestEvidenceTaskActiveChangeReloadsAfterCachedRefResolution(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+		slug, change := createEvidenceTaskFixture(t, root)
+
+		readCtx := newStateReadContext(root)
+		ref, err := resolveActiveChangeRefWithReadContext(readCtx, "")
+		require.NoError(t, err)
+		require.Equal(t, slug, ref.Slug)
+
+		change.Status = model.ChangeStatusDone
+		change.CurrentState = model.StateDone
+		require.NoError(t, state.SaveChange(root, change))
+
+		_, err = loadActiveChangeWithReadContext(
+			readCtx,
+			ref.Slug,
+			"cannot record task evidence for governed status %q",
+			"Task evidence can only be recorded for an active governed change.",
+		)
+		cliErr := asCLIError(err)
+		require.NotNil(t, cliErr)
+		assert.Equal(t, "not_active", cliErr.ErrorCode)
+		assert.Equal(t, string(model.ChangeStatusDone), cliErr.Details["status"])
+		assert.Equal(t, model.ChangeStatusDone, readCtx.changes[slug].Status)
+	})
+}

--- a/internal/engine/capability/resolver.go
+++ b/internal/engine/capability/resolver.go
@@ -265,31 +265,21 @@ func collectSupports(reg *Registry, sig Signals, route *RouteSelection) []Attach
 		routeID = route.BackingID
 	}
 
-	type match struct {
-		skill Skill
-		mode  AttachmentMode
-	}
-	all := reg.All()
-	matches := make([]match, 0, len(all))
-	for _, sk := range all {
+	out := make([]Attachment, 0, 3)
+	for _, sk := range reg.All() {
+		if len(out) >= 3 {
+			break
+		}
 		if sk.ID == routeID {
 			continue
 		}
 		if mode, ok := pickSupportAttachment(sk, sig); ok {
-			matches = append(matches, match{skill: sk, mode: mode})
+			out = append(out, Attachment{
+				SkillID: sk.ID,
+				Kind:    mode,
+				Reason:  sk.Summary,
+			})
 		}
-	}
-
-	out := make([]Attachment, 0, 3)
-	for _, m := range matches {
-		if len(out) >= 3 {
-			break
-		}
-		out = append(out, Attachment{
-			SkillID: m.skill.ID,
-			Kind:    m.mode,
-			Reason:  m.skill.Summary,
-		})
 	}
 	return out
 }

--- a/internal/engine/progression/advance_governed.go
+++ b/internal/engine/progression/advance_governed.go
@@ -127,7 +127,13 @@ func AdvanceGoverned(root, slug string, opts ...AdvanceOptions) (summary Advance
 	// --changed-file, or record it as a verification/investigation kind, which is
 	// exempt). This fails closed: the block is kept, only the masking wipe is
 	// removed.
-	if target, err := scopeContractRepairTarget(root, change, executionSummaryCtx.Summary); err != nil {
+	// A single memoized workspace changed-file scan is shared by the scope-contract
+	// and sensitive-evidence repair evaluators below so this advance pass forks git
+	// at most once. The scan stays lazy: it runs only when an evaluator first needs
+	// it (inside the ExecutionSummaryReady-gated closure), so a not-ready summary or
+	// a scope-contract early-return never forks git.
+	changedFilesScan := sharedWorkspaceChangedFilesScan()
+	if target, err := scopeContractRepairTarget(root, change, executionSummaryCtx.Summary, changedFilesScan); err != nil {
 		return AdvanceSummary{}, err
 	} else if target.SkillName != "" {
 		if fromState == model.StateS2Implement {
@@ -141,7 +147,7 @@ func AdvanceGoverned(root, slug string, opts ...AdvanceOptions) (summary Advance
 		// Do not force implement/wave-orchestration to replay after review has
 		// started.
 	}
-	if target, err := sensitiveEvidenceRepairTarget(root, change, executionSummaryCtx.Summary); err != nil {
+	if target, err := sensitiveEvidenceRepairTarget(root, change, executionSummaryCtx.Summary, changedFilesScan); err != nil {
 		return AdvanceSummary{}, err
 	} else if target.SkillName != "" {
 		if fromState == model.StateS2Implement {

--- a/internal/engine/progression/authority.go
+++ b/internal/engine/progression/authority.go
@@ -60,7 +60,7 @@ func EvaluateReviewAuthority(root string, change model.Change) (ReviewAuthority,
 }
 
 func evaluateReviewAuthorityWithPolicy(root string, change model.Change, policy governance.PresetPolicy) (ReviewAuthority, error) {
-	return evaluateReviewAuthorityWithPolicyAndRecords(root, change, policy, nil)
+	return evaluateReviewAuthorityWithPolicyAndRecords(root, change, policy, nil, nil)
 }
 
 func evaluateReviewAuthorityWithPolicyAndRecords(
@@ -68,12 +68,13 @@ func evaluateReviewAuthorityWithPolicyAndRecords(
 	change model.Change,
 	policy governance.PresetPolicy,
 	verificationRecords map[string]model.VerificationRecord,
+	prebuiltSnapshot *prebuiltGovernanceSnapshot,
 ) (ReviewAuthority, error) {
 	executionSummaryCtx, err := state.LoadRelevantExecutionSummaryContext(root, change)
 	if err != nil {
 		return ReviewAuthority{}, err
 	}
-	reviewSelection, err := reviewSkillSelectionForAuthority(root, change)
+	reviewSelection, err := reviewSkillSelectionForAuthority(root, change, prebuiltSnapshot)
 	if err != nil {
 		return ReviewAuthority{}, err
 	}
@@ -169,7 +170,41 @@ func filterReviewAuthorityS3TaskPlanDriftBlockers(blockers []model.ReasonCode) [
 	return out
 }
 
-func reviewSkillSelectionForAuthority(root string, change model.Change) (engineskill.ReviewSkillSelection, error) {
+// prebuiltGovernanceSnapshot carries a governance snapshot already materialized by
+// a readiness evaluation, tagged with the change identity it was built for. The
+// review-authority path reuses it — instead of rebuilding the identical governance
+// snapshot the readiness pass already produced — only when that identity matches
+// the change being evaluated. A mismatch (a future caller threading a snapshot
+// built for a different change or lifecycle state) falls back to a fresh rebuild
+// rather than silently reusing a wrong snapshot.
+type prebuiltGovernanceSnapshot struct {
+	change   model.Change
+	snapshot model.GovernanceSnapshot
+}
+
+// reviewSelectionFor returns the review-skill selection derived from the prebuilt
+// snapshot's active controls and whether it is safe to reuse for change. Reuse is
+// gated on change identity (non-empty matching slug and identical current state);
+// a nil receiver, an untagged snapshot, or any identity mismatch reports false so
+// the caller rebuilds.
+func (p *prebuiltGovernanceSnapshot) reviewSelectionFor(change model.Change) (engineskill.ReviewSkillSelection, bool) {
+	if p == nil {
+		return engineskill.ReviewSkillSelection{}, false
+	}
+	slug := strings.TrimSpace(p.change.Slug)
+	if slug == "" || slug != strings.TrimSpace(change.Slug) {
+		return engineskill.ReviewSkillSelection{}, false
+	}
+	if p.change.CurrentState != change.CurrentState {
+		return engineskill.ReviewSkillSelection{}, false
+	}
+	return ReviewSkillSelectionFromControls(p.snapshot.ActiveControls), true
+}
+
+func reviewSkillSelectionForAuthority(root string, change model.Change, prebuiltSnapshot *prebuiltGovernanceSnapshot) (engineskill.ReviewSkillSelection, error) {
+	if selection, ok := prebuiltSnapshot.reviewSelectionFor(change); ok {
+		return selection, nil
+	}
 	paths, err := state.ResolveChangePaths(root, change)
 	if err != nil {
 		return engineskill.ReviewSkillSelection{}, err

--- a/internal/engine/progression/evidence_repair.go
+++ b/internal/engine/progression/evidence_repair.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"sync"
 
 	"github.com/signalridge/slipway/internal/engine/action"
 	"github.com/signalridge/slipway/internal/engine/governance"
@@ -388,6 +389,28 @@ func staleEvidenceAuthorityLabel(workflowState model.WorkflowState, subStep mode
 	return string(workflowState)
 }
 
+// sharedWorkspaceChangedFilesScan returns a memoized workspace changed-file scan
+// shared by the scope-contract and sensitive-evidence repair evaluators so a
+// single AdvanceGoverned pass forks git at most once instead of once per
+// evaluator. The scan runs lazily on first call — which happens inside an
+// evaluator closure, after executionSummaryRepairTarget's ExecutionSummaryReady
+// and S2-position guards — so a not-ready summary, or a scope-contract evaluator
+// that early-returns before the sensitive-evidence evaluator runs, still never
+// forks git. Both evaluators resolve identical paths (same root+change), so
+// memoizing on the paths supplied by the first call is equivalent to the
+// per-evaluator scan it replaces; only the git fork is shared, and it returns the
+// same changed slice scopeContractWorkspaceChangedFiles yields today.
+func sharedWorkspaceChangedFilesScan() func(state.ResolvedChangePaths) []string {
+	var once sync.Once
+	var changed []string
+	return func(paths state.ResolvedChangePaths) []string {
+		once.Do(func() {
+			changed = scopeContractWorkspaceChangedFiles(paths)
+		})
+		return changed
+	}
+}
+
 // scopeContractRepairTarget returns an S2_IMPLEMENT repair target when a
 // satisfied execution summary nonetheless fails the Scope Contract. The Scope
 // Contract is owned by S2_IMPLEMENT because it scores wave-execution evidence,
@@ -395,13 +418,14 @@ func staleEvidenceAuthorityLabel(workflowState model.WorkflowState, subStep mode
 // callers use this target as a blocker/review-alignment hint; this helper does not
 // mutate lifecycle state. It returns the zero target when the summary is not
 // ready, the change has not yet reached S2_IMPLEMENT, evaluation errors are
-// surfaced elsewhere, or the contract passes.
-func scopeContractRepairTarget(root string, change model.Change, summary *model.ExecutionSummary) (EvidenceRepairTarget, error) {
+// surfaced elsewhere, or the contract passes. changedFiles is the shared memoized
+// workspace scan (see sharedWorkspaceChangedFilesScan).
+func scopeContractRepairTarget(root string, change model.Change, summary *model.ExecutionSummary, changedFiles func(state.ResolvedChangePaths) []string) (EvidenceRepairTarget, error) {
 	return executionSummaryRepairTarget(root, change, summary, func(paths state.ResolvedChangePaths) []model.ReasonCode {
 		report, err := scopecontract.EvaluateBundleWithChangedFiles(
 			paths.GovernedBundleDir,
 			summary,
-			scopeContractWorkspaceChangedFiles(paths),
+			changedFiles(paths),
 		)
 		if err != nil {
 			return nil
@@ -410,9 +434,9 @@ func scopeContractRepairTarget(root string, change model.Change, summary *model.
 	})
 }
 
-func sensitiveEvidenceRepairTarget(root string, change model.Change, summary *model.ExecutionSummary) (EvidenceRepairTarget, error) {
+func sensitiveEvidenceRepairTarget(root string, change model.Change, summary *model.ExecutionSummary, changedFiles func(state.ResolvedChangePaths) []string) (EvidenceRepairTarget, error) {
 	return executionSummaryRepairTarget(root, change, summary, func(paths state.ResolvedChangePaths) []model.ReasonCode {
-		return sensitiveevidence.Evaluate(summary, scopeContractWorkspaceChangedFiles(paths)).Blockers
+		return sensitiveevidence.Evaluate(summary, changedFiles(paths)).Blockers
 	})
 }
 

--- a/internal/engine/progression/readiness.go
+++ b/internal/engine/progression/readiness.go
@@ -339,11 +339,17 @@ func evaluateGovernanceReadinessBaseWithReaders(
 	}
 
 	if opts.IncludeReviewSurface || effectiveState == model.StateS3Review {
+		// Thread the governance snapshot already built above (snap) into the
+		// review-authority path so it reuses the same ActiveControls/review
+		// selection instead of rebuilding an identical snapshot. It is tagged with
+		// evaluationChange — the exact change/bundle the authority path would
+		// otherwise re-resolve — so reuse only happens on an identity match.
 		reviewSurface, err := evaluateReviewAuthorityWithPolicyAndRecords(
 			root,
 			evaluationChange,
 			policy,
 			verificationRecords,
+			&prebuiltGovernanceSnapshot{change: evaluationChange, snapshot: snap},
 		)
 		if err != nil {
 			return GovernanceReadiness{}, err
@@ -485,7 +491,12 @@ func (r GovernanceReadiness) cachedReviewAuthority() (ReviewAuthority, bool) {
 	return ReviewAuthority{}, false
 }
 
-func previewGovernanceSnapshotForReadiness(
+// previewGovernanceSnapshotForReadiness materializes the read-only governance
+// snapshot shared across the readiness surfaces. It is a package-level var (like
+// the applyGovernedFileTransaction/appendLifecycleEvent seams) so tests can count
+// how many times a single readiness evaluation builds the snapshot and assert the
+// readiness->review-authority path reuses it rather than rebuilding.
+var previewGovernanceSnapshotForReadiness = func(
 	root string,
 	change model.Change,
 	bundleDir string,

--- a/internal/engine/progression/readiness_optimization_test.go
+++ b/internal/engine/progression/readiness_optimization_test.go
@@ -784,3 +784,99 @@ func gitForReadinessOptimizationTests(t *testing.T, root string, args ...string)
 	out, err := cmd.CombinedOutput()
 	require.NoErrorf(t, err, "git %v failed: %s", args, string(out))
 }
+
+// installSnapshotBuildCounter wraps the package-level governance-snapshot builder
+// seam with a counter and returns a pointer to the count. The original builder is
+// restored on cleanup. Callers must NOT run in parallel: swapping the shared seam
+// is only race-free during the sequential (non-parallel) test phase.
+func installSnapshotBuildCounter(t *testing.T) *int {
+	t.Helper()
+
+	original := previewGovernanceSnapshotForReadiness
+	t.Cleanup(func() { previewGovernanceSnapshotForReadiness = original })
+
+	var builds int
+	previewGovernanceSnapshotForReadiness = func(root string, change model.Change, bundleDir string) (model.GovernanceSnapshot, error) {
+		builds++
+		return original(root, change, bundleDir)
+	}
+	return &builds
+}
+
+func TestEvaluateGovernanceReadinessBuildsGovernanceSnapshotOnceThroughReviewAuthority(t *testing.T) {
+	// No t.Parallel(): this test swaps the package-level snapshot-builder seam to
+	// count materializations, so it must run in the non-parallel phase.
+	root := t.TempDir()
+	initGitWorkspaceForReadinessOptimizationTests(t, root)
+	require.NoError(t, bootstrap.InitWorkspace(root, nil, false))
+
+	change := model.NewChange("readiness-authority-snapshot-once")
+	change.CurrentState = model.StateS3Review
+	require.NoError(t, state.SaveChange(root, change))
+
+	builds := installSnapshotBuildCounter(t)
+
+	readiness, err := EvaluateGovernanceReadiness(root, change, GovernanceReadinessOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, *builds,
+		"S3 readiness must build the governance snapshot exactly once and thread it into the review-authority path instead of rebuilding it")
+
+	reused, ok := readiness.cachedReviewAuthority()
+	require.True(t, ok, "S3 readiness must cache the review authority built from the threaded snapshot")
+
+	// The autopass path (EvaluateReviewAuthority, nil prebuilt) must still rebuild
+	// the snapshot and produce an identical authority outcome, proving the reuse
+	// optimization is observably behavior-preserving.
+	*builds = 0
+	rebuilt, err := EvaluateReviewAuthority(root, change)
+	require.NoError(t, err)
+	assert.Positive(t, *builds,
+		"EvaluateReviewAuthority (autopass path) must rebuild the snapshot when no prebuilt snapshot is threaded (nil => rebuild)")
+
+	assert.ElementsMatch(t, rebuilt.SelectedReviewSkills, reused.SelectedReviewSkills,
+		"reused-snapshot selected review skills must match the rebuilt selection")
+	assert.ElementsMatch(t, rebuilt.Blockers, reused.Blockers,
+		"reused-snapshot review authority outcome must match the rebuilt outcome")
+}
+
+func TestReviewAuthorityReusesPrebuiltSnapshotOnlyOnChangeIdentityMatch(t *testing.T) {
+	// No t.Parallel(): swaps the package-level snapshot-builder seam.
+	root := t.TempDir()
+	initGitWorkspaceForReadinessOptimizationTests(t, root)
+	require.NoError(t, bootstrap.InitWorkspace(root, nil, false))
+
+	change := model.NewChange("review-authority-prebuilt-identity-guard")
+	change.CurrentState = model.StateS3Review
+	require.NoError(t, state.SaveChange(root, change))
+
+	policy, err := governance.ResolvePresetPolicy(root, change)
+	require.NoError(t, err)
+	paths, err := state.ResolveChangePaths(root, change)
+	require.NoError(t, err)
+	snap, err := governance.PreviewGovernanceSnapshot(root, change, paths.GovernedBundleDir)
+	require.NoError(t, err)
+
+	builds := installSnapshotBuildCounter(t)
+
+	// Matching change identity => reuse, no rebuild.
+	*builds = 0
+	matched, err := evaluateReviewAuthorityWithPolicyAndRecords(root, change, policy, nil,
+		&prebuiltGovernanceSnapshot{change: change, snapshot: snap})
+	require.NoError(t, err)
+	assert.Zero(t, *builds,
+		"a prebuilt snapshot matching the change identity must be reused without rebuilding the governance snapshot")
+
+	// Mismatched change identity => fall back to a rebuild rather than silently
+	// reusing a snapshot built for a different change.
+	*builds = 0
+	fallback, err := evaluateReviewAuthorityWithPolicyAndRecords(root, change, policy, nil,
+		&prebuiltGovernanceSnapshot{change: model.NewChange("some-other-change"), snapshot: model.GovernanceSnapshot{}})
+	require.NoError(t, err)
+	assert.Positive(t, *builds,
+		"a prebuilt snapshot for a different change must fall back to a rebuild, not be silently reused")
+
+	assert.ElementsMatch(t, fallback.SelectedReviewSkills, matched.SelectedReviewSkills,
+		"reused-snapshot selection must equal the rebuilt selection")
+	assert.ElementsMatch(t, fallback.Blockers, matched.Blockers,
+		"reused-snapshot review authority outcome must equal the rebuilt outcome")
+}

--- a/internal/engine/progression/scope_contract_gate_test.go
+++ b/internal/engine/progression/scope_contract_gate_test.go
@@ -53,7 +53,7 @@ func TestScopeContractRepairTargetReturnsS2RepairWhenChangedFilesMissing(t *test
 	t.Parallel()
 	root, change := seedScopeContractChange(t, model.StateS3Review)
 
-	target, err := scopeContractRepairTarget(root, change, codeTaskSummary(nil))
+	target, err := scopeContractRepairTarget(root, change, codeTaskSummary(nil), sharedWorkspaceChangedFilesScan())
 	require.NoError(t, err)
 
 	assert.Equal(t, SkillWaveOrchestration, target.SkillName)
@@ -74,7 +74,7 @@ func TestScopeContractRepairTargetEmptyWhenContractSatisfied(t *testing.T) {
 	t.Parallel()
 	root, change := seedScopeContractChange(t, model.StateS3Review)
 
-	target, err := scopeContractRepairTarget(root, change, codeTaskSummary([]string{"cmd/next.go"}))
+	target, err := scopeContractRepairTarget(root, change, codeTaskSummary([]string{"cmd/next.go"}), sharedWorkspaceChangedFilesScan())
 	require.NoError(t, err)
 	assert.Empty(t, target.SkillName, "a satisfied scope contract must not trigger a repair")
 }
@@ -84,7 +84,7 @@ func TestScopeContractRepairTargetEmptyWhenSummaryNotReady(t *testing.T) {
 	t.Parallel()
 	root, change := seedScopeContractChange(t, model.StateS3Review)
 
-	target, err := scopeContractRepairTarget(root, change, nil)
+	target, err := scopeContractRepairTarget(root, change, nil, sharedWorkspaceChangedFilesScan())
 	require.NoError(t, err)
 	assert.Empty(t, target.SkillName, "no repair without a ready execution summary")
 }
@@ -101,7 +101,7 @@ func TestScopeContractRepairTargetRoutesDriftToS2Repair(t *testing.T) {
 
 	// task-a is planned for cmd/next.go but records a changed file outside that
 	// scope, so the only contract failure is out-of-scope drift.
-	target, err := scopeContractRepairTarget(root, change, codeTaskSummary([]string{"scratch.txt"}))
+	target, err := scopeContractRepairTarget(root, change, codeTaskSummary([]string{"scratch.txt"}), sharedWorkspaceChangedFilesScan())
 	require.NoError(t, err)
 
 	assert.Equal(t, SkillWaveOrchestration, target.SkillName)
@@ -121,7 +121,7 @@ func TestSensitiveEvidenceRepairTargetReturnsS2RepairWhenMarkerMissing(t *testin
 
 	root, change := seedSensitiveEvidenceExecution(t, model.StateS3Review, "go-test:./...")
 
-	target, err := sensitiveEvidenceRepairTarget(root, change, sensitiveMigrationSummary("go-test:./..."))
+	target, err := sensitiveEvidenceRepairTarget(root, change, sensitiveMigrationSummary("go-test:./..."), sharedWorkspaceChangedFilesScan())
 	require.NoError(t, err)
 
 	assert.Equal(t, SkillWaveOrchestration, target.SkillName)
@@ -182,7 +182,7 @@ func TestSensitiveEvidenceRepairTargetEmptyWhenMarkerPresent(t *testing.T) {
 
 	root, change := seedSensitiveEvidenceExecution(t, model.StateS3Review, "migration-applied:goose up")
 
-	target, err := sensitiveEvidenceRepairTarget(root, change, sensitiveMigrationSummary("migration-applied:goose up"))
+	target, err := sensitiveEvidenceRepairTarget(root, change, sensitiveMigrationSummary("migration-applied:goose up"), sharedWorkspaceChangedFilesScan())
 	require.NoError(t, err)
 	assert.Empty(t, target.SkillName, "matching sensitive evidence must not trigger a repair")
 }

--- a/internal/state/execution_repair.go
+++ b/internal/state/execution_repair.go
@@ -178,11 +178,7 @@ func wavePlanRepairHint() string {
 }
 
 func wavePlanRepairDrift(root string, change model.Change, plan model.WavePlan, summary *model.ExecutionSummary) (bool, bool, error) {
-	currentStructuralHash, err := CurrentTasksPlanStructuralState(root, change)
-	if err != nil {
-		return false, false, err
-	}
-	currentScopeHash, err := CurrentTasksPlanScopeState(root, change)
+	currentStructuralHash, currentScopeHash, err := currentTasksPlanStructuralAndScopeState(root, change)
 	if err != nil {
 		return false, false, err
 	}

--- a/internal/state/execution_summary.go
+++ b/internal/state/execution_summary.go
@@ -624,9 +624,13 @@ func stalePlanningPairs(root string, change model.Change, summary *model.Executi
 
 	sources := []stalePlanningSource{}
 	tasksPath := filepath.Join(bundleDir, "tasks.md")
+	// One tasks.md read+parse yields both hashes; the scope value is still only
+	// consulted under the !tasksPlanDrift branch below, unchanged. currentErr is
+	// the same error either public accessor would have returned.
+	currentStructuralHash, currentScopeHash, currentErr := currentTasksPlanStructuralAndScopeState(root, change)
 	tasksPlanDrift := false
-	if currentHash, err := CurrentTasksPlanStructuralState(root, change); err == nil {
-		if strings.TrimSpace(summary.TasksPlanHash) != "" && currentHash != strings.TrimSpace(summary.TasksPlanHash) {
+	if currentErr == nil {
+		if strings.TrimSpace(summary.TasksPlanHash) != "" && currentStructuralHash != strings.TrimSpace(summary.TasksPlanHash) {
 			tasksPlanDrift = true
 			sources = append(sources, stalePlanningSource{
 				path:       tasksPath,
@@ -641,14 +645,13 @@ func stalePlanningPairs(root string, change model.Change, summary *model.Executi
 		})
 	}
 	if !tasksPlanDrift {
-		currentScopeHash, currentScopeErr := CurrentTasksPlanScopeState(root, change)
 		storedScopeHash, hasStoredScopeHash, storedScopeErr := storedTasksPlanScopeHash(root, change)
-		if currentScopeErr == nil && storedScopeErr == nil && hasStoredScopeHash && currentScopeHash != storedScopeHash {
+		if currentErr == nil && storedScopeErr == nil && hasStoredScopeHash && currentScopeHash != storedScopeHash {
 			sources = append(sources, stalePlanningSource{
 				path:       tasksPath,
 				nextAction: "rerun wave-orchestration so Slipway derives the current wave projection and refreshes execution-summary.yaml",
 			})
-		} else if currentScopeErr != nil && storedScopeErr == nil && hasStoredScopeHash {
+		} else if currentErr != nil && storedScopeErr == nil && hasStoredScopeHash {
 			sources = append(sources, stalePlanningSource{
 				path:       tasksPath,
 				nextAction: "restore readable tasks.md, then rerun wave-orchestration to refresh execution-summary.yaml",

--- a/internal/state/wave_execution.go
+++ b/internal/state/wave_execution.go
@@ -256,6 +256,19 @@ func CurrentTasksPlanScopeState(root string, change model.Change) (string, error
 	return hashes.Scope, err
 }
 
+// currentTasksPlanStructuralAndScopeState returns both the structural and scope
+// state from a single tasks.md read+parse. In-package callers that need both
+// (execution-repair drift, stale-planning diagnostics) use this instead of
+// calling CurrentTasksPlanStructuralState and CurrentTasksPlanScopeState
+// back-to-back, which would read and parse tasks.md twice. The public
+// single-value accessors are unchanged for external callers. On failure the
+// error is identical to what either public accessor returns, since both derive
+// from currentTaskPlanHashesAndNodes.
+func currentTasksPlanStructuralAndScopeState(root string, change model.Change) (structural, scope string, err error) {
+	hashes, _, err := currentTaskPlanHashesAndNodes(root, change)
+	return hashes.Structural, hashes.Scope, err
+}
+
 // CurrentTasksPlanTaskIDs returns the task IDs declared by the current tasks.md,
 // in dependency-projected order. It is the authority for "what tasks does the
 // plan name now", independent of the last-materialized wave-plan.yaml cache, so
@@ -349,19 +362,42 @@ func LoadWaveRuns(root, slug string, runVersion int) ([]model.WaveRun, error) {
 		if err != nil {
 			return nil, err
 		}
-		evidenceRunVersion, err := waveEvidenceRunVersion(raw)
-		if err != nil {
-			return nil, fmt.Errorf("classify wave run %q: %w", path, err)
+		// Single decode on the common path: strict known-fields decode FIRST, then
+		// classify by the decoded run_summary_version. yaml.v3 KnownFields is a
+		// decoder-level setting and cannot be re-applied after a lenient decode, so
+		// strict-first is the only order that preserves the previous
+		// probe-then-strict behavior without reading the file twice for every
+		// well-formed run.
+		var run model.WaveRun
+		strictErr := decodeYAMLKnownFields(raw, &run)
+		if strictErr == nil {
+			// Clean, known-fields file: the decoded version drives classification,
+			// reproducing the run_summary_version<1 hard error and the
+			// non-matching-version skip exactly as the removed version probe did. A
+			// clean non-matching-version file MUST be skipped, never included.
+			if run.RunSummaryVersion < 1 {
+				return nil, fmt.Errorf("classify wave run %q: %w", path, errWaveRunSummaryVersionRequired)
+			}
+			if run.RunSummaryVersion != runVersion {
+				continue
+			}
+			run.Normalize()
+			runs = append(runs, run)
+			continue
+		}
+		// Strict decode failed. Fall back to a lenient one-field version probe to
+		// decide skip-vs-surface: a foreign/non-matching-version run is skipped
+		// without surfacing the strict error, while a matching-version run with an
+		// unknown field still surfaces it. A probe error (unparseable YAML or
+		// run_summary_version<1) reproduces the previous classify-stage error.
+		evidenceRunVersion, probeErr := waveEvidenceRunVersion(raw)
+		if probeErr != nil {
+			return nil, fmt.Errorf("classify wave run %q: %w", path, probeErr)
 		}
 		if evidenceRunVersion != runVersion {
 			continue
 		}
-		var run model.WaveRun
-		if err := decodeYAMLKnownFields(raw, &run); err != nil {
-			return nil, fmt.Errorf("parse wave run %q: %w", path, err)
-		}
-		run.Normalize()
-		runs = append(runs, run)
+		return nil, fmt.Errorf("parse wave run %q: %w", path, strictErr)
 	}
 	for i := range runs {
 		if err := runs[i].Validate(i + 1); err != nil {
@@ -371,6 +407,12 @@ func LoadWaveRuns(root, slug string, runVersion int) ([]model.WaveRun, error) {
 	return runs, nil
 }
 
+// errWaveRunSummaryVersionRequired is the shared classification error for a wave
+// run whose run_summary_version is absent or < 1. LoadWaveRuns reproduces it on
+// both the strict-decode-success path and the lenient version-probe fallback so
+// the two paths surface an identical wrapped error.
+var errWaveRunSummaryVersionRequired = errors.New("run_summary_version is required")
+
 func waveEvidenceRunVersion(raw []byte) (int, error) {
 	var payload struct {
 		RunSummaryVersion int `yaml:"run_summary_version"`
@@ -379,7 +421,7 @@ func waveEvidenceRunVersion(raw []byte) (int, error) {
 		return 0, fmt.Errorf("parse wave run: %w", err)
 	}
 	if payload.RunSummaryVersion < 1 {
-		return 0, fmt.Errorf("run_summary_version is required")
+		return 0, errWaveRunSummaryVersionRequired
 	}
 	return payload.RunSummaryVersion, nil
 }

--- a/internal/state/wave_execution_test.go
+++ b/internal/state/wave_execution_test.go
@@ -44,6 +44,79 @@ task_runs:
 	assert.Equal(t, "task-b", runs[0].TaskRuns[0].TaskID)
 }
 
+// TestLoadWaveRunsStrictFirstMixedVersionClassification pins the strict-decode-first
+// classification order: a clean non-matching-version file (and a foreign
+// unknown-field file at a non-matching version) is skipped without surfacing a
+// strict decode error, while a matching-version file with an unknown field still
+// errors, and a run_summary_version < 1 file still hard-errors with the same
+// "classify wave run ...: run_summary_version is required" wrapping.
+func TestLoadWaveRunsStrictFirstMixedVersionClassification(t *testing.T) {
+	t.Parallel()
+
+	const runVersion = 2
+
+	newDir := func(t *testing.T, slug string) (string, string) {
+		t.Helper()
+		root := t.TempDir()
+		dir := WaveEvidenceDir(root, slug)
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		return root, dir
+	}
+	writeRun := func(t *testing.T, dir, name, body string) {
+		t.Helper()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644))
+	}
+
+	t.Run("clean non-matching-version file is skipped not errored", func(t *testing.T) {
+		t.Parallel()
+		root, dir := newDir(t, "wave-strict-skip-clean")
+		// Clean, known-fields-only file at a different run version: it strict-decodes
+		// fine and MUST be skipped, never included alongside the matching run.
+		writeRun(t, dir, "wave-old.yaml", "wave_index: 1\nrun_summary_version: 1\nverdict: pass\n")
+		writeRun(t, dir, "wave-01.yaml", "wave_index: 1\nrun_summary_version: 2\nverdict: pass\n")
+
+		runs, err := LoadWaveRuns(root, "wave-strict-skip-clean", runVersion)
+		require.NoError(t, err)
+		require.Len(t, runs, 1)
+		assert.Equal(t, runVersion, runs[0].RunSummaryVersion)
+	})
+
+	t.Run("foreign non-matching-version file is skipped without surfacing strict error", func(t *testing.T) {
+		t.Parallel()
+		root, dir := newDir(t, "wave-strict-skip-foreign")
+		// Unknown-field ("foreign") run at a non-matching version: the strict decode
+		// fails, but the lenient version probe skips it just as the previous
+		// probe-first classification did. The strict error must NOT surface.
+		writeRun(t, dir, "wave-foreign.yaml", "wave_index: 1\nrun_summary_version: 1\nverdict: pass\nunknown_field: nope\n")
+
+		runs, err := LoadWaveRuns(root, "wave-strict-skip-foreign", runVersion)
+		require.NoError(t, err)
+		require.Empty(t, runs)
+	})
+
+	t.Run("matching-version file with unknown field still errors", func(t *testing.T) {
+		t.Parallel()
+		root, dir := newDir(t, "wave-strict-unknown-field")
+		writeRun(t, dir, "wave-01.yaml", "wave_index: 1\nrun_summary_version: 2\nverdict: pass\nunknown_field: nope\n")
+
+		_, err := LoadWaveRuns(root, "wave-strict-unknown-field", runVersion)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "parse wave run")
+		assert.Contains(t, err.Error(), "unknown_field", "a matching-version unknown field surfaces the strict decode error")
+	})
+
+	t.Run("run_summary_version below one hard-errors with classify wrapping", func(t *testing.T) {
+		t.Parallel()
+		root, dir := newDir(t, "wave-strict-version-zero")
+		writeRun(t, dir, "wave-01.yaml", "wave_index: 1\nrun_summary_version: 0\nverdict: pass\n")
+
+		_, err := LoadWaveRuns(root, "wave-strict-version-zero", runVersion)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "classify wave run")
+		assert.Contains(t, err.Error(), "run_summary_version is required")
+	})
+}
+
 func TestOrphanTaskEvidenceIgnoresPreviousRunVersionEvidence(t *testing.T) {
 	t.Parallel()
 

--- a/internal/state/worktree.go
+++ b/internal/state/worktree.go
@@ -786,14 +786,23 @@ func cloneWorktreeRecords(in []gitWorktreeRecord) []gitWorktreeRecord {
 	return out
 }
 
+type normalizePathCacheEntry struct {
+	once     sync.Once
+	value    string
+	resolved bool
+}
+
 // normalizePathCache memoizes successful filepath.EvalSymlinks resolutions so
-// NormalizePath performs the syscall at most once per distinct absolute path
-// per process. The key is the post-filepath.Abs absolute path (cwd-independent)
-// and the value is the cleaned resolved path (a string). Only successful
-// resolutions are cached: on EvalSymlinks failure NormalizePath falls back to
-// the absolute path exactly as before and caches nothing, so a path that later
-// becomes resolvable is still re-resolved. sync.Map is safe for concurrent use.
+// NormalizePath performs the syscall at most once per distinct absolute path per
+// process invocation. The key is the post-filepath.Abs absolute path
+// (cwd-independent) and the value is the cleaned resolved path. Only successful
+// resolutions are retained: on EvalSymlinks failure NormalizePath falls back to
+// the cleaned absolute path and drops the entry, so a path that later becomes
+// resolvable is still re-resolved. sync.Map is safe for concurrent use; sync.Once
+// on each entry deduplicates concurrent first callers for the same path.
 var normalizePathCache sync.Map
+
+var normalizePathEvalSymlinks = filepath.EvalSymlinks
 
 // NormalizePath resolves a path to its canonical absolute form with symlink resolution.
 // Used for worktree path comparison across the codebase.
@@ -802,13 +811,21 @@ func NormalizePath(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if cached, ok := normalizePathCache.Load(abs); ok {
-		return cached.(string), nil
+	entryAny, _ := normalizePathCache.LoadOrStore(abs, &normalizePathCacheEntry{})
+	entry := entryAny.(*normalizePathCacheEntry)
+	entry.once.Do(func() {
+		if real, err := normalizePathEvalSymlinks(abs); err == nil {
+			entry.value = filepath.Clean(real)
+			entry.resolved = true
+			return
+		}
+		entry.value = filepath.Clean(abs)
+	})
+	if !entry.resolved {
+		// EvalSymlinks failed: don't retain the unresolved fallback, so a path
+		// that later becomes resolvable (e.g. a worktree created after this
+		// call) is re-resolved instead of returning a stale unresolved value.
+		normalizePathCache.CompareAndDelete(abs, entry)
 	}
-	if real, err := filepath.EvalSymlinks(abs); err == nil {
-		resolved := filepath.Clean(real)
-		normalizePathCache.Store(abs, resolved)
-		return resolved, nil
-	}
-	return filepath.Clean(abs), nil
+	return entry.value, nil
 }

--- a/internal/state/worktree.go
+++ b/internal/state/worktree.go
@@ -786,6 +786,15 @@ func cloneWorktreeRecords(in []gitWorktreeRecord) []gitWorktreeRecord {
 	return out
 }
 
+// normalizePathCache memoizes successful filepath.EvalSymlinks resolutions so
+// NormalizePath performs the syscall at most once per distinct absolute path
+// per process. The key is the post-filepath.Abs absolute path (cwd-independent)
+// and the value is the cleaned resolved path (a string). Only successful
+// resolutions are cached: on EvalSymlinks failure NormalizePath falls back to
+// the absolute path exactly as before and caches nothing, so a path that later
+// becomes resolvable is still re-resolved. sync.Map is safe for concurrent use.
+var normalizePathCache sync.Map
+
 // NormalizePath resolves a path to its canonical absolute form with symlink resolution.
 // Used for worktree path comparison across the codebase.
 func NormalizePath(path string) (string, error) {
@@ -793,8 +802,13 @@ func NormalizePath(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if cached, ok := normalizePathCache.Load(abs); ok {
+		return cached.(string), nil
+	}
 	if real, err := filepath.EvalSymlinks(abs); err == nil {
-		abs = real
+		resolved := filepath.Clean(real)
+		normalizePathCache.Store(abs, resolved)
+		return resolved, nil
 	}
 	return filepath.Clean(abs), nil
 }

--- a/internal/state/worktree.go
+++ b/internal/state/worktree.go
@@ -787,19 +787,16 @@ func cloneWorktreeRecords(in []gitWorktreeRecord) []gitWorktreeRecord {
 }
 
 type normalizePathCacheEntry struct {
-	once     sync.Once
-	value    string
-	resolved bool
+	once  sync.Once
+	value string
 }
 
-// normalizePathCache memoizes successful filepath.EvalSymlinks resolutions so
-// NormalizePath performs the syscall at most once per distinct absolute path per
-// process invocation. The key is the post-filepath.Abs absolute path
-// (cwd-independent) and the value is the cleaned resolved path. Only successful
-// resolutions are retained: on EvalSymlinks failure NormalizePath falls back to
-// the cleaned absolute path and drops the entry, so a path that later becomes
-// resolvable is still re-resolved. sync.Map is safe for concurrent use; sync.Once
-// on each entry deduplicates concurrent first callers for the same path.
+// normalizePathCache memoizes filepath.EvalSymlinks results so NormalizePath
+// performs the syscall at most once per distinct absolute path per process
+// invocation. The key is the post-filepath.Abs absolute path (cwd-independent)
+// and the value is the cleaned resolved path, or the cleaned absolute fallback
+// when EvalSymlinks fails. sync.Map is safe for concurrent use; sync.Once on
+// each entry deduplicates concurrent first callers for the same path.
 var normalizePathCache sync.Map
 
 var normalizePathEvalSymlinks = filepath.EvalSymlinks
@@ -816,16 +813,9 @@ func NormalizePath(path string) (string, error) {
 	entry.once.Do(func() {
 		if real, err := normalizePathEvalSymlinks(abs); err == nil {
 			entry.value = filepath.Clean(real)
-			entry.resolved = true
 			return
 		}
 		entry.value = filepath.Clean(abs)
 	})
-	if !entry.resolved {
-		// EvalSymlinks failed: don't retain the unresolved fallback, so a path
-		// that later becomes resolvable (e.g. a worktree created after this
-		// call) is re-resolved instead of returning a stale unresolved value.
-		normalizePathCache.CompareAndDelete(abs, entry)
-	}
 	return entry.value, nil
 }

--- a/internal/state/worktree.go
+++ b/internal/state/worktree.go
@@ -787,16 +787,19 @@ func cloneWorktreeRecords(in []gitWorktreeRecord) []gitWorktreeRecord {
 }
 
 type normalizePathCacheEntry struct {
-	once  sync.Once
-	value string
+	once     sync.Once
+	value    string
+	resolved bool
 }
 
-// normalizePathCache memoizes filepath.EvalSymlinks results so NormalizePath
-// performs the syscall at most once per distinct absolute path per process
-// invocation. The key is the post-filepath.Abs absolute path (cwd-independent)
-// and the value is the cleaned resolved path, or the cleaned absolute fallback
-// when EvalSymlinks fails. sync.Map is safe for concurrent use; sync.Once on
-// each entry deduplicates concurrent first callers for the same path.
+// normalizePathCache memoizes successful filepath.EvalSymlinks resolutions so
+// NormalizePath performs the syscall at most once per distinct absolute path per
+// process invocation. The key is the post-filepath.Abs absolute path
+// (cwd-independent) and the value is the cleaned resolved path. Only successful
+// resolutions are retained: on EvalSymlinks failure NormalizePath falls back to
+// the cleaned absolute path and drops the entry, so a path that later becomes
+// resolvable is still re-resolved. sync.Map is safe for concurrent use; sync.Once
+// on each entry deduplicates concurrent first callers for the same path.
 var normalizePathCache sync.Map
 
 var normalizePathEvalSymlinks = filepath.EvalSymlinks
@@ -813,9 +816,16 @@ func NormalizePath(path string) (string, error) {
 	entry.once.Do(func() {
 		if real, err := normalizePathEvalSymlinks(abs); err == nil {
 			entry.value = filepath.Clean(real)
+			entry.resolved = true
 			return
 		}
 		entry.value = filepath.Clean(abs)
 	})
+	if !entry.resolved {
+		// EvalSymlinks failed: don't retain the unresolved fallback, so a path
+		// that later becomes resolvable (e.g. a worktree created after this
+		// call) is re-resolved instead of returning a stale unresolved value.
+		normalizePathCache.CompareAndDelete(abs, entry)
+	}
 	return entry.value, nil
 }

--- a/internal/state/worktree_test.go
+++ b/internal/state/worktree_test.go
@@ -44,47 +44,28 @@ func resetNormalizePathTestState(t *testing.T) {
 	})
 }
 
-func TestNormalizePathDoesNotCacheFallbackOnEvalSymlinksError(t *testing.T) {
+func TestNormalizePathCachesFallbackOnEvalSymlinksError(t *testing.T) {
 	resetNormalizePathTestState(t)
 
 	path := filepath.Join(t.TempDir(), "missing", "path")
 	abs, err := filepath.Abs(path)
 	require.NoError(t, err)
 
-	resolved := filepath.Clean(filepath.Join(abs, "resolved"))
 	var calls int
-	fail := true
 	normalizePathEvalSymlinks = func(got string) (string, error) {
 		calls++
 		assert.Equal(t, abs, got)
-		if fail {
-			return "", os.ErrNotExist
-		}
-		return resolved, nil
+		return "", os.ErrNotExist
 	}
 
-	// While EvalSymlinks fails, NormalizePath returns the cleaned absolute
-	// fallback but must not cache it: every call re-resolves.
 	first, err := NormalizePath(path)
 	require.NoError(t, err)
 	second, err := NormalizePath(path)
 	require.NoError(t, err)
+
 	assert.Equal(t, filepath.Clean(abs), first)
-	assert.Equal(t, filepath.Clean(abs), second)
-	assert.Equal(t, 2, calls)
-
-	// Once the path becomes resolvable, the next call picks up the real value
-	// (proving no stale unresolved entry was cached) and caches it thereafter.
-	fail = false
-	third, err := NormalizePath(path)
-	require.NoError(t, err)
-	assert.Equal(t, resolved, third)
-	assert.Equal(t, 3, calls)
-
-	fourth, err := NormalizePath(path)
-	require.NoError(t, err)
-	assert.Equal(t, resolved, fourth)
-	assert.Equal(t, 3, calls)
+	assert.Equal(t, first, second)
+	assert.Equal(t, 1, calls)
 }
 
 func TestNormalizePathDeduplicatesConcurrentFirstCallers(t *testing.T) {

--- a/internal/state/worktree_test.go
+++ b/internal/state/worktree_test.go
@@ -44,28 +44,47 @@ func resetNormalizePathTestState(t *testing.T) {
 	})
 }
 
-func TestNormalizePathCachesFallbackOnEvalSymlinksError(t *testing.T) {
+func TestNormalizePathDoesNotCacheFallbackOnEvalSymlinksError(t *testing.T) {
 	resetNormalizePathTestState(t)
 
 	path := filepath.Join(t.TempDir(), "missing", "path")
 	abs, err := filepath.Abs(path)
 	require.NoError(t, err)
 
+	resolved := filepath.Clean(filepath.Join(abs, "resolved"))
 	var calls int
+	fail := true
 	normalizePathEvalSymlinks = func(got string) (string, error) {
 		calls++
 		assert.Equal(t, abs, got)
-		return "", os.ErrNotExist
+		if fail {
+			return "", os.ErrNotExist
+		}
+		return resolved, nil
 	}
 
+	// While EvalSymlinks fails, NormalizePath returns the cleaned absolute
+	// fallback but must not cache it: every call re-resolves.
 	first, err := NormalizePath(path)
 	require.NoError(t, err)
 	second, err := NormalizePath(path)
 	require.NoError(t, err)
-
 	assert.Equal(t, filepath.Clean(abs), first)
-	assert.Equal(t, first, second)
-	assert.Equal(t, 1, calls)
+	assert.Equal(t, filepath.Clean(abs), second)
+	assert.Equal(t, 2, calls)
+
+	// Once the path becomes resolvable, the next call picks up the real value
+	// (proving no stale unresolved entry was cached) and caches it thereafter.
+	fail = false
+	third, err := NormalizePath(path)
+	require.NoError(t, err)
+	assert.Equal(t, resolved, third)
+	assert.Equal(t, 3, calls)
+
+	fourth, err := NormalizePath(path)
+	require.NoError(t, err)
+	assert.Equal(t, resolved, fourth)
+	assert.Equal(t, 3, calls)
 }
 
 func TestNormalizePathDeduplicatesConcurrentFirstCallers(t *testing.T) {

--- a/internal/state/worktree_test.go
+++ b/internal/state/worktree_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -28,6 +30,120 @@ func recordsContainPath(records []gitWorktreeRecord, path string) bool {
 		}
 	}
 	return false
+}
+
+func resetNormalizePathTestState(t *testing.T) {
+	t.Helper()
+
+	oldEvalSymlinks := normalizePathEvalSymlinks
+	normalizePathCache = sync.Map{}
+	normalizePathEvalSymlinks = filepath.EvalSymlinks
+	t.Cleanup(func() {
+		normalizePathCache = sync.Map{}
+		normalizePathEvalSymlinks = oldEvalSymlinks
+	})
+}
+
+func TestNormalizePathDoesNotCacheFallbackOnEvalSymlinksError(t *testing.T) {
+	resetNormalizePathTestState(t)
+
+	path := filepath.Join(t.TempDir(), "missing", "path")
+	abs, err := filepath.Abs(path)
+	require.NoError(t, err)
+
+	resolved := filepath.Clean(filepath.Join(abs, "resolved"))
+	var calls int
+	fail := true
+	normalizePathEvalSymlinks = func(got string) (string, error) {
+		calls++
+		assert.Equal(t, abs, got)
+		if fail {
+			return "", os.ErrNotExist
+		}
+		return resolved, nil
+	}
+
+	// While EvalSymlinks fails, NormalizePath returns the cleaned absolute
+	// fallback but must not cache it: every call re-resolves.
+	first, err := NormalizePath(path)
+	require.NoError(t, err)
+	second, err := NormalizePath(path)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Clean(abs), first)
+	assert.Equal(t, filepath.Clean(abs), second)
+	assert.Equal(t, 2, calls)
+
+	// Once the path becomes resolvable, the next call picks up the real value
+	// (proving no stale unresolved entry was cached) and caches it thereafter.
+	fail = false
+	third, err := NormalizePath(path)
+	require.NoError(t, err)
+	assert.Equal(t, resolved, third)
+	assert.Equal(t, 3, calls)
+
+	fourth, err := NormalizePath(path)
+	require.NoError(t, err)
+	assert.Equal(t, resolved, fourth)
+	assert.Equal(t, 3, calls)
+}
+
+func TestNormalizePathDeduplicatesConcurrentFirstCallers(t *testing.T) {
+	resetNormalizePathTestState(t)
+
+	path := filepath.Join(t.TempDir(), "target")
+	require.NoError(t, os.MkdirAll(path, 0o755))
+	abs, err := filepath.Abs(path)
+	require.NoError(t, err)
+
+	var calls atomic.Int64
+	var startedOnce sync.Once
+	started := make(chan struct{})
+	release := make(chan struct{})
+	normalizePathEvalSymlinks = func(got string) (string, error) {
+		calls.Add(1)
+		if got != abs {
+			return "", os.ErrInvalid
+		}
+		startedOnce.Do(func() {
+			close(started)
+		})
+		<-release
+		return got, nil
+	}
+
+	const workers = 16
+	var wg sync.WaitGroup
+	errs := make(chan error, workers)
+	results := make(chan string, workers)
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			got, err := NormalizePath(path)
+			if err != nil {
+				errs <- err
+				return
+			}
+			results <- got
+		}()
+	}
+
+	<-started
+	close(release)
+	wg.Wait()
+	close(errs)
+	close(results)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	count := 0
+	for got := range results {
+		assert.Equal(t, filepath.Clean(abs), got)
+		count++
+	}
+	assert.Equal(t, workers, count)
+	assert.Equal(t, int64(1), calls.Load())
 }
 
 func TestPersistScopeWorktreeMetadata(t *testing.T) {

--- a/internal/toolgen/legacy_command_skill_signatures.go
+++ b/internal/toolgen/legacy_command_skill_signatures.go
@@ -1,0 +1,245 @@
+package toolgen
+
+import "strings"
+
+const legacyGeneratedCommandSkillTrigger = "<legacy-command-trigger>"
+
+type legacyGeneratedCommandSkillSignature struct {
+	commandID              string
+	description            string
+	class                  string
+	tier                   string
+	includeInstallMetadata bool
+	body                   string
+}
+
+// legacyGeneratedCommandSkillSignatures is a generated-content signature set for
+// pre-manifest command-skill residue. Names alone are never deletion authority:
+// callers only reach these signatures after parsing a command_id, confirming it
+// is absent from the current command registry, and checking the full file body.
+var legacyGeneratedCommandSkillSignatures = []legacyGeneratedCommandSkillSignature{
+	{
+		commandID:              "stats",
+		description:            "Show repo-wide governance freshness and workflow statistics",
+		class:                  string(CommandClassQuery),
+		tier:                   "diagnostics",
+		includeInstallMetadata: true,
+		body: legacyGeneratedCommandSkillBody(
+			"# Stats",
+			"",
+			"Show repo-wide governance freshness and workflow statistics across every change.",
+			"",
+			"## Invocation",
+			"```bash",
+			"slipway stats --json",
+			"```",
+			"",
+			"## Contract",
+			"- Read-only repo-wide observability: active/archived counts, freshness summaries,",
+			"  and workflow statistics. It is not scoped to a single change — use",
+			"  `slipway status` for the active change.",
+			"",
+			"## Flags",
+			"- `--json`: JSON output",
+			"",
+			"## Arguments",
+			"```text",
+			"[--json]",
+			"```",
+			"",
+			"## Prerequisites",
+			"- `.slipway.yaml` must exist (run `slipway init` first)",
+		),
+	},
+	{
+		commandID:              "learn",
+		description:            "Preview governance learning proposals from lifecycle evidence",
+		class:                  string(CommandClassQuery),
+		tier:                   "diagnostics",
+		includeInstallMetadata: true,
+		body: legacyGeneratedCommandSkillBody(
+			"# Learn",
+			"",
+			"Preview read-only governance learning proposals derived from accumulated",
+			"lifecycle evidence.",
+			"",
+			"## Invocation",
+			"```bash",
+			"slipway learn --preview --json",
+			"```",
+			"",
+			"## Contract",
+			"- Read-only and non-mutating: it surfaces *proposed* governance adjustments for",
+			"  human review; it never applies them. Proposals are advisory only.",
+			"- `--preview` is the default. This is a maintainer/observability surface, not a",
+			"  step in driving a single change.",
+			"",
+			"## Flags",
+			"- `--preview`: generate read-only governance learning proposals (default true)",
+			"- `--json`: JSON output",
+			"",
+			"## Arguments",
+			"```text",
+			"[--preview] [--json]",
+			"```",
+			"",
+			"## Prerequisites",
+			"- `.slipway.yaml` must exist (run `slipway init` first)",
+		),
+	},
+	{
+		commandID:              "checkpoint",
+		description:            "Set an active checkpoint to pause wave execution and request user input",
+		class:                  string(CommandClassMutation),
+		tier:                   "situational",
+		includeInstallMetadata: true,
+		body: legacyGeneratedCommandSkillBody(
+			"# Checkpoint",
+			"",
+			"Pause wave execution and request user input for a specific task.",
+			"",
+			"## Invocation",
+			"```bash",
+			"slipway checkpoint --task-id <task_id> [--type <type>] [--allowed-responses <responses>] --json",
+			"```",
+			"",
+			"## Contract",
+			"- Sets an active checkpoint on the current governed change.",
+			"- Only valid during `S2_IMPLEMENT` state.",
+			"- Only one checkpoint can be active at a time.",
+			"- Resume with `slipway run --resume-response \"<response>\"`.",
+			"- After checkpoint resume, a **fresh subagent MUST be spawned** — do NOT continue in the same context.",
+			"",
+			"## When to Use",
+			"- Task encounters a blocker requiring human judgment (architectural decision, ambiguous requirement).",
+			"- Task encounters deviation that requires user decision.",
+			"- Retry budget exhausted — surface failure to user for decision.",
+			"",
+			"## Flags",
+			"- `--task-id <id>`: ID of the paused task (required)",
+			"- `--type <type>`: Checkpoint type — `human_verify` (default), `decision`, `human_action`",
+			"- `--allowed-responses <responses>`: Comma-separated allowed response values (required for `type=decision`)",
+			"- `--json`: JSON output",
+			"- `--change <slug>`: target a specific active change",
+			"",
+			"## Arguments",
+			"```text",
+			"--task-id <id> [--type human_verify|decision|human_action] [--allowed-responses <value> ...] [--json] [--change <slug>]",
+			"```",
+			"",
+			"## Prerequisites",
+			"- `.slipway.yaml` must exist (run `slipway init` first)",
+			"- An active governed change must be in S2_IMPLEMENT with a materialized wave plan (run `slipway repair` if `wave-plan.yaml` is missing).",
+		),
+	},
+	{
+		commandID:   "pivot",
+		description: "Reroute or rescope an active change",
+		class:       string(CommandClassMutation),
+		tier:        "situational",
+		body: legacyGeneratedCommandSkillBody(
+			"# Pivot",
+			"",
+			"Reroute (re-evaluate the routing/discovery decision) or rescope (reopen intake to",
+			"amend scope) an active change. Both set `needs_discovery=true` and clear",
+			"execution residue.",
+			"",
+			"## Invocation",
+			"```bash",
+			"slipway pivot --reroute",
+			"slipway pivot --rescope",
+			"```",
+			"",
+			"## Contract",
+			"- Show pivot summary with before/after state.",
+			"- Confirm pivot action with user before executing.",
+			"- `--reroute` (the default when no flag is given) is valid in `S1_PLAN`,",
+			"  `S2_IMPLEMENT`, or `S3_REVIEW`; it returns the change to `S1_PLAN`",
+			"  with discovery forced on. An invalid state is blocked (`pivot_state_invalid`).",
+			"- `--rescope` is valid in `S2_IMPLEMENT` or `S3_REVIEW`; it returns",
+			"  the change to `S0_INTAKE` (intake/clarify) and clears the intent",
+			"  `## Approved Summary` so it must be re-confirmed. Before execution",
+			"  (`S0_INTAKE`/`S1_PLAN`) and terminal states are blocked",
+			"  (`rescope_state_invalid`).",
+			"",
+			"## Flags",
+			"- `--reroute`: Re-evaluate routing/discovery and re-enter `S1_PLAN` (valid in S1_PLAN/S2_IMPLEMENT/S3_REVIEW).",
+			"- `--rescope`: Reopen intake — return to `S0_INTAKE` to amend scope, clearing the Approved Summary (valid in S2_IMPLEMENT/S3_REVIEW).",
+			"- `--json`: JSON output",
+			"- `--change <slug>`: target a specific active change",
+			"",
+			"## Arguments",
+			"```text",
+			"[--reroute|--rescope] [--json] [--change <slug>]",
+			"```",
+			"",
+			"## Prerequisites",
+			"- `.slipway.yaml` must exist (run `slipway init` first)",
+			"- an active change must exist, or pass `--change <slug>` when supported.",
+		),
+	},
+}
+
+func legacyGeneratedCommandSkillBody(lines ...string) string {
+	return strings.Join(lines, "\n")
+}
+
+func matchesLegacyGeneratedCommandSkillSignature(content string, cfg ToolConfig, commandID string) bool {
+	content, ok := normalizeLegacyGeneratedCommandSkillTrigger(content, cfg, commandID)
+	if !ok {
+		return false
+	}
+	for _, signature := range legacyGeneratedCommandSkillSignatures {
+		if signature.commandID != commandID {
+			continue
+		}
+		if content == signature.content() {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeLegacyGeneratedCommandSkillTrigger(content string, cfg ToolConfig, commandID string) (string, bool) {
+	triggerLine := "trigger: \"" + commandTrigger(cfg, commandID) + "\"\n"
+	if strings.Count(content, triggerLine) != 1 {
+		return "", false
+	}
+	normalized := "trigger: \"" + legacyGeneratedCommandSkillTrigger + "\"\n"
+	return strings.Replace(content, triggerLine, normalized, 1), true
+}
+
+func (s legacyGeneratedCommandSkillSignature) content() string {
+	var b strings.Builder
+	b.WriteString("---\n")
+	b.WriteString("name: ")
+	b.WriteString(adapterSkillName(s.commandID))
+	b.WriteByte('\n')
+	b.WriteString("description: ")
+	b.WriteString(yamlDoubleQuoted(s.description))
+	b.WriteByte('\n')
+	if s.includeInstallMetadata {
+		b.WriteString("install_profiles:\n")
+		b.WriteString("  - full\n")
+		b.WriteString("requires: []\n")
+	}
+	b.WriteString("command_id: \"")
+	b.WriteString(s.commandID)
+	b.WriteString("\"\n")
+	b.WriteString("trigger: \"")
+	b.WriteString(legacyGeneratedCommandSkillTrigger)
+	b.WriteString("\"\n")
+	b.WriteString("class: \"")
+	b.WriteString(s.class)
+	b.WriteString("\"\n")
+	b.WriteString("tier: \"")
+	b.WriteString(s.tier)
+	b.WriteString("\"\n")
+	b.WriteString("surface: \"skill\"\n")
+	b.WriteString("---\n")
+	b.WriteString(strings.TrimRight(s.body, "\n"))
+	b.WriteString("\n\n")
+	b.WriteString(commandSkillFooter(s.commandID))
+	b.WriteByte('\n')
+	return b.String()
+}

--- a/internal/toolgen/toolgen.go
+++ b/internal/toolgen/toolgen.go
@@ -1626,248 +1626,6 @@ func isGeneratedCommandSkillContent(content string, cfg ToolConfig, commandID st
 	return false, nil
 }
 
-const legacyGeneratedCommandSkillTrigger = "<legacy-command-trigger>"
-
-type legacyGeneratedCommandSkillSignature struct {
-	commandID              string
-	description            string
-	class                  string
-	tier                   string
-	includeInstallMetadata bool
-	body                   string
-}
-
-// legacyGeneratedCommandSkillSignatures is a generated-content signature set for
-// pre-manifest command-skill residue. Names alone are never deletion authority:
-// callers only reach these signatures after parsing a command_id, confirming it
-// is absent from the current command registry, and checking the full file body.
-var legacyGeneratedCommandSkillSignatures = []legacyGeneratedCommandSkillSignature{
-	{
-		commandID:              "stats",
-		description:            "Show repo-wide governance freshness and workflow statistics",
-		class:                  string(CommandClassQuery),
-		tier:                   "diagnostics",
-		includeInstallMetadata: true,
-		body: legacyGeneratedCommandSkillBody(
-			"# Stats",
-			"",
-			"Show repo-wide governance freshness and workflow statistics across every change.",
-			"",
-			"## Invocation",
-			"```bash",
-			"slipway stats --json",
-			"```",
-			"",
-			"## Contract",
-			"- Read-only repo-wide observability: active/archived counts, freshness summaries,",
-			"  and workflow statistics. It is not scoped to a single change — use",
-			"  `slipway status` for the active change.",
-			"",
-			"## Flags",
-			"- `--json`: JSON output",
-			"",
-			"## Arguments",
-			"```text",
-			"[--json]",
-			"```",
-			"",
-			"## Prerequisites",
-			"- `.slipway.yaml` must exist (run `slipway init` first)",
-		),
-	},
-	{
-		commandID:              "learn",
-		description:            "Preview governance learning proposals from lifecycle evidence",
-		class:                  string(CommandClassQuery),
-		tier:                   "diagnostics",
-		includeInstallMetadata: true,
-		body: legacyGeneratedCommandSkillBody(
-			"# Learn",
-			"",
-			"Preview read-only governance learning proposals derived from accumulated",
-			"lifecycle evidence.",
-			"",
-			"## Invocation",
-			"```bash",
-			"slipway learn --preview --json",
-			"```",
-			"",
-			"## Contract",
-			"- Read-only and non-mutating: it surfaces *proposed* governance adjustments for",
-			"  human review; it never applies them. Proposals are advisory only.",
-			"- `--preview` is the default. This is a maintainer/observability surface, not a",
-			"  step in driving a single change.",
-			"",
-			"## Flags",
-			"- `--preview`: generate read-only governance learning proposals (default true)",
-			"- `--json`: JSON output",
-			"",
-			"## Arguments",
-			"```text",
-			"[--preview] [--json]",
-			"```",
-			"",
-			"## Prerequisites",
-			"- `.slipway.yaml` must exist (run `slipway init` first)",
-		),
-	},
-	{
-		commandID:              "checkpoint",
-		description:            "Set an active checkpoint to pause wave execution and request user input",
-		class:                  string(CommandClassMutation),
-		tier:                   "situational",
-		includeInstallMetadata: true,
-		body: legacyGeneratedCommandSkillBody(
-			"# Checkpoint",
-			"",
-			"Pause wave execution and request user input for a specific task.",
-			"",
-			"## Invocation",
-			"```bash",
-			"slipway checkpoint --task-id <task_id> [--type <type>] [--allowed-responses <responses>] --json",
-			"```",
-			"",
-			"## Contract",
-			"- Sets an active checkpoint on the current governed change.",
-			"- Only valid during `S2_IMPLEMENT` state.",
-			"- Only one checkpoint can be active at a time.",
-			"- Resume with `slipway run --resume-response \"<response>\"`.",
-			"- After checkpoint resume, a **fresh subagent MUST be spawned** — do NOT continue in the same context.",
-			"",
-			"## When to Use",
-			"- Task encounters a blocker requiring human judgment (architectural decision, ambiguous requirement).",
-			"- Task encounters deviation that requires user decision.",
-			"- Retry budget exhausted — surface failure to user for decision.",
-			"",
-			"## Flags",
-			"- `--task-id <id>`: ID of the paused task (required)",
-			"- `--type <type>`: Checkpoint type — `human_verify` (default), `decision`, `human_action`",
-			"- `--allowed-responses <responses>`: Comma-separated allowed response values (required for `type=decision`)",
-			"- `--json`: JSON output",
-			"- `--change <slug>`: target a specific active change",
-			"",
-			"## Arguments",
-			"```text",
-			"--task-id <id> [--type human_verify|decision|human_action] [--allowed-responses <value> ...] [--json] [--change <slug>]",
-			"```",
-			"",
-			"## Prerequisites",
-			"- `.slipway.yaml` must exist (run `slipway init` first)",
-			"- An active governed change must be in S2_IMPLEMENT with a materialized wave plan (run `slipway repair` if `wave-plan.yaml` is missing).",
-		),
-	},
-	{
-		commandID:   "pivot",
-		description: "Reroute or rescope an active change",
-		class:       string(CommandClassMutation),
-		tier:        "situational",
-		body: legacyGeneratedCommandSkillBody(
-			"# Pivot",
-			"",
-			"Reroute (re-evaluate the routing/discovery decision) or rescope (reopen intake to",
-			"amend scope) an active change. Both set `needs_discovery=true` and clear",
-			"execution residue.",
-			"",
-			"## Invocation",
-			"```bash",
-			"slipway pivot --reroute",
-			"slipway pivot --rescope",
-			"```",
-			"",
-			"## Contract",
-			"- Show pivot summary with before/after state.",
-			"- Confirm pivot action with user before executing.",
-			"- `--reroute` (the default when no flag is given) is valid in `S1_PLAN`,",
-			"  `S2_IMPLEMENT`, or `S3_REVIEW`; it returns the change to `S1_PLAN`",
-			"  with discovery forced on. An invalid state is blocked (`pivot_state_invalid`).",
-			"- `--rescope` is valid in `S2_IMPLEMENT` or `S3_REVIEW`; it returns",
-			"  the change to `S0_INTAKE` (intake/clarify) and clears the intent",
-			"  `## Approved Summary` so it must be re-confirmed. Before execution",
-			"  (`S0_INTAKE`/`S1_PLAN`) and terminal states are blocked",
-			"  (`rescope_state_invalid`).",
-			"",
-			"## Flags",
-			"- `--reroute`: Re-evaluate routing/discovery and re-enter `S1_PLAN` (valid in S1_PLAN/S2_IMPLEMENT/S3_REVIEW).",
-			"- `--rescope`: Reopen intake — return to `S0_INTAKE` to amend scope, clearing the Approved Summary (valid in S2_IMPLEMENT/S3_REVIEW).",
-			"- `--json`: JSON output",
-			"- `--change <slug>`: target a specific active change",
-			"",
-			"## Arguments",
-			"```text",
-			"[--reroute|--rescope] [--json] [--change <slug>]",
-			"```",
-			"",
-			"## Prerequisites",
-			"- `.slipway.yaml` must exist (run `slipway init` first)",
-			"- an active change must exist, or pass `--change <slug>` when supported.",
-		),
-	},
-}
-
-func legacyGeneratedCommandSkillBody(lines ...string) string {
-	return strings.Join(lines, "\n")
-}
-
-func matchesLegacyGeneratedCommandSkillSignature(content string, cfg ToolConfig, commandID string) bool {
-	content, ok := normalizeLegacyGeneratedCommandSkillTrigger(content, cfg, commandID)
-	if !ok {
-		return false
-	}
-	for _, signature := range legacyGeneratedCommandSkillSignatures {
-		if signature.commandID != commandID {
-			continue
-		}
-		if content == signature.content() {
-			return true
-		}
-	}
-	return false
-}
-
-func normalizeLegacyGeneratedCommandSkillTrigger(content string, cfg ToolConfig, commandID string) (string, bool) {
-	triggerLine := "trigger: \"" + commandTrigger(cfg, commandID) + "\"\n"
-	if strings.Count(content, triggerLine) != 1 {
-		return "", false
-	}
-	normalized := "trigger: \"" + legacyGeneratedCommandSkillTrigger + "\"\n"
-	return strings.Replace(content, triggerLine, normalized, 1), true
-}
-
-func (s legacyGeneratedCommandSkillSignature) content() string {
-	var b strings.Builder
-	b.WriteString("---\n")
-	b.WriteString("name: ")
-	b.WriteString(adapterSkillName(s.commandID))
-	b.WriteByte('\n')
-	b.WriteString("description: ")
-	b.WriteString(yamlDoubleQuoted(s.description))
-	b.WriteByte('\n')
-	if s.includeInstallMetadata {
-		b.WriteString("install_profiles:\n")
-		b.WriteString("  - full\n")
-		b.WriteString("requires: []\n")
-	}
-	b.WriteString("command_id: \"")
-	b.WriteString(s.commandID)
-	b.WriteString("\"\n")
-	b.WriteString("trigger: \"")
-	b.WriteString(legacyGeneratedCommandSkillTrigger)
-	b.WriteString("\"\n")
-	b.WriteString("class: \"")
-	b.WriteString(s.class)
-	b.WriteString("\"\n")
-	b.WriteString("tier: \"")
-	b.WriteString(s.tier)
-	b.WriteString("\"\n")
-	b.WriteString("surface: \"skill\"\n")
-	b.WriteString("---\n")
-	b.WriteString(strings.TrimRight(s.body, "\n"))
-	b.WriteString("\n\n")
-	b.WriteString(commandSkillFooter(s.commandID))
-	b.WriteByte('\n')
-	return b.String()
-}
-
 func renderedCommandSkillAsRetiredCommand(cfg ToolConfig, sourceID, retiredID string) (string, error) {
 	content, err := renderCommandSkill(cfg, sourceID)
 	if err != nil {
@@ -2787,7 +2545,12 @@ func defaultFileModeForPath(path string) os.FileMode {
 	return 0o644
 }
 
-func mergePiRegistrationSettingsJSONWithPlan(root string, cfg ToolConfig, refresh bool, plan *toolRefreshPlan) error {
+// mergeSettingsJSONWithPlan applies the shared settings.json read-modify-write
+// scaffold: it honors the non-refresh skip guard, loads any existing settings
+// object, invokes mutate to apply the caller's changes, then marshals and writes
+// the result (respecting the refresh plan when present). mutate edits the decoded
+// settings map in place.
+func mergeSettingsJSONWithPlan(root string, cfg ToolConfig, refresh bool, plan *toolRefreshPlan, mutate func(settings map[string]any) error) error {
 	settingsPath := filepath.Join(root, cfg.SettingsPath)
 	if !refresh {
 		if _, err := os.Stat(settingsPath); err == nil {
@@ -2805,15 +2568,11 @@ func mergePiRegistrationSettingsJSONWithPlan(root string, cfg ToolConfig, refres
 		return err
 	}
 
-	settings["enableSkillCommands"] = true
-	if err := mergeStringArraySetting(settings, "skills", "./skills"); err != nil {
-		return fmt.Errorf("%s: %w", cfg.SettingsPath, err)
-	}
-	if err := mergeStringArraySetting(settings, "prompts", "./prompts"); err != nil {
-		return fmt.Errorf("%s: %w", cfg.SettingsPath, err)
+	if err := mutate(settings); err != nil {
+		return err
 	}
 
-	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil { // #nosec G301 -- directory is a user-facing project or governance artifact location where searchable mode is intentional.
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil { // #nosec G301 -- directory is a user-facing project or governance artifact location where executable/searchable mode is intentional.
 		return err
 	}
 	content, err := json.MarshalIndent(settings, "", "  ")
@@ -2824,7 +2583,20 @@ func mergePiRegistrationSettingsJSONWithPlan(root string, cfg ToolConfig, refres
 	if refresh && plan != nil {
 		return plan.writeUnmanagedFile(settingsPath, content, 0o644)
 	}
-	return os.WriteFile(settingsPath, content, 0o644) // #nosec G306 -- file is a user-facing project artifact where operator-readable mode is intentional.
+	return os.WriteFile(settingsPath, content, 0o644) // #nosec G306 -- file is a user-facing project or governance artifact where operator-readable mode is intentional.
+}
+
+func mergePiRegistrationSettingsJSONWithPlan(root string, cfg ToolConfig, refresh bool, plan *toolRefreshPlan) error {
+	return mergeSettingsJSONWithPlan(root, cfg, refresh, plan, func(settings map[string]any) error {
+		settings["enableSkillCommands"] = true
+		if err := mergeStringArraySetting(settings, "skills", "./skills"); err != nil {
+			return fmt.Errorf("%s: %w", cfg.SettingsPath, err)
+		}
+		if err := mergeStringArraySetting(settings, "prompts", "./prompts"); err != nil {
+			return fmt.Errorf("%s: %w", cfg.SettingsPath, err)
+		}
+		return nil
+	})
 }
 
 func mergeCodexHooksTOMLWithPlan(root string, cfg ToolConfig, refresh bool, plan *toolRefreshPlan) error {
@@ -2936,63 +2708,36 @@ func mergeStringArraySetting(settings map[string]any, key, value string) error {
 }
 
 func mergeHookSettingsJSONWithPlan(root string, cfg ToolConfig, refresh bool, plan *toolRefreshPlan) error {
-	settingsPath := filepath.Join(root, cfg.SettingsPath)
-	if !refresh {
-		if _, err := os.Stat(settingsPath); err == nil {
-			return nil
+	return mergeSettingsJSONWithPlan(root, cfg, refresh, plan, func(settings map[string]any) error {
+		var hooks map[string]any
+		switch existingHooks := settings["hooks"].(type) {
+		case nil:
+			hooks = map[string]any{}
+		case map[string]any:
+			hooks = existingHooks
+		default:
+			return fmt.Errorf("%s contains a non-object hooks field", cfg.SettingsPath)
 		}
-	}
 
-	settings := map[string]any{}
-	existing, err := os.ReadFile(settingsPath) // #nosec G304 -- path is resolved from repository or governed artifact authority before this read.
-	if err == nil {
-		if err := json.Unmarshal(existing, &settings); err != nil {
-			return fmt.Errorf("parse %s: %w", cfg.SettingsPath, err)
+		// Inside the Slipway source tree these inline commands are rewritten to the
+		// in-repo go-run launch (see hookLaunch / renderCodexHooksBlock) so a
+		// dogfooding checkout runs its own HEAD instead of a stale PATH release that
+		// may predate the current `--tool` flag. settings.json is per-machine, so the
+		// rewrite is rendered for the local host. pruneStaleSlipwayHookCommands still
+		// recognizes both the bare and the go-run forms across refreshes.
+		sessionCmd := applyHookLaunchPrefix(sessionStartHookCommand, root)
+		promptCmd := applyHookLaunchPrefix(contextPressureHookCommand, root)
+		if strings.TrimSpace(cfg.SessionEvent) != "" && strings.TrimSpace(cfg.SessionHook) != "" {
+			pruneStaleSlipwayHookCommands(hooks, cfg.SessionEvent, cfg.SessionHook, sessionCmd)
+			mergeHookEventCommand(hooks, cfg.SessionEvent, sessionCmd)
 		}
-	} else if !errors.Is(err, fs.ErrNotExist) {
-		return err
-	}
-
-	var hooks map[string]any
-	switch existingHooks := settings["hooks"].(type) {
-	case nil:
-		hooks = map[string]any{}
-	case map[string]any:
-		hooks = existingHooks
-	default:
-		return fmt.Errorf("%s contains a non-object hooks field", cfg.SettingsPath)
-	}
-
-	// Inside the Slipway source tree these inline commands are rewritten to the
-	// in-repo go-run launch (see hookLaunch / renderCodexHooksBlock) so a
-	// dogfooding checkout runs its own HEAD instead of a stale PATH release that
-	// may predate the current `--tool` flag. settings.json is per-machine, so the
-	// rewrite is rendered for the local host. pruneStaleSlipwayHookCommands still
-	// recognizes both the bare and the go-run forms across refreshes.
-	sessionCmd := applyHookLaunchPrefix(sessionStartHookCommand, root)
-	promptCmd := applyHookLaunchPrefix(contextPressureHookCommand, root)
-	if strings.TrimSpace(cfg.SessionEvent) != "" && strings.TrimSpace(cfg.SessionHook) != "" {
-		pruneStaleSlipwayHookCommands(hooks, cfg.SessionEvent, cfg.SessionHook, sessionCmd)
-		mergeHookEventCommand(hooks, cfg.SessionEvent, sessionCmd)
-	}
-	if strings.TrimSpace(cfg.PostToolEvent) != "" && strings.TrimSpace(cfg.PostToolHook) != "" {
-		pruneStaleSlipwayHookCommands(hooks, cfg.PostToolEvent, cfg.PostToolHook, promptCmd)
-		mergeHookEventCommand(hooks, cfg.PostToolEvent, promptCmd)
-	}
-	settings["hooks"] = hooks
-
-	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil { // #nosec G301 -- directory is a user-facing project or governance artifact location where executable/searchable mode is intentional.
-		return err
-	}
-	content, err := json.MarshalIndent(settings, "", "  ")
-	if err != nil {
-		return err
-	}
-	content = append(content, '\n')
-	if refresh && plan != nil {
-		return plan.writeUnmanagedFile(settingsPath, content, 0o644)
-	}
-	return os.WriteFile(settingsPath, content, 0o644) // #nosec G306 -- file is a user-facing project or governance artifact where operator-readable mode is intentional.
+		if strings.TrimSpace(cfg.PostToolEvent) != "" && strings.TrimSpace(cfg.PostToolHook) != "" {
+			pruneStaleSlipwayHookCommands(hooks, cfg.PostToolEvent, cfg.PostToolHook, promptCmd)
+			mergeHookEventCommand(hooks, cfg.PostToolEvent, promptCmd)
+		}
+		settings["hooks"] = hooks
+		return nil
+	})
 }
 
 func legacyShellHookPath(basePath string) string {
@@ -3178,34 +2923,27 @@ func firstShellScriptArg(fields []string) (string, bool) {
 	return "", false
 }
 
+func hookCommandEntry(command string) map[string]any {
+	return map[string]any{
+		"hooks": []any{
+			map[string]any{
+				"type":    "command",
+				"command": command,
+			},
+		},
+	}
+}
+
 func mergeHookEventCommand(hooks map[string]any, eventName, command string) {
 	rawEntries, ok := hooks[eventName]
 	if !ok {
-		hooks[eventName] = []any{
-			map[string]any{
-				"hooks": []any{
-					map[string]any{
-						"type":    "command",
-						"command": command,
-					},
-				},
-			},
-		}
+		hooks[eventName] = []any{hookCommandEntry(command)}
 		return
 	}
 
 	entries, ok := rawEntries.([]any)
 	if !ok {
-		hooks[eventName] = []any{
-			map[string]any{
-				"hooks": []any{
-					map[string]any{
-						"type":    "command",
-						"command": command,
-					},
-				},
-			},
-		}
+		hooks[eventName] = []any{hookCommandEntry(command)}
 		return
 	}
 
@@ -3229,14 +2967,7 @@ func mergeHookEventCommand(hooks map[string]any, eventName, command string) {
 		}
 	}
 
-	hooks[eventName] = append(entries, map[string]any{
-		"hooks": []any{
-			map[string]any{
-				"type":    "command",
-				"command": command,
-			},
-		},
-	})
+	hooks[eventName] = append(entries, hookCommandEntry(command))
 }
 
 func commandTrigger(cfg ToolConfig, commandID string) string {


### PR DESCRIPTION
## Summary
Behavior-preserving optimization/dedup pass completing the structural residual that PR #414 deliberately deferred as "better as its own governed change" (it reaches the readiness/authority core). **Hard invariant: observably behavior-preserving** — no public CLI/JSON/gate-outcome/generated-surface change; all 19 toolgen generated goldens byte-identical.

## Targets (11, across 5 packages)
| # | Target | Site |
|---|--------|------|
| A1c | memoize `NormalizePath` EvalSymlinks (success-only cache + per-entry `sync.Once` dedup) | `internal/state/worktree.go` |
| A3a | reuse the discarded read-context in `evidence task` | `cmd/evidence.go` |
| A2c | hoist git changed-files scan to feed both repair evaluators once | `internal/engine/progression/{advance_governed,evidence_repair}.go` |
| A2b | thread one governance snapshot through S3 review-authority (identity-gated reuse, fresh rebuild on mismatch) — **highest risk** | `internal/engine/progression/{readiness,authority}.go` |
| D-evidence | single evidence-tasks dir walk for version + session-owner | `cmd/evidence.go` |
| D1 | combined tasks.md structural+scope parse (one read+parse) | `internal/state/wave_execution.go` |
| D2 | single strict-first wave-run decode, **preserving skip-before-strict-validate** for non-matching versions | `internal/state/wave_execution.go` |
| F-done | extract shared `done.marked` + archive finalize tail | `cmd/done.go` |
| F2a/F2d/F2e | dedup toolgen settings.json scaffold + hook-entry literal; move legacy command-skill fixture to a same-package `.go` file | `internal/toolgen/*` |
| G4 | early-break `collectSupports` after 3 ID-sorted matches | `internal/engine/capability/resolver.go` |

## Out of scope (deliberate non-defects)
- **A1b** worktree HEAD probe — deliberate correctness tradeoff (detects in-place branch switches)
- **G2** `Change` value receivers — required for `yaml.Marshaler`
- **A3b** run-loop per-iteration read-context — a fresh context is minted on purpose so iteration 2+ observes post-advance disk state; threading one context would serve stale state (not behavior-preserving)

## Follow-up correctness fixes (post-review)
Two hardening fixes on top of the governed body, keeping the same behavior-preserving invariant:
- **A3a lock-freshness (`b4f32fa`)** — the governed body's `loadActiveChangeWithReadContext` reused the pre-lock change snapshot cached during active-ref resolution, so the in-lock `not_active` precheck read stale state. Switched to a fresh in-lock reload (`reloadChange`) so a concurrent transition to `done`/`archived` between ref resolution and lock acquisition can't slip past the fail-closed check. Restores the original `loadActiveChange` semantics. Locked by `TestEvidenceTaskActiveChangeReloadsAfterCachedRefResolution`.
- **A1c success-only, settled (`916c0b6` reverts `4880aef`)** — A1c keeps the per-entry `sync.Once` dedup but caches **only successful** resolutions. An interim commit (`4880aef`) cached the EvalSymlinks-failure fallback too; that violates REQ-002 ("result identical to the unconditional evaluation for every input") and the behavior-preserving invariant, because a path normalized while unresolvable and again after it becomes resolvable in the same process (e.g. `EnsureDefaultWorktreeForChange` normalizes a worktree path before creating it, then binding re-normalizes it) would return a stale unresolved value. Reverted; failure now drops the cache entry (`CompareAndDelete`) so it re-resolves.

## Verification
Governed via Slipway. All S3 review peers + terminal ship-verification PASS on fresh independent-context evidence:
- **spec-compliance** (bidirectional trace, all 11 targets at cited sites, no scope escape) · **code-quality** · **independent** (adversarial, could not break the invariant) · **security** (no containment/path-validation/strict-decode weakening) · **ship-verification** (terminal)
- `gofmt -s -l` clean · `go build ./...` · `go vet ./...` · `go test ./...` green · `golangci-lint run` **0 issues** · 19 toolgen goldens byte-identical
- D2 skip-before-strict-validate + A2b build-once/identity-gate are test-locked (`TestLoadWaveRunsStrictFirstMixedVersionClassification`, readiness snapshot-once/fallback tests)
- Follow-up fixes re-verified: full `go test ./...` green, `golangci-lint` 0 issues (A3a reload test + A1c success-only dedup/re-resolve tests pass under `-race`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
