### PR TITLE
docs: restore README badges lost in the history rewrite

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -8,7 +8,20 @@
 <p>
   <a href="https://github.com/signalridge/slipway/actions/workflows/ci.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/signalridge/slipway/ci.yml?branch=main&style=for-the-badge&logo=github&label=CI"></a>&nbsp;
   <a href="https://github.com/signalridge/slipway/actions/workflows/docs.yml"><img alt="Docs" src="https://img.shields.io/github/actions/workflow/status/signalridge/slipway/docs.yml?branch=main&style=for-the-badge&logo=astro&label=Docs"></a>&nbsp;
-  <a href="https://github.com/signalridge/slipway/releases"><img alt="Release" src="https://img.shields.io/github/v/release/signalridge/slipway?style=for-the-badge&logo=github"></a>
+  <a href="https://github.com/signalridge/slipway/releases"><img alt="Release" src="https://img.shields.io/github/v/release/signalridge/slipway?style=for-the-badge&logo=github"></a>&nbsp;
+  <a href="https://pkg.go.dev/github.com/signalridge/slipway"><img alt="Go Reference" src="https://img.shields.io/badge/Go-Reference-00ADD8?style=for-the-badge&logo=go&logoColor=white"></a>
+</p>
+
+<p>
+  <a href="docs/ja/installation.md"><img alt="Homebrew Cask" src="https://img.shields.io/badge/Homebrew_Cask-FBB040?style=flat-square&logo=homebrew&logoColor=black"></a>
+  <a href="docs/ja/installation.md"><img alt="Scoop" src="https://img.shields.io/badge/Scoop-00BFFF?style=flat-square&logo=windows&logoColor=white"></a>
+  <a href="docs/ja/installation.md"><img alt="AUR" src="https://img.shields.io/badge/AUR-1793D1?style=flat-square&logo=archlinux&logoColor=white"></a>
+  <a href="docs/ja/installation.md"><img alt="Nix" src="https://img.shields.io/badge/Nix-5277C3?style=flat-square&logo=nixos&logoColor=white"></a>
+  <a href="docs/ja/installation.md"><img alt="Docker" src="https://img.shields.io/badge/Docker-2496ED?style=flat-square&logo=docker&logoColor=white"></a>
+  <a href="docs/ja/installation.md"><img alt="deb" src="https://img.shields.io/badge/deb-A81D33?style=flat-square&logo=debian&logoColor=white"></a>
+  <a href="docs/ja/installation.md"><img alt="rpm" src="https://img.shields.io/badge/rpm-EE0000?style=flat-square&logo=redhat&logoColor=white"></a>
+  <a href="docs/ja/installation.md"><img alt="apk" src="https://img.shields.io/badge/apk-0D597F?style=flat-square&logo=alpinelinux&logoColor=white"></a>
+  <a href="docs/ja/installation.md"><img alt="Go" src="https://img.shields.io/badge/Go-00ADD8?style=flat-square&logo=go&logoColor=white"></a>
 </p>
 
 [ドキュメント](https://signalridge.github.io/slipway/ja/) ·
@@ -146,3 +159,7 @@ Run data は リポジトリ の Git common directory にある `<git-common-dir
 ## ライセンス
 
 Slipway は [BSD 3-Clause License](LICENSE) で提供されます。
+
+## リポジトリの状態
+
+![Repobeats 分析画像](https://repobeats.axiom.co/api/embed/20e468225cab8a858d9bc969314a0e9c3d12bddb.svg "Repobeats 分析画像")

--- a/README.md
+++ b/README.md
@@ -8,7 +8,20 @@
 <p>
   <a href="https://github.com/signalridge/slipway/actions/workflows/ci.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/signalridge/slipway/ci.yml?branch=main&style=for-the-badge&logo=github&label=CI"></a>&nbsp;
   <a href="https://github.com/signalridge/slipway/actions/workflows/docs.yml"><img alt="Docs" src="https://img.shields.io/github/actions/workflow/status/signalridge/slipway/docs.yml?branch=main&style=for-the-badge&logo=astro&label=Docs"></a>&nbsp;
-  <a href="https://github.com/signalridge/slipway/releases"><img alt="Release" src="https://img.shields.io/github/v/release/signalridge/slipway?style=for-the-badge&logo=github"></a>
+  <a href="https://github.com/signalridge/slipway/releases"><img alt="Release" src="https://img.shields.io/github/v/release/signalridge/slipway?style=for-the-badge&logo=github"></a>&nbsp;
+  <a href="https://pkg.go.dev/github.com/signalridge/slipway"><img alt="Go Reference" src="https://img.shields.io/badge/Go-Reference-00ADD8?style=for-the-badge&logo=go&logoColor=white"></a>
+</p>
+
+<p>
+  <a href="docs/en/installation.md"><img alt="Homebrew Cask" src="https://img.shields.io/badge/Homebrew_Cask-FBB040?style=flat-square&logo=homebrew&logoColor=black"></a>
+  <a href="docs/en/installation.md"><img alt="Scoop" src="https://img.shields.io/badge/Scoop-00BFFF?style=flat-square&logo=windows&logoColor=white"></a>
+  <a href="docs/en/installation.md"><img alt="AUR" src="https://img.shields.io/badge/AUR-1793D1?style=flat-square&logo=archlinux&logoColor=white"></a>
+  <a href="docs/en/installation.md"><img alt="Nix" src="https://img.shields.io/badge/Nix-5277C3?style=flat-square&logo=nixos&logoColor=white"></a>
+  <a href="docs/en/installation.md"><img alt="Docker" src="https://img.shields.io/badge/Docker-2496ED?style=flat-square&logo=docker&logoColor=white"></a>
+  <a href="docs/en/installation.md"><img alt="deb" src="https://img.shields.io/badge/deb-A81D33?style=flat-square&logo=debian&logoColor=white"></a>
+  <a href="docs/en/installation.md"><img alt="rpm" src="https://img.shields.io/badge/rpm-EE0000?style=flat-square&logo=redhat&logoColor=white"></a>
+  <a href="docs/en/installation.md"><img alt="apk" src="https://img.shields.io/badge/apk-0D597F?style=flat-square&logo=alpinelinux&logoColor=white"></a>
+  <a href="docs/en/installation.md"><img alt="Go" src="https://img.shields.io/badge/Go-00ADD8?style=flat-square&logo=go&logoColor=white"></a>
 </p>
 
 [Documentation](https://signalridge.github.io/slipway/en/) ·
@@ -188,3 +201,7 @@ sensitive material.
 ## License
 
 Slipway is distributed under the [BSD 3-Clause License](LICENSE).
+
+## Repository status
+
+![Repobeats analytics image](https://repobeats.axiom.co/api/embed/20e468225cab8a858d9bc969314a0e9c3d12bddb.svg "Repobeats analytics image")

--- a/README.zh.md
+++ b/README.zh.md
@@ -8,7 +8,20 @@
 <p>
   <a href="https://github.com/signalridge/slipway/actions/workflows/ci.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/signalridge/slipway/ci.yml?branch=main&style=for-the-badge&logo=github&label=CI"></a>&nbsp;
   <a href="https://github.com/signalridge/slipway/actions/workflows/docs.yml"><img alt="Docs" src="https://img.shields.io/github/actions/workflow/status/signalridge/slipway/docs.yml?branch=main&style=for-the-badge&logo=astro&label=Docs"></a>&nbsp;
-  <a href="https://github.com/signalridge/slipway/releases"><img alt="Release" src="https://img.shields.io/github/v/release/signalridge/slipway?style=for-the-badge&logo=github"></a>
+  <a href="https://github.com/signalridge/slipway/releases"><img alt="Release" src="https://img.shields.io/github/v/release/signalridge/slipway?style=for-the-badge&logo=github"></a>&nbsp;
+  <a href="https://pkg.go.dev/github.com/signalridge/slipway"><img alt="Go Reference" src="https://img.shields.io/badge/Go-Reference-00ADD8?style=for-the-badge&logo=go&logoColor=white"></a>
+</p>
+
+<p>
+  <a href="docs/zh/installation.md"><img alt="Homebrew Cask" src="https://img.shields.io/badge/Homebrew_Cask-FBB040?style=flat-square&logo=homebrew&logoColor=black"></a>
+  <a href="docs/zh/installation.md"><img alt="Scoop" src="https://img.shields.io/badge/Scoop-00BFFF?style=flat-square&logo=windows&logoColor=white"></a>
+  <a href="docs/zh/installation.md"><img alt="AUR" src="https://img.shields.io/badge/AUR-1793D1?style=flat-square&logo=archlinux&logoColor=white"></a>
+  <a href="docs/zh/installation.md"><img alt="Nix" src="https://img.shields.io/badge/Nix-5277C3?style=flat-square&logo=nixos&logoColor=white"></a>
+  <a href="docs/zh/installation.md"><img alt="Docker" src="https://img.shields.io/badge/Docker-2496ED?style=flat-square&logo=docker&logoColor=white"></a>
+  <a href="docs/zh/installation.md"><img alt="deb" src="https://img.shields.io/badge/deb-A81D33?style=flat-square&logo=debian&logoColor=white"></a>
+  <a href="docs/zh/installation.md"><img alt="rpm" src="https://img.shields.io/badge/rpm-EE0000?style=flat-square&logo=redhat&logoColor=white"></a>
+  <a href="docs/zh/installation.md"><img alt="apk" src="https://img.shields.io/badge/apk-0D597F?style=flat-square&logo=alpinelinux&logoColor=white"></a>
+  <a href="docs/zh/installation.md"><img alt="Go" src="https://img.shields.io/badge/Go-00ADD8?style=flat-square&logo=go&logoColor=white"></a>
 </p>
 
 [文档](https://signalridge.github.io/slipway/zh/) ·
@@ -145,3 +158,7 @@ Run 数据位于仓库 Git common directory 下的 `<git-common-dir>/slipway/run
 ## 许可证
 
 Slipway 使用 [BSD 3-Clause License](LICENSE)。
+
+## 仓库状态
+
+![Repobeats 分析图](https://repobeats.axiom.co/api/embed/20e468225cab8a858d9bc969314a0e9c3d12bddb.svg "Repobeats 分析图")


### PR DESCRIPTION
## What

The July 2026 history rewrite dropped three badge groups from all three README translations (`README.md`, `README.zh.md`, `README.ja.md`). This restores them from `backup/main-20260718-002707`:

1. **Go Reference badge** — `pkg.go.dev/github.com/signalridge/slipway`, in the `for-the-badge` status row (plus the `&nbsp;` separator that went with it).
2. **Install-channel badges** — Homebrew Cask, Scoop, AUR, Nix, Docker, deb, rpm, apk, Go.
3. **Repobeats analytics embed** — under a repository-status heading at the end of each README.

## One deliberate change from the backup

The backup pointed all nine install badges at `docs/installation.md`. That path no longer exists — installation docs are now per-locale — so each README links to its own `docs/en/`, `docs/zh/`, or `docs/ja/installation.md`.

## Verification

- `python3 acceptance/link_check.py` → `73 Markdown/MDX files, 581 local link observations: ok`. This checker covers HTML `href`/`src` attributes in the root READMEs, so the badge link targets are confirmed to resolve.
- Every badge URL returns HTTP 200 with no `invalid`/`not found` marker in the returned SVG — the `alpinelinux`, `archlinux`, `nixos`, and `homebrew` logo slugs all render.
- The Repobeats embed returns a 37 KB SVG and the pkg.go.dev page returns 200.
- All nine advertised channels still have a corresponding section in all three installation guides, so no badge claims a channel that was retired.

## Note

Repobeats is a third-party analytics embed: rendering the README issues a request to `repobeats.axiom.co`. It was present before the rewrite, so it is restored as-is — say the word if you'd rather drop it and keep only the shields.io badges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)