### PR TITLE
docs: fix documentation site layout defects

### DIFF
--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -8,6 +8,8 @@
 //     the first paragraph), stripping the now-duplicate H1 from the body;
 //   - rewrite relative `*.md` links to base-aware Starlight routes;
 //   - rewrite `assets/**` image references to the copied public asset URLs;
+//   - wrap diagram images in a link to the standalone asset, so the full-size
+//     original is reachable from the downscaled figure in the prose column;
 //   - map each edit link back to its repository source instead of generated output;
 //   - drop mkdocs-only `markdown` HTML attributes.
 //
@@ -99,6 +101,18 @@ function rewriteLinks(body, currentDir) {
   });
 }
 
+// Diagrams are drawn on a 1200px canvas with 9.5-11px labels. Inside the prose
+// column they scale to roughly 6px, and on a phone to under 3px. Wrapping each
+// one in a link to its own asset keeps the full-size original one click away.
+// The stylesheet hangs its framing off the href, so this stays plain Markdown
+// rather than raw HTML with a hand-escaped alt attribute.
+function linkDiagrams(body) {
+  return body.replace(
+    /(?<!\[)!\[([^\]]*)\]\(([^)\s]*\/assets\/diagrams\/[^)\s]+)\)/g,
+    (_whole, alt, src) => `[![${alt}](${src})](${src})`,
+  );
+}
+
 function deriveDescription(body) {
   const lines = body.split('\n');
   for (let i = 0; i < lines.length; i++) {
@@ -162,6 +176,7 @@ function transform(raw, rel, lastUpdated) {
 
   const description = deriveDescription(body);
   body = rewriteLinks(body, currentDir);
+  body = linkDiagrams(body);
   body = body.replace(/\s+markdown(=("1"|'1'))?(?=[\s>])/g, ''); // drop mkdocs md_in_html attr
   body = body.replace(/^\n+/, ''); // trim leading blank lines left by H1 removal
 

--- a/website/src/content/docs/en/index.mdx
+++ b/website/src/content/docs/en/index.mdx
@@ -4,6 +4,7 @@ description: An explicitly invoked soft autopilot for AI coding.
 template: splash
 editUrl: https://github.com/signalridge/slipway/edit/main/website/src/content/docs/en/index.mdx
 hero:
+  title: An explicitly invoked soft autopilot for AI coding
   tagline: One Action at a time—investigate facts, clarify real decisions, implement, review read-only, and recover while the user stays in control.
   image:
     file: ../../../assets/slipway-wordmark.svg
@@ -28,7 +29,7 @@ Slipway is a user-invoked soft autopilot for AI coding. A host writes the code; 
 
 One Run advances one versioned Action at a time: `orient → clarify when needed → implement → review when enabled and code changed → summarize`. Every Action can be skipped, a Run can stop and resume, Review never edits code, and `ended` means only that the automatic queue is empty.
 
-<CardGrid stagger>
+<CardGrid>
   <Card title="Use it" icon="rocket">
     Start from the task you want to accomplish; start ad hoc or from a self-contained GitHub Change Issue.
 

--- a/website/src/content/docs/ja/index.mdx
+++ b/website/src/content/docs/ja/index.mdx
@@ -4,6 +4,7 @@ description: ユーザーが明示的に起動する AI コーディング向け
 template: splash
 editUrl: https://github.com/signalridge/slipway/edit/main/website/src/content/docs/ja/index.mdx
 hero:
+  title: ユーザーが明示的に起動する AI コーディング向けの補助自動化ツール
   tagline: Action を1つずつ進める。事実確認、one-by-one の澄清、実装、read-only Review、復旧を、ユーザー制御の下で行います。
   image:
     file: ../../../assets/slipway-wordmark.svg
@@ -28,7 +29,7 @@ Slipway は、ユーザーが明示的に起動する AI コーディング向�
 
 1回の Run は バージョン付き Action を1つずつ進めます：`orient → 必要なら clarify → implement → コード変更があり有効な場合は review → summarize`。Action は skip 可能、Run は stop/resume 可能、Review は コードを編集せず、`ended` は 自動キュー が空であることだけを示します。
 
-<CardGrid stagger>
+<CardGrid>
   <Card title="Slipway を使う" icon="rocket">
     達成したいタスクから始めます。アドホックまたは自己完結型 GitHub Change Issue から起動します。
 

--- a/website/src/content/docs/zh/index.mdx
+++ b/website/src/content/docs/zh/index.mdx
@@ -4,6 +4,7 @@ description: 用户主动启动的 AI 编程辅助自动化。
 template: splash
 editUrl: https://github.com/signalridge/slipway/edit/main/website/src/content/docs/zh/index.mdx
 hero:
+  title: 用户主动启动的 AI 编程辅助自动化
   tagline: 每次推进一个 Action——先查事实、逐个澄清、实施、只读 Review、可恢复，同时始终由用户掌控。
   image:
     file: ../../../assets/slipway-wordmark.svg
@@ -28,7 +29,7 @@ Slipway 是一款由用户主动调用的 AI 编程辅助自动化。宿主写�
 
 一次 Run 每次推进一个版本化 Action：`orient → 必要时 clarify → implement → 代码已变化且启用时 review → summarize`。每项 Action 可以 skip，Run 可以 stop/resume，Review 不改代码，`ended` 只表示自动队列为空。
 
-<CardGrid stagger>
+<CardGrid>
   <Card title="使用 Slipway" icon="rocket">
     从你要完成的任务开始：ad hoc 或从一个自包含 GitHub Change Issue 启动。
 

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -59,10 +59,38 @@ a.site-title img {
 	box-shadow: 0 14px 30px -10px rgba(255, 122, 89, 0.65);
 }
 
+/* The hero headline is a sentence, not the product name — the wordmark beside
+   it already carries that. Starlight's hero scale tops out at 64px, which is
+   sized for one word; a sentence at that size crowds out everything under it. */
+.hero h1 {
+	font-size: clamp(var(--sl-text-2xl), calc(0.25rem + 2.6vw), var(--sl-text-4xl));
+	text-wrap: balance;
+	/* `ch` measures a Latin digit, so a character cap tuned for English wraps
+	   the CJK headlines two words early — ja was splitting 起動 across lines.
+	   Let the hero column set the width and balance the lines within it;
+	   `auto-phrase` breaks Japanese on phrase boundaries where supported. */
+	word-break: auto-phrase;
+}
+
 /* Tagline reads as supporting copy, not a second headline. */
 .hero .tagline {
 	max-width: 48ch;
 	color: var(--sl-color-gray-2);
+}
+
+/* Splash pages have no sidebar, so Starlight widens their container to
+   67.5rem. That is the right width for the card grid and the wrong one for
+   running text: the intro paragraphs were setting ~135 characters per line.
+   Cap the prose only; the grid below keeps the full width. */
+html:not([data-has-sidebar]) .sl-markdown-content > :is(p, ul, ol, blockquote) {
+	max-width: 72ch;
+}
+
+/* Starlight's card grid is fixed at two columns above 50rem, which strands the
+   third landing card alone in a row and leaves the cell beside it empty. The
+   splash container is 67.5rem wide, so let the track count follow the cards. */
+html:not([data-has-sidebar]) .card-grid {
+	grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
 }
 
 /* Card grid accent on the landing page. */
@@ -76,6 +104,76 @@ a.site-title img {
 }
 .card .icon {
 	color: var(--slip-coral);
+}
+
+/* Documentation pages carry reference tables three prose columns wide and
+   diagrams drawn on a 1200px canvas. Starlight's 45rem default squeezes both.
+   The pane between the sidebars stops giving width at ~50rem, so this buys
+   every pixel actually on offer without pushing the table of contents. */
+[data-has-sidebar] {
+	--sl-content-width: 52rem;
+}
+
+/* Reference tables: keep identifiers whole and stop header cells from
+   collapsing to one word per line. `slipway-propose` was wrapping after the
+   hyphen inside narrow cells, which reads as two different commands. */
+.sl-markdown-content th {
+	text-wrap: balance;
+}
+.sl-markdown-content :is(td, th) {
+	vertical-align: top;
+}
+
+/* Only once the cells have room to keep them: below this width, forcing
+   identifiers whole makes the table scroll sideways instead, which costs more
+   than the wrap does. */
+@media (min-width: 50rem) {
+	.sl-markdown-content :is(td, th) > code {
+		white-space: nowrap;
+	}
+}
+
+/* Diagrams are authored at 1200px wide with 9.5-11px labels, so at prose width
+   their text renders around 6px and on a phone under 3px. Frame them, give
+   them the full column, and make the image a link to the standalone file so
+   the full-size original is one tap away. `sync-docs.mjs` adds that link; the
+   corner glyph is its affordance, and carries no text to translate. */
+.sl-markdown-content a[href*="/assets/diagrams/"]:has(> img) {
+	position: relative;
+	display: block;
+	margin-inline: auto;
+}
+.sl-markdown-content a[href*="/assets/diagrams/"]:has(> img) > img {
+	display: block;
+	width: 100%;
+	border: 1px solid var(--sl-color-gray-5);
+	border-radius: 0.5rem;
+	background: var(--sl-color-bg);
+	cursor: zoom-in;
+}
+.sl-markdown-content a[href*="/assets/diagrams/"]:has(> img)::after {
+	content: '⤢';
+	position: absolute;
+	inset-block-start: 0.5rem;
+	inset-inline-end: 0.5rem;
+	display: grid;
+	place-items: center;
+	inline-size: 1.75rem;
+	block-size: 1.75rem;
+	border: 1px solid var(--sl-color-gray-5);
+	border-radius: 0.375rem;
+	background: var(--sl-color-bg);
+	color: var(--sl-color-gray-2);
+	font-size: var(--sl-text-sm);
+	line-height: 1;
+	opacity: 0.75;
+	transition: opacity 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+.sl-markdown-content a[href*="/assets/diagrams/"]:has(> img):hover::after,
+.sl-markdown-content a[href*="/assets/diagrams/"]:has(> img):focus-visible::after {
+	opacity: 1;
+	color: var(--slip-violet);
+	border-color: var(--slip-violet);
 }
 
 /* Landing page demo videos. */


### PR DESCRIPTION
## Summary

The published site squeezed its densest content into the narrowest column Starlight offers, and the landing page ran text at 135 characters per line. Found by measuring the rendered pages, not by reading the source.

| Problem | Evidence | Fix |
| --- | --- | --- |
| Diagrams illegible | 1200px canvas with 9.5–11px labels rendered at 720px desktop (→~6px) and 358px mobile (→<3px) | Framed, full-column, and linked to the standalone asset so the full-size original is one tap away |
| Landing prose at 135 chars/line | Splash pages have no sidebar, so Starlight widens the container to 67.5rem — right for the card grid, wrong for running text | Cap splash prose at 72ch |
| Card grid left an empty cell | `CardGrid` is fixed at two columns above 50rem; the third card was stranded, and `stagger` additionally shoved card 2 down 5rem | Let the track count follow the cards; drop `stagger` |
| Identifiers split across lines | `slipway-propose` / `slipway-decompose` wrapped after the hyphen inside table cells, reading as two different commands | Keep inline code whole in cells above 50rem |
| Reference tables cramped | Three-column prose tables in the 45rem default; rows up to 157px tall | Content width 45rem → 52rem |
| "Slipway" three times above the fold | Header wordmark + hero H1 + hero wordmark image | Hero leads with what Slipway does; headline reuses each locale's existing page `description` rather than new copy |

`sync-docs.mjs` gained one transform: diagram images are wrapped in a link to their own asset. It emits plain Markdown, so no hand-escaped `alt` attribute — the stylesheet hangs its framing off the `href`.

## Verification

- `npm run build` — clean against the CI warning pattern
- `python3 -I acceptance/link_check.py --require-site` — ok at 73 files / 2999 link observations / 53 built pages
- Rendered checks at 390 / 1024 / 1280 / 1440 / 1920 / 2560px, both themes, across `en`, `zh`, `ja`: no horizontal page overflow, no content/table-of-contents collision

Measured results: diagrams 720 → 788px and now openable at full size, landing prose 1080 → 726px, cards three equal columns at equal height, broken identifiers 3 → 0, tallest table row 129 → 101px.

## Notes

- **No dark-mode change.** I suspected `<img>`-embedded SVGs couldn't see the page's `data-theme`; they can — Chromium propagates `color-scheme` into SVG image documents, and the diagrams already carry `prefers-color-scheme` blocks.
- **The identifier rule is scoped to ≥50rem on purpose.** Unscoped, it made phone-width tables scroll sideways instead.
- **Still open:** the wide three-column table in `idea-to-run-workflow` scrolls inside its container on phones. That is its min-content width and it behaves identically on the live site today; fixing it means restructuring that table's content, not styling it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)