### PR TITLE
fix(next): route next_skill to ship-verification when only the ship gate is stale (#412)

### DIFF
--- a/cmd/next_skill_view.go
+++ b/cmd/next_skill_view.go
@@ -789,6 +789,13 @@ func reviewAlignmentSkillForBlockers(selectedReviewSkills []string, blockers []m
 
 func reviewAlignmentSkillForTarget(selectedReviewSkills []string, target string) string {
 	target = strings.TrimSpace(target)
+	// The terminal ship-verification gate is not a selected review peer; it is
+	// owned by nextS3ShipAuthoritySkill. A stale/blocked ship gate must fall
+	// through to that resolver rather than be redirected to the head-of-batch
+	// review peer by the fallback below (#412).
+	if target == progression.SkillShipVerification {
+		return ""
+	}
 	if stringInSlice(selectedReviewSkills, target) {
 		return target
 	}

--- a/cmd/progression_next_test.go
+++ b/cmd/progression_next_test.go
@@ -1957,7 +1957,7 @@ func TestRunJSONRoutesToShipVerificationWhenStaleGateIsTheOnlyBlocker(t *testing
 		progression.AdvanceSummary{
 			Action:    "blocked",
 			FromState: model.StateS3Review,
-			Blockers:  []model.ReasonCode{model.NewReasonCode("required_skill_stale", "ship-verification:run_version")},
+			Blockers:  []model.ReasonCode{model.NewReasonCode("required_skill_stale", "ship-verification:tracked.go")},
 		},
 		&change,
 		nil,
@@ -1988,6 +1988,66 @@ func TestRunJSONRoutesToShipVerificationWhenStaleGateIsTheOnlyBlocker(t *testing
 		"recovery steps should target ship-verification")
 	assert.NotContains(t, joinedRecovery, progression.SkillSpecComplianceReview,
 		"a stale ship gate must not steer recovery at a fresh review peer")
+}
+
+// The #412 guard lives in reviewAlignmentSkillForTarget, which has two live
+// caller edges: the required_skill_stale case (surfaced from advance blockers,
+// exercised end-to-end by the test above) AND the review_alignment_required
+// case. The latter is what a real digest-drifted-but-passing ship-verification
+// record produces: IsReviewSkill("ship-verification") is false, so the terminal
+// gate is not filtered out of the stale-evidence authorities, and
+// StaleEvidenceRepairAvailable injects review_alignment_required:ship-verification
+// into view.Blockers (next_skill_view.go). Locking the resolver directly for
+// both blocker codes ensures the guard cannot be narrowed to only one case
+// without a failing test — a gap the end-to-end TempDir test cannot catch,
+// because it has no on-disk ship record and therefore never injects
+// review_alignment_required.
+func TestReviewAlignmentResolverFallsThroughForTerminalShipGate(t *testing.T) {
+	t.Parallel()
+
+	// spec-compliance-review is head-of-batch, so an unguarded fallback would
+	// mis-map the terminal ship target to it — the exact #412 regression.
+	selected := []string{
+		progression.SkillSpecComplianceReview,
+		progression.SkillCodeQualityReview,
+	}
+
+	t.Run("target resolver returns empty for the terminal ship gate", func(t *testing.T) {
+		assert.Empty(t, reviewAlignmentSkillForTarget(selected, progression.SkillShipVerification))
+	})
+
+	t.Run("both blocker-code caller edges fall through", func(t *testing.T) {
+		cases := []struct {
+			name    string
+			blocker model.ReasonCode
+		}{
+			{
+				name:    "review_alignment_required (real digest-drift injection edge)",
+				blocker: model.NewReasonCode("review_alignment_required", progression.SkillShipVerification),
+			},
+			{
+				name:    "required_skill_stale (advance-blocker edge)",
+				blocker: model.NewReasonCode("required_skill_stale", "ship-verification:tracked.go"),
+			},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				assert.Empty(t,
+					reviewAlignmentSkillForBlockers(selected, []model.ReasonCode{tc.blocker}),
+					"terminal ship gate must fall through to nextS3ShipAuthoritySkill, not a review peer")
+			})
+		}
+	})
+
+	// Positive control: the guard must stay narrow. Genuine upstream-realignment
+	// targets still map to their review peer, proving the ship-gate guard does
+	// not over-suppress legitimate review-alignment routing.
+	t.Run("legitimate upstream realignment is unaffected", func(t *testing.T) {
+		assert.Equal(t, progression.SkillSpecComplianceReview,
+			reviewAlignmentSkillForTarget(selected, progression.SkillPlanAudit))
+		assert.Equal(t, progression.SkillCodeQualityReview,
+			reviewAlignmentSkillForTarget(selected, progression.SkillWaveOrchestration))
+	})
 }
 
 func TestDiagnosticCommandsExposePathAuthorityWhenFreshnessUnknown(t *testing.T) {

--- a/cmd/progression_next_test.go
+++ b/cmd/progression_next_test.go
@@ -1926,6 +1926,70 @@ func TestRunJSONRoutesToShipVerificationAfterReviewSetWithoutDisplayPromotion(t 
 	assert.Empty(t, view.NextSkill.BlockingName)
 }
 
+// Regression for #412: when every selected review peer is fresh and the only
+// stale gate is the terminal ship-verification gate (surfaced as a digest-drift
+// required_skill_stale blocker), next_skill.name must route to ship-verification
+// and not fall through to the static head-of-batch review peer. The #420 test
+// above locks the ship_gate_blocked variant, which never enters the
+// review-alignment resolver; the required_skill_stale variant does, and used to
+// be redirected to selectedReviewSkills[0] (spec-compliance-review),
+// contradicting the correct blockers[]/recovery steps.
+func TestRunJSONRoutesToShipVerificationWhenStaleGateIsTheOnlyBlocker(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	ensureTestGitRepo(t, root)
+	initTestWorkspace(t, root)
+
+	change := model.NewChange("ship-verification-stale-gate")
+	change.QualityMode = model.QualityModeStandard
+	change.CurrentState = model.StateS3Review
+	change.PlanSubStep = model.PlanSubStepNone
+
+	view := nextView{
+		Slug:         change.Slug,
+		CurrentState: model.StateS3Review,
+		InputContext: nextContext{WorkspaceRoot: root},
+	}
+	err := assembleSkillViewWithOptions(
+		root,
+		&view,
+		changeRef{Slug: change.Slug},
+		progression.AdvanceSummary{
+			Action:    "blocked",
+			FromState: model.StateS3Review,
+			Blockers:  []model.ReasonCode{model.NewReasonCode("required_skill_stale", "ship-verification:run_version")},
+		},
+		&change,
+		nil,
+		passingSelectedReviewEvidenceForNextSkillTests(1),
+		nil,
+		assembleSkillViewOptions{
+			IncludeReviewContext: true,
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, view.NextSkill)
+	// The terminal ship gate is owned by nextS3ShipAuthoritySkill, not the
+	// review-alignment fallback; a stale ship gate must not be redirected to a
+	// review peer.
+	assert.Equal(t, progression.SkillShipVerification, view.NextSkill.Name)
+
+	// next_skill must agree with the (already correct) recovery steps, which the
+	// command layer derives from view.Blockers. Mirror that here and assert the
+	// recovery targets re-recording ship-verification, not a fresh review peer.
+	view.Recovery = model.BuildRecovery(view.Blockers)
+	require.NotNil(t, view.Recovery)
+	var recoveryCommands []string
+	for _, step := range view.Recovery.Steps {
+		recoveryCommands = append(recoveryCommands, step.Command)
+	}
+	joinedRecovery := strings.Join(recoveryCommands, "\n")
+	assert.Contains(t, joinedRecovery, progression.SkillShipVerification,
+		"recovery steps should target ship-verification")
+	assert.NotContains(t, joinedRecovery, progression.SkillSpecComplianceReview,
+		"a stale ship gate must not steer recovery at a fresh review peer")
+}
+
 func TestDiagnosticCommandsExposePathAuthorityWhenFreshnessUnknown(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()


### PR DESCRIPTION
## Summary

Fixes #412. When every selected S3 review peer is fresh and the only outstanding gate is the terminal **ship-verification** gate (surfaced as a digest-drift `required_skill_stale:ship-verification` blocker), `slipway next --json` reported `next_skill.name: spec-compliance-review` — the static head-of-batch review peer. That **contradicted** the already-correct `blockers[]` and `recovery.steps[].command` (which pointed at `evidence skill --skill ship-verification`) and could steer an agent into re-recording an already-fresh peer instead of running ship-verification.

## Root cause

`reviewAlignmentSkillForBlockers` handles a `required_skill_stale` blocker by calling `reviewAlignmentSkillForTarget`, whose catch-all fallback returns `selectedReviewSkills[0]`. Ship-verification is the **terminal gate**, not a selected review peer, so it fell through to that fallback and was redirected to `spec-compliance-review` — preempting the correct `nextS3ShipAuthoritySkill` resolver that runs later in the S3 block.

## Fix

Guard `reviewAlignmentSkillForTarget` to return `""` for the terminal ship-verification target, so control falls through to `nextS3ShipAuthoritySkill`, which routes to ship-verification. The guard sits in the shared helper, so it covers **both** of its live caller edges: the `required_skill_stale` case and the `review_alignment_required` case. Genuine upstream-realignment targets (`plan-audit` / `wave-orchestration`) are untouched, and `blockers[]`/`recovery` remain correct.

Note on the injected blocker: `IsReviewSkill("ship-verification")` is `false`, so the terminal gate is **not** filtered out of the stale-evidence authorities. In the real digest-drift scenario (a passing-but-drifted ship-verification record on disk, other peers fresh), `StaleEvidenceRepairAvailable` therefore **does** inject `review_alignment_required:ship-verification`. That is not spurious — the guard re-routes it to `nextS3ShipAuthoritySkill` just like the `required_skill_stale` edge — but it means the injection edge is a real code path, not an absent one. (An earlier draft of this description claimed no `review_alignment_required` was injected; that was true only of the `TempDir` test fixture, which has no on-disk ship record.)

## Note on #420

The prior #420 fix believed #412 was already resolved and added a regression test — but that test locks the `ship_gate_blocked` variant, which **never enters the review-alignment resolver**, so it passed while missing the real defect. This PR adds a test for the `required_skill_stale:ship-verification` (digest-drift) variant that #412 actually describes, and asserts `next_skill` agrees with the derived recovery steps.

## Verification

- New RED→GREEN E2E test `TestRunJSONRoutesToShipVerificationWhenStaleGateIsTheOnlyBlocker` (uses the natural digest-drift blocker form `required_skill_stale:ship-verification:tracked.go`).
- New direct resolver test `TestReviewAlignmentResolverFallsThroughForTerminalShipGate` locks **both** guard caller edges (`review_alignment_required` and `required_skill_stale`) plus a positive control that `plan-audit`/`wave-orchestration` still route to their review peer — closing the blind spot where the guard could be narrowed to one case and stay green. Verified RED→GREEN by neutralizing the guard.
- `go test ./cmd/` green (full package).
- `gofmt -s` clean; `golangci-lint run ./cmd/...` → 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
