### PR TITLE
fix(status): honest done-ready and gate JSON surfaces (#411, #413)

### DIFF
--- a/cmd/next.go
+++ b/cmd/next.go
@@ -745,7 +745,7 @@ func projectDoneReadyForReadOnlyQuery(root string, change *model.Change, advance
 		FromState: model.StateS3Review,
 		Reason:    "governance_gates_passed",
 		Message:   "Governance gates passed; run `slipway done` to finalize.",
-		Blockers:  []model.ReasonCode{model.NewReasonCode("run_slipway_done_to_finalize", "")},
+		Blockers:  []model.ReasonCode{model.NewReasonCode(reasonRunSlipwayDoneToFinalize, "")},
 	}
 	return nil
 }

--- a/cmd/progression_next_test.go
+++ b/cmd/progression_next_test.go
@@ -2519,6 +2519,9 @@ func TestNextReturnsDoneReadyWithoutNextSkillAfterGovernedShipPasses(t *testing.
 	assert.Equal(t, model.StateS3Review, view.CurrentState)
 	assert.Nil(t, view.NextSkill)
 	assert.Contains(t, model.ReasonSpecs(view.Blockers), "run_slipway_done_to_finalize")
+	// The only outstanding blocker is the terminal finalize prompt, so overall
+	// readiness must read as awaiting_finalize rather than blocked.
+	assert.Equal(t, "awaiting_finalize", view.OverallReadinessFreshness)
 	// ship-verification is the single always-required terminal gate; once it
 	// passes there is no optional-closeout advisory to surface.
 	assert.NotContains(t, strings.Join(view.Warnings, "\n"), "optional_closeout_available")
@@ -2533,6 +2536,7 @@ func TestNextReturnsDoneReadyWithoutNextSkillAfterGovernedShipPasses(t *testing.
 	assert.Nil(t, handoff.NextSkill)
 	assert.Contains(t, model.ReasonSpecs(handoff.Blockers), "run_slipway_done_to_finalize")
 	assert.NotContains(t, model.ReasonSpecs(handoff.Blockers), "no_skill_required:S3_REVIEW")
+	assert.Equal(t, "awaiting_finalize", handoff.OverallReadinessFreshness)
 }
 
 func TestNextReturnsDoneReadyWithShipVerificationAttestationForStandardRequestPath(t *testing.T) {
@@ -2622,6 +2626,68 @@ func TestNextDiagnosticsSkillEvidenceRoutesToShipVerificationAfterReviewSet(t *t
 		assert.Equal(t, "passing", statusBySkill[progression.SkillSpecComplianceReview].Status)
 		assert.False(t, statusBySkill[progression.SkillShipVerification].HasEvidence)
 		assert.Equal(t, "missing", statusBySkill[progression.SkillShipVerification].Status)
+	})
+}
+
+// TestNextRoutesNameToShipVerificationWhenOnlyShipVerificationStale is the #412
+// regression lock: in S3 with every selected review peer fresh/passing and only
+// ship-verification stale (a passing record whose digest is not fresh),
+// next_skill.name must point at ship-verification (the authoritative next
+// action), not at the head-of-batch review peer. display_name legitimately
+// stays the head of the review batch; only name must advance to the real next
+// action.
+func TestNextRoutesNameToShipVerificationWhenOnlyShipVerificationStale(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	withCommandWorkspace(t, root, func() {
+		initTestWorkspace(t, root)
+
+		slug := createGovernedRequest(t, root, levelNonDiscovery, "stale ship-verification name routing contract")
+		change, err := state.LoadChange(root, slug)
+		require.NoError(t, err)
+
+		change.WorkflowPreset = model.WorkflowPresetStandard
+		change.QualityMode = model.QualityModeStandard
+		change.CurrentState = model.StateS3Review
+		change.PlanSubStep = model.PlanSubStepNone
+		require.NoError(t, state.SaveChange(root, change))
+
+		bundlePath := filepath.Join(root, "artifacts", "changes", change.Slug)
+		require.NoError(t, os.MkdirAll(bundlePath, 0o755))
+		writeShipReadyGovernedBundle(t, root, change)
+		writeAssuranceMD(t, root, change.Slug, validAssuranceContent())
+		// Current execution is run version 2; wave and every review peer are fresh
+		// at run version 2.
+		writePassingExecutionSummary(t, root, slug, 2, "t-01")
+		writePassingWaveEvidence(t, root, slug, 2)
+		writePassingReviewEvidencePack(t, root, slug, 2)
+		// ship-verification carries a passing record stamped at the OLDER run
+		// version 1, so it is stale relative to the current run version 2 — the
+		// exact #412 scenario (all peers fresh, only ship-verification stale).
+		writeSkillVerification(t, root, slug, progression.SkillShipVerification, model.VerificationRecord{
+			Verdict:    model.VerificationVerdictPass,
+			Blockers:   []model.ReasonCode{},
+			Timestamp:  time.Now().UTC(),
+			RunVersion: 1,
+			References: []string{
+				"verification:pass",
+				"closeout:assurance_complete=pass",
+				"closeout:reviewer_independence=pass",
+			},
+		})
+
+		cmd := commandForRoot(t, root, makeNextCmd())
+		cmd.SetArgs([]string{"--json", "--diagnostics", "--change", slug})
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		require.NoError(t, cmd.Execute())
+
+		var view nextView
+		require.NoError(t, json.Unmarshal(out.Bytes(), &view))
+		require.NotNil(t, view.NextSkill, "advanced=%+v blockers=%v warnings=%v", view.Advanced, model.ReasonSpecs(view.Blockers), view.Warnings)
+		// The authoritative next action is ship-verification, not a passing peer.
+		assert.Equal(t, progression.SkillShipVerification, view.NextSkill.Name)
 	})
 }
 

--- a/cmd/status_view_build.go
+++ b/cmd/status_view_build.go
@@ -14,6 +14,16 @@ import (
 	"github.com/signalridge/slipway/internal/state"
 )
 
+// reasonRunSlipwayDoneToFinalize is the terminal next-action prompt appended in
+// the done-ready projection. It is a Warning-severity "run `slipway done`"
+// pointer, not a real gate or evidence failure, so overall readiness reports it
+// as awaiting_finalize rather than blocked.
+const reasonRunSlipwayDoneToFinalize = "run_slipway_done_to_finalize"
+
+// readinessAwaitingFinalize is the overall-readiness value used when the only
+// outstanding blocker is the terminal finalize prompt.
+const readinessAwaitingFinalize = "awaiting_finalize"
+
 func buildStatusViewFromChangeWithReadContext(readCtx *stateReadContext, change model.Change) (statusView, error) {
 	readCtx.rememberChange(change)
 	return buildGovernedStatusViewWithReadContext(readCtx, change)
@@ -324,7 +334,10 @@ func projectGovernanceEvidenceFreshness(readiness progression.GovernanceReadines
 }
 
 func projectOverallReadinessFreshness(executionFreshness, governanceFreshness string, blockers []model.ReasonCode) string {
-	if len(model.NormalizeReasonCodes(blockers)) > 0 {
+	if normalized := model.NormalizeReasonCodes(blockers); len(normalized) > 0 {
+		if reasonCodesAreSolelyFinalizePrompt(normalized) {
+			return readinessAwaitingFinalize
+		}
 		return "blocked"
 	}
 	if executionFreshness == "stale" || governanceFreshness == "stale" {
@@ -334,6 +347,22 @@ func projectOverallReadinessFreshness(executionFreshness, governanceFreshness st
 		return "unknown"
 	}
 	return "fresh"
+}
+
+// reasonCodesAreSolelyFinalizePrompt reports whether the normalized blocker set
+// is non-empty and every entry is the terminal finalize prompt. When true, the
+// change is done-ready and only awaiting `slipway done`; any other coexisting
+// blocker means a real gate/evidence failure and readiness stays blocked.
+func reasonCodesAreSolelyFinalizePrompt(normalized []model.ReasonCode) bool {
+	if len(normalized) == 0 {
+		return false
+	}
+	for _, reason := range normalized {
+		if reason.Code != reasonRunSlipwayDoneToFinalize {
+			return false
+		}
+	}
+	return true
 }
 
 func projectCurrentActionContract(change model.Change, readiness progression.GovernanceReadiness) (string, string) {
@@ -592,7 +621,7 @@ func applyDoneReadyProjection(change model.Change, evaluations map[gate.GateID]g
 	view.DoneReady = true
 	view.Blockers = appendReasonCodes(
 		view.Blockers,
-		[]model.ReasonCode{model.NewReasonCode("run_slipway_done_to_finalize", "")},
+		[]model.ReasonCode{model.NewReasonCode(reasonRunSlipwayDoneToFinalize, "")},
 	)
 }
 

--- a/cmd/status_view_build_test.go
+++ b/cmd/status_view_build_test.go
@@ -156,10 +156,37 @@ func TestBuildGovernedStatusViewExposesDoneReadyReadiness(t *testing.T) {
 
 	assert.Equal(t, true, payload["done_ready"])
 	assert.Equal(t, "active", payload["lifecycle_status"])
+	// The terminal finalize prompt is a next-action pointer, not a real gate or
+	// evidence failure, so overall readiness must read as awaiting_finalize rather
+	// than blocked even though a Warning-severity blocker is present.
+	assert.Equal(t, "awaiting_finalize", payload["overall_readiness_freshness"])
+	assert.Equal(t, "awaiting_finalize", view.OverallReadinessFreshness)
 	assert.Contains(t, model.ReasonSpecs(view.Blockers), "run_slipway_done_to_finalize")
 	assert.Contains(t, view.Narrative, "Done-ready")
 	assert.Contains(t, view.Narrative, "slipway done")
 	assert.Contains(t, renderStatusText(view), "slipway done")
+}
+
+func TestProjectOverallReadinessFreshnessFinalizePrompt(t *testing.T) {
+	t.Parallel()
+
+	finalize := model.NewReasonCode(reasonRunSlipwayDoneToFinalize, "")
+	realBlocker := model.NewReasonCode("required_skill_missing", "ship-verification")
+
+	// Sole finalize prompt is a done-ready next-action pointer, not a blocker.
+	assert.Equal(t, "awaiting_finalize", projectOverallReadinessFreshness(
+		"fresh", "fresh", []model.ReasonCode{finalize},
+	))
+
+	// A real coexisting blocker wins: readiness stays blocked.
+	assert.Equal(t, "blocked", projectOverallReadinessFreshness(
+		"fresh", "fresh", []model.ReasonCode{finalize, realBlocker},
+	))
+
+	// No blockers with fresh evidence stays fresh.
+	assert.Equal(t, "fresh", projectOverallReadinessFreshness(
+		"fresh", "fresh", nil,
+	))
 }
 
 func TestLoadStatusChangeBySlugFallsBackToArchivedForMissingActiveAuthority(t *testing.T) {

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
@@ -722,4 +723,33 @@ func TestChangeAuthorityIncludesRuntimeFields(t *testing.T) {
 	assert.Contains(t, string(b), "evidence_refs:")
 	assert.Contains(t, string(b), "last_auto_passed_states:")
 	assert.Contains(t, string(b), "review_intent_drift_failures:")
+}
+
+func TestGateRecordMarshalJSONOmitsZeroUpdatedAt(t *testing.T) {
+	t.Parallel()
+
+	// Gate status is derived on the fly and carries no persisted transition time.
+	// A zero UpdatedAt must be omitted rather than serialized as the misleading
+	// "0001-01-01T00:00:00Z" (time.Time's zero value defeats omitempty).
+	record := GateRecord{GateID: "G_ship", Status: GateStatusApproved}
+	b, err := json.Marshal(record)
+	require.NoError(t, err)
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(b, &payload))
+
+	assert.Equal(t, "G_ship", payload["gate_id"])
+	assert.Equal(t, string(GateStatusApproved), payload["status"])
+	_, hasUpdatedAt := payload["updated_at"]
+	assert.False(t, hasUpdatedAt, "zero UpdatedAt must be omitted from JSON")
+	// reason_codes stays omitted when empty, matching the struct-tag behavior.
+	_, hasReasonCodes := payload["reason_codes"]
+	assert.False(t, hasReasonCodes)
+
+	// A real transition time is still emitted in RFC3339 form when present.
+	stamp := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	record.UpdatedAt = stamp
+	b, err = json.Marshal(record)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(b, &payload))
+	assert.Equal(t, stamp.Format(time.RFC3339), payload["updated_at"])
 }

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -168,6 +169,30 @@ type GateRecord struct {
 	Status      GateStatus   `yaml:"status" json:"status"`
 	ReasonCodes []ReasonCode `yaml:"reason_codes,omitempty" json:"reason_codes,omitempty"`
 	UpdatedAt   time.Time    `yaml:"updated_at,omitempty" json:"updated_at,omitempty"`
+}
+
+// MarshalJSON omits updated_at when it is the zero time. Gate status is derived
+// on the fly from current evidence and carries no persisted transition
+// timestamp, so a zero UpdatedAt must not serialize as the misleading
+// "0001-01-01T00:00:00Z" (time.Time's zero value is not skipped by omitempty).
+// A non-zero UpdatedAt is still emitted in RFC3339 form so a real transition
+// time remains forward compatible if one is ever plumbed through.
+func (r GateRecord) MarshalJSON() ([]byte, error) {
+	type gateRecordAlias struct {
+		GateID      string       `json:"gate_id"`
+		Status      GateStatus   `json:"status"`
+		ReasonCodes []ReasonCode `json:"reason_codes,omitempty"`
+		UpdatedAt   *time.Time   `json:"updated_at,omitempty"`
+	}
+	alias := gateRecordAlias{
+		GateID:      r.GateID,
+		Status:      r.Status,
+		ReasonCodes: r.ReasonCodes,
+	}
+	if !r.UpdatedAt.IsZero() {
+		alias.UpdatedAt = &r.UpdatedAt
+	}
+	return json.Marshal(alias)
 }
 
 type TaskVerdict string


### PR DESCRIPTION
Bundles three JSON-surface readability fixes surfaced while dogfooding the governed S3 → done-ready flow. All are surface/semantics fixes — the authoritative recovery paths were already correct.

## #411 — done-ready no longer reads as failure
The done-ready projection appends a Warning-severity `run_slipway_done_to_finalize` next-action prompt, which made `overall_readiness_freshness` report `"blocked"` despite `done_ready:true` + `G_ship:approved`. `projectOverallReadinessFreshness` now returns a distinct **`awaiting_finalize`** when the only outstanding blocker is that terminal finalize prompt; any real coexisting blocker still wins as `"blocked"`. A shared const is reused at both `cmd` emission sites.

## #413 — approved gate `updated_at` no longer a misleading zero-time
Approved `G_ship`/`G_plan` serialized `updated_at:"0001-01-01T00:00:00Z"`. Gate status is derived on the fly from current evidence and carries **no persisted transition timestamp**, so fabricating a render-time `time.Now()` would violate evidence discipline. `GateRecord.MarshalJSON` instead **omits `updated_at` when zero** (`time.Time` ignores `omitempty`) and still emits RFC3339 if a real transition time is ever plumbed.

## #412 — already resolved; regression-locked
Already fixed on current `main` (post #414/#415 skill-resolution refactor): `next_skill.name` already routes to `ship-verification` when all review peers are fresh and only ship-verification is stale. Adds a stale-specific regression test locking that contract. **No production change.**

## Verification
- `go test ./...` — all packages green
- `golangci-lint run` — 0 issues; `gofmt -s -l` clean
- No test weakened: only **added** assertions; existing `"blocked"` assertions on real blockers left intact. No new reason code (so `reason_code_contract_test.go` unchanged); no docs/schema enumerate readiness values.

Fixes #411
Fixes #413
Refs #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)